### PR TITLE
feat: add onscroll event handler support

### DIFF
--- a/crates/rinch-core/src/dom/render_scope.rs
+++ b/crates/rinch-core/src/dom/render_scope.rs
@@ -242,6 +242,25 @@ impl RenderScope {
         crate::events::register_file_drop_handler(crate::events::FileDropCallback::new(callback))
     }
 
+    /// Register a scroll event handler and return its ID.
+    ///
+    /// The handler receives the current scroll offset (scroll_top) as `f64`.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let handler_id = scope.register_scroll_handler(|scroll_top| {
+    ///     println!("Scrolled to: {}", scroll_top);
+    /// });
+    /// element.set_attribute("data-onscroll", &handler_id.to_string());
+    /// ```
+    pub fn register_scroll_handler<F: Fn(f64) + 'static>(
+        &mut self,
+        callback: F,
+    ) -> crate::events::EventHandlerId {
+        crate::events::register_scroll_handler(crate::events::ScrollCallback::new(callback))
+    }
+
     /// Dispose of this scope and all child scopes.
     pub fn dispose(mut self) {
         // Dispose child scopes first

--- a/crates/rinch-core/src/events/handlers.rs
+++ b/crates/rinch-core/src/events/handlers.rs
@@ -113,6 +113,48 @@ impl<F: Fn(Vec<PathBuf>) + 'static> crate::element::IntoEventHandler<FileDropCal
     }
 }
 
+/// Cloneable callback for scroll events.
+///
+/// Receives the current scroll offset (scroll_top) as `f64`.
+#[derive(Clone)]
+pub struct ScrollCallback(pub Rc<dyn Fn(f64)>);
+
+impl ScrollCallback {
+    /// Create a new scroll callback from a function.
+    pub fn new<F: Fn(f64) + 'static>(f: F) -> Self {
+        Self(Rc::new(f))
+    }
+
+    /// Invoke the callback with the current scroll offset.
+    pub fn invoke(&self, scroll_top: f64) {
+        (self.0)(scroll_top)
+    }
+}
+
+impl<F: Fn(f64) + 'static> From<F> for ScrollCallback {
+    fn from(f: F) -> Self {
+        Self::new(f)
+    }
+}
+
+impl std::fmt::Debug for ScrollCallback {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ScrollCallback(...)")
+    }
+}
+
+impl crate::element::IntoEventHandler<ScrollCallback> for ScrollCallback {
+    fn into_event_handler(self) -> ScrollCallback {
+        self
+    }
+}
+
+impl<F: Fn(f64) + 'static> crate::element::IntoEventHandler<ScrollCallback> for F {
+    fn into_event_handler(self) -> ScrollCallback {
+        ScrollCallback::from(self)
+    }
+}
+
 /// Global counter for generating unique event handler IDs.
 static NEXT_HANDLER_ID: AtomicUsize = AtomicUsize::new(0);
 
