### PR TITLE
docs(skill): clarify class/style repaint + add rinch-debug/MCP section

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "rinch",
       "source": "./claude-plugin",
       "description": "Best practices and code guidance for building UIs with the Rinch GUI framework for Rust",
-      "version": "0.2.1"
+      "version": "0.3.2"
     }
   ]
 }

--- a/.claude/rules/rinch-best-practices.md
+++ b/.claude/rules/rinch-best-practices.md
@@ -36,6 +36,8 @@ p { {|| count.get().to_string()} }
 
 Applies to text, attributes, styles, classes — anything with `.get()` in rsx needs `{|| ...}`.
 
+**Class and style repaint exactly like text.** A reactive `class:`/`style:` closure on a raw element marks the node paint-dirty and triggers a redraw through the same path as reactive text — there is *no* "the attribute updates but the screen doesn't repaint" limitation. Never add manual repaint/refresh workarounds to force a redraw (that's a re-render, see the Core Mental Model). A frozen `class:`/`style:` means a missing `{|| }` wrapper or mutating non-`Signal` state, not a missing repaint.
+
 ### 2. Don't manually wrap rsx props
 
 The `rsx!` macro auto-wraps. Manual wrapping double-wraps and causes confusing type errors. The fallback codegen uses `.into()`, so bare values auto-wrap into `Option<T>` fields.
@@ -110,6 +112,16 @@ There are two drag systems. The HTML5-port instinct of `draggable: true` + `ondr
   ```
 
 - **Element-to-element DnD (drag a card into a list):** use the data-attribute drag system. **`data-ondragmove` fires on the source every motion event**; **`data-ondragover` fires on the drop target every motion event** — both are per-frame, not just at endpoints. `data-ondragstart` / `data-ondragend` fire at endpoints; `data-ondragenter` / `data-ondragleave` fire on target boundary crossings.
+
+## Iterating & Debugging: rinch-debug + MCP server
+
+Rinch ships a debug bridge that lets an AI assistant **see and drive a running app** — screenshots, live DOM inspection (layout bounds + computed styles), and input injection. Use it to *visually verify* changes instead of guessing.
+
+Enable it with the `debug` feature: `rinch = { workspace = true, features = ["desktop", "debug"] }`. The embedded `rinch-debug` server then auto-starts on a random localhost port and writes discovery to `~/.rinch/debug/{pid}.json` (disable at runtime with `RINCH_DEBUG=0`).
+
+The standalone `rinch-mcp-server` binary bridges Claude to running apps, exposing tools: `launch_app`, `screenshot` (inline PNG), `dom_tree` / `get_node`, `query_selector`, `get_computed_styles`, `click` / `type_text` / `wait_frame`, `close_app`. Recommended loop: `launch_app` → `screenshot` → inspect → `click` → `wait_frame` → `screenshot` → `close_app` → edit → repeat.
+
+**If the `rinch__*` MCP tools aren't available, suggest the user install the server** — it isn't set up automatically. Build with `cargo build -p rinch-mcp-server` (or `cargo install --path crates/rinch-mcp-server`), then add it to `.mcp.json` pointing at the built binary. Headless/CI: run under `Xvfb` with `DISPLAY` set (`launch_app` forwards `DISPLAY`).
 
 ## Quick Checklist
 

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rinch",
   "description": "Best practices and code guidance for building UIs with the Rinch GUI framework for Rust",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": {
     "name": "Rinch Contributors"
   },

--- a/claude-plugin/skills/rinch/SKILL.md
+++ b/claude-plugin/skills/rinch/SKILL.md
@@ -81,6 +81,8 @@ span { {|| format!("{} items", items.get().len())} }
 
 **Self-check:** Every `.get()` inside `rsx!` should be inside a `{|| ...}`. If it's not, it's almost certainly a bug.
 
+**Class and style repaint exactly like text.** A reactive `class:` or `style:` closure on a raw element marks the node paint-dirty and triggers a redraw through the same path as reactive text — there is *no* "the attribute updates but the screen doesn't repaint" limitation. So never add manual repaint/refresh workarounds to force a redraw (that violates Rule 1). If a reactive `class:`/`style:` looks frozen, the cause is a missing `{|| }` wrapper (value captured once) or mutating state that isn't a `Signal` — not a missing repaint.
+
 ## Rule 3: Don't manually wrap rsx prop values
 
 The `rsx!` macro auto-wraps props. Manual wrapping causes double-wrapping and confusing type errors.
