### PR TITLE
feat: CSS text-overflow: ellipsis support

### DIFF
--- a/crates/rinch-dom/src/computed_style/from_props.rs
+++ b/crates/rinch-dom/src/computed_style/from_props.rs
@@ -264,6 +264,7 @@ impl ComputedStyle {
                 "overflow-wrap" | "word-wrap" => {
                     style.overflow_wrap = OverflowWrapValue::parse(value)
                 }
+                "text-overflow" => style.text_overflow = TextOverflowValue::parse(value),
 
                 // Grid properties
                 "grid-template-columns" => {

--- a/crates/rinch-dom/src/computed_style/from_stylo/mod.rs
+++ b/crates/rinch-dom/src/computed_style/from_stylo/mod.rs
@@ -218,6 +218,7 @@ impl ComputedStyle {
             text_underline_offset: None,
             white_space: white_space_from_stylo(&text.white_space_collapse, &text.text_wrap_mode),
             overflow_wrap: overflow_wrap_from_stylo(&text.overflow_wrap),
+            text_overflow: text_overflow_from_stylo(&cv.clone_text_overflow()),
 
             // Grid - extract from Stylo
             grid_template_columns: grid_template_tracks_from_stylo(

--- a/crates/rinch-dom/src/computed_style/from_stylo/typography.rs
+++ b/crates/rinch-dom/src/computed_style/from_stylo/typography.rs
@@ -132,3 +132,14 @@ pub(super) fn overflow_wrap_from_stylo(
         StyloOW::Anywhere => OverflowWrapValue::Anywhere,
     }
 }
+
+pub(super) fn text_overflow_from_stylo(
+    to: &style::values::computed::TextOverflow,
+) -> TextOverflowValue {
+    use style::values::specified::text::TextOverflowSide;
+    // CSS text-overflow: ellipsis sets the "second" (end) side
+    match to.second {
+        TextOverflowSide::Ellipsis => TextOverflowValue::Ellipsis,
+        _ => TextOverflowValue::Clip,
+    }
+}

--- a/crates/rinch-dom/src/computed_style/mod.rs
+++ b/crates/rinch-dom/src/computed_style/mod.rs
@@ -147,6 +147,7 @@ pub struct ComputedStyle {
     pub text_underline_offset: Option<f32>,
     pub white_space: WhiteSpaceValue,
     pub overflow_wrap: OverflowWrapValue,
+    pub text_overflow: TextOverflowValue,
 
     // Grid properties - skip serialization (taffy types don't impl Serialize)
     #[serde(skip)]
@@ -264,6 +265,7 @@ impl Default for ComputedStyle {
             text_underline_offset: None,
             white_space: WhiteSpaceValue::default(),
             overflow_wrap: OverflowWrapValue::default(),
+            text_overflow: TextOverflowValue::default(),
 
             grid_template_columns: Vec::new(),
             grid_template_rows: Vec::new(),

--- a/crates/rinch-dom/src/computed_style/values.rs
+++ b/crates/rinch-dom/src/computed_style/values.rs
@@ -539,6 +539,24 @@ impl OverflowValue {
     }
 }
 
+/// CSS text-overflow property values.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Serialize)]
+pub enum TextOverflowValue {
+    #[default]
+    Clip,
+    Ellipsis,
+}
+
+impl TextOverflowValue {
+    /// Parse from CSS string value.
+    pub fn parse(value: &str) -> Self {
+        match value.trim() {
+            "ellipsis" => Self::Ellipsis,
+            _ => Self::Clip,
+        }
+    }
+}
+
 /// CSS font-style property values.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Serialize)]
 pub enum FontStyleValue {

--- a/crates/rinch-dom/src/dom_impl/dom_document_impl.rs
+++ b/crates/rinch-dom/src/dom_impl/dom_document_impl.rs
@@ -76,6 +76,8 @@ impl DomDocument for RinchDocument {
             color: AlphaColor::<Srgb>::from_rgba8(0, 0, 0, 255), // default black, updated from parent
             no_wrap: false,                                      // default, updated from parent
             overflow_wrap: crate::computed_style::OverflowWrapValue::default(),
+            text_overflow: crate::computed_style::TextOverflowValue::default(),
+            parent_overflow_hidden: false,
         });
         let taffy_id = self
             .tree
@@ -342,6 +344,8 @@ impl DomDocument for RinchDocument {
                     color: AlphaColor::<Srgb>::from_rgba8(0, 0, 0, 255),
                     no_wrap: false,
                     overflow_wrap: crate::computed_style::OverflowWrapValue::default(),
+                    text_overflow: crate::computed_style::TextOverflowValue::default(),
+                    parent_overflow_hidden: false,
                 });
                 let taffy_id = self
                     .tree

--- a/crates/rinch-dom/src/dom_impl/mod.rs
+++ b/crates/rinch-dom/src/dom_impl/mod.rs
@@ -73,9 +73,10 @@ impl Default for RinchDocument {
 impl RinchDocument {
     /// Create a new document with root and body nodes.
     pub fn new() -> Self {
-        // Enable CSS Grid support in Stylo
+        // Enable CSS Grid and text-overflow support in Stylo
         // This must be called before any CSS parsing happens
         style_config::set_bool("layout.grid.enabled", true);
+        style_config::set_bool("layout.unimplemented", true);
 
         // Create the Stylo Device with default viewport and settings
         let viewport_size = euclid::Size2D::new(800.0, 600.0);

--- a/crates/rinch-dom/src/dom_impl/mod.rs
+++ b/crates/rinch-dom/src/dom_impl/mod.rs
@@ -276,6 +276,19 @@ impl RinchDocument {
                 let dd = self.default_display_for_node(node_id);
                 let mut taffy_style = node.computed_style.to_taffy_style(dd);
 
+                // HTML element must fill the viewport and clip horizontal overflow
+                if node_id == self.tree.html_id {
+                    if taffy_style.size.width == taffy::Dimension::auto() {
+                        taffy_style.size.width = taffy::Dimension::percent(1.0);
+                    }
+                    if taffy_style.size.height == taffy::Dimension::auto() {
+                        taffy_style.size.height = taffy::Dimension::percent(1.0);
+                    }
+                    if taffy_style.overflow.x == taffy::Overflow::Visible {
+                        taffy_style.overflow.x = taffy::Overflow::Clip;
+                    }
+                }
+
                 // Body node needs the same overrides as apply_stylo_styles_to_taffy
                 if node_id == self.tree.body_id {
                     if taffy_style.flex_grow == 0.0 {

--- a/crates/rinch-dom/src/ifc.rs
+++ b/crates/rinch-dom/src/ifc.rs
@@ -75,7 +75,7 @@ impl RinchDocument {
                 }
             }
 
-            let inline_layout = Self::build_inline_layout(
+            let mut inline_layout = Self::build_inline_layout(
                 &self.tree.nodes,
                 root_id,
                 max_width,
@@ -83,6 +83,33 @@ impl RinchDocument {
                 &mut self.font_cx,
                 paint_layout_cx,
             );
+
+            // text-overflow: ellipsis — if text overflows the container, truncate and add "…"
+            {
+                use crate::computed_style::{OverflowValue, TextOverflowValue, WhiteSpaceValue};
+                let cs = &self.tree.nodes[root_id].computed_style;
+                let container_width = max_width.unwrap_or(f32::INFINITY);
+                if matches!(cs.text_overflow, TextOverflowValue::Ellipsis)
+                    && matches!(cs.white_space, WhiteSpaceValue::NoWrap | WhiteSpaceValue::Pre)
+                    && matches!(cs.overflow_x, OverflowValue::Hidden | OverflowValue::Clip)
+                    && inline_layout.layout.width() > container_width
+                    && container_width > 0.0
+                {
+                    // Collect text content from the inline layout
+                    let full_text = inline_layout.text_content.clone();
+                    if !full_text.is_empty() {
+                        inline_layout = Self::build_ellipsis_layout(
+                            &self.tree.nodes,
+                            root_id,
+                            &full_text,
+                            container_width,
+                            1.0,
+                            &mut self.font_cx,
+                            paint_layout_cx,
+                        );
+                    }
+                }
+            }
 
             // Write positions from Parley layout back to child nodes
             // Walk the layout lines to find positioned inline boxes and text runs
@@ -96,10 +123,14 @@ impl RinchDocument {
     ///
     /// Uses the exact layouts built during Taffy measurement to ensure
     /// paint uses identical text shaping results.
+    /// Also handles text-overflow: ellipsis by truncating text and appending "…"
+    /// when the parent has overflow: hidden + white-space: nowrap + text-overflow: ellipsis.
     pub(crate) fn copy_cached_text_layouts(
         &mut self,
         cache: HashMap<(usize, u32), parley::layout::Layout<Brush>>,
     ) {
+        use crate::computed_style::{OverflowValue, TextOverflowValue, WhiteSpaceValue};
+
         // First collect node IDs and their layouts to apply
         let updates: Vec<(usize, parley::layout::Layout<Brush>)> = self
             .tree
@@ -144,6 +175,9 @@ impl RinchDocument {
             })
             .collect();
 
+        // Collect ellipsis rebuild requests: (node_id, text_content, available_width)
+        let mut ellipsis_rebuilds: Vec<(usize, String, f32)> = Vec::new();
+
         // Apply the updates with alignment
         for (id, mut layout) in updates {
             // Get text-align from parent's computed style
@@ -153,9 +187,163 @@ impl RinchDocument {
                 .map(|p| p.computed_style.text_align.to_parley())
                 .unwrap_or(parley::layout::Alignment::Start);
 
+            // Check if text-overflow: ellipsis applies
+            let needs_ellipsis = parent_id
+                .and_then(|p| self.tree.nodes.get(p))
+                .is_some_and(|parent| {
+                    matches!(parent.computed_style.text_overflow, TextOverflowValue::Ellipsis)
+                        && matches!(
+                            parent.computed_style.white_space,
+                            WhiteSpaceValue::NoWrap | WhiteSpaceValue::Pre
+                        )
+                        && matches!(
+                            parent.computed_style.overflow_x,
+                            OverflowValue::Hidden | OverflowValue::Clip
+                        )
+                });
+
+            if needs_ellipsis {
+                let parent_width = parent_id
+                    .and_then(|p| self.tree.nodes.get(p))
+                    .map(|p| p.layout.width)
+                    .unwrap_or(f32::INFINITY);
+
+                // Check if text overflows its parent
+                if layout.width() > parent_width && parent_width > 0.0 {
+                    if let NodeKind::Text(text_data) = &self.tree.nodes[id].kind {
+                        ellipsis_rebuilds.push((id, text_data.content.clone(), parent_width));
+                        continue; // Skip normal caching; will be rebuilt below
+                    }
+                }
+            }
+
             // Apply alignment before caching
             layout.align(alignment, parley::layout::AlignmentOptions::default());
 
+            self.tree.nodes[id].cached_text_parley = Some(Box::new(layout));
+        }
+
+        // Rebuild layouts for text nodes that need ellipsis truncation
+        for (id, content, available_width) in ellipsis_rebuilds {
+            let parent_id = self.tree.nodes[id].parent;
+            let parent = parent_id.and_then(|p| self.tree.nodes.get(p));
+            let font_size = parent.map(|p| p.computed_style.font_size).unwrap_or(16.0);
+            let font_weight = parent.map(|p| p.computed_style.font_weight).unwrap_or(400.0);
+            let font_family = parent
+                .map(|p| {
+                    if p.computed_style.font_family.is_empty() {
+                        "sans-serif".to_string()
+                    } else {
+                        p.computed_style.font_family.clone()
+                    }
+                })
+                .unwrap_or_else(|| "sans-serif".to_string());
+            let color = parent
+                .and_then(|p| p.computed_style.color)
+                .unwrap_or_else(|| peniko::color::AlphaColor::<peniko::color::Srgb>::from_rgba8(0, 0, 0, 255));
+            let line_height = parent.and_then(|p| p.computed_style.line_height.to_parley());
+            let alignment = parent
+                .map(|p| p.computed_style.text_align.to_parley())
+                .unwrap_or(parley::layout::Alignment::Start);
+
+            // Measure the ellipsis "…" width first
+            let ellipsis = "…";
+            let ellipsis_width = {
+                let mut builder = self.layout_cx.ranged_builder(&mut self.font_cx, ellipsis, 1.0, true);
+                builder.push_default(parley::style::StyleProperty::FontSize(font_size));
+                if (font_weight - 400.0).abs() > 1.0 {
+                    builder.push_default(parley::style::StyleProperty::FontWeight(
+                        parley::style::FontWeight::new(font_weight),
+                    ));
+                }
+                builder.push_default(parley::style::StyleProperty::FontStack(
+                    parley::style::FontStack::Source(std::borrow::Cow::Owned(font_family.clone())),
+                ));
+                let mut layout = builder.build(ellipsis);
+                layout.break_all_lines(None);
+                layout.width()
+            };
+
+            let target_width = available_width - ellipsis_width;
+            if target_width <= 0.0 {
+                // Not even room for the ellipsis — just show ellipsis
+                let mut builder = self.layout_cx.ranged_builder(&mut self.font_cx, ellipsis, 1.0, true);
+                builder.push_default(parley::style::StyleProperty::FontSize(font_size));
+                builder.push_default(parley::style::StyleProperty::Brush(Brush::Solid(color)));
+                builder.push_default(parley::style::StyleProperty::FontStack(
+                    parley::style::FontStack::Source(std::borrow::Cow::Owned(font_family)),
+                ));
+                if (font_weight - 400.0).abs() > 1.0 {
+                    builder.push_default(parley::style::StyleProperty::FontWeight(
+                        parley::style::FontWeight::new(font_weight),
+                    ));
+                }
+                if let Some(lh) = line_height {
+                    builder.push_default(parley::style::StyleProperty::LineHeight(lh));
+                }
+                let mut layout = builder.build(ellipsis);
+                layout.break_all_lines(None);
+                layout.align(alignment, parley::layout::AlignmentOptions::default());
+                self.tree.nodes[id].cached_text_parley = Some(Box::new(layout));
+                continue;
+            }
+
+            // Binary search for the longest prefix that fits within target_width
+            let chars: Vec<char> = content.chars().collect();
+            let mut lo: usize = 0;
+            let mut hi: usize = chars.len();
+            let mut best_len = 0;
+
+            while lo <= hi {
+                let mid = (lo + hi) / 2;
+                if mid == 0 {
+                    lo = 1;
+                    continue;
+                }
+                let prefix: String = chars[..mid].iter().collect();
+                let mut builder = self.layout_cx.ranged_builder(&mut self.font_cx, &prefix, 1.0, true);
+                builder.push_default(parley::style::StyleProperty::FontSize(font_size));
+                if (font_weight - 400.0).abs() > 1.0 {
+                    builder.push_default(parley::style::StyleProperty::FontWeight(
+                        parley::style::FontWeight::new(font_weight),
+                    ));
+                }
+                builder.push_default(parley::style::StyleProperty::FontStack(
+                    parley::style::FontStack::Source(std::borrow::Cow::Owned(font_family.clone())),
+                ));
+                let mut layout = builder.build(&prefix);
+                layout.break_all_lines(None);
+
+                if layout.width() <= target_width {
+                    best_len = mid;
+                    lo = mid + 1;
+                } else {
+                    if mid == 0 {
+                        break;
+                    }
+                    hi = mid - 1;
+                }
+            }
+
+            // Build final layout with truncated text + ellipsis
+            let truncated: String = chars[..best_len].iter().collect::<String>().trim_end().to_string() + ellipsis;
+            let mut builder = self.layout_cx.ranged_builder(&mut self.font_cx, &truncated, 1.0, true);
+            builder.push_default(parley::style::StyleProperty::FontSize(font_size));
+            builder.push_default(parley::style::StyleProperty::Brush(Brush::Solid(color)));
+            builder.push_default(parley::style::StyleProperty::FontStack(
+                parley::style::FontStack::Source(std::borrow::Cow::Owned(font_family)),
+            ));
+            if (font_weight - 400.0).abs() > 1.0 {
+                builder.push_default(parley::style::StyleProperty::FontWeight(
+                    parley::style::FontWeight::new(font_weight),
+                ));
+            }
+            if let Some(lh) = line_height {
+                builder.push_default(parley::style::StyleProperty::LineHeight(lh));
+            }
+            let mut layout = builder.build(&truncated);
+            layout.break_all_lines(None);
+            layout.align(alignment, parley::layout::AlignmentOptions::default());
             self.tree.nodes[id].cached_text_parley = Some(Box::new(layout));
         }
     }
@@ -749,7 +937,12 @@ impl RinchDocument {
 
         let (text_layout, text_content) = builder.build();
         let mut text_layout = text_layout;
-        text_layout.break_all_lines(max_width);
+        // white-space: nowrap/pre prevents line wrapping — use infinite width
+        let effective_max_width = match root_computed.white_space {
+            WhiteSpaceValue::NoWrap | WhiteSpaceValue::Pre => None,
+            _ => max_width,
+        };
+        text_layout.break_all_lines(effective_max_width);
 
         // Apply text-align from computed style
         let alignment = root_computed.text_align.to_parley();
@@ -762,6 +955,115 @@ impl RinchDocument {
             text_ranges,
             background_spans,
             max_width: max_width.unwrap_or(f32::INFINITY),
+        }
+    }
+
+    /// Build an IFC layout with ellipsis truncation.
+    ///
+    /// Binary-searches for the longest text prefix that fits within `container_width`
+    /// when combined with an ellipsis character, then rebuilds the layout.
+    #[allow(clippy::too_many_arguments)]
+    fn build_ellipsis_layout(
+        nodes: &slab::Slab<Node>,
+        root_id: usize,
+        full_text: &str,
+        container_width: f32,
+        scale: f32,
+        font_cx: &mut parley::FontContext,
+        layout_cx: &mut parley::LayoutContext<Brush>,
+    ) -> InlineLayout {
+        let root_computed = &nodes[root_id].computed_style;
+        let font_size = root_computed.font_size * scale;
+        let font_family: std::borrow::Cow<'static, str> = if root_computed.font_family.is_empty() {
+            "sans-serif".into()
+        } else {
+            root_computed.font_family.clone().into()
+        };
+        let font_weight = parley::style::FontWeight::new(root_computed.font_weight);
+        let color = root_computed
+            .color
+            .unwrap_or_else(|| peniko::color::AlphaColor::<peniko::color::Srgb>::from_rgba8(0, 0, 0, 255));
+        let line_height = root_computed.line_height.to_parley();
+        let alignment = root_computed.text_align.to_parley();
+
+        let ellipsis = "\u{2026}";
+
+        // Measure ellipsis width
+        let ellipsis_width = {
+            let mut b = layout_cx.ranged_builder(font_cx, ellipsis, scale, true);
+            b.push_default(parley::style::StyleProperty::FontSize(font_size));
+            b.push_default(parley::style::StyleProperty::FontWeight(font_weight));
+            b.push_default(parley::style::StyleProperty::FontStack(
+                parley::style::FontStack::Source(font_family.clone()),
+            ));
+            let mut l = b.build(ellipsis);
+            l.break_all_lines(None);
+            l.width()
+        };
+
+        let target_width = container_width - ellipsis_width;
+        let chars: Vec<char> = full_text.chars().collect();
+        let mut best_len = 0;
+
+        if target_width > 0.0 {
+            let mut lo: usize = 0;
+            let mut hi: usize = chars.len();
+            while lo <= hi {
+                let mid = (lo + hi) / 2;
+                if mid == 0 {
+                    lo = 1;
+                    continue;
+                }
+                let prefix: String = chars[..mid].iter().collect();
+                let mut b = layout_cx.ranged_builder(font_cx, &prefix, scale, true);
+                b.push_default(parley::style::StyleProperty::FontSize(font_size));
+                b.push_default(parley::style::StyleProperty::FontWeight(font_weight));
+                b.push_default(parley::style::StyleProperty::FontStack(
+                    parley::style::FontStack::Source(font_family.clone()),
+                ));
+                let mut l = b.build(&prefix);
+                l.break_all_lines(None);
+                if l.width() <= target_width {
+                    best_len = mid;
+                    lo = mid + 1;
+                } else {
+                    if mid == 0 {
+                        break;
+                    }
+                    hi = mid - 1;
+                }
+            }
+        }
+
+        // Build final layout: truncated text + ellipsis
+        let truncated: String = chars[..best_len]
+            .iter()
+            .collect::<String>()
+            .trim_end()
+            .to_string()
+            + ellipsis;
+
+        let mut b = layout_cx.ranged_builder(font_cx, &truncated, scale, true);
+        b.push_default(parley::style::StyleProperty::FontSize(font_size));
+        b.push_default(parley::style::StyleProperty::Brush(Brush::Solid(color)));
+        b.push_default(parley::style::StyleProperty::FontWeight(font_weight));
+        b.push_default(parley::style::StyleProperty::FontStack(
+            parley::style::FontStack::Source(font_family),
+        ));
+        if let Some(lh) = line_height {
+            b.push_default(parley::style::StyleProperty::LineHeight(lh));
+        }
+        let mut layout = b.build(&truncated);
+        layout.break_all_lines(None);
+        layout.align(alignment, parley::layout::AlignmentOptions::default());
+
+        InlineLayout {
+            layout,
+            text_content: truncated,
+            child_positions: Vec::new(),
+            text_ranges: Vec::new(),
+            background_spans: Vec::new(),
+            max_width: container_width,
         }
     }
 

--- a/crates/rinch-dom/src/layout_engine.rs
+++ b/crates/rinch-dom/src/layout_engine.rs
@@ -394,7 +394,7 @@ impl RinchDocument {
     /// to avoid walking all text nodes.
     #[allow(clippy::type_complexity)]
     pub(crate) fn sync_dirty_text_contexts(&mut self) {
-        use crate::computed_style::WhiteSpaceValue;
+        use crate::computed_style::{OverflowValue, WhiteSpaceValue};
         let mut updates: Vec<(
             taffy::NodeId,
             usize,
@@ -405,6 +405,8 @@ impl RinchDocument {
             AlphaColor<Srgb>,
             bool,
             crate::computed_style::OverflowWrapValue,
+            crate::computed_style::TextOverflowValue,
+            bool,
         )> = Vec::new();
 
         for &id in &self.tree.dirty_nodes {
@@ -428,6 +430,8 @@ impl RinchDocument {
                 color,
                 no_wrap,
                 overflow_wrap,
+                text_overflow,
+                parent_overflow_hidden,
             ) = node
                 .parent
                 .and_then(|p| self.tree.nodes.get(p))
@@ -455,6 +459,11 @@ impl RinchDocument {
                         WhiteSpaceValue::NoWrap | WhiteSpaceValue::Pre
                     );
                     let overflow_wrap = parent.computed_style.overflow_wrap;
+                    let text_overflow = parent.computed_style.text_overflow;
+                    let parent_overflow_hidden = matches!(
+                        parent.computed_style.overflow_x,
+                        OverflowValue::Hidden | OverflowValue::Clip
+                    );
                     (
                         font_size,
                         font_weight,
@@ -463,6 +472,8 @@ impl RinchDocument {
                         color,
                         no_wrap,
                         overflow_wrap,
+                        text_overflow,
+                        parent_overflow_hidden,
                     )
                 })
                 .unwrap_or((
@@ -473,6 +484,8 @@ impl RinchDocument {
                     AlphaColor::<Srgb>::from_rgba8(0, 0, 0, 255),
                     false,
                     crate::computed_style::OverflowWrapValue::default(),
+                    crate::computed_style::TextOverflowValue::default(),
+                    false,
                 ));
 
             updates.push((
@@ -485,6 +498,8 @@ impl RinchDocument {
                 color,
                 no_wrap,
                 overflow_wrap,
+                text_overflow,
+                parent_overflow_hidden,
             ));
         }
 
@@ -498,6 +513,8 @@ impl RinchDocument {
             color,
             no_wrap,
             overflow_wrap,
+            text_overflow,
+            parent_overflow_hidden,
         ) in updates
         {
             if let Some(ctx) = self.tree.taffy.get_node_context_mut(taffy_id)
@@ -511,6 +528,8 @@ impl RinchDocument {
                 tm.color = color;
                 tm.no_wrap = no_wrap;
                 tm.overflow_wrap = overflow_wrap;
+                tm.text_overflow = text_overflow;
+                tm.parent_overflow_hidden = parent_overflow_hidden;
             }
         }
     }
@@ -521,7 +540,7 @@ impl RinchDocument {
     /// from the parent element's computed style.
     #[allow(clippy::type_complexity)]
     pub(crate) fn sync_text_contexts(&mut self) {
-        use crate::computed_style::WhiteSpaceValue;
+        use crate::computed_style::{OverflowValue, WhiteSpaceValue};
         let mut updates: Vec<(
             taffy::NodeId,
             usize,
@@ -532,6 +551,8 @@ impl RinchDocument {
             AlphaColor<Srgb>,
             bool,
             crate::computed_style::OverflowWrapValue,
+            crate::computed_style::TextOverflowValue,
+            bool,
         )> = Vec::new();
 
         for (id, node) in &self.tree.nodes {
@@ -550,6 +571,8 @@ impl RinchDocument {
                     color,
                     no_wrap,
                     overflow_wrap,
+                    text_overflow,
+                    parent_overflow_hidden,
                 ) = node
                     .parent
                     .and_then(|p| self.tree.nodes.get(p))
@@ -578,6 +601,11 @@ impl RinchDocument {
                             WhiteSpaceValue::NoWrap | WhiteSpaceValue::Pre
                         );
                         let overflow_wrap = parent.computed_style.overflow_wrap;
+                        let text_overflow = parent.computed_style.text_overflow;
+                        let parent_overflow_hidden = matches!(
+                            parent.computed_style.overflow_x,
+                            OverflowValue::Hidden | OverflowValue::Clip
+                        );
                         (
                             font_size,
                             font_weight,
@@ -586,6 +614,8 @@ impl RinchDocument {
                             color,
                             no_wrap,
                             overflow_wrap,
+                            text_overflow,
+                            parent_overflow_hidden,
                         )
                     })
                     .unwrap_or((
@@ -596,6 +626,8 @@ impl RinchDocument {
                         AlphaColor::<Srgb>::from_rgba8(0, 0, 0, 255),
                         false,
                         crate::computed_style::OverflowWrapValue::default(),
+                        crate::computed_style::TextOverflowValue::default(),
+                        false,
                     ));
 
                 updates.push((
@@ -608,6 +640,8 @@ impl RinchDocument {
                     color,
                     no_wrap,
                     overflow_wrap,
+                    text_overflow,
+                    parent_overflow_hidden,
                 ));
             }
         }
@@ -622,6 +656,8 @@ impl RinchDocument {
             color,
             no_wrap,
             overflow_wrap,
+            text_overflow,
+            parent_overflow_hidden,
         ) in updates
         {
             if let Some(ctx) = self.tree.taffy.get_node_context_mut(taffy_id)
@@ -635,6 +671,8 @@ impl RinchDocument {
                 tm.color = color;
                 tm.no_wrap = no_wrap;
                 tm.overflow_wrap = overflow_wrap;
+                tm.text_overflow = text_overflow;
+                tm.parent_overflow_hidden = parent_overflow_hidden;
             }
         }
     }

--- a/crates/rinch-dom/src/node.rs
+++ b/crates/rinch-dom/src/node.rs
@@ -110,6 +110,10 @@ pub struct TextMeasure {
     pub no_wrap: bool,
     /// Overflow wrap mode (controls emergency line-breaking).
     pub overflow_wrap: crate::computed_style::OverflowWrapValue,
+    /// Text overflow mode (clip or ellipsis).
+    pub text_overflow: crate::computed_style::TextOverflowValue,
+    /// Whether parent has overflow: hidden (needed for text-overflow to apply).
+    pub parent_overflow_hidden: bool,
 }
 
 /// Layout result for a node after Taffy computation.

--- a/crates/rinch-dom/src/style_resolution/mod.rs
+++ b/crates/rinch-dom/src/style_resolution/mod.rs
@@ -427,6 +427,20 @@ impl RinchDocument {
             let dd = self.default_display_for_node(node_id);
             let mut taffy_style = self.tree.nodes[node_id].computed_style.to_taffy_style(dd);
 
+            // HTML element must fill the viewport and clip horizontal overflow
+            // (mirrors browser behavior where the viewport constrains content width).
+            if node_id == self.tree.html_id {
+                if taffy_style.size.width == taffy::Dimension::auto() {
+                    taffy_style.size.width = taffy::Dimension::percent(1.0);
+                }
+                if taffy_style.size.height == taffy::Dimension::auto() {
+                    taffy_style.size.height = taffy::Dimension::percent(1.0);
+                }
+                if taffy_style.overflow.x == taffy::Overflow::Visible {
+                    taffy_style.overflow.x = taffy::Overflow::Clip;
+                }
+            }
+
             // Body node needs flex_grow: 1 and height: auto to fill the viewport
             if node_id == self.tree.body_id {
                 if taffy_style.flex_grow == 0.0 {

--- a/crates/rinch-dom/tests/computed_style_tests.rs
+++ b/crates/rinch-dom/tests/computed_style_tests.rs
@@ -2,7 +2,7 @@ use rinch_core::dom::DomDocument;
 use rinch_dom::RinchDocument;
 use rinch_dom::computed_style::{
     BackgroundValue, BorderStyleValue, CursorValue, PointerEventsValue, PositionValue,
-    VisibilityValue,
+    TextOverflowValue, VisibilityValue, WhiteSpaceValue, OverflowValue,
 };
 
 // Helper to check approximate float equality
@@ -734,5 +734,57 @@ fn test_filter_grayscale() {
         approx_eq(node.computed_style.filter_grayscale, 1.0, 0.01),
         "filter_grayscale should be approximately 1.0, got {}",
         node.computed_style.filter_grayscale
+    );
+}
+
+// ===== Text Overflow Tests =====
+
+#[test]
+fn test_text_overflow_ellipsis() {
+    let mut doc = RinchDocument::new();
+    let body = doc.body();
+    let div = doc.create_element("div");
+    doc.set_attribute(
+        div,
+        "style",
+        "overflow: hidden; white-space: nowrap; text-overflow: ellipsis; width: 200px",
+    );
+    doc.append_child(body, div);
+    doc.resolve_layout(800.0, 600.0);
+
+    let node = doc.tree.get(div.0).unwrap();
+    assert_eq!(
+        node.computed_style.text_overflow,
+        TextOverflowValue::Ellipsis,
+        "text_overflow should be Ellipsis, got {:?}",
+        node.computed_style.text_overflow
+    );
+    assert_eq!(
+        node.computed_style.white_space,
+        WhiteSpaceValue::NoWrap,
+        "white_space should be NoWrap, got {:?}",
+        node.computed_style.white_space
+    );
+    assert!(
+        matches!(node.computed_style.overflow_x, OverflowValue::Hidden),
+        "overflow_x should be Hidden, got {:?}",
+        node.computed_style.overflow_x
+    );
+}
+
+#[test]
+fn test_text_overflow_default_is_clip() {
+    let mut doc = RinchDocument::new();
+    let body = doc.body();
+    let div = doc.create_element("div");
+    doc.set_attribute(div, "style", "width: 200px");
+    doc.append_child(body, div);
+    doc.resolve_layout(800.0, 600.0);
+
+    let node = doc.tree.get(div.0).unwrap();
+    assert_eq!(
+        node.computed_style.text_overflow,
+        TextOverflowValue::Clip,
+        "default text_overflow should be Clip"
     );
 }

--- a/examples/ui-zoo/src/sections/css_features.rs
+++ b/examples/ui-zoo/src/sections/css_features.rs
@@ -227,6 +227,62 @@ pub fn css_features_section() -> NodeHandle {
                 }
             }
 
+            // Group 8: Text Overflow
+            Space { h: "xl" }
+            Title { order: 3, "Text Overflow" }
+            Text { size: "sm", color: "dimmed", "text-overflow: ellipsis with overflow: hidden and white-space: nowrap" }
+            Space { h: "md" }
+
+            Stack { gap: "md",
+                // Fixed width container — text should truncate with ellipsis
+                div { style: "width: 200px; border: 1px solid var(--rinch-color-gray-5); border-radius: 4px; padding: 8px;",
+                    div { style: "overflow: hidden; white-space: nowrap; text-overflow: ellipsis;",
+                        "This is a long sentence that should be truncated with an ellipsis character"
+                    }
+                }
+
+                // Wider container — same text should show more before truncating
+                div { style: "width: 350px; border: 1px solid var(--rinch-color-gray-5); border-radius: 4px; padding: 8px;",
+                    div { style: "overflow: hidden; white-space: nowrap; text-overflow: ellipsis;",
+                        "This is a long sentence that should be truncated with an ellipsis character"
+                    }
+                }
+
+                // Full width — text fits so no ellipsis should appear
+                div { style: "border: 1px solid var(--rinch-color-gray-5); border-radius: 4px; padding: 8px;",
+                    div { style: "overflow: hidden; white-space: nowrap; text-overflow: ellipsis;",
+                        "Short text — no truncation needed"
+                    }
+                }
+
+                // Flex layout test: flex: 1 child should truncate
+                Text { size: "sm", weight: "bold", "Flex layout:" }
+                div { style: "display: flex; gap: 8px; border: 1px solid var(--rinch-color-gray-5); border-radius: 4px; padding: 8px;",
+                    div { style: "width: 80px; flex-shrink: 0; color: var(--rinch-color-blue-6); font-weight: bold;",
+                        "Label"
+                    }
+                    div { style: "flex: 1; min-width: 0; overflow: hidden; white-space: nowrap; text-overflow: ellipsis;",
+                        "This is the value text in a flex child that should truncate with ellipsis when it overflows the available space in the flex container"
+                    }
+                }
+
+                // Without text-overflow (just clip) — for comparison
+                Text { size: "sm", weight: "bold", "Without ellipsis (just clip):" }
+                div { style: "width: 200px; border: 1px solid var(--rinch-color-gray-5); border-radius: 4px; padding: 8px;",
+                    div { style: "overflow: hidden; white-space: nowrap;",
+                        "This text is clipped without any ellipsis indicator at the end"
+                    }
+                }
+
+                // Without overflow hidden — should not truncate (just overflow)
+                Text { size: "sm", weight: "bold", "Without overflow: hidden (wraps normally):" }
+                div { style: "width: 200px; border: 1px solid var(--rinch-color-gray-5); border-radius: 4px; padding: 8px;",
+                    div { style: "text-overflow: ellipsis;",
+                        "This text has text-overflow: ellipsis but no overflow: hidden so it wraps normally"
+                    }
+                }
+            }
+
             Space { h: "xl" }
             Title { order: 2, "Click Transitions" }
             Text { size: "sm", color: "dimmed", "Click the elements below to toggle CSS transitions" }


### PR DESCRIPTION
## Summary
- Enable Stylo's `text-overflow` property by setting `layout.unimplemented` pref, and wire up Stylo→ComputedStyle conversion
- Implement `white-space: nowrap` in IFC by passing infinite width to Parley's line breaker
- Add ellipsis truncation in the IFC path using binary search to find the longest text prefix that fits with "…" appended
- Includes UI Zoo demo section with 6 test cases and computed_style unit tests

## Details
Requires all three CSS properties to work together: `text-overflow: ellipsis` + `overflow: hidden` + `white-space: nowrap`.

Changes span 4 layers:
1. **Stylo pref** — `style_config::set_bool("layout.unimplemented", true)` 
2. **Stylo→ComputedStyle** — `text_overflow_from_stylo()` 
3. **IFC nowrap** — `break_all_lines(None)` for nowrap/pre
4. **IFC ellipsis** — `build_ellipsis_layout()` binary search

Also includes the html viewport overflow fix (506b40c).

## Test plan
- [x] All 33 computed_style tests pass (including new `test_text_overflow_ellipsis` and `test_text_overflow_default_is_clip`)
- [x] All 24 rinch-dom tests pass
- [x] Visual verification via debug screenshot — all 6 UI Zoo test cases render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)