### PR TITLE
fix(components): DropdownMenu close paths + Select panel width (#33, #34)

### DIFF
--- a/crates/rinch-components/src/dropdown_menu.rs
+++ b/crates/rinch-components/src/dropdown_menu.rs
@@ -2,6 +2,7 @@
 //!
 //! A dropdown menu component (distinct from native AppMenu/Menu).
 
+use rinch_core::Callback;
 use rinch_core::Component;
 use rinch_core::Signal;
 use rinch_core::dom::{NodeHandle, RenderScope};
@@ -105,7 +106,9 @@ impl std::str::FromStr for DropdownMenuPosition {
 /// let show_menu = Signal::new(false);
 ///
 /// rsx! {
-///     DropdownMenu { opened: show_menu.get(),
+///     DropdownMenu {
+///         opened_fn: move || show_menu.get(),
+///         on_close: move || show_menu.set(false),
 ///         DropdownMenuTarget {
 ///             Button { onclick: move || show_menu.update(|v| *v = !*v),
 ///                 "Options"
@@ -133,14 +136,28 @@ pub struct DropdownMenu {
     pub radius: String,
     /// Shadow size.
     pub shadow: String,
-    /// Whether clicking outside closes menu.
+    /// Whether clicking outside closes menu. Requires `on_close` to actually
+    /// close — the menu's open state is owned by the caller via `opened_fn`,
+    /// and the backdrop fires `on_close` so the caller can flip their signal.
     pub close_on_click_outside: bool,
-    /// Whether clicking item closes menu.
+    /// Whether clicking an item closes the menu. Requires `on_close`; when
+    /// true, item clicks fire `on_close` automatically so the caller doesn't
+    /// need `set(false)` boilerplate inside every item's onclick.
     pub close_on_item_click: bool,
+    /// Fired when the user clicks outside the menu or clicks a menu item
+    /// (gated by `close_on_click_outside` and `close_on_item_click` flags).
+    /// The caller should set their `opened_fn` source to false from here.
+    pub on_close: Option<Callback>,
     /// Width of the dropdown.
     pub width: String,
     /// Z-index.
     pub z_index: Option<i32>,
+    /// Internal signal shared with DropdownMenuItem children via thread-local
+    /// (set in Default::default before items render). Items publish a close
+    /// request by setting it to false; DropdownMenu observes that to fire
+    /// `on_close`. Set automatically — not a user prop.
+    #[doc(hidden)]
+    pub _close_signal: Signal<bool>,
 }
 
 impl std::fmt::Debug for DropdownMenu {
@@ -155,6 +172,13 @@ impl std::fmt::Debug for DropdownMenu {
 
 impl Default for DropdownMenu {
     fn default() -> Self {
+        // Set the thread-local close signal here (not in render) so
+        // DropdownMenuItem children — constructed and rendered AFTER this
+        // Default::default() call but BEFORE Component::render — can capture
+        // it. Initialized to true; items publish a close request by setting
+        // it to false. Same pattern as ContextMenu.
+        let close_sig = Signal::new(true);
+        set_menu_close_signal(close_sig);
         Self {
             opened: false,
             opened_fn: None,
@@ -164,8 +188,10 @@ impl Default for DropdownMenu {
             shadow: String::new(),
             close_on_click_outside: true,
             close_on_item_click: true,
+            on_close: None,
             width: String::new(),
             z_index: None,
+            _close_signal: close_sig,
         }
     }
 }
@@ -219,6 +245,10 @@ impl DropdownMenu {
 
 impl Component for DropdownMenu {
     fn render(&self, __scope: &mut RenderScope, children: &[NodeHandle]) -> NodeHandle {
+        // Children captured the close signal in their own render() pass; clear
+        // the thread-local so it doesn't leak to siblings or outer scopes.
+        clear_menu_close_signal();
+
         let is_opened = if let Some(ref opened_fn) = self.opened_fn {
             opened_fn()
         } else {
@@ -314,6 +344,76 @@ impl Component for DropdownMenu {
                 }
                 was_open.set(is_open);
             });
+        }
+
+        // close_on_item_click: items publish close requests by setting
+        // _close_signal to false (via the thread-local set in Default).
+        // We observe true→false transitions and forward to on_close. Don't
+        // write back to close_sig inside this effect — that would borrow_mut
+        // the running effect's own closure and panic. Instead, a separate
+        // effect resets close_sig to true on the next opened_fn rising edge
+        // (menu reopen), so the next item click is observable as a fresh
+        // transition.
+        if self.close_on_item_click && self.on_close.is_some() {
+            let close_sig = self._close_signal;
+            let cb = self.on_close.clone().unwrap();
+            let last = std::rc::Rc::new(std::cell::Cell::new(true));
+            let last_e = last.clone();
+            Effect::new(move || {
+                let is_true = close_sig.get();
+                if last_e.get() && !is_true {
+                    cb.invoke();
+                }
+                last_e.set(is_true);
+            });
+
+            // Reset close_sig to true on opened_fn rising edge so the next
+            // item click registers as a transition. Separate effect = no
+            // re-entrancy with the transition watcher above.
+            if let Some(ref opened_fn) = self.opened_fn {
+                let f = opened_fn.clone();
+                let last_open = std::rc::Rc::new(std::cell::Cell::new(false));
+                Effect::new(move || {
+                    let open = f();
+                    if open && !last_open.get() {
+                        close_sig.set(true);
+                    }
+                    last_open.set(open);
+                });
+            }
+        }
+
+        // close_on_click_outside: render an invisible full-viewport backdrop
+        // that fires on_close when clicked. Sibling of the dropdown content
+        // inside the position:relative root; z-index below the dropdown so
+        // option clicks still hit the items. Mirrors the Select pattern.
+        if self.close_on_click_outside && self.on_close.is_some() {
+            let backdrop = rinch_macros::rsx! { div { class: "rinch-dropdown-menu__backdrop" } };
+            let initial = if is_opened {
+                "display: block"
+            } else {
+                "display: none"
+            };
+            backdrop.set_attribute("style", initial);
+
+            if let Some(ref opened_fn) = self.opened_fn {
+                let backdrop_c = backdrop.clone();
+                let f = opened_fn.clone();
+                Effect::new(move || {
+                    let style = if f() {
+                        "display: block"
+                    } else {
+                        "display: none"
+                    };
+                    backdrop_c.set_attribute("style", style);
+                });
+            }
+
+            let cb = self.on_close.clone().unwrap();
+            let handler_id = __scope.register_handler(move || cb.invoke());
+            backdrop.set_attribute("data-rid", &handler_id.0.to_string());
+
+            root.append_child(&backdrop);
         }
 
         root

--- a/crates/rinch-components/src/styles/dropdown_menu.rs
+++ b/crates/rinch-components/src/styles/dropdown_menu.rs
@@ -118,6 +118,19 @@ pub fn styles() -> String {
     margin: var(--rinch-spacing-xs) 0;
 }
 
+/* Backdrop — invisible full-viewport overlay that catches outside clicks
+   when close_on_click_outside is true. z-index sits below the dropdown
+   panel (z-index: 100) so option clicks still land on the items. */
+.rinch-dropdown-menu__backdrop {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 99;
+    display: none;
+}
+
 /* Radius */
 .rinch-dropdown-menu--radius-xs .rinch-dropdown-menu__dropdown { border-radius: var(--rinch-radius-xs); }
 .rinch-dropdown-menu--radius-sm .rinch-dropdown-menu__dropdown { border-radius: var(--rinch-radius-sm); }

--- a/crates/rinch-components/src/styles/select.rs
+++ b/crates/rinch-components/src/styles/select.rs
@@ -111,6 +111,12 @@ pub fn styles() -> String {
     margin-bottom: 4px;
 }
 
+/* Options demand a single-line intrinsic width via `white-space: nowrap`.
+   The column-flex panel sizes its cross axis to the widest child's
+   intrinsic width, so this is what actually grows the panel past
+   `min-width: 100%` up to the `max-width` cap (the `width: max-content`
+   above is a defensive hint — Stylo currently parses it as Auto). Without
+   nowrap, options wrap inside the trigger-width panel and nothing grows. */
 .rinch-select__option {
     padding: 8px var(--rinch-spacing-sm);
     font-size: var(--rinch-font-size-sm);
@@ -118,6 +124,7 @@ pub fn styles() -> String {
     border-radius: var(--rinch-radius-sm);
     cursor: pointer;
     user-select: none;
+    white-space: nowrap;
 }
 
 .rinch-select__option:hover {

--- a/crates/rinch-components/src/styles/select.rs
+++ b/crates/rinch-components/src/styles/select.rs
@@ -79,12 +79,17 @@ pub fn styles() -> String {
     transition: transform 200ms ease;
 }
 
-/* Dropdown overlay */
+/* Dropdown overlay
+   Width: trigger width is the floor (min-width: 100%), but the panel grows
+   to fit the widest option (width: max-content). max-width caps it so
+   pathologically long labels don't escape the viewport. See GH #33. */
 .rinch-select__dropdown {
     position: absolute;
     top: 100%;
     left: 0;
-    right: 0;
+    min-width: 100%;
+    width: max-content;
+    max-width: min(calc(100vw - 16px), 480px);
     margin-top: 4px;
     display: none;
     flex-direction: column;

--- a/examples/overflow-test/Cargo.toml
+++ b/examples/overflow-test/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "overflow-test"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+rinch = { workspace = true, features = ["desktop", "debug", "components", "theme"] }
+rinch-core = { workspace = true }

--- a/examples/overflow-test/src/main.rs
+++ b/examples/overflow-test/src/main.rs
@@ -1,0 +1,55 @@
+use rinch::prelude::*;
+
+// Issue #32 repro: closure parameter inside a for-loop iter expression.
+// Previously failed with "cannot find value `b` in this scope" because the
+// shadow-locals scanner emitted `let b = b.clone();` for the closure param.
+#[component]
+fn ruler() -> NodeHandle {
+    let total_bars: u32 = 16;
+    rsx! {
+        div { style: "padding: 16px; display: flex; gap: 8px",
+            // The closure param `b` is the only `b` in scope. Pre-fix: macro
+            // emitted `let b = b.clone();` for the for-loop iter, which failed
+            // to compile since no outer `b` exists.
+            for bar in (0..total_bars).filter(|b| b % 4 == 0).collect::<Vec<u32>>() {
+                span { key: bar.to_string(),
+                    style: "padding: 4px 8px; background: #ddd; border-radius: 4px",
+                    {bar.to_string()}
+                }
+            }
+        }
+    }
+}
+
+// Also exercise tuple-destructure closure params + a non-Copy capture in the
+// same iter expr (the original #26 fix still works for real captures).
+#[component]
+fn pairs() -> NodeHandle {
+    let prefix = String::from("pair");
+    let data: Vec<(i32, i32)> = vec![(1, 2), (3, 4), (5, 6), (7, 4)];
+    rsx! {
+        div { style: "padding: 16px; display: flex; flex-direction: column; gap: 4px",
+            for pair in data.iter().filter(|(a, b)| a < b).cloned().collect::<Vec<_>>() {
+                div { key: format!("{:?}", pair),
+                    {format!("{}: {:?}", prefix, pair)}
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn app() -> NodeHandle {
+    rsx! {
+        div { style: "font-family: system-ui; padding: 16px",
+            div { "Ruler (every 4th of 16 bars):" }
+            {ruler(__scope)}
+            div { "Pairs (a < b filter, tuple destructure, captured prefix):" }
+            {pairs(__scope)}
+        }
+    }
+}
+
+fn main() {
+    rinch::run("issue #32 repro", 600, 300, app);
+}

--- a/examples/ui-zoo/src/sections/overlays.rs
+++ b/examples/ui-zoo/src/sections/overlays.rs
@@ -179,32 +179,25 @@ pub fn overlays_section() -> NodeHandle {
                         }
                         Text { size: "sm", color: "dimmed", "Click to open a menu of actions." }
                         Divider {}
-                        DropdownMenu { opened_fn: move || dropdown_opened.get(),
+                        DropdownMenu {
+                            opened_fn: move || dropdown_opened.get(),
+                            on_close: move || dropdown_opened.set(false),
                             DropdownMenuTarget {
                                 Button { onclick: move || dropdown_opened.update(|v| *v = !*v), "Open Menu" }
                             }
                             DropdownMenuDropdown {
                                 DropdownMenuItem {
-                                    onclick: move || {
-                                        dropdown_selection.set("Edit".to_string());
-                                        dropdown_opened.set(false);
-                                    },
+                                    onclick: move || dropdown_selection.set("Edit".to_string()),
                                     "Edit"
                                 }
                                 DropdownMenuItem {
-                                    onclick: move || {
-                                        dropdown_selection.set("Duplicate".to_string());
-                                        dropdown_opened.set(false);
-                                    },
+                                    onclick: move || dropdown_selection.set("Duplicate".to_string()),
                                     "Duplicate"
                                 }
                                 DropdownMenuDivider {}
                                 DropdownMenuItem {
                                     color: "red",
-                                    onclick: move || {
-                                        dropdown_selection.set("Delete".to_string());
-                                        dropdown_opened.set(false);
-                                    },
+                                    onclick: move || dropdown_selection.set("Delete".to_string()),
                                     "Delete"
                                 }
                             }


### PR DESCRIPTION
## Summary

Two component fixes from rawdaw feedback:

- **#33 — Select dropdown panel width.** Panel was pinned to the trigger via `left: 0; right: 0`, so wider option labels wrapped (key-picker reported "C# major" wrapping under a "C major" trigger). Switch to `min-width: 100%; width: max-content; max-width: min(calc(100vw - 16px), 480px)` — short option lists still align to the trigger as a floor, longer options let the panel grow, viewport cap stops pathological labels from escaping.
- **#34 — DropdownMenu close paths.** `close_on_click_outside` / `close_on_item_click` were declared but unwired. Added `on_close: Option<Callback>` plus a backdrop element (z-index 99, below the dropdown's 100, mirrors the Select pattern). Item-click closing reuses the thread-local close-signal that ContextMenu already drives — set in `Default::default()` so item children capture it before they render, then a transition-detecting effect in `render()` forwards `true→false` to `on_close`. A second effect resets the signal on `opened_fn`'s rising edge so the next item click is a fresh transition. (Resetting inside the transition effect itself re-enters via `Signal::set → notify → flush_effects → run_effect`, which `borrow_mut`'s the effect's own closure and panics — found this the hard way.)
- ui-zoo overlays demo now uses `on_close` instead of `dropdown_opened.set(false)` boilerplate in every item handler.

## Test plan

- [x] `cargo build -p ui-zoo-desktop --release`
- [x] Launch ui-zoo-desktop via MCP, navigate to Overlays
- [x] Open DropdownMenu → click outside → menu closes, badge stays "None"
- [x] Open → click "Edit" → menu closes, badge updates to "Edit"
- [x] Re-open → click "Delete" → menu closes, badge updates to "Delete" (verifies rising-edge reset)
- [x] Inspected Select dropdown's computed styles on Inputs page: `min_width: 100%`, `max_width: 480px`, `right: Auto`, `width: Auto`
- [x] Pre-commit (fmt + clippy + wasm check) passes

Fixes #33, fixes #34.