### PR TITLE
fix(runtime): gate cross-thread repaint on actual reactive change

### DIFF
--- a/crates/rinch/src/shell/rinch_runtime.rs
+++ b/crates/rinch/src/shell/rinch_runtime.rs
@@ -1423,6 +1423,11 @@ impl ApplicationHandler for RinchRuntime {
     }
 
     fn proxy_wake_up(&mut self, event_loop: &dyn ActiveEventLoop) {
+        // Track whether any reactive state changes while we drain queued work,
+        // so the redraw decision below can key off the actual cause (a signal
+        // changed) instead of repainting on every wake.
+        rinch_core::clear_signals_changed();
+
         // Drain main-thread callback queue.
         drain_main_queue();
 
@@ -1432,12 +1437,18 @@ impl ApplicationHandler for RinchRuntime {
             self.handle_native_event(event, event_loop);
         }
 
-        // A cross-thread signal update (drained above) may have mutated the
-        // scene without resolve_and_repaint detecting a change; force a repaint
-        // so background-thread Signal::send()/update_send() reliably show up
-        // (previously the new DOM only painted on the next input event).
-        if let Some(w) = &self.window {
-            w.request_redraw();
+        // A cross-thread Signal::send()/update_send() drained above runs its
+        // effects on this thread, but the ReRender handler's resolve_and_repaint
+        // doesn't always flag that mutation as a paint-worthy change (e.g. the
+        // dirty state was already consumed earlier in this batch). If a signal
+        // actually changed — or the DOM is still dirty — force a repaint so
+        // background-thread updates reliably show up instead of waiting for the
+        // next input event. Wakes that change nothing (window controls, debug
+        // commands, no-op callbacks) skip the redraw.
+        if rinch_core::signals_changed() || self.app.has_pending_layout() {
+            if let Some(w) = &self.window {
+                w.request_redraw();
+            }
         }
 
         // Also resolve DevTools if signals changed


### PR DESCRIPTION
## Background

#45 fixed background-thread `Signal::send()` / `update_send()` not painting until the next input event by adding an **unconditional** `request_redraw()` on every `proxy_wake_up`. This is the follow-up "real fix" referenced in that PR's review.

## Problem with the blunt approach

`proxy_wake_up` fires for *every* main-thread wake, not just cross-thread signal updates. Repainting unconditionally means a full window repaint on:
- window-control events (minimize/maximize/show/hide)
- no-op `run_on_main_thread` callbacks
- **every rinch-debug command** — including each MCP `screenshot`

## Investigation

I traced the cross-thread path and reproduced it empirically (temporary background-thread updater in `hello_rinch_dom`, with `paint()` / the `ReRender` handler / `proxy_wake_up` instrumented, running the app directly and capturing stderr so no debug commands contaminate the result):

- In the common case `resolve_and_repaint` **already returns `true`** and the existing action → `request_redraw` path already repaints — so without *any* workaround, every background `send()` painted correctly in my environment. The unconditional redraw is largely redundant; the original bug is a narrower timing/platform edge case.
- The unconditional redraw's measurable cost is the extra repaints on non-reactive wakes (notably every screenshot).

## Fix

Gate the redraw on whether reactive state actually changed during the wake, using the existing-but-unused `rinch_core::signals_changed()` flag (set on every `Signal` notify) plus `has_pending_layout()`:

```rust
rinch_core::clear_signals_changed();   // top of proxy_wake_up
// ... drain_main_queue(); handle native events ...
if rinch_core::signals_changed() || self.app.has_pending_layout() {
    if let Some(w) = &self.window { w.request_redraw(); }
}
```

This is the same explicit-dirty-flag pattern the `embed` API already uses. The cross-thread repaint **guarantee is preserved** (any `send()`/`update_send()` sets `signals_changed` → redraw, independent of what `resolve_and_repaint` returns), while wakes that change nothing skip the repaint.

## Verification

| Scenario | Result |
|---|---|
| Software, no workaround | background sends repaint fine (common path already works) |
| Software, this fix | repaints on every send; **7 redundant redraws suppressed**; paint count matches no-workaround baseline (no extra frames) |
| Debug build + MCP screenshots | screenshots show live values; debug-command wakes suppressed (no forced window repaint) |

`cargo build` (software + GPU features), `clippy`, and `fmt --check` all clean. Only `crates/rinch/src/shell/rinch_runtime.rs` changes.

## Note

`resolve_and_repaint`'s early-return guard checks `dirty_nodes`/`styles_dirty`/`theme_changed` but not `layout_dirty` (unlike `has_pending_layout()`). Left unchanged here since the `signals_changed` gate makes the redraw guarantee independent of it; worth a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)