### PR TITLE
fix: constrain html element to viewport width

### DIFF
--- a/crates/rinch-dom/src/dom_impl/mod.rs
+++ b/crates/rinch-dom/src/dom_impl/mod.rs
@@ -276,6 +276,19 @@ impl RinchDocument {
                 let dd = self.default_display_for_node(node_id);
                 let mut taffy_style = node.computed_style.to_taffy_style(dd);
 
+                // HTML element must fill the viewport and clip horizontal overflow
+                if node_id == self.tree.html_id {
+                    if taffy_style.size.width == taffy::Dimension::auto() {
+                        taffy_style.size.width = taffy::Dimension::percent(1.0);
+                    }
+                    if taffy_style.size.height == taffy::Dimension::auto() {
+                        taffy_style.size.height = taffy::Dimension::percent(1.0);
+                    }
+                    if taffy_style.overflow.x == taffy::Overflow::Visible {
+                        taffy_style.overflow.x = taffy::Overflow::Clip;
+                    }
+                }
+
                 // Body node needs the same overrides as apply_stylo_styles_to_taffy
                 if node_id == self.tree.body_id {
                     if taffy_style.flex_grow == 0.0 {

--- a/crates/rinch-dom/src/style_resolution/mod.rs
+++ b/crates/rinch-dom/src/style_resolution/mod.rs
@@ -427,6 +427,20 @@ impl RinchDocument {
             let dd = self.default_display_for_node(node_id);
             let mut taffy_style = self.tree.nodes[node_id].computed_style.to_taffy_style(dd);
 
+            // HTML element must fill the viewport and clip horizontal overflow
+            // (mirrors browser behavior where the viewport constrains content width).
+            if node_id == self.tree.html_id {
+                if taffy_style.size.width == taffy::Dimension::auto() {
+                    taffy_style.size.width = taffy::Dimension::percent(1.0);
+                }
+                if taffy_style.size.height == taffy::Dimension::auto() {
+                    taffy_style.size.height = taffy::Dimension::percent(1.0);
+                }
+                if taffy_style.overflow.x == taffy::Overflow::Visible {
+                    taffy_style.overflow.x = taffy::Overflow::Clip;
+                }
+            }
+
             // Body node needs flex_grow: 1 and height: auto to fill the viewport
             if node_id == self.tree.body_id {
                 if taffy_style.flex_grow == 0.0 {


### PR DESCRIPTION
## Summary
- Adds viewport width/height constraints and overflow-x: clip to the `<html>` element during Taffy style sync
- Mirrors browser behavior where the viewport constrains content width, preventing horizontal overflow in both desktop and web apps
- Applied in both `style_resolution/mod.rs` and `dom_impl/mod.rs` code paths

## Test plan
- [x] Verified in UI Zoo desktop app — content no longer overflows viewport horizontally
- [x] Verified in gitrinching app — same fix applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)