### PR TITLE
Fix missing CSS style recomputation in insert_before and replace_node

### DIFF
--- a/crates/rinch-dom/src/dom_impl/dom_document_impl.rs
+++ b/crates/rinch-dom/src/dom_impl/dom_document_impl.rs
@@ -201,6 +201,9 @@ impl DomDocument for RinchDocument {
         self.tree.layout_dirty = true; // Structural change needs full layout
         self.tree.ifc_dirty = true; // Tree structure changed
         self.push_dirty_flags(p, DirtyFlags::LAYOUT | DirtyFlags::CHILDREN);
+
+        // Recompute styles for the inserted subtree to pick up ancestor-based selectors
+        self.recompute_node_styles_recursive(c);
     }
 
     fn replace_node(&mut self, old: NodeId, new: NodeId) {
@@ -247,6 +250,9 @@ impl DomDocument for RinchDocument {
             self.tree.layout_dirty = true; // Structural change needs full layout
             self.tree.ifc_dirty = true; // Tree structure changed
             self.push_dirty_flags(parent_id, DirtyFlags::LAYOUT | DirtyFlags::CHILDREN);
+
+            // Recompute styles for the new subtree to pick up ancestor-based selectors
+            self.recompute_node_styles_recursive(new.0);
         }
     }
 


### PR DESCRIPTION
## Summary

- `insert_before` and `replace_node` in `DomDocumentImpl` were missing `recompute_node_styles_recursive()` calls that `append_child` already had
- This caused nodes inserted via `for_each_dom` reconciliation to keep browser default styles (serif, 16px, #000000) instead of inheriting CSS from parent elements
- Manifested as tree nodes losing all styling after re-render (e.g., after label change triggers `for_each_dom_typed` reconciliation)

## Test plan

- [x] Verified in Pimble app: renamed tree node now retains correct font, size, padding, border-radius
- [ ] Verify no regressions in other components that use `insert_before` / `replace_node`

🤖 Generated with [Claude Code](https://claude.com/claude-code)