### PR TITLE
perf: layout fast paths for large DOMs (v2)

### DIFF
--- a/crates/rinch-dom/src/dom_impl/dom_document_impl.rs
+++ b/crates/rinch-dom/src/dom_impl/dom_document_impl.rs
@@ -131,8 +131,11 @@ impl DomDocument for RinchDocument {
         self.tree.ifc_dirty = true; // Tree structure changed
         self.push_dirty_flags(p, DirtyFlags::LAYOUT | DirtyFlags::CHILDREN);
 
-        // Recompute styles for the inserted subtree to pick up ancestor-based selectors
-        self.recompute_node_styles_recursive(c);
+        // Recompute styles for the inserted subtree to pick up ancestor-based selectors.
+        // Suppressed during bulk DOM operations (render_block_at) to batch into one pass.
+        if !self.tree.suppress_inline_restyle {
+            self.recompute_node_styles_recursive(c);
+        }
 
         // If a text node is appended to a <style> element, load its content as CSS
         self.maybe_load_style_css(p);
@@ -285,6 +288,23 @@ impl DomDocument for RinchDocument {
 
     fn set_text_content(&mut self, node: NodeId, text: &str) {
         let n = node.0;
+
+        // Fast path: skip if content is already identical.
+        match &self.tree.nodes[n].kind {
+            NodeKind::Text(t) if t.content == text => return,
+            NodeKind::Element(_) => {
+                let children = &self.tree.nodes[n].children;
+                if children.len() == 1 {
+                    if let NodeKind::Text(t) = &self.tree.nodes[children[0]].kind {
+                        if t.content == text {
+                            return;
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+
         // Invalidate IFC if this node belongs to one
         self.invalidate_ifc_for_node(n);
         // Also invalidate parent's IFC
@@ -546,8 +566,6 @@ impl DomDocument for RinchDocument {
             }
 
             // Update Taffy inset directly (skip full style resolution).
-            // mark_dirty clears this node's cache but NOT children's caches,
-            // so children won't be re-measured.
             if let Some(taffy_id) = self.tree.nodes[node.0].taffy_id {
                 if let Ok(mut taffy_style) = self.tree.taffy.style(taffy_id).cloned() {
                     let taffy_val = new_val.to_taffy();
@@ -559,14 +577,31 @@ impl DomDocument for RinchDocument {
                         _ => unreachable!(),
                     }
                     let _ = self.tree.taffy.set_style(taffy_id, taffy_style);
-                    self.tree.layout_dirty = true;
                 }
             }
 
-            // Mark dirty and request full repaint so the old position gets cleared.
-            self.tree.nodes[node.0]
-                .dirty
-                .insert(DirtyFlags::LAYOUT | DirtyFlags::PAINT);
+            // For left/top with pixel values, compute the layout position directly
+            // instead of triggering a full Taffy compute_layout (which walks the
+            // entire tree). Account for margin so the position is correct even on
+            // elements with non-zero margins.
+            match property {
+                "left" => {
+                    let margin = self.tree.nodes[node.0].computed_style.margin_left.to_px();
+                    self.tree.nodes[node.0].layout.x = new_val.to_px() + margin;
+                }
+                "top" => {
+                    let margin = self.tree.nodes[node.0].computed_style.margin_top.to_px();
+                    self.tree.nodes[node.0].layout.y = new_val.to_px() + margin;
+                }
+                // right/bottom need containing block size — fall back to full layout
+                "right" | "bottom" => {
+                    self.tree.layout_dirty = true;
+                }
+                _ => unreachable!(),
+            }
+
+            // Mark paint dirty (not layout dirty for left/top — we computed it above).
+            self.tree.nodes[node.0].dirty.insert(DirtyFlags::PAINT);
             self.tree.dirty_nodes.insert(node.0);
             self.tree.full_repaint_needed = true;
             return;

--- a/crates/rinch-dom/src/ifc.rs
+++ b/crates/rinch-dom/src/ifc.rs
@@ -13,7 +13,7 @@ impl RinchDocument {
     ///
     /// Uses the computed width from Taffy as the available width for Parley line breaking.
     pub(crate) fn build_ifc_layouts(&mut self, paint_layout_cx: &mut parley::LayoutContext<Brush>) {
-        // Collect IFC roots (elements that have inline children with ifc_root set)
+        // Discover all IFC roots (cheap O(n) walk — just checks a field per node).
         let mut ifc_roots: Vec<usize> = Vec::new();
         for (id, node) in &self.tree.nodes {
             if !node.is_element() {
@@ -25,7 +25,6 @@ impl RinchDocument {
             ) {
                 continue;
             }
-            // Check if any child has ifc_root pointing to this node
             let is_ifc = node.children.iter().any(|&child_id| {
                 self.tree
                     .nodes
@@ -38,11 +37,21 @@ impl RinchDocument {
             }
         }
 
+        // Only rebuild Parley TextLayouts for dirty IFC roots (the expensive part).
+        // When dirty_ifc_text_roots is empty, rebuild all (structural IFC change).
+        let rebuild_all = self.tree.dirty_ifc_text_roots.is_empty();
+
         for root_id in ifc_roots {
             // Skip collapsed blocks (virtualized) — no Parley work needed.
             // Drop any existing text_layout to free memory.
             if self.tree.nodes[root_id].estimated_height.is_some() {
                 self.tree.nodes[root_id].text_layout = None;
+                continue;
+            }
+
+            // Skip IFC roots that aren't dirty (scoped rebuild).
+            // This turns O(all_roots) Parley work into O(dirty_roots).
+            if !rebuild_all && !self.tree.dirty_ifc_text_roots.contains(&root_id) {
                 continue;
             }
 

--- a/crates/rinch-dom/src/node.rs
+++ b/crates/rinch-dom/src/node.rs
@@ -611,6 +611,10 @@ pub struct NodeTree {
     /// True if any layout-affecting Taffy style changed since last compute.
     /// When false, `resolve_layout()` can skip Taffy compute + IFC rebuild.
     pub layout_dirty: bool,
+    /// When true, `append_child` skips inline `recompute_node_styles_recursive`.
+    /// Used during bulk DOM operations (block re-render) to batch style resolution
+    /// into a single pass instead of one per child.
+    pub suppress_inline_restyle: bool,
     /// True when an absolute/fixed element moved via the inset fast path.
     /// The app checks this to force a full scene repaint (clearing old position).
     pub full_repaint_needed: bool,
@@ -744,6 +748,7 @@ impl NodeTree {
             style_roots: Vec::new(),
             styles_dirty: true, // Initial render needs styles
             layout_dirty: true, // Initial render needs layout
+            suppress_inline_restyle: false,
             full_repaint_needed: false,
             ifc_dirty: true, // Initial render needs IFC setup
             taffy,

--- a/crates/rinch-dom/src/style_resolution/mod.rs
+++ b/crates/rinch-dom/src/style_resolution/mod.rs
@@ -250,7 +250,10 @@ impl RinchDocument {
     /// Recompute styles recursively for a node and all its descendants.
     /// This is needed when a node is inserted into a new parent, as ancestor-based
     /// CSS selectors (like `.parent .child`) need to be re-evaluated with the new ancestor chain.
-    pub(crate) fn recompute_node_styles_recursive(&mut self, node_id: usize) {
+    /// Recompute Stylo styles for a node and all its descendants, then apply
+    /// to Taffy. Called after bulk DOM operations to batch style resolution
+    /// into a single pass.
+    pub fn recompute_node_styles_recursive(&mut self, node_id: usize) {
         if !self.tree.nodes[node_id].is_element() {
             return;
         }

--- a/crates/rinch/src/ce_ops.rs
+++ b/crates/rinch/src/ce_ops.rs
@@ -597,6 +597,51 @@ impl CeOps {
         })
     }
 
+    /// Try to surgically update a single text node instead of full block re-render.
+    ///
+    /// Returns true if the surgical update was performed. Only works when the
+    /// block has a single unmarked text run and a single text node child in DOM.
+    fn try_surgical_text_update(&mut self, pos: usize) -> bool {
+        let resolved = self
+            .editor_doc
+            .resolve_position(rinch_editor::Position::new(pos));
+        let block_idx = match resolved {
+            Ok(r) => r.block_index,
+            Err(_) => return false,
+        };
+        let runs = self.editor_doc.block_inline_runs(block_idx);
+        // Only handle single unmarked text run
+        if runs.len() != 1 || !runs[0].marks.is_empty() {
+            return false;
+        }
+        let new_text = &runs[0].text;
+        let dom_node = match self.block_map.dom_node(block_idx) {
+            Some(n) => n,
+            None => return false,
+        };
+        // Check DOM has a single text child
+        let d = self.doc.borrow();
+        let children = &d.tree.nodes[dom_node].children;
+        if children.len() != 1 {
+            return false;
+        }
+        let text_node_id = children[0];
+        let is_text = d
+            .tree
+            .get(text_node_id)
+            .and_then(|n| n.text_content())
+            .is_some();
+        if !is_text {
+            return false;
+        }
+        drop(d);
+
+        // Surgical update: just change the text content
+        let mut d = self.doc.borrow_mut();
+        d.set_text_content(rinch_core::dom::NodeId(text_node_id), new_text);
+        true
+    }
+
     /// Rebuild the BlockMap from the current DOM state.
     pub(crate) fn rebuild_block_map(&mut self) {
         let d = self.doc.borrow();
@@ -1188,11 +1233,19 @@ impl ContentEditableApi for CeOps {
         // 4. Mutate EditorDocument (source of truth)
         let _ = self.editor_doc.insert_text(EditorPosition(pos), text);
 
-        // 5. Re-render the affected block from EditorDocument state
-        self.render_block_containing(pos);
+        // 5. Update DOM to match EditorDocument.
+        // Fast path: for a single unmarked text run, surgically update the
+        // existing text node via set_text_content (O(1), triggers only IFC
+        // text root rebuild). This avoids clearing + re-creating all children
+        // (O(N) with N style resolution passes per child).
+        let new_pos = pos + text.len();
+        let did_surgical = self.try_surgical_text_update(pos);
+        if !did_surgical {
+            // Full block re-render (marks changed, multiple runs, etc.)
+            self.render_block_containing(pos);
+        }
 
         // 6. Update cursor to after inserted text
-        let new_pos = pos + text.len();
         self.set_cursor_from_editor_pos(new_pos);
 
         // 7. Dispatch event and commit

--- a/crates/rinch/src/ce_render.rs
+++ b/crates/rinch/src/ce_render.rs
@@ -516,9 +516,15 @@ pub(crate) fn render_block_at(
     let desired_tag = block_data_to_dom_tag(block_data);
 
     if current_tag == desired_tag {
-        // Same tag: just clear children and re-render inline content
+        // Same tag: just clear children and re-render inline content.
+        // Suppress per-child style resolution during the re-render —
+        // batch into one pass at the end. This turns N resolve_styles()
+        // calls (one per append_child) into 1.
         clear_children(d, existing_dom_node);
+        d.tree.suppress_inline_restyle = true;
         render_inline_content(d, existing_dom_node, &block_data.content);
+        d.tree.suppress_inline_restyle = false;
+        d.recompute_node_styles_recursive(existing_dom_node);
         existing_dom_node
     } else {
         // Tag changed: create new element, insert before old, remove old

--- a/crates/rinch/src/lib.rs
+++ b/crates/rinch/src/lib.rs
@@ -194,7 +194,6 @@ pub use shell::{
 };
 
 pub use rinch_core as core;
-pub use rinch_platform as platform;
 /// Reactive primitives (Signal, Effect, Memo, Scope).
 ///
 /// Most reactive types are re-exported in the prelude. `Effect` is intentionally
@@ -205,6 +204,7 @@ pub use rinch_platform as platform;
 /// use rinch::reactive::Effect;
 /// ```
 pub use rinch_core::reactive;
+pub use rinch_platform as platform;
 #[cfg(feature = "gpu")]
 pub use rinch_renderer as renderer;
 


### PR DESCRIPTION
## Summary

Correct implementation of the performance ideas from #15, without the
style desync, layout propagation, or mixed-change bugs.

Six optimizations:

1. **Inset fast path** — `set_style("left"/"top")` on absolute/fixed elements
   computes `layout.x/y` directly (accounting for margin), bypassing Taffy
   `compute_layout`. Keeps style attribute + Stylo PDB in sync. Falls back
   to `layout_dirty` for `right`/`bottom`.

2. **Scoped IFC rebuild** — `build_ifc_layouts` only rebuilds Parley
   TextLayouts for dirty roots (`dirty_ifc_text_roots`), not all roots.
   Discovery walk still runs (cheap), expensive Parley work is scoped.

3. **Text content early-out** — `set_text_content` skips all work if
   content is already identical.

4. **Surgical text update** — `insert_text` on a single unmarked run uses
   `set_text_content` on the existing text node instead of clearing all
   children and re-creating them. O(1) vs O(N) per keystroke.

5. **Batched style resolution** — `render_block_at` suppresses per-child
   `recompute_node_styles_recursive` during bulk re-render, does one pass
   at the end. N style passes → 1.

6. **`suppress_inline_restyle` flag** — `append_child` checks this flag
   to skip inline style resolution, enabling #5.

## Differences from #15

- **Style attribute kept in sync** — no desync when other properties are set
  during a drag
- **Margin accounted for** in direct layout.x/y computation
- **`layout_dirty` still set for text changes** — parent height propagation
  works correctly when text grows/shrinks
- **IFC discovery walk preserved** — no missed roots on mixed
  structural + text changes
- **No debug `eprintln!` statements**

## Test plan

- [x] All 52 CE CRDT sync tests pass
- [x] Clippy clean
- [ ] Floating panel drag smooth on large DOMs
- [ ] Text updates don't trigger full Parley rebuild
- [ ] UI Zoo examples render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)