### PR TITLE
fix(macros): rsx for-loop capture scanner skips if-let/while-let/match bindings

### DIFF
--- a/crates/rinch-macros/src/dom_codegen/control_flow.rs
+++ b/crates/rinch-macros/src/dom_codegen/control_flow.rs
@@ -29,6 +29,9 @@ use super::DomCodegenContext;
 ///   inside the expression itself (issue #32 — `.filter(|b| b % 4 == 0)` must
 ///   not shadow a non-existent outer `b`). Scope-tracked via a stack pushed on
 ///   `Closure` / `Block` entry and popped on exit.
+/// - Excludes identifiers bound by `if let` / `while let` (incl. `&&`
+///   let-chains) patterns and `match` arm patterns, each scoped to the branch
+///   that can actually see them — the `if let` analogue of the #32 fix.
 ///
 /// The collected list is used to emit `let #id = #id.clone();` shadow bindings
 /// before the inner `move ||` closure is constructed. Cloning Copy types via
@@ -49,6 +52,30 @@ fn collect_capture_idents(expr: &syn::Expr) -> Vec<syn::Ident> {
     impl Collector {
         fn is_locally_bound(&self, name: &str) -> bool {
             self.locals.iter().any(|frame| frame.contains(name))
+        }
+
+        /// Scan an `if`/`while` condition that may introduce `let` bindings
+        /// (`if let`, `while let`, and `&&` let-chains). Each scrutinee
+        /// expression is visited so its identifiers resolve against the
+        /// *current* scope — which already includes bindings from earlier links
+        /// of a let-chain (`if let Some(x) = a && x > 0`) — while the names
+        /// bound by each pattern are added to the top `locals` frame so the
+        /// branch body (pushed by the caller) skips them. A plain boolean
+        /// condition just falls through to a normal visit.
+        fn scan_cond<'ast>(&mut self, cond: &'ast syn::Expr) {
+            match cond {
+                syn::Expr::Let(let_expr) => {
+                    self.visit_expr(&let_expr.expr);
+                    if let Some(frame) = self.locals.last_mut() {
+                        collect_pat_idents(&let_expr.pat, frame);
+                    }
+                }
+                syn::Expr::Binary(bin) if matches!(bin.op, syn::BinOp::And(_)) => {
+                    self.scan_cond(&bin.left);
+                    self.scan_cond(&bin.right);
+                }
+                other => self.visit_expr(other),
+            }
         }
     }
 
@@ -132,6 +159,45 @@ fn collect_capture_idents(expr: &syn::Expr) -> Vec<syn::Ident> {
             if let Some(frame) = self.locals.last_mut() {
                 collect_pat_idents(&local.pat, frame);
             }
+        }
+
+        fn visit_expr_if(&mut self, node: &'ast syn::ExprIf) {
+            // `if let PAT = scrutinee { then } else { else }` binds the names in
+            // `PAT` only within `then` — NOT the scrutinee and NOT the else
+            // branch. The default visitor doesn't know this, so it would treat
+            // those names as outer captures and emit `let name = name.clone();`
+            // for a binding that doesn't exist (the `if let` analogue of #32).
+            // A plain `if cond` leaves the pushed frame empty and is unaffected.
+            self.locals.push(HashSet::new());
+            self.scan_cond(&node.cond);
+            self.visit_block(&node.then_branch);
+            self.locals.pop();
+            if let Some((_, else_branch)) = &node.else_branch {
+                self.visit_expr(else_branch);
+            }
+        }
+
+        fn visit_expr_while(&mut self, node: &'ast syn::ExprWhile) {
+            // `while let PAT = scrutinee { body }` — same scoping as `if let`,
+            // with the pattern visible in the body.
+            self.locals.push(HashSet::new());
+            self.scan_cond(&node.cond);
+            self.visit_block(&node.body);
+            self.locals.pop();
+        }
+
+        fn visit_arm(&mut self, arm: &'ast syn::Arm) {
+            // A `match` arm pattern binds names visible in the arm's guard and
+            // body only. The scrutinee is visited by `visit_expr_match` in the
+            // outer scope, so we only scope the arm here.
+            let mut frame = HashSet::new();
+            collect_pat_idents(&arm.pat, &mut frame);
+            self.locals.push(frame);
+            if let Some((_, guard)) = &arm.guard {
+                self.visit_expr(guard);
+            }
+            self.visit_expr(&arm.body);
+            self.locals.pop();
         }
     }
 