@@ -131,6 +173,7 @@ thread_local! {
     static EVENT_REGISTRY: RefCell<EventRegistry> = RefCell::new(EventRegistry::new());
     static INPUT_REGISTRY: RefCell<InputRegistry> = RefCell::new(InputRegistry::new());
     static FILE_DROP_REGISTRY: RefCell<FileDropRegistry> = RefCell::new(FileDropRegistry::new());
+    static SCROLL_REGISTRY: RefCell<ScrollRegistry> = RefCell::new(ScrollRegistry::new());
     static INPUT_CONTEXT: RefCell<InputContext> = RefCell::new(InputContext::default());
     /// Flag to signal that an input event was handled and a re-render may be needed.
     static INPUT_EVENT_HANDLED: RefCell<bool> = const { RefCell::new(false) };
@@ -177,6 +220,19 @@ pub struct FileDropRegistry {
 }
 
 impl FileDropRegistry {
+    fn new() -> Self {
+        Self {
+            handlers: HashMap::new(),
+        }
+    }
+}
+
+/// Registry that maps event handler IDs to scroll callbacks.
+pub struct ScrollRegistry {
+    handlers: HashMap<EventHandlerId, ScrollCallback>,
+}
+
+impl ScrollRegistry {
     fn new() -> Self {
         Self {
             handlers: HashMap::new(),
@@ -336,6 +392,32 @@ pub fn dispatch_file_drop_event(id: EventHandlerId, paths: Vec<PathBuf>) -> bool
     }
 }
 
+/// Register a scroll event handler and return its ID.
+///
+/// The handler will be called when an element with the corresponding
+/// `data-onscroll` attribute is scrolled, passing the current scroll offset.
+pub fn register_scroll_handler(callback: ScrollCallback) -> EventHandlerId {
+    let id = next_handler_id();
+    SCROLL_REGISTRY.with(|registry| {
+        registry.borrow_mut().handlers.insert(id, callback);
+    });
+    id
+}
+
+/// Dispatch a scroll event to the handler with the given ID.
+///
+/// Returns `true` if a handler was found and called.
+pub fn dispatch_scroll_event(id: EventHandlerId, scroll_top: f64) -> bool {
+    let handler: Option<ScrollCallback> =
+        SCROLL_REGISTRY.with(|registry| registry.borrow().handlers.get(&id).cloned());
+    if let Some(h) = handler {
+        h.invoke(scroll_top);
+        true
+    } else {
+        false
+    }
+}
+
 /// Check if an input event was handled since last check, and clear the flag.
 ///
 /// This allows the shell to know if a re-render is needed after processing
@@ -359,6 +441,9 @@ pub fn clear_handlers() {
         registry.borrow_mut().handlers.clear();
     });
     FILE_DROP_REGISTRY.with(|registry| {
+        registry.borrow_mut().handlers.clear();
+    });
+    SCROLL_REGISTRY.with(|registry| {
         registry.borrow_mut().handlers.clear();
     });
     reset_handler_ids();

--- a/crates/rinch-macros/src/dom_codegen/html.rs
+++ b/crates/rinch-macros/src/dom_codegen/html.rs
@@ -92,6 +92,14 @@ pub fn element_to_dom_html(element: &RsxElement, ctx: &mut DomCodegenContext) ->
                         #elem_var.set_attribute("data-oninput", &__handler_id.0.to_string());
                     }
                 }
