### PR TITLE
fix(runtime): repaint after cross-thread signal drain

### DIFF
--- a/crates/rinch/src/shell/rinch_runtime.rs
+++ b/crates/rinch/src/shell/rinch_runtime.rs
@@ -1432,6 +1432,14 @@ impl ApplicationHandler for RinchRuntime {
             self.handle_native_event(event, event_loop);
         }
 
+        // A cross-thread signal update (drained above) may have mutated the
+        // scene without resolve_and_repaint detecting a change; force a repaint
+        // so background-thread Signal::send()/update_send() reliably show up
+        // (previously the new DOM only painted on the next input event).
+        if let Some(w) = &self.window {
+            w.request_redraw();
+        }
+
         // Also resolve DevTools if signals changed
         if self.devtools_window.is_some() {
             self.resolve_devtools();


### PR DESCRIPTION
## Problem

A `Signal::send()` / `update_send()` from a **background thread** mutates the
scene, but `resolve_and_repaint` doesn't always flag that mutation as a change —
so the new DOM only painted on the *next* input event. UI driven from a worker
thread (e.g. a tokio backend bridging events into signals) appeared to "stick"
until the user moved the mouse or clicked.

## Fix

After draining cross-thread signal updates in the runtime's event handling,
explicitly `request_redraw()` on the window so those updates reliably paint.

## Impact

Small and self-contained (8 lines in `rinch_runtime.rs`). Needed by apps that
update the UI from a background thread — surfaced while building a Quick Share
GUI whose tokio backend pushes status/incoming-transfer state into signals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)