@@ -637,5 +703,57 @@ mod tests {
         // The original #26 case — a non-Copy fn param used in the iter source.
         let captures = caps("variant_options(default_variant.clone())");
         assert!(captures.contains(&"default_variant".to_string()));
+    }
+
+    #[test]
+    fn if_let_binding_is_not_a_capture() {
+        // The repro: `cid` is bound by `if let` inside a filter closure and used
+        // in the then-branch. It must not be treated as an outer capture, while
+        // the scrutinee `active_pane` still is.
+        let captures = caps(
+            "items.into_iter().filter(|f| if let Pane::Editor(ref cid) = active_pane.get() { f.id == *cid } else { false })",
+        );
+        assert!(captures.contains(&"items".to_string()));
+        assert!(captures.contains(&"active_pane".to_string()));
+        assert!(!captures.contains(&"cid".to_string()));
+    }
+
+    #[test]
+    fn if_let_else_branch_does_not_see_binding() {
+        // A name used only in the else branch IS an outer capture; the `if let`
+        // pattern binding does not leak there.
+        let captures =
+            caps("{ if let Some(x) = maybe { vec![x] } else { vec![fallback] } }");
+        assert!(captures.contains(&"maybe".to_string()));
+        assert!(captures.contains(&"fallback".to_string()));
+        assert!(!captures.contains(&"x".to_string()));
+    }
+
+    #[test]
+    fn match_arm_binding_is_not_a_capture() {
+        let captures = caps(
+            "items.iter().filter(|i| match active.get() { Pane::Editor(ref c) => i.id == *c, _ => false })",
+        );
+        assert!(captures.contains(&"items".to_string()));
+        assert!(captures.contains(&"active".to_string()));
+        assert!(!captures.contains(&"c".to_string()));
+    }
+
+    #[test]
+    fn while_let_binding_is_not_a_capture() {
+        let captures = caps("{ while let Some(n) = cursor.next() { total += n; } vec![total] }");
+        assert!(captures.contains(&"cursor".to_string()));
+        assert!(captures.contains(&"total".to_string()));
+        assert!(!captures.contains(&"n".to_string()));
+    }
+
+    #[test]
+    fn let_chain_later_link_sees_earlier_binding() {
+        // In `if let Some(x) = a && x > 0`, `x` in the second link resolves to
+        // the binding from the first — not an outer capture. `a` is a capture.
+        let captures = caps("{ if let Some(x) = a && x > threshold { vec![x] } else { vec![] } }");
+        assert!(captures.contains(&"a".to_string()));
+        assert!(captures.contains(&"threshold".to_string()));
+        assert!(!captures.contains(&"x".to_string()));
     }
 }

