### PR TITLE
fix(layout): flex gap ignores inline children inside display:contents wrappers (#41)

### DIFF
--- a/crates/rinch-dom/src/ifc.rs
+++ b/crates/rinch-dom/src/ifc.rs
@@ -694,6 +694,17 @@ impl RinchDocument {
             ) {
                 continue;
             }
+            // A `display: contents` element generates no box, so it can't
+            // establish an inline formatting context. When it flattens into a
+            // flex container (sync_display_contents reparents its children there),
+            // those children become flex items — an IFC rooted here would fight
+            // the flattening and overlap them (issue #41). Inside a block
+            // container the existing IFC handling is left unchanged.
+            if node.computed_style.display == crate::computed_style::values::DisplayValue::Contents
+                && Self::contents_ancestor_is_flex(&self.tree.nodes, id)
+            {
+                continue;
+            }
 
             let inline_children: Vec<usize> = node
                 .children
@@ -784,6 +795,25 @@ impl RinchDocument {
                     .set_node_context(root_taffy, Some(NodeContext::InlineRoot(root_id)));
             }
         }
+    }
+
+    /// Whether the nearest non-`display:contents` ancestor of `node_id` is a flex
+    /// container. Used to decide that a `display:contents` node's children are
+    /// flattened into a flex context (so the contents node must not be an IFC
+    /// root). Walks up through chained `display:contents` ancestors.
+    fn contents_ancestor_is_flex(nodes: &slab::Slab<Node>, node_id: usize) -> bool {
+        use crate::computed_style::values::DisplayValue;
+        let mut cur = nodes.get(node_id).and_then(|n| n.parent);
+        while let Some(anc_id) = cur {
+            match nodes.get(anc_id) {
+                Some(a) if a.computed_style.display == DisplayValue::Contents => {
+                    cur = a.parent;
+                }
+                Some(a) => return a.display_mode == DisplayMode::Flex,
+                None => return false,
+            }
+        }
+        false
     }
 
     /// Pre-compute layout for inline-block children that were detached from Taffy.

--- a/crates/rinch-dom/tests/layout_tests.rs
+++ b/crates/rinch-dom/tests/layout_tests.rs
@@ -624,3 +624,61 @@ fn test_display_contents_mixed_siblings() {
     assert_eq!(la.x, 60.0, "contents child at x=60");
     assert_eq!(ln2.x, 130.0, "normal2 at x=130");
 }
+
+/// Issue #41: a flex container's `gap` must account for the widths of
+/// **inline-level** children that live inside a `display:contents` wrapper
+/// (as emitted by rsx `if`/`match`). Before the fix, the contents wrapper was
+/// wrongly treated as an inline-formatting-context root, so its children were
+/// laid out inline instead of as flex items — collapsing the gap and overlapping.
+#[test]
+fn test_display_contents_flex_gap_inline_children() {
+    let mut doc = RinchDocument::new();
+    let body = doc.body();
+    let container = doc.create_element("div");
+    doc.set_attribute(
+        container,
+        "style",
+        "display: flex; flex-direction: row; gap: 12px; width: 400px",
+    );
+    doc.append_child(body, container);
+
+    let wrapper = doc.create_element("div");
+    doc.set_attribute(wrapper, "style", "display: contents");
+    doc.append_child(container, wrapper);
+
+    // Inline-level children (inline-block) with fixed widths → deterministic.
+    let a = doc.create_element("span");
+    doc.set_attribute(
+        a,
+        "style",
+        "display: inline-block; width: 50px; height: 20px",
+    );
+    doc.append_child(wrapper, a);
+    let b = doc.create_element("span");
+    doc.set_attribute(
+        b,
+        "style",
+        "display: inline-block; width: 60px; height: 20px",
+    );
+    doc.append_child(wrapper, b);
+    let c = doc.create_element("span");
+    doc.set_attribute(
+        c,
+        "style",
+        "display: inline-block; width: 40px; height: 20px",
+    );
+    doc.append_child(wrapper, c);
+
+    doc.resolve_layout(800.0, 600.0);
+
+    let la = doc.tree.get(a.0).unwrap().layout;
+    let lb = doc.tree.get(b.0).unwrap().layout;
+    let lc = doc.tree.get(c.0).unwrap().layout;
+    // gap = 12: a at 0, b at 50+12, c at 62+60+12 — no overlap.
+    assert_eq!(la.x, 0.0, "a.x");
+    assert_eq!(lb.x, 62.0, "b.x must account for a's width + gap");
+    assert_eq!(
+        lc.x, 134.0,
+        "c.x must account for b's width + gap (not overlap b)"
+    );
+}


### PR DESCRIPTION
Closes #41.

## Problem

A flex container with `gap` didn't account for the width of **inline-level** children (a `span`, a `button`, …) that live inside a `display:contents` wrapper — the wrapper rsx emits for `if`/`match` conditional branches. The next sibling was positioned as if the wrapped child had zero width, so it overlapped.

```rust
div { style: "display: flex; gap: 12px; align-items: center",
    if cond.get() {
        button { "First" }   // ok
        span { "Middle" }    // ok
        button { "Last" }    // BUG: overlapped "Middle"
    }
}
```

## Root cause

`sync_display_contents()` flattens a `display:contents` wrapper's children into the nearest real ancestor (here the flex container) as Taffy flex items. But `setup_inline_formatting_contexts()` then saw the wrapper (resolved `display_mode == Block`) with inline children and made it an **inline-formatting-context root** — laying those children out inline and marking them `ifc_root`, fighting the flex flattening. Net result: the items were positioned by an IFC on a phantom (no-box) node instead of as gapped flex items.

A `display:contents` element generates no box and can never establish an IFC.

## Fix

Skip a `display:contents` node as an IFC-root candidate **when it flattens into a flex container** — in that case its children are blockified into flex items, so no IFC belongs there. A small `contents_ancestor_is_flex` helper walks up through chained `display:contents` ancestors to the nearest real ancestor and checks for `display: flex`.

Deliberately scoped to the flex case (the reported bug). Inside a **block** container the existing IFC handling is left untouched.

## Tests

- New `test_display_contents_flex_gap_inline_children` (in `layout_tests.rs`) asserts the three inline-block children get gap-correct, non-overlapping x positions. It **fails before this change** and passes after.
- Full `rinch-dom` suite: 219 pass (incl. all existing `display:contents` tests).
- Visually verified with the rinch debug tools: the buggy flex container now lays out `First / Middle / Last` identically to a no-`if` control (x = 28 / 75 / 140), no overlap.

## Out of scope (follow-up #61)

The **block-parent** analogue — `display:contents` + inline children inside a block container — is also broken (inline text dropped/mispositioned), but it's **pre-existing** and a larger fix (it needs the block container to establish the IFC through the wrapper, plus inline-block read-back work). This PR does not change block-parent behavior; tracked in #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
