### PR TITLE
fix(gpu): reconfigure surface on Outdated/Lost instead of dying permanently

### DIFF
--- a/crates/rinch/src/shell/desktop.rs
+++ b/crates/rinch/src/shell/desktop.rs
@@ -337,10 +337,20 @@ impl PlatformRenderer for WgpuRenderer {
         height: u32,
         base_color: Color,
     ) -> Result<(), RenderError> {
-        let surface_texture = self
-            .surface
-            .get_current_texture()
-            .map_err(|_| RenderError::SurfaceLost)?;
+        let surface_texture = match self.surface.get_current_texture() {
+            Ok(t) => t,
+            // Swapchain went stale (resize/DPI/occlusion/GPU reset) — recreate it and retry once.
+            Err(wgpu::SurfaceError::Outdated | wgpu::SurfaceError::Lost) => {
+                self.surface.configure(&self.device, &self.surface_config);
+                match self.surface.get_current_texture() {
+                    Ok(t) => t,
+                    Err(_) => return Ok(()), // try again on the next redraw
+                }
+            }
+            // Transient — skip this frame.
+            Err(wgpu::SurfaceError::Timeout) => return Ok(()),
+            Err(e) => return Err(RenderError::Internal(format!("get_current_texture: {e:?}"))),
+        };
 
         let render_texture_view = self
             .render_texture


### PR DESCRIPTION
## Problem

`WgpuRenderer::render_scene` mapped **every** `Surface::get_current_texture()` error to a hard `RenderError::SurfaceLost` and returned, without ever reconfiguring the surface. Since the swapchain is only (re)configured in `resize()` and at init, a surface that goes `Outdated`/`Lost` for a non-resize reason (presentation stall, occlusion/DPI change, GPU reset) was never recreated. The caller (`rinch_runtime.rs`) just prints `Paint error: surface lost` and returns, so once the surface goes stale every subsequent `RedrawRequested` errors and the window never paints again — a permanent dead viewport.

## Fix

In the per-frame present path, recover per the wgpu contract:

- **`Outdated` / `Lost`** → reconfigure the surface and retry `get_current_texture()` once. If the retry also fails, skip the frame (`Ok(())`) so the next redraw tries again.
- **`Timeout`** → skip the frame (transient).
- **`OutOfMemory` / `Other`** → forwarded as `RenderError::Internal` instead of being mislabeled as a surface loss.

The existing `resize()` reconfigure path is unchanged — this only adds the missing recovery to the present path, so a transient surface loss self-heals on the next frame.

## Testing

- `cargo build -p rinch --features gpu` — clean (this code is `gpu`-feature-gated).
- Pre-commit suite (fmt, clippy, WASM build) passed.

No automated regression test: surface loss is a GPU-driver-level event that isn't deterministically reproducible (the report notes ~1/3 of the time after a presentation stall) and can't be triggered from a unit test.

Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)