--- a/crates/rinch-macros/src/dom_codegen/control_flow.rs
+++ b/crates/rinch-macros/src/dom_codegen/control_flow.rs
@@ -62,7 +62,7 @@ fn collect_capture_idents(expr: &syn::Expr) -> Vec<syn::Ident> {
         /// bound by each pattern are added to the top `locals` frame so the
         /// branch body (pushed by the caller) skips them. A plain boolean
         /// condition just falls through to a normal visit.
-        fn scan_cond<'ast>(&mut self, cond: &'ast syn::Expr) {
+        fn scan_cond(&mut self, cond: &syn::Expr) {
             match cond {
                 syn::Expr::Let(let_expr) => {
                     self.visit_expr(&let_expr.expr);
@@ -722,8 +722,12 @@ mod tests {
     fn if_let_else_branch_does_not_see_binding() {
         // A name used only in the else branch IS an outer capture; the `if let`
         // pattern binding does not leak there.
-        let captures =
-            caps("{ if let Some(x) = maybe { vec![x] } else { vec![fallback] } }");
+        //
+        // NB: use array literals (`[..]`), not `vec![..]`. `syn`'s visitor treats
+        // macro token streams as opaque, so an ident only ever referenced inside a
+        // `vec![..]` is invisible to the scanner and would never be collected —
+        // which would make the `fallback` assertion below spuriously fail.
+        let captures = caps("{ if let Some(x) = maybe { [x] } else { [fallback] } }");
         assert!(captures.contains(&"maybe".to_string()));
         assert!(captures.contains(&"fallback".to_string()));
         assert!(!captures.contains(&"x".to_string()));
@@ -741,7 +745,7 @@ mod tests {
 
     #[test]
     fn while_let_binding_is_not_a_capture() {
-        let captures = caps("{ while let Some(n) = cursor.next() { total += n; } vec![total] }");
+        let captures = caps("{ while let Some(n) = cursor.next() { total += n; } [total] }");
         assert!(captures.contains(&"cursor".to_string()));
         assert!(captures.contains(&"total".to_string()));
         assert!(!captures.contains(&"n".to_string()));
@@ -751,9 +755,36 @@ mod tests {
     fn let_chain_later_link_sees_earlier_binding() {
         // In `if let Some(x) = a && x > 0`, `x` in the second link resolves to
         // the binding from the first — not an outer capture. `a` is a capture.
-        let captures = caps("{ if let Some(x) = a && x > threshold { vec![x] } else { vec![] } }");
+        let captures = caps("{ if let Some(x) = a && x > threshold { [x] } else { [] } }");
         assert!(captures.contains(&"a".to_string()));
         assert!(captures.contains(&"threshold".to_string()));
         assert!(!captures.contains(&"x".to_string()));
+    }
+
+    #[test]
+    fn match_guard_sees_arm_binding() {
+        // A `match` arm guard can reference the names bound by its pattern, so
+        // those names are not outer captures — but a name used *only* in the guard
+        // (`limit`) still is.
+        let captures = caps(
+            "items.iter().filter(|i| match active.get() { Editor(c) if c > limit => true, _ => false })",
+        );
+        assert!(captures.contains(&"items".to_string()));
+        assert!(captures.contains(&"active".to_string()));
+        assert!(captures.contains(&"limit".to_string()));
+        assert!(!captures.contains(&"c".to_string()));
+    }
+
+    #[test]
+    fn nested_else_if_let_scopes_each_branch() {
+        // `else if let Some(y) = b` recurses through the same `visit_expr_if`
+        // path, so `y` is scoped to its own branch (not a capture) while both
+        // scrutinees `a` and `b` are captured.
+        let captures =
+            caps("{ if let Some(x) = a { [x] } else if let Some(y) = b { [y] } else { [] } }");
+        assert!(captures.contains(&"a".to_string()));
+        assert!(captures.contains(&"b".to_string()));
+        assert!(!captures.contains(&"x".to_string()));
+        assert!(!captures.contains(&"y".to_string()));
     }
 }


### PR DESCRIPTION
## Problem

The rsx `for`-loop capture scanner (`collect_capture_idents` in `crates/rinch-macros/src/dom_codegen/control_flow.rs`) walks a `for` iterator expression and emits `let name = name.clone();` shadow bindings for every identifier that *looks* like an outer local (lowercase, single-segment path). To avoid cloning names that aren't outer locals, the #32 fix taught it to skip identifiers bound by **closure params** and **`let` statements** — but it never learned about names bound by **`if let`**, **`while let`**, or **`match` arm** patterns.

So this real-world rsx (a `for` iterating a `.filter(...)` whose closure uses `if let`):

```rust
for fb in feedback.into_iter().filter(|f| {
    if let Pane::Editor(ref cid) = active.get() {
        f.id == *cid
    } else {
        false
    }
}) { ... }
```

made the scanner treat `cid` (bound by `if let`, used only in the then-branch) as an outer capture and emit `let cid = cid.clone();` for a binding that doesn't exist:

```
error[E0425]: cannot find value `cid` in this scope
```

Only `for` iterators hit this — rsx `if` blocks render via a separate re-destructure path (`generate_if_block`), so the identical `if let` inside an rsx `if` compiled fine. That asymmetry is what made it surprising.

## Fix

Give `if let` / `while let` / `match` the same scope-frame treatment that closures and `let` already get:

- **`visit_expr_if`** / **`visit_expr_while`** push a `locals` frame, then call a new **`scan_cond`** helper on the condition. `scan_cond` visits each scrutinee expression in the *outer* scope (so the scrutinee's own identifiers are still captured) and adds the names bound by each pattern to the frame, so the branch body skips them. The `else` branch is visited *outside* the frame (it can't see the bindings).
- **`scan_cond`** also recurses through `&&` let-chains, so a later link correctly sees an earlier binding — `if let Some(x) = a && x > 0` treats `x` as bound, `a` as a capture.
- **`visit_arm`** scopes each `match` arm's pattern to that arm's guard and body; the scrutinee is still visited by the default `visit_expr_match` in the outer scope.

This mirrors the existing `visit_expr_closure` / `visit_local` handling — it's the `if let` analogue of the #32 fix.

## Tests

Added unit tests in the existing `mod tests`:
- `if_let_binding_is_not_a_capture` (the repro)
- `if_let_else_branch_does_not_see_binding`
- `match_arm_binding_is_not_a_capture`
- `while_let_binding_is_not_a_capture`
- `let_chain_later_link_sees_earlier_binding`

> Note: I couldn't run `cargo test -p rinch-macros` locally — its dev-dependency on the full `rinch` crate pulls in desktop GPU/windowing deps that need system `fontconfig`, which isn't available in my headless environment (the crate's Cargo.toml already documents this caveat). `cargo build -p rinch-macros` passes. I validated the fix **end-to-end** instead: a downstream app with the exact repro above fails to compile before this change and compiles cleanly after (via the local path dependency). Please confirm the new unit tests pass in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)