### PR TITLE
feat: inject_platform_event for synthetic input injection

### DIFF
--- a/crates/rinch/src/lib.rs
+++ b/crates/rinch/src/lib.rs
@@ -188,11 +188,12 @@ pub use rinch_macros::{component, rsx};
 #[cfg(feature = "desktop")]
 #[allow(deprecated)]
 pub use shell::{
-    run, run_on_main_thread, run_rinch, run_rinch_with_window_props, run_with_menu, run_with_theme,
-    run_with_window_props, run_with_window_props_and_menu,
+    inject_platform_event, run, run_on_main_thread, run_rinch, run_rinch_with_window_props,
+    run_with_menu, run_with_theme, run_with_window_props, run_with_window_props_and_menu,
 };
 
 pub use rinch_core as core;
+pub use rinch_platform as platform;
 /// Reactive primitives (Signal, Effect, Memo, Scope).
 ///
 /// Most reactive types are re-exported in the prelude. `Effect` is intentionally

--- a/crates/rinch/src/shell/mod.rs
+++ b/crates/rinch/src/shell/mod.rs
@@ -20,6 +20,7 @@ pub mod types;
 pub mod window;
 
 pub use devtools_store::DevToolsStore;
+pub use rinch_runtime::inject_platform_event;
 #[allow(deprecated)]
 pub use rinch_runtime::{run_on_main_thread, run_rinch, run_rinch_with_window_props};
 pub use types::{ElementLayout, HoveredElementInfo, RinchEvent};

--- a/crates/rinch/src/shell/rinch_runtime.rs
+++ b/crates/rinch/src/shell/rinch_runtime.rs
@@ -131,6 +131,36 @@ pub enum RinchNativeEvent {
     ShowWindow,
     /// Hide the window.
     HideWindow,
+    /// An injected platform event (e.g. synthetic gamepad input).
+    InjectedPlatformEvent(PlatformEvent),
+}
+
+/// Inject a synthetic [`PlatformEvent`] into the rinch event loop.
+///
+/// The event is queued and processed on the next event loop tick, just like
+/// real platform events from winit. The runtime uses the current window size
+/// and scale factor when dispatching.
+///
+/// This is useful for translating gamepad input or other external input
+/// sources into rinch UI events (e.g. arrow key presses for focus navigation).
+///
+/// Must be called from the main thread or any thread — the event is queued
+/// behind a `Mutex` and the event loop proxy is woken.
+///
+/// # Example
+///
+/// ```ignore
+/// use rinch_platform::{PlatformEvent, KeyCode, Modifiers};
+///
+/// // Simulate a down-arrow key press for gamepad D-pad
+/// rinch::inject_platform_event(PlatformEvent::KeyDown {
+///     key: KeyCode::ArrowDown,
+///     text: None,
+///     modifiers: Modifiers::default(),
+/// });
+/// ```
+pub fn inject_platform_event(event: PlatformEvent) {
+    send_native_event(RinchNativeEvent::InjectedPlatformEvent(event));
 }
 
 // ── RinchRuntime ─────────────────────────────────────────────────────────────
@@ -1682,6 +1712,7 @@ impl RinchRuntime {
             }
             RinchNativeEvent::ShowWindow => PlatformEvent::UserEvent(UserEvent::ShowWindow),
             RinchNativeEvent::HideWindow => PlatformEvent::UserEvent(UserEvent::HideWindow),
+            RinchNativeEvent::InjectedPlatformEvent(pe) => pe,
         };
         let size = self.window_size();
         let scale = self.scale_factor();


### PR DESCRIPTION
## Summary

- Adds `inject_platform_event(PlatformEvent)` — queues a synthetic platform event into the rinch event loop
- Re-exports `rinch_platform` as `rinch::platform` for convenient access to `PlatformEvent`, `KeyCode`, `Modifiers`
- New `InjectedPlatformEvent` variant on `RinchNativeEvent`, dispatched identically to real winit events

## Motivation

Game engines with gamepad support need to translate controller input (D-pad, face buttons) into UI navigation events so rinch menus, text inputs, and focus navigation work with gamepads. This function lets the host application inject synthetic keyboard/mouse events from any thread.

## Usage

```rust
use rinch_platform::{PlatformEvent, KeyCode, Modifiers};

// Translate gamepad D-pad down → arrow key for menu navigation
rinch::inject_platform_event(PlatformEvent::KeyDown {
    key: KeyCode::ArrowDown,
    text: None,
    modifiers: Modifiers::default(),
});
```

Events are queued behind a `Mutex` and processed on the next event loop tick via `send_native_event()` — the same mechanism used by `run_on_main_thread()`.

## Test plan

- [x] Compiles with `cargo check -p rinch`
- [x] Integrated and tested in RKIField engine — gamepad D-pad/A/B buttons successfully navigate rinch UI panels via this function
- [ ] Manual test: call `inject_platform_event` with KeyDown/KeyUp, verify rinch processes them identically to real keyboard input

🤖 Generated with [Claude Code](https://claude.com/claude-code)