### PR TITLE
fix(wayland): preserve non-UTF8 XDG_DATA_DIRS entries in launcher check

### DIFF
--- a/crates/rinch/src/shell/rinch_runtime.rs
+++ b/crates/rinch/src/shell/rinch_runtime.rs
@@ -2364,12 +2364,15 @@ fn install_wayland_icon(app_id: &str, png_data: &[u8]) {
 /// application directory (`$XDG_DATA_DIRS`, default `/usr/local/share:/usr/share`).
 #[cfg(target_os = "linux")]
 fn system_desktop_entry_exists(app_id: &str) -> bool {
-    let dirs = std::env::var("XDG_DATA_DIRS")
-        .unwrap_or_else(|_| "/usr/local/share:/usr/share".to_string());
+    // Read XDG_DATA_DIRS as an OsString and split with split_paths so non-UTF8
+    // directory entries are preserved (var() would drop the whole value to the
+    // default on any non-UTF8 byte).
+    let dirs = std::env::var_os("XDG_DATA_DIRS")
+        .unwrap_or_else(|| std::ffi::OsString::from("/usr/local/share:/usr/share"));
     let rel = format!("applications/{app_id}.desktop");
-    dirs.split(':')
-        .filter(|p| !p.is_empty())
-        .any(|p| std::path::Path::new(p).join(&rel).exists())
+    std::env::split_paths(&dirs)
+        .filter(|p| !p.as_os_str().is_empty())
+        .any(|p| p.join(&rel).exists())
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
Follow-up to #48.

`system_desktop_entry_exists()` read `XDG_DATA_DIRS` with `std::env::var()`, which returns `Err` on any non-UTF8 byte and silently fell back to the default `/usr/local/share:/usr/share`. On a system whose `XDG_DATA_DIRS` contains a non-UTF8 path, the real system directories would be dropped — so a packaged launcher could go undetected and the `NoDisplay` icon stub would still be written, reintroducing the exact shadowing bug #48 fixed.

Switch to `std::env::var_os()` + `std::env::split_paths()`, which preserves every entry as an `OsStr` and splits on the platform path separator. Empty segments are still filtered out.

```rust
let dirs = std::env::var_os("XDG_DATA_DIRS")
    .unwrap_or_else(|| std::ffi::OsString::from("/usr/local/share:/usr/share"));
let rel = format!("applications/{app_id}.desktop");
std::env::split_paths(&dirs)
    .filter(|p| !p.as_os_str().is_empty())
    .any(|p| p.join(&rel).exists())
```

This also makes the parsing consistent with `install_wayland_icon`, which already reads `XDG_DATA_HOME` via `var_os`.

`cargo build` / `clippy` / `fmt --check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)