### PR TITLE
feat(ce): derive serde on interchange types + fix link/href round-trip (#50)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -655,6 +655,8 @@ Rinch has a built-in contenteditable system for rich-text editing. Set `contente
 
 **Architecture:** CRDT-first. Every mutation flows through `EditorDocument` (Automerge CRDT) first, then the DOM is re-rendered as a view. The `EditorDocument` is always present on every CE element — no opt-in required. The `collaboration` feature only gates sync methods (`save_incremental`, `load_incremental`, `apply_remote_changes`).
 
+**Persisting content:** `Vec<BlockData>` (from `extract_content()`) is the canonical save/load shape. Enable the optional `serde` feature (`rinch-core/serde`, or `serde` on the `rinch` facade) to derive `Serialize`/`Deserialize` on `BlockData`/`InlineRunData`/`InlineMarkData`. The wire format is snake_case (`block_type`, `mark_type`) — the durable persistence contract.
+
 **Full guide:** `docs/src/guide/contenteditable.md`
 
 ### Key Types (all in `rinch_core::ce`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4687,6 +4687,8 @@ dependencies = [
 name = "rinch-core"
 version = "0.1.0"
 dependencies = [
+ "serde",
+ "serde_json",
  "thiserror 1.0.69",
  "tracing",
 ]

--- a/crates/rinch-core/Cargo.toml
+++ b/crates/rinch-core/Cargo.toml
@@ -8,7 +8,14 @@ description = "Core types and traits for the rinch GUI framework"
 [features]
 default = []
 theme = []
+# Derive serde on the contenteditable interchange types (BlockData /
+# InlineRunData / InlineMarkData) so downstream apps can persist CE content.
+serde = ["dep:serde"]
 
 [dependencies]
 thiserror.workspace = true
 tracing.workspace = true
+serde = { version = "1", optional = true, features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/rinch-core/src/ce.rs
+++ b/crates/rinch-core/src/ce.rs
@@ -283,7 +283,13 @@ impl std::fmt::Debug for CeEventDispatcher {
 // ============================================================================
 
 /// A block of content (paragraph, heading, list item, etc.) for save/load.
+///
+/// With the `serde` feature, this and the nested [`InlineRunData`] /
+/// [`InlineMarkData`] serialize using their field names verbatim (snake_case:
+/// `block_type`, `mark_type`). Those keys are the durable wire format — treat
+/// renames as a breaking change to persisted content.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BlockData {
     /// Block type: "paragraph", "heading", "bullet_list", "ordered_list",
     /// "blockquote", "code_block", "horizontal_rule", etc.
@@ -296,6 +302,7 @@ pub struct BlockData {
 
 /// A run of text with inline marks (bold, italic, etc.).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InlineRunData {
     /// The text content of this run.
     pub text: String,
@@ -305,6 +312,7 @@ pub struct InlineRunData {
 
 /// An inline mark (bold, italic, code, etc.).
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct InlineMarkData {
     /// Mark type: "bold", "italic", "code", "underline", "strike", etc.
     pub mark_type: String,
@@ -735,5 +743,38 @@ mod tests {
 
         clear_ce_event_listeners();
         assert_eq!(ce_event_listener_count(), 0);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn block_data_serde_round_trip_snake_case() {
+        use std::collections::HashMap;
+
+        let mut block_attrs = HashMap::new();
+        block_attrs.insert("level".to_string(), "2".to_string());
+
+        let mut link_attrs = HashMap::new();
+        link_attrs.insert("href".to_string(), "https://example.com".to_string());
+
+        let blocks = vec![BlockData {
+            block_type: "heading".to_string(),
+            attrs: block_attrs,
+            content: vec![InlineRunData {
+                text: "Title".to_string(),
+                marks: vec![InlineMarkData {
+                    mark_type: "link".to_string(),
+                    attrs: link_attrs,
+                }],
+            }],
+        }];
+
+        let json = serde_json::to_string(&blocks).expect("serialize");
+        // Field names use the Rust snake_case identifiers verbatim — this is the
+        // durable wire format consumers persist against.
+        assert!(json.contains("\"block_type\""), "got: {json}");
+        assert!(json.contains("\"mark_type\""), "got: {json}");
+
+        let round: Vec<BlockData> = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(blocks, round, "BlockData must round-trip losslessly");
     }
 }

--- a/crates/rinch/Cargo.toml
+++ b/crates/rinch/Cargo.toml
@@ -118,3 +118,6 @@ web = ["dep:rinch-web"]
 video = ["dep:rinch-video"]
 image-network = ["dep:ureq"]
 collaboration = ["rinch-editor/collaboration"]
+# Derive serde on the CE interchange types (BlockData / InlineRunData /
+# InlineMarkData) for persisting contenteditable content.
+serde = ["rinch-core/serde"]

--- a/crates/rinch/src/ce_render.rs
+++ b/crates/rinch/src/ce_render.rs
@@ -39,6 +39,7 @@ pub(crate) fn mark_type_to_tag(mark_type: &str) -> &str {
         "highlight" => "mark",
         "subscript" => "sub",
         "superscript" => "sup",
+        "link" => "a",
         other => other,
     }
 }
@@ -135,7 +136,14 @@ pub(crate) fn extract_inline_runs(
     // Element node: check if it's a formatting tag
     let tag = node.tag().unwrap_or("");
     let mut marks = active_marks.to_vec();
-    if let Some(mark_type) = tag_to_mark_type(tag) {
+    if tag == "a" {
+        // Link mark — preserve all attributes (href, title, target, …) so
+        // links round-trip through extract_content() → load_content().
+        marks.push(InlineMarkData {
+            mark_type: "link".to_string(),
+            attrs: node.attributes.clone(),
+        });
+    } else if let Some(mark_type) = tag_to_mark_type(tag) {
         marks.push(InlineMarkData {
             mark_type: mark_type.to_string(),
             attrs: HashMap::new(),
@@ -374,6 +382,11 @@ pub(crate) fn render_inline_content(
             for mark in &run.marks {
                 let tag = mark_type_to_tag(&mark.mark_type);
                 let el = d.create_element(tag);
+                // Apply mark attributes (e.g. a link's `href`) so they survive
+                // load_content() — symmetric with extract_inline_runs().
+                for (name, value) in &mark.attrs {
+                    d.set_attribute(el, name, value);
+                }
                 d.append_child(rinch_core::dom::NodeId(wrapper_id), el);
                 wrapper_id = el.0;
             }

--- a/crates/rinch/tests/ce_crdt_sync.rs
+++ b/crates/rinch/tests/ce_crdt_sync.rs
@@ -387,6 +387,9 @@ fn clear_formatting() {
     }
 }
 
+// Link mark href round-trip lives in tests/ce_link_roundtrip.rs (not gated behind
+// `collaboration`, so it runs in a default `cargo test -p rinch`).
+
 // ============================================================================
 // Undo / Redo
 // ============================================================================

--- a/crates/rinch/tests/ce_link_roundtrip.rs
+++ b/crates/rinch/tests/ce_link_roundtrip.rs
@@ -1,0 +1,92 @@
+//! Link mark `href` round-trips through `load_content()` → `extract_content()`.
+//!
+//! This guards the CE DOM-bridge fix in `ce_render.rs` (recognize `<a>` on
+//! extract, apply `mark.attrs` on render, map `"link"` → `"a"`). The bug is
+//! independent of collaboration, so — unlike `ce_crdt_sync.rs` — this file is
+//! NOT gated behind `#![cfg(feature = "collaboration")]` and runs in a plain
+//! `cargo test -p rinch`.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use rinch_core::ce::{BlockData, ContentEditableApi, DomCursor, InlineMarkData, InlineRunData};
+use rinch_core::dom::{DomDocument, NodeId};
+use rinch_dom::RinchDocument;
+
+/// Build a bare CeOps with one empty `<p>` — no collaboration enabled.
+fn new_ce() -> rinch::ce_ops::CeOps {
+    let doc = Rc::new(RefCell::new(RinchDocument::new()));
+    let ce_root;
+    let initial_cursor;
+    {
+        let mut d = doc.borrow_mut();
+        let body = NodeId(1);
+        ce_root = d.create_element("div");
+        d.append_child(body, ce_root);
+        d.set_attribute(ce_root, "contenteditable", "true");
+
+        let p = d.create_element("p");
+        d.append_child(ce_root, p);
+        let text = d.create_text("");
+        d.append_child(p, text);
+        initial_cursor = DomCursor::new(text.0, 0);
+    }
+    rinch::ce_ops::CeOps::new(doc, ce_root.0, initial_cursor)
+}
+
+#[test]
+fn link_href_round_trips_through_load_and_extract() {
+    let mut ops = new_ce();
+
+    let mut href_attrs = HashMap::new();
+    href_attrs.insert("href".to_string(), "https://example.com".to_string());
+
+    let blocks = vec![BlockData {
+        block_type: "paragraph".to_string(),
+        attrs: HashMap::new(),
+        content: vec![
+            InlineRunData {
+                text: "See ".to_string(),
+                marks: vec![],
+            },
+            InlineRunData {
+                text: "this link".to_string(),
+                marks: vec![InlineMarkData {
+                    mark_type: "link".to_string(),
+                    attrs: href_attrs,
+                }],
+            },
+        ],
+    }];
+
+    // load_content renders the DOM (render_inline_content); extract_content reads
+    // it back (extract_inline_runs). Before the fix, the <a>'s href was dropped on
+    // both legs (and "link" produced a bogus <link> element).
+    ops.load_content(&blocks);
+    let extracted = ops.extract_content();
+
+    let link_run = extracted
+        .iter()
+        .flat_map(|b| &b.content)
+        .find(|r| r.text == "this link")
+        .expect("link run should survive round-trip");
+    let link_mark = link_run
+        .marks
+        .iter()
+        .find(|m| m.mark_type == "link")
+        .expect("link mark should survive round-trip");
+    assert_eq!(
+        link_mark.attrs.get("href").map(|s| s.as_str()),
+        Some("https://example.com"),
+        "href must round-trip through load_content → extract_content"
+    );
+
+    // The CRDT view (always present, no collaboration needed) must agree with the
+    // DOM extract — same link, same href.
+    assert_eq!(
+        extracted,
+        ops.editor_doc().to_block_data(),
+        "DOM extract and CRDT to_block_data must agree on the link"
+    );
+}

--- a/docs/src/guide/contenteditable.md
+++ b/docs/src/guide/contenteditable.md
@@ -308,10 +308,36 @@ pub struct InlineRunData {
 }
 
 pub struct InlineMarkData {
-    pub mark_type: String,                     // "bold", "italic", "code", etc.
-    pub attrs: HashMap<String, String>,
+    pub mark_type: String,                     // "bold", "italic", "code", "link", etc.
+    pub attrs: HashMap<String, String>,        // e.g. {"href": "https://…"} for links
 }
 ```
+
+### Persisting content (serde)
+
+`Vec<BlockData>` is the canonical save/load representation. Enable the optional `serde`
+feature to derive `Serialize`/`Deserialize` on `BlockData`, `InlineRunData`, and
+`InlineMarkData`, so content can be persisted directly — no mirror struct, one source of
+truth for the format:
+
+```toml
+# via the rinch facade:
+rinch = { workspace = true, features = ["desktop", "serde"] }
+# or depending on rinch-core directly:
+rinch-core = { workspace = true, features = ["serde"] }
+```
+
+```rust
+let blocks = api.borrow().extract_content();
+let json = serde_json::to_string(&blocks)?;        // store it
+// …later…
+let blocks: Vec<BlockData> = serde_json::from_str(&json)?;
+api.borrow_mut().load_content(&blocks);            // restore it
+```
+
+The wire format uses the struct field names verbatim (snake_case: `block_type`,
+`mark_type`). Link marks carry their `href` in `attrs` and round-trip losslessly through
+`extract_content()` → `load_content()`.
 
 ## Keyboard Shortcuts
 


### PR DESCRIPTION
Closes #50.

## What

Make `Vec<BlockData>` a trustworthy interchange format for contenteditable content — two parts in one pass, since serializing a lossy representation isn't useful:

1. **Optional `serde` feature** on `rinch-core` deriving `Serialize`/`Deserialize` on the CE interchange types (`BlockData`, `InlineRunData`, `InlineMarkData`), with a passthrough `serde` feature on the `rinch` facade. The wire format uses the struct field names verbatim (snake_case: `block_type`, `mark_type`) and is pinned as the durable persistence contract via a doc-comment + unit test.

2. **Link/attribute round-trip fix** in the CE DOM bridge (the issue's "companion bug to confirm"). It was worse than described — links were lost in **three** spots, not two:
   - `mark_type_to_tag`: `"link"` fell through the `other => other` catch-all and produced a bogus `<link>` element → now maps `"link" => "a"`.
   - `render_inline_content`: never applied `mark.attrs`, so `href` was dropped on load → now applies them (symmetric with extract).
   - `extract_inline_runs`: didn't recognize `<a>`, so `href` was dropped on extract → now recognizes `<a>` as a `"link"` mark and copies its attributes.

The model layer (`rinch-editor`) already round-tripped links correctly via `wrap_mark`/`MarkData::with_attrs`; only the DOM bridge was lossy. After this, DOM `extract_content()` and CRDT `to_block_data()` agree on links.

## Tests

- `rinch-core`: serde round-trip unit test (asserts snake_case keys + lossless round-trip).
- `rinch`: link `href` round-trip integration test in a new `tests/ce_link_roundtrip.rs` that is **not** gated behind `collaboration`, so it runs in a default `cargo test -p rinch` (the bridge fix is independent of that feature).

Verified: rinch-core 61/61 (serde on) / 60/60 (serde off); CE sync 52/52; link guard passes by default; the optional `serde` dep does **not** leak into the default dependency graph.

## Scope note

A follow-up (#59) tracks the **same bug class** for `text_color`/`highlight` marks (renders a garbage `<text_color>` element; color dropped on extract). It's out of scope here — left as its own issue.

## Review

Adversarially reviewed across correctness / completeness / serde-API lenses before finalizing; the review caught that the regression test was initially hidden behind the `collaboration` feature gate (fixed) and that the snake_case format choice is sound for a Rust-to-Rust consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