@@ -297,6 +299,55 @@ rsx! {
 ```
 
 No special syntax needed — conditions, iterators, and scrutinees are auto-wrapped in Effects.
+
+## Iterating & Debugging: rinch-debug + MCP server
+
+Rinch ships a debug bridge that lets an AI assistant (or any external tool) **see and drive a running rinch app** — take screenshots, inspect the live DOM with computed styles and layout bounds, and inject input. Use it to visually verify changes instead of guessing.
+
+**Enable it in the app** — add the `debug` feature:
+
+```toml
+[dependencies]
+rinch = { workspace = true, features = ["desktop", "debug"] }
+```
+
+The embedded `rinch-debug` server then auto-starts on a random localhost port and writes a discovery file to `~/.rinch/debug/{pid}.json`. Disable at runtime with `RINCH_DEBUG=0`.
+
+**The MCP server** (`rinch-mcp-server`) is a standalone binary that bridges Claude to running apps. Once configured, these tools become available:
+
+| Tool | Use |
+|------|-----|
+| `launch_app` | Build, run, and auto-connect to a package |
+| `screenshot` | Capture the window as an inline PNG (directly viewable) |
+| `dom_tree` / `get_node` | Inspect the live DOM with layout bounds + computed styles |
+| `query_selector` | Find nodes by tag, `.class`, `[attr]`, `[attr=value]` |
+| `get_computed_styles` | Resolved CSS for a node |
+| `click` / `type_text` / `wait_frame` | Drive interaction and observe reactive updates |
+| `close_app` | Shut the app down cleanly |
+
+**Recommended loop:** `launch_app` → `screenshot` → inspect (`dom_tree` / `get_computed_styles`) → `click` → `wait_frame` → `screenshot` → `close_app` → edit → repeat. This is the fastest way to confirm layout, styling, and that reactive updates actually repaint.
+
+**If the `rinch__*` MCP tools aren't available, suggest the user install the server.** It is not set up automatically. Point them to:
+
+```bash
+cargo build -p rinch-mcp-server   # or: cargo install --path crates/rinch-mcp-server
+```
+
+Then add it to `.mcp.json` (pointing at the built binary for fast startup):
+
+```json
+{
+  "mcpServers": {
+    "rinch": {
+      "command": "/path/to/rinch/target/debug/rinch-mcp-server",
+      "args": [],
+      "cwd": "/path/to/rinch"
+    }
+  }
+}
+```
+
+(Headless/CI: run under `Xvfb` with `DISPLAY` set; `launch_app` forwards `DISPLAY` automatically.)
 
 ## Quick Reference: Application Entry Point
 


### PR DESCRIPTION
## What

Updates the rinch plugin **skill** and the auto-loaded best-practices **rule** with two clarifications, and bumps the plugin version so clients pick up the change.

### 1. Reactive `class:`/`style:` repaint clarification
Investigated the claim that *"reactive class:/style: on raw elements update the DOM but don't repaint."* It's **not true** in the current codebase:

- Statically, `class:`/`style:` closures compile to the same reactive-attribute Effect → `set_attribute("class"/"style", …)`, which marks the node `STYLE | LAYOUT | PAINT` dirty (`dom_document_impl.rs`). A signal change fires `on_signal_change` → `ReRender` → `resolve_and_repaint()` → `scene_dirty = true` → `request_redraw()` — the same path as reactive text.
- Verified empirically: a minimal app driving reactive text + inline `style:` + `class:` from one signal repaints **all three** on toggle (software backend).

The note redirects the "attribute updates but the screen doesn't repaint" symptom to its real causes (missing `{|| }` wrapper / mutating non-`Signal` state) and discourages manual repaint workarounds (which violate the no-re-render model). Likely a historical bug, since fixed (e.g. `69f91f8`, `5c65905`, `8dcd1e0`).

### 2. rinch-debug + MCP server documentation
Both files now document the `debug`-feature bridge and the standalone `rinch-mcp-server` (screenshots, DOM inspection, input injection), with an explicit instruction to **suggest the user install the MCP server when its tools aren't available** (it isn't set up automatically).

### 3. Version bump
- `claude-plugin/.claude-plugin/plugin.json`: `0.3.1` → `0.3.2` (cache is keyed by this; without a bump, clients keep serving the cached copy).
- `.claude-plugin/marketplace.json`: `0.2.1` → `0.3.2` — reconciled the pre-existing drift so the manifests agree.

## Files
- `claude-plugin/skills/rinch/SKILL.md`
- `.claude/rules/rinch-best-practices.md`
- `claude-plugin/.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`

## Notes
Skill change reaches installed clients only after `/plugin marketplace update rinch`. The rule is repo-local and takes effect immediately on checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)