### PR TITLE
Add onmousedown/onmouseup/onmousemove handlers + web event parity

### DIFF
--- a/crates/rinch-core/src/events/mod.rs
+++ b/crates/rinch-core/src/events/mod.rs
@@ -38,6 +38,23 @@ pub struct TextHitInfo {
     pub valid: bool,
 }
 
+/// Which mouse button triggered a pointer event.
+///
+/// Defaults to [`MouseButton::Left`] so existing click/hover/drag contexts
+/// (which don't track a button) are unaffected. This is a `rinch-core`-local
+/// type so the events layer stays free of any platform dependency; backends map
+/// their native button type onto it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MouseButton {
+    /// Primary button (usually left).
+    #[default]
+    Left,
+    /// Middle button (wheel press).
+    Middle,
+    /// Secondary button (usually right).
+    Right,
+}
+
 /// Click event context with mouse position and element bounds.
 ///
 /// This data is available to event handlers during callback execution.
@@ -61,6 +78,18 @@ pub struct ClickContext {
     pub viewport_width: f32,
     /// Viewport height in logical pixels.
     pub viewport_height: f32,
+    /// Which mouse button triggered the event.
+    ///
+    /// Meaningful for `onmousedown`/`onmouseup` (and `oncontextmenu`, which is
+    /// always [`MouseButton::Right`]). Defaults to [`MouseButton::Left`] for
+    /// `onclick`/`onmousemove`/hover/drag contexts that don't carry a button.
+    pub button: MouseButton,
+    /// Keyboard modifier state (Shift/Ctrl/Alt/Meta) at the time of the event.
+    ///
+    /// Populated for mouse events on both backends. The global
+    /// [`get_modifier_state`] is not used for this — it is filled directly from
+    /// the live platform/browser modifier state when the context is set.
+    pub modifiers: ModifierState,
 }
 
 impl ClickContext {

--- a/crates/rinch-core/src/lib.rs
+++ b/crates/rinch-core/src/lib.rs
@@ -51,9 +51,9 @@ pub use context::{
 pub use events::{
     AncestorBounds, ClickContext, ContentEditableClickData, ContentEditableDragData, Drag,
     DragContext, EventCallback, EventHandlerId, FileDropCallback, InputCallback, InputContext,
-    KeyEventData, ModifierState, SelectionAction, TextHitInfo, check_and_clear_input_handled,
-    clear_ce_click_interceptor, clear_ce_drag_interceptor, clear_handlers,
-    clear_keyboard_interceptor, clear_selection_callback, clear_selection_snapshot,
+    KeyEventData, ModifierState, MouseButton, SelectionAction, TextHitInfo,
+    check_and_clear_input_handled, clear_ce_click_interceptor, clear_ce_drag_interceptor,
+    clear_handlers, clear_keyboard_interceptor, clear_selection_callback, clear_selection_snapshot,
     clear_selection_sync_callback, click_ancestors, dispatch_ce_click, dispatch_ce_drag,
     dispatch_event, dispatch_file_drop_event, dispatch_input_event, dispatch_keyboard_event,
     dispatch_selection, find_click_ancestor, finish_drag, fire_selection_sync, get_click_context,

--- a/crates/rinch-macros/src/dom_codegen/html.rs
+++ b/crates/rinch-macros/src/dom_codegen/html.rs
@@ -125,6 +125,9 @@ pub fn element_to_dom_html(element: &RsxElement, ctx: &mut DomCodegenContext) ->
                     "oncontextmenu" => "data-oncontextmenu",
                     "onmouseenter" => "data-onenter",
                     "onmouseleave" => "data-onleave",
+                    "onmousedown" => "data-onmousedown",
+                    "onmouseup" => "data-onmouseup",
+                    "onmousemove" => "data-onmousemove",
                     _ => "data-rid", // onclick and all other events
                 };
                 quote! {

--- a/crates/rinch-web/src/event_delegation.rs
+++ b/crates/rinch-web/src/event_delegation.rs
@@ -13,6 +13,72 @@ use rinch_core::events;
 
 use crate::web_document::WebDocument;
 
+thread_local! {
+    /// The element currently under the pointer that carries a `data-onenter`/
+    /// `data-onleave` handler. Used to implement non-bubbling
+    /// `mouseenter`/`mouseleave` semantics: enter/leave fire exactly once when
+    /// the resolved handler element under the pointer changes (moving between
+    /// descendants of the same handler element fires nothing). This is the
+    /// correct hover model; note it does not byte-for-byte match the desktop
+    /// backend, which keys on the raw hit-test node and may re-fire.
+    static LAST_HOVER: std::cell::RefCell<Option<web_sys::Element>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+/// Map a browser `MouseEvent.button` index onto the core button enum.
+fn mouse_button_from_event(event: &web_sys::MouseEvent) -> events::MouseButton {
+    match event.button() {
+        1 => events::MouseButton::Middle,
+        2 => events::MouseButton::Right,
+        _ => events::MouseButton::Left,
+    }
+}
+
+/// Read the keyboard modifier state carried by a browser mouse event.
+fn modifiers_from_event(event: &web_sys::MouseEvent) -> events::ModifierState {
+    events::ModifierState {
+        shift: event.shift_key(),
+        ctrl: event.ctrl_key(),
+        alt: event.alt_key(),
+        meta: event.meta_key(),
+    }
+}
+
+/// Compare two elements by DOM node identity.
+fn same_element(a: &web_sys::Element, b: &web_sys::Element) -> bool {
+    let a_node: &web_sys::Node = a.as_ref();
+    let b_node: &web_sys::Node = b.as_ref();
+    a_node.is_same_node(Some(b_node))
+}
+
+/// Walk up from `el` to the nearest ancestor carrying `attr`, set the
+/// [`events::ClickContext`] (cursor + element bounds + button + modifiers from
+/// `event`), and dispatch the registered handler. Mirrors the `data-rid`
+/// pattern; used for `data-onmousedown`/`data-onmouseup`/`data-onmousemove`.
+fn dispatch_mouse_attr(el: &web_sys::Element, attr: &str, event: &web_sys::MouseEvent) {
+    let selector = format!("[{attr}]");
+    if let Ok(Some(target_el)) = el.closest(&selector)
+        && let Some(id_str) = target_el.get_attribute(attr)
+        && let Ok(id) = id_str.parse::<usize>()
+    {
+        let rect = target_el.get_bounding_client_rect();
+        events::set_click_context(events::ClickContext {
+            mouse_x: event.client_x() as f32,
+            mouse_y: event.client_y() as f32,
+            element_x: rect.x() as f32,
+            element_y: rect.y() as f32,
+            element_width: rect.width() as f32,
+            element_height: rect.height() as f32,
+            text_hit: Default::default(),
+            viewport_width: 0.0,
+            viewport_height: 0.0,
+            button: mouse_button_from_event(event),
+            modifiers: modifiers_from_event(event),
+        });
+        events::dispatch_event(events::EventHandlerId(id));
+    }
+}
+
 /// Convert a UTF-16 code unit offset within a string to a UTF-8 byte offset.
 fn utf16_offset_to_utf8_bytes(text: &str, utf16_offset: u32) -> usize {
     let mut utf16_count = 0u32;
@@ -148,8 +214,20 @@ pub fn setup_event_delegation(doc: &WebDocument) {
                 rinch::render_surface::set_focused_surface(None);
             }
 
+            // Additive: fire data-onmousedown before the click dispatch below,
+            // matching DOM order (mousedown precedes click) and the desktop arm.
+            dispatch_mouse_attr(&el, "data-onmousedown", &event);
+
+            // Click dispatch (data-rid fires on mousedown). The primary (left)
+            // button always clicks; a non-primary button clicks only when there
+            // is no contextmenu handler in the ancestry — mirroring the desktop
+            // right-click gate where oncontextmenu suppresses the click.
+            let click_allowed =
+                event.button() == 0 || el.closest("[data-oncontextmenu]").ok().flatten().is_none();
+
             // Walk up from target to find nearest [data-rid]
-            if let Ok(Some(rid_el)) = el.closest("[data-rid]")
+            if click_allowed
+                && let Ok(Some(rid_el)) = el.closest("[data-rid]")
                 && let Some(rid_str) = rid_el.get_attribute("data-rid")
                 && let Ok(rid) = rid_str.parse::<usize>()
             {
@@ -172,6 +250,8 @@ pub fn setup_event_delegation(doc: &WebDocument) {
                     text_hit,
                     viewport_width: 0.0,
                     viewport_height: 0.0,
+                    button: mouse_button_from_event(&event),
+                    modifiers: modifiers_from_event(&event),
                 });
 
                 // Prevent browser default behavior (e.g. text selection
@@ -193,15 +273,58 @@ pub fn setup_event_delegation(doc: &WebDocument) {
         if drag_active {
             event.prevent_default();
         }
+
+        if let Some(target) = event.target()
+            && let Ok(el) = target.dyn_into::<web_sys::Element>()
+        {
+            dispatch_mouse_attr(&el, "data-onmousemove", &event);
+
+            // Hover: fire data-onleave on the old element and data-onenter on the
+            // new one whenever the resolved hover element changes.
+            let new_hover = el.closest("[data-onenter],[data-onleave]").ok().flatten();
+            LAST_HOVER.with(|lh| {
+                let changed = {
+                    let cur = lh.borrow();
+                    match (cur.as_ref(), new_hover.as_ref()) {
+                        (Some(old), Some(new)) => !same_element(old, new),
+                        (None, None) => false,
+                        _ => true,
+                    }
+                };
+                if !changed {
+                    return;
+                }
+                // Drop all borrows before dispatching (handlers may re-enter).
+                let old = lh.borrow().clone();
+                if let Some(old_el) = old
+                    && let Some(id_str) = old_el.get_attribute("data-onleave")
+                    && let Ok(id) = id_str.parse::<usize>()
+                {
+                    events::dispatch_event(events::EventHandlerId(id));
+                }
+                if let Some(new_el) = new_hover.as_ref()
+                    && let Some(id_str) = new_el.get_attribute("data-onenter")
+                    && let Ok(id) = id_str.parse::<usize>()
+                {
+                    events::dispatch_event(events::EventHandlerId(id));
+                }
+                *lh.borrow_mut() = new_hover;
+            });
+        }
     }) as Box<dyn FnMut(_)>);
     browser_doc
         .add_event_listener_with_callback("mousemove", mousemove_closure.as_ref().unchecked_ref())
         .unwrap();
     mousemove_closure.forget();
 
-    // Mouseup delegation: stop active drag operations.
-    let mouseup_closure = Closure::wrap(Box::new(move |_event: web_sys::MouseEvent| {
+    // Mouseup delegation: stop active drag operations and fire data-onmouseup.
+    let mouseup_closure = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
         rinch_core::Drag::cancel();
+        if let Some(target) = event.target()
+            && let Ok(el) = target.dyn_into::<web_sys::Element>()
+        {
+            dispatch_mouse_attr(&el, "data-onmouseup", &event);
+        }
     }) as Box<dyn FnMut(_)>);
     browser_doc
         .add_event_listener_with_callback("mouseup", mouseup_closure.as_ref().unchecked_ref())
@@ -305,4 +428,60 @@ pub fn setup_event_delegation(doc: &WebDocument) {
         .add_event_listener_with_callback("input", input_closure.as_ref().unchecked_ref())
         .unwrap();
     input_closure.forget();
+
+    // Contextmenu delegation: dispatch data-oncontextmenu and suppress the
+    // native browser menu when a handler is found.
+    let contextmenu_closure = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
+        if let Some(target) = event.target()
+            && let Ok(el) = target.dyn_into::<web_sys::Element>()
+            && let Ok(Some(menu_el)) = el.closest("[data-oncontextmenu]")
+            && let Some(id_str) = menu_el.get_attribute("data-oncontextmenu")
+            && let Ok(id) = id_str.parse::<usize>()
+        {
+            let rect = menu_el.get_bounding_client_rect();
+            events::set_click_context(events::ClickContext {
+                mouse_x: event.client_x() as f32,
+                mouse_y: event.client_y() as f32,
+                element_x: rect.x() as f32,
+                element_y: rect.y() as f32,
+                element_width: rect.width() as f32,
+                element_height: rect.height() as f32,
+                text_hit: Default::default(),
+                viewport_width: 0.0,
+                viewport_height: 0.0,
+                button: events::MouseButton::Right,
+                modifiers: modifiers_from_event(&event),
+            });
+            event.prevent_default();
+            events::dispatch_event(events::EventHandlerId(id));
+        }
+    }) as Box<dyn FnMut(_)>);
+    browser_doc
+        .add_event_listener_with_callback(
+            "contextmenu",
+            contextmenu_closure.as_ref().unchecked_ref(),
+        )
+        .unwrap();
+    contextmenu_closure.forget();
+
+    // Scroll delegation: the native `scroll` event fires on the scrolled element
+    // and does NOT bubble, so register in the capture phase to catch all
+    // descendants with a single document-level listener.
+    let scroll_closure = Closure::wrap(Box::new(move |event: web_sys::Event| {
+        if let Some(target) = event.target()
+            && let Ok(el) = target.dyn_into::<web_sys::Element>()
+            && let Some(id_str) = el.get_attribute("data-onscroll")
+            && let Ok(id) = id_str.parse::<usize>()
+        {
+            events::dispatch_scroll_event(events::EventHandlerId(id), el.scroll_top() as f64);
+        }
+    }) as Box<dyn FnMut(_)>);
+    browser_doc
+        .add_event_listener_with_callback_and_bool(
+            "scroll",
+            scroll_closure.as_ref().unchecked_ref(),
+            true, // capture phase
+        )
+        .unwrap();
+    scroll_closure.forget();
 }