+            } else if event_name == "onscroll" {
+                // Scroll events use register_scroll_handler with Fn(f64)
+                quote! {
+                    {
+                        let __handler_id = __scope.register_scroll_handler(#handler);
+                        #elem_var.set_attribute("data-onscroll", &__handler_id.0.to_string());
+                    }
+                }
             } else if event_name == "onfiledrop" {
                 // OS file-drop events use register_file_drop_handler with Fn(Vec<PathBuf>)
                 quote! {

--- a/crates/rinch/src/app/event_dispatch.rs
+++ b/crates/rinch/src/app/event_dispatch.rs
@@ -161,13 +161,29 @@ impl RinchApp {
                     let scroll_delta = (dy as f64 / track_height) * drag.content_height;
                     let new_scroll = (drag.start_scroll + scroll_delta).clamp(0.0, max_scroll);
 
+                    let mut scroll_handler_to_fire: Option<(usize, f64)> = None;
                     if let Some(doc) = &self.doc {
                         let mut d = doc.borrow_mut();
+                        // Extract handler ID before mutable node access to avoid borrow conflicts
+                        let handler_id = d
+                            .tree
+                            .nodes
+                            .get(node_id)
+                            .and_then(|n| n.attributes.get("data-onscroll"))
+                            .and_then(|s| s.parse::<usize>().ok());
                         if let Some(node) = d.tree.nodes.get_mut(node_id) {
                             node.scroll_offset.1 = new_scroll;
                             node.dirty.insert(rinch_dom::DirtyFlags::PAINT);
                             d.tree.push_dirty(node_id);
                         }
+                        d.tree.dirty_nodes.insert(node_id);
+                        if let Some(hid) = handler_id {
+                            scroll_handler_to_fire = Some((hid, new_scroll));
+                        }
+                    }
+                    if let Some((handler_id, scroll_top)) = scroll_handler_to_fire {
+                        use rinch_core::events::{EventHandlerId, dispatch_scroll_event};
+                        dispatch_scroll_event(EventHandlerId(handler_id), scroll_top);
                     }
                     actions.push(AppAction::RequestRedraw);
                     return actions;
@@ -340,6 +356,7 @@ impl RinchApp {
                 };
 
                 if let Some((node_id, content_height, container_height)) = scrollbar_hit {
+                    let mut scroll_handler_to_fire: Option<(usize, f64)> = None;
                     if let Some(doc) = &self.doc {
                         let mut d = doc.borrow_mut();
                         let node_abs_y = compute_absolute_y(&d.tree, node_id);
@@ -350,10 +367,20 @@ impl RinchApp {
                         let click_ratio = ((y as f64 - track_top) / track_height).clamp(0.0, 1.0);
                         let new_scroll = click_ratio * max_scroll;
 
+                        let handler_id = d
+                            .tree
+                            .nodes
+                            .get(node_id)
+                            .and_then(|n| n.attributes.get("data-onscroll"))
+                            .and_then(|s| s.parse::<usize>().ok());
                         if let Some(node) = d.tree.nodes.get_mut(node_id) {
                             node.scroll_offset.1 = new_scroll;
                             node.dirty.insert(rinch_dom::DirtyFlags::PAINT);
                             d.tree.push_dirty(node_id);
+                        }
+                        d.tree.dirty_nodes.insert(node_id);
+                        if let Some(hid) = handler_id {
+                            scroll_handler_to_fire = Some((hid, new_scroll));
                         }
 
                         self.scrollbar_drag = Some(ScrollbarDrag {
@@ -363,6 +390,10 @@ impl RinchApp {
                             content_height,
                             container_height,
                         });
+                    }
+                    if let Some((handler_id, scroll_top)) = scroll_handler_to_fire {
+                        use rinch_core::events::{EventHandlerId, dispatch_scroll_event};
+                        dispatch_scroll_event(EventHandlerId(handler_id), scroll_top);
                     }
                     actions.push(AppAction::RequestRedraw);
                 } else {
@@ -509,6 +540,7 @@ impl RinchApp {
                     let hit_node = hit_test(&doc.borrow().tree, x, y);
                     if let Some(hit_node) = hit_node {
                         let mut doc_mut = doc.borrow_mut();
+                        let mut scroll_handler_to_fire: Option<(usize, f64)> = None;
 
                         // Vertical scrolling
                         if delta_y.abs() > 0.0
@@ -521,13 +553,30 @@ impl RinchApp {
                                 compute_visible_content_area_height(&doc_mut.tree, scroll_node_id);
                             let max_scroll = (content_height - visible_height).max(0.0);
 
-                            if let Some(node) = doc_mut.tree.nodes.get_mut(scroll_node_id) {
-                                let new_y = (node.scroll_offset.1 - delta_y).clamp(0.0, max_scroll);
-                                if new_y != node.scroll_offset.1 {
+                            // Read handler ID before mutable borrow
+                            let handler_id = doc_mut
+                                .tree
+                                .nodes
+                                .get(scroll_node_id)
+                                .and_then(|n| n.attributes.get("data-onscroll"))
+                                .and_then(|s| s.parse::<usize>().ok());
+                            let old_y = doc_mut
+                                .tree
+                                .nodes
+                                .get(scroll_node_id)
+                                .map(|n| n.scroll_offset.1)
+                                .unwrap_or(0.0);
+                            let new_y = (old_y - delta_y).clamp(0.0, max_scroll);
+                            if new_y != old_y {
+                                if let Some(node) = doc_mut.tree.nodes.get_mut(scroll_node_id) {
                                     node.scroll_offset.1 = new_y;
                                     node.dirty.insert(rinch_dom::DirtyFlags::PAINT);
                                     doc_mut.tree.push_dirty(scroll_node_id);
                                     self.scene_dirty = true;
+                                }
+                                doc_mut.tree.dirty_nodes.insert(scroll_node_id);
+                                if let Some(hid) = handler_id {
+                                    scroll_handler_to_fire = Some((hid, new_y));
                                 }
                             }
                         }
@@ -555,6 +604,10 @@ impl RinchApp {
                         }
 
                         drop(doc_mut);
+                        if let Some((handler_id, scroll_top)) = scroll_handler_to_fire {
+                            use rinch_core::events::{EventHandlerId, dispatch_scroll_event};
+                            dispatch_scroll_event(EventHandlerId(handler_id), scroll_top);
+                        }
                         actions.push(AppAction::RequestRedraw);
                     }
                 }


### PR DESCRIPTION
## Summary
- Adds `ScrollCallback` type and `ScrollRegistry` for scroll event handlers (mirrors the pattern used by `InputCallback`/`FileDropCallback`)
- Adds `onscroll` RSX prop support via macro codegen — registers handler with `data-onscroll` attribute
- Dispatches scroll events from all three scroll paths: mousewheel, scrollbar click, and scrollbar drag
- Handler receives current `scroll_top` offset as `f64`

## Usage
```rust
div style="overflow-y: auto; height: 400px"
    onscroll={move |y: f64| { scroll_signal.set(y); }}
{
    // scrollable content
}
```

## Test plan
- [ ] Verify mousewheel scroll fires onscroll handler with correct offset
- [ ] Verify scrollbar drag fires onscroll handler continuously
- [ ] Verify scrollbar click fires onscroll handler
- [ ] Verify no regression in existing scroll behavior without onscroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)