### PR TITLE
feat: drag end callback, ondragmove dispatch, click context for ondragend

### DIFF
--- a/crates/rinch-core/src/events/drag.rs
+++ b/crates/rinch-core/src/events/drag.rs
@@ -77,6 +77,7 @@ pub fn start_drag<F>(
 /// viewport pixel coordinates to the callback.
 pub struct DragStateAbsolute {
     pub on_drag: Box<dyn Fn(f32, f32) + 'static>,
+    pub on_end: Option<Box<dyn FnOnce(f32, f32) + 'static>>,
 }
 
 thread_local! {
@@ -109,11 +110,50 @@ where
     ACTIVE_DRAG_ABSOLUTE.with(|drag| {
         *drag.borrow_mut() = Some(DragStateAbsolute {
             on_drag: Box::new(on_drag),
+            on_end: None,
         });
     });
 }
 
+/// Start an absolute-coordinate drag with an end callback.
+///
+/// Same as `start_drag_absolute`, but `on_end` is called once when the
+/// drag finishes (mouseup) with the final `(mouse_x, mouse_y)`.
+pub fn start_drag_absolute_with_end<F, E>(on_drag: F, on_end: E)
+where
+    F: Fn(f32, f32) + 'static,
+    E: FnOnce(f32, f32) + 'static,
+{
+    // Clear percentage-based drag if any
+    stop_drag();
+    ACTIVE_DRAG_ABSOLUTE.with(|drag| {
+        *drag.borrow_mut() = Some(DragStateAbsolute {
+            on_drag: Box::new(on_drag),
+            on_end: Some(Box::new(on_end)),
+        });
+    });
+}
+
+/// Finish and stop the absolute drag, calling `on_end` if set.
+///
+/// Called by the runtime on mouseup with the final cursor position.
+pub fn finish_drag(mouse_x: f32, mouse_y: f32) {
+    // Take the on_end callback from absolute drag before clearing.
+    let on_end = ACTIVE_DRAG_ABSOLUTE.with(|drag| {
+        drag.borrow_mut().take().and_then(|s| s.on_end)
+    });
+    // Clear percentage-based drag too.
+    ACTIVE_DRAG.with(|drag| {
+        *drag.borrow_mut() = None;
+    });
+    // Fire the end callback after clearing state.
+    if let Some(cb) = on_end {
+        cb(mouse_x, mouse_y);
+    }
+}
+
 /// Stop the current drag operation (both percentage and absolute).
+/// Does NOT call `on_end` — use `finish_drag` for that.
 pub fn stop_drag() {
     ACTIVE_DRAG.with(|drag| {
         *drag.borrow_mut() = None;

--- a/crates/rinch-core/src/lib.rs
+++ b/crates/rinch-core/src/lib.rs
@@ -54,7 +54,8 @@ pub use events::{
     request_focus, request_selection_clear, save_selection_snapshot, set_ce_click_interceptor,
     set_ce_drag_interceptor, set_click_context, set_input_context, set_keyboard_interceptor,
     set_modifier_state, set_selection_callback, set_selection_sync_callback, start_drag,
-    start_drag_absolute, stop_drag, take_pending_focus_request, take_pending_selection_clear,
+    finish_drag, start_drag_absolute, start_drag_absolute_with_end, stop_drag,
+    take_pending_focus_request, take_pending_selection_clear,
     update_drag,
 };
 

--- a/crates/rinch/src/app/event_dispatch.rs
+++ b/crates/rinch/src/app/event_dispatch.rs
@@ -90,6 +90,21 @@ impl RinchApp {
                         }
                     }
 
+                    // Fire ondragmove on source so editor can track cursor position.
+                    if let Some(doc) = &self.doc {
+                        let (cx, cy) = drag.cursor;
+                        events::set_click_context(events::ClickContext {
+                            mouse_x: cx,
+                            mouse_y: cy,
+                            element_x: 0.0,
+                            element_y: 0.0,
+                            element_width: 0.0,
+                            element_height: 0.0,
+                            text_hit: Default::default(),
+                        });
+                        Self::dispatch_drag_attr(doc, drag.node_id, "data-ondragmove");
+                    }
+
                     self.scene_dirty = true;
                     actions.push(AppAction::SetCursor(rinch_platform::CursorStyle::Grabbing));
                     actions.push(AppAction::RequestRedraw);
@@ -376,8 +391,18 @@ impl RinchApp {
                             Self::dispatch_drag_attr(doc, target_id, "data-ondragleave");
                         }
                     }
-                    // Fire ondragend on source
+                    // Fire ondragend on source — set click context so handler can read cursor pos.
                     if let Some(doc) = &self.doc {
+                        let (cx, cy) = drag.cursor;
+                        events::set_click_context(events::ClickContext {
+                            mouse_x: cx,
+                            mouse_y: cy,
+                            element_x: 0.0,
+                            element_y: 0.0,
+                            element_width: 0.0,
+                            element_height: 0.0,
+                            text_hit: Default::default(),
+                        });
                         Self::dispatch_drag_attr(doc, drag.node_id, "data-ondragend");
                     }
                     self.scene_dirty = true;
@@ -412,7 +437,7 @@ impl RinchApp {
                     }
                 }
 
-                rinch_core::stop_drag();
+                rinch_core::finish_drag(x, y);
                 self.scrollbar_drag = None;
                 self.ce_selecting = false;
 

--- a/crates/rinch/src/lib.rs
+++ b/crates/rinch/src/lib.rs
@@ -117,7 +117,7 @@ pub mod prelude {
     // Event handling - click context, drag support, input callbacks, file-drop callbacks
     pub use rinch_core::{
         ClickContext, DragContext, FileDropCallback, InputCallback, get_click_context, start_drag,
-        start_drag_absolute,
+        start_drag_absolute, start_drag_absolute_with_end,
     };
     pub use rinch_macros::{component, rsx};
     // Window control functions


### PR DESCRIPTION
## Summary

- **`start_drag_absolute_with_end(on_drag, on_end)`** — new variant of `start_drag_absolute` that accepts an `on_end: FnOnce(f32, f32)` callback, invoked on mouseup with the final cursor position. Enables drag-to-dock workflows where the drop action depends on where the drag ended.
- **`finish_drag(x, y)`** — replaces `stop_drag()` in the mouseup handler. Calls the `on_end` callback (if set) before clearing drag state. `stop_drag()` still exists for cancellation (e.g., Escape key).
- **`data-ondragmove` dispatch** — fires on the drag source node during active DnD tracking (MouseMove), so handlers can track cursor position throughout the drag.
- **Click context before `ondragend`** — sets `ClickContext` with cursor position before dispatching `data-ondragend`, so the handler can read the final mouse position via `get_click_context()`.

## Test plan

- [ ] Verify existing `start_drag_absolute` behavior unchanged (sliders, splitters, panel resize)
- [ ] Verify `start_drag_absolute_with_end` fires `on_end` callback on mouseup
- [ ] Verify `data-ondragmove` fires during active DnD drags
- [ ] Verify `get_click_context()` returns correct position in `ondragend` handlers
- [ ] Verify `stop_drag()` does NOT fire `on_end` (cancellation path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)