--- a/crates/rinch/src/app/click_handling.rs
+++ b/crates/rinch/src/app/click_handling.rs
@@ -453,6 +453,8 @@ impl RinchApp {
                         text_hit,
                         viewport_width,
                         viewport_height,
+                        button: events::MouseButton::Left,
+                        modifiers: self.modifier_state(),
                     });
                     events::set_click_ancestors(Self::collect_click_ancestors(&d.tree, node_id));
 

--- a/crates/rinch/src/app/debug_commands.rs
+++ b/crates/rinch/src/app/debug_commands.rs
@@ -104,6 +104,7 @@ impl RinchApp {
                 let mouse_button = parse_button(button);
                 if mouse_button == MouseButton::Right {
                     // Right-click: try oncontextmenu dispatch first, then fallback
+                    let mods = self.modifier_state();
                     let mut handled = false;
                     if let Some(doc) = &self.doc {
                         let hit_id = {
@@ -113,7 +114,7 @@ impl RinchApp {
                         if let Some(hit_id) = hit_id {
                             let vw = window_size.0 as f32 / scale_factor as f32;
                             let vh = window_size.1 as f32 / scale_factor as f32;
-                            if Self::dispatch_oncontextmenu(doc, hit_id, x, y, vw, vh) {
+                            if Self::dispatch_oncontextmenu(doc, hit_id, x, y, vw, vh, mods) {
                                 actions.push(AppAction::RequestRedraw);
                                 handled = true;
                             }
@@ -148,9 +149,18 @@ impl RinchApp {
             DebugCommandKind::MouseDown { x, y, ref button } => {
                 let mouse_button = parse_button(button);
                 self.cursor_pos = Some((x, y));
+                self.dispatch_mouse_attr(
+                    "data-onmousedown",
+                    x,
+                    y,
+                    Self::core_button(mouse_button),
+                    window_size.0 as f32 / scale_factor as f32,
+                    window_size.1 as f32 / scale_factor as f32,
+                );
 
                 if mouse_button == MouseButton::Right {
                     // Right-click: try oncontextmenu dispatch first
+                    let mods = self.modifier_state();
                     let mut handled = false;
                     if let Some(doc) = &self.doc {
                         let hit_id = {
@@ -160,7 +170,7 @@ impl RinchApp {
                         if let Some(hit_id) = hit_id {
                             let vw = window_size.0 as f32 / scale_factor as f32;
                             let vh = window_size.1 as f32 / scale_factor as f32;
-                            if Self::dispatch_oncontextmenu(doc, hit_id, x, y, vw, vh) {
+                            if Self::dispatch_oncontextmenu(doc, hit_id, x, y, vw, vh, mods) {
                                 actions.push(AppAction::RequestRedraw);
                                 handled = true;
                             }
@@ -225,6 +235,14 @@ impl RinchApp {
             }
             DebugCommandKind::MouseUp { x, y, ref button } => {
                 let mouse_button = parse_button(button);
+                self.dispatch_mouse_attr(
+                    "data-onmouseup",
+                    x,
+                    y,
+                    Self::core_button(mouse_button),
+                    window_size.0 as f32 / scale_factor as f32,
+                    window_size.1 as f32 / scale_factor as f32,
+                );
 
                 // Dispatch MouseUp to focused render surface
                 if let Some(surface_id) = crate::render_surface::focused_surface_id() {
@@ -313,6 +331,14 @@ impl RinchApp {
             }
             DebugCommandKind::MouseMove { x, y } => {
                 self.cursor_pos = Some((x, y));
+                self.dispatch_mouse_attr(
+                    "data-onmousemove",
+                    x,
+                    y,
+                    events::MouseButton::Left,
+                    window_size.0 as f32 / scale_factor as f32,
+                    window_size.1 as f32 / scale_factor as f32,
+                );
 
                 // Drag-and-drop: pending → active transition
                 if let Some(ref pending) = self.pending_drag {

--- a/crates/rinch/src/app/event_dispatch.rs
+++ b/crates/rinch/src/app/event_dispatch.rs
@@ -40,6 +40,17 @@ impl RinchApp {
             PlatformEvent::MouseMove { x, y } => {
                 self.cursor_pos = Some((x, y));
 
+                // Additive: fire data-onmousemove before any drag/scroll/hover
+                // logic below (which can early-return).
+                self.dispatch_mouse_attr(
+                    "data-onmousemove",
+                    x,
+                    y,
+                    events::MouseButton::Left,
+                    vp_w,
+                    vp_h,
+                );
+
                 // ── Drag-and-drop: pending → active transition ────────────
                 if let Some(ref pending) = self.pending_drag {
                     let dx = x - pending.mousedown_pos.0;
@@ -173,6 +184,8 @@ impl RinchApp {
                             text_hit: Default::default(),
                             viewport_width: vp_w,
                             viewport_height: vp_h,
+                            button: events::MouseButton::Left,
+                            modifiers: events::ModifierState::default(),
                         });
                         Self::dispatch_drag_attr(doc, drag.node_id, "data-ondragmove");
                     }
@@ -390,6 +403,17 @@ impl RinchApp {
                 y,
                 button: MouseButton::Left,
             } => {
+                // Additive: fire data-onmousedown before the resize/drag/scroll/
+                // click logic below (which can early-return).
+                self.dispatch_mouse_attr(
+                    "data-onmousedown",
+                    x,
+                    y,
+                    events::MouseButton::Left,
+                    vp_w,
+                    vp_h,
+                );
+
                 // Check resize edge for borderless windows
                 if let Some(ref props) = self.window_props {
                     if props.borderless && props.resizable {
@@ -514,9 +538,19 @@ impl RinchApp {
                 }
             }
             PlatformEvent::MouseDown { x, y, button } => {
+                self.dispatch_mouse_attr(
+                    "data-onmousedown",
+                    x,
+                    y,
+                    Self::core_button(button),
+                    vp_w,
+                    vp_h,
+                );
+
                 let mut handled = false;
                 if button == MouseButton::Right {
                     // Right-click: try oncontextmenu dispatch first
+                    let mods = self.modifier_state();
                     if let Some(doc) = &self.doc {
                         let hit_id = {
                             let d = doc.borrow();
@@ -525,7 +559,7 @@ impl RinchApp {
                         if let Some(hit_id) = hit_id {
                             let vw = window_size.0 as f32 / scale_factor as f32;
                             let vh = window_size.1 as f32 / scale_factor as f32;
-                            if Self::dispatch_oncontextmenu(doc, hit_id, x, y, vw, vh) {
+                            if Self::dispatch_oncontextmenu(doc, hit_id, x, y, vw, vh, mods) {
                                 actions.push(AppAction::RequestRedraw);
                                 handled = true;
                             }
@@ -541,6 +575,15 @@ impl RinchApp {
                 }
             }
             PlatformEvent::MouseUp { x, y, button } => {
+                self.dispatch_mouse_attr(
+                    "data-onmouseup",
+                    x,
+                    y,
+                    Self::core_button(button),
+                    vp_w,
+                    vp_h,
+                );
+
                 // ── Drag-and-drop: complete or cancel ─────────────────────
                 if let Some(pending) = self.pending_drag.take() {
                     // Threshold was never crossed — fire normal click instead
@@ -585,6 +628,8 @@ impl RinchApp {
                             text_hit: Default::default(),
                             viewport_width: vp_w,
                             viewport_height: vp_h,
+                            button: events::MouseButton::Left,
+                            modifiers: self.modifier_state(),
                         });
                         Self::dispatch_drag_attr(doc, drag.node_id, "data-ondragend");
                     }
@@ -1170,6 +1215,7 @@ impl RinchApp {
         y: f32,
         viewport_width: f32,
         viewport_height: f32,
+        modifiers: events::ModifierState,
     ) -> bool {
         let handler_info = {
             let d = doc.borrow();
@@ -1216,6 +1262,8 @@ impl RinchApp {
                 text_hit: events::TextHitInfo::default(),
                 viewport_width,
                 viewport_height,
+                button: events::MouseButton::Right,
+                modifiers,
             });
             events::dispatch_event(events::EventHandlerId(id));
             true
@@ -1368,6 +1416,8 @@ impl RinchApp {
                 text_hit: events::TextHitInfo::default(),
                 viewport_width: 0.0,
                 viewport_height: 0.0,
+                button: events::MouseButton::Left,
+                modifiers: events::ModifierState::default(),
             });
             events::dispatch_event(events::EventHandlerId(id));
         }
@@ -1396,6 +1446,99 @@ impl RinchApp {
             found
         };
         if let Some(id) = handler_id {
+            events::dispatch_event(events::EventHandlerId(id));
+        }
+    }
+
+    /// Map a platform mouse button onto the `rinch-core` button enum carried by
+    /// [`events::ClickContext`].
+    pub(super) fn core_button(button: MouseButton) -> events::MouseButton {
+        match button {
+            MouseButton::Left => events::MouseButton::Left,
+            MouseButton::Right => events::MouseButton::Right,
+            MouseButton::Middle => events::MouseButton::Middle,
+        }
+    }
+
+    /// Snapshot the live platform modifier state as the core
+    /// [`events::ModifierState`] stored in [`events::ClickContext`].
+    pub(super) fn modifier_state(&self) -> events::ModifierState {
+        events::ModifierState {
+            shift: self.modifiers.shift,
+            ctrl: self.modifiers.ctrl,
+            alt: self.modifiers.alt,
+            meta: self.modifiers.meta,
+        }
+    }
+
+    /// Hit-test `(x, y)`, walk up for `attr`, set the [`events::ClickContext`]
+    /// (cursor + target bounds + button + modifiers), and dispatch the handler.
+    ///
+    /// Additive notification used for `data-onmousedown`/`data-onmouseup`/
+    /// `data-onmousemove`. It never consumes the event, so it is safe to call at
+    /// the top of the MouseDown/MouseUp/MouseMove arms before the existing
+    /// click/drag/scroll logic (which may early-return).
+    pub(super) fn dispatch_mouse_attr(
+        &self,
+        attr: &str,
+        x: f32,
+        y: f32,
+        button: events::MouseButton,
+        vp_w: f32,
+        vp_h: f32,
+    ) {
+        let Some(doc) = &self.doc else { return };
+        let handler_info = {
+            let d = doc.borrow();
+            let Some(hit_id) = hit_test(&d.tree, x, y) else {
+                return;
+            };
+            let mut current = Some(hit_id);
+            let mut found = None;
+            while let Some(nid) = current {
+                if let Some(node) = d.tree.get(nid) {
+                    if let Some(val) = node.attributes.get(attr) {
+                        if let Ok(id) = val.parse::<usize>() {
+                            // Compute element absolute position
+                            let mut ax = node.layout.x;
+                            let mut ay = node.layout.y;
+                            let mut pid = node.parent;
+                            while let Some(p) = pid {
+                                if let Some(pn) = d.tree.get(p) {
+                                    ax += pn.layout.x;
+                                    ay += pn.layout.y;
+                                    ax -= pn.scroll_offset.0 as f32;
+                                    ay -= pn.scroll_offset.1 as f32;
+                                    pid = pn.parent;
+                                } else {
+                                    break;
+                                }
+                            }
+                            found = Some((id, ax, ay, node.layout.width, node.layout.height));
+                        }
+                        break;
+                    }
+                    current = node.parent;
+                } else {
+                    break;
+                }
+            }
+            found
+        };
+        if let Some((id, elem_x, elem_y, elem_w, elem_h)) = handler_info {
+            events::set_click_context(events::ClickContext {
+                mouse_x: x,
+                mouse_y: y,
+                element_x: elem_x,
+                element_y: elem_y,
+                element_width: elem_w,
+                element_height: elem_h,
+                text_hit: events::TextHitInfo::default(),
+                viewport_width: vp_w,
+                viewport_height: vp_h,
+                button,
+                modifiers: self.modifier_state(),
+            });
             events::dispatch_event(events::EventHandlerId(id));
         }
     }

--- a/crates/rinch/src/lib.rs
+++ b/crates/rinch/src/lib.rs
@@ -128,8 +128,8 @@ pub mod prelude {
     };
     // Event handling - click context, drag support, input callbacks, file-drop callbacks
     pub use rinch_core::{
-        ClickContext, Drag, DragContext, FileDropCallback, InputCallback, get_click_context,
-        restore_drag_ghost, suppress_drag_ghost,
+        ClickContext, Drag, DragContext, FileDropCallback, InputCallback, ModifierState,
+        MouseButton, get_click_context, restore_drag_ghost, suppress_drag_ghost,
     };
     pub use rinch_macros::{component, rsx};
     // Window control functions

--- a/docs/src/guide/rsx-syntax.md
+++ b/docs/src/guide/rsx-syntax.md
@@ -71,6 +71,56 @@ rsx! {
 }
 ```
 
+## Event Handlers
+
+Event handlers are `on*` attributes on HTML elements. Pointer/click handlers are
+`Fn()` closures; read the cursor position, button, and modifier keys from
+`get_click_context()`:
+
+```rust
+use rinch::prelude::*;
+
+rsx! {
+    div {
+        onclick: || println!("clicked"),
+        onmousedown: || {
+            let ctx = get_click_context();
+            match ctx.button {
+                MouseButton::Right => println!("right press"),
+                _ if ctx.modifiers.shift => println!("shift+press"),
+                _ => println!("press at {}, {}", ctx.mouse_x, ctx.mouse_y),
+            }
+        },
+        onmouseup: || println!("released"),
+        onmousemove: || { /* fires on every move over this element */ },
+        onmouseenter: || println!("hover in"),
+        onmouseleave: || println!("hover out"),
+        oncontextmenu: || println!("right-click menu"),
+        "Interactive"
+    }
+}
+```
+
+Supported HTML-element event attributes:
+
+| Attribute | Fires | Closure |
+|---|---|---|
+| `onclick` | Primary press (rinch dispatches click on mousedown) | `Fn()` |
+| `onmousedown` / `onmouseup` | Pointer press / release (any button) | `Fn()` |
+| `onmousemove` | Pointer moves over the element | `Fn()` |
+| `onmouseenter` / `onmouseleave` | Pointer enters / leaves the element | `Fn()` |
+| `oncontextmenu` | Right-click (suppresses the native menu when handled) | `Fn()` |
+| `oninput` / `onchange` | `<input>`/`<textarea>` value change | `Fn(String)` |
+| `onscroll` | Scroll container scrolls | `Fn(f64)` (scrollTop) |
+| `ondragstart` … `ondrop`, `ondragend` | Element drag-and-drop | `Fn()` |
+| `onfiledrop`, `onfiledragenter`/`onfiledragleave` | OS → app file drop | `Fn(Vec<PathBuf>)` / `Fn()` |
+
+Mouse and click handlers read per-event data from `get_click_context()`:
+`mouse_x`/`mouse_y`, element bounds (`relative_x()`, `percent_x()`, …),
+`button` (`MouseButton::{Left, Middle, Right}`), and `modifiers`
+(`shift`/`ctrl`/`alt`/`meta`). These behave identically on the desktop and web
+(WASM) backends.
+
 ## Components
 
 Components are custom UI elements written in PascalCase. They implement the `Component` trait and render directly to DOM nodes:


### PR DESCRIPTION
Stacked on #52 (the `rinch-web` extraction). Review/merge that first.

## Summary

Adds app-facing **`onmousedown` / `onmouseup` / `onmousemove`** handlers on **both** backends, and closes several **web/desktop event-dispatch parity gaps** that the now-unified `rinch-web` backend made tractable. (This is the follow-on to the "rinch didn't have mouseup/mousedown" gap — which traced back to the old paint-web fork wiring only `click`.)

## Handlers (desktop + web)
- `onmousedown` / `onmouseup` / `onmousemove` on any HTML element. Dispatched **additively** at the top of the desktop `MouseDown`/`MouseUp`/`MouseMove` arms — they never consume the event, so existing click / drag-threshold / scrollbar / contextmenu behavior is unchanged.
- `ClickContext` gains **`button`** (`MouseButton`) and **`modifiers`** (`ModifierState`), filled from the live platform/browser state. Handlers read them via `get_click_context()`. Both types are now in the prelude.
- The MCP debug path (`mouse_down`/`up`/`move`, `right_click`) mirrors the real arms, so the handlers are drivable via `rinch-mcp-server`.

## Web event parity (`crates/rinch-web`)
The web delegation now also dispatches, matching desktop semantics:
- `data-oncontextmenu` (suppresses the native menu only when handled; `button = Right`)
- hover (`data-onenter` / `data-onleave`) with non-bubbling mouseenter/leave semantics
- `data-onscroll` (capture-phase listener, since `scroll` doesn't bubble)
- **Fix:** right-click no longer fires `onclick` when a contextmenu handler is present (mirrors the desktop gate)

Desktop `oncontextmenu` now carries live modifiers (was hardcoded default).

## Deferred (its own PR)
The web `data-ondrag*` attribute suite — it's a from-scratch mouse-synthesis (drag-threshold + over-target tracking), larger and riskier than these mirrors, and deserves isolated testing.

## Verification
- `cargo check --workspace`, `cargo clippy` (`-D warnings` via the pre-commit hook), `rustfmt` — clean
- `cargo build --target wasm32-unknown-unknown` — clean for both web examples
- Two adversarial review passes; this PR incorporates their fixes (the right-click double-dispatch was caught and fixed here)

Note: verified statically (builds + clippy + wasm + review). End-to-end runtime exercise of the new handlers (desktop via MCP, web via browser) is not yet done — happy to add a demo + MCP/Playwright check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)