### PR TITLE
feat(editor): new ProseMirror-style rich-text editor (M0–M5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3289,6 +3289,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "new-editor-demo"
+version = "0.1.0"
+dependencies = [
+ "rinch",
+ "rinch-editor-core",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4615,6 +4623,7 @@ dependencies = [
  "rinch-dom",
  "rinch-editable",
  "rinch-editor",
+ "rinch-editor-core",
  "rinch-macros",
  "rinch-platform",
  "rinch-renderer",
@@ -4774,6 +4783,10 @@ name = "rinch-editor-core"
 version = "0.1.0"
 dependencies = [
  "pretty_assertions",
+ "pulldown-cmark",
+ "regex",
+ "serde",
+ "serde_json",
  "thiserror 1.0.69",
 ]
 

--- a/crates/rinch-core/Cargo.toml
+++ b/crates/rinch-core/Cargo.toml
@@ -11,6 +11,10 @@ theme = []
 # Derive serde on the contenteditable interchange types (BlockData /
 # InlineRunData / InlineMarkData) so downstream apps can persist CE content.
 serde = ["dep:serde"]
+# Expose `dom::mock::MockDomDocument`, a headless `DomDocument` test double, to
+# downstream crates' tests (e.g. the new editor view in `rinch`). Test-only —
+# enabled via dev-dependencies, never in a production build.
+test-util = []
 
 [dependencies]
 thiserror.workspace = true

--- a/crates/rinch-core/src/dom/mock.rs
+++ b/crates/rinch-core/src/dom/mock.rs
@@ -13,7 +13,6 @@ pub struct MockDomDocument {
 }
 
 struct MockNode {
-    #[allow(dead_code)]
     kind: MockNodeKind,
     text: String,
     attributes: std::collections::HashMap<String, String>,
@@ -21,7 +20,6 @@ struct MockNode {
     parent: Option<NodeId>,
 }
 
-#[allow(dead_code)] // tag is stored for debugging but not read
 enum MockNodeKind {
     Element(String),
     Text,
@@ -294,5 +292,37 @@ impl DomDocument for MockDomDocument {
 
     fn query_node_layout(&self, _node_id: u64) -> Option<(f32, f32, f32, f32)> {
         None // Mock returns None
+    }
+
+    fn tag_name(&self, node: NodeId) -> Option<String> {
+        match &self.nodes.get(&node)?.kind {
+            MockNodeKind::Element(tag) => Some(tag.clone()),
+            _ => None,
+        }
+    }
+
+    fn node_type(&self, node: NodeId) -> Option<u16> {
+        match &self.nodes.get(&node)?.kind {
+            MockNodeKind::Element(_) => Some(1),
+            MockNodeKind::Text => Some(3),
+            MockNodeKind::Comment => Some(8),
+        }
+    }
+
+    fn text_content(&self, node: NodeId) -> Option<String> {
+        let n = self.nodes.get(&node)?;
+        match n.kind {
+            MockNodeKind::Text | MockNodeKind::Comment => Some(n.text.clone()),
+            MockNodeKind::Element(_) => {
+                // Concatenate descendant text (depth-first), matching the real DOM.
+                let mut out = String::new();
+                for &child in &n.children {
+                    if let Some(t) = self.text_content(child) {
+                        out.push_str(&t);
+                    }
+                }
+                Some(out)
+            }
+        }
     }
 }

--- a/crates/rinch-core/src/dom/mod.rs
+++ b/crates/rinch-core/src/dom/mod.rs
@@ -69,8 +69,10 @@
 //! }
 //! ```
 
-#[cfg(test)]
-mod mock;
+/// A headless [`DomDocument`](traits::DomDocument) implementation for tests.
+/// Available to downstream test code via the `test-util` feature.
+#[cfg(any(test, feature = "test-util"))]
+pub mod mock;
 mod render_scope;
 pub mod traits;
 

--- a/crates/rinch-core/src/dom/traits.rs
+++ b/crates/rinch-core/src/dom/traits.rs
@@ -249,6 +249,18 @@ pub trait DomDocument {
     /// Returns the (x, y, width, height) of the node's layout box.
     fn query_node_layout(&self, node_id: u64) -> Option<(f32, f32, f32, f32)>;
 
+    /// Per-line selection rectangles `(x, y, width, height)`, layout-local to the
+    /// node's inline layout, covering the byte range `[a, b)`. Used to render a
+    /// text selection's highlight. Default: empty (no inline layout / mock).
+    fn query_selection_rects(
+        &self,
+        _node_id: u64,
+        _byte_a: usize,
+        _byte_b: usize,
+    ) -> Vec<(f32, f32, f32, f32)> {
+        Vec::new()
+    }
+
     /// Get the tag name of an element node.
     ///
     /// Returns `Some("div")`, `Some("p")`, etc. for elements, `None` for text/comment nodes.

--- a/crates/rinch-dom/src/dom_impl/dom_document_impl.rs
+++ b/crates/rinch-dom/src/dom_impl/dom_document_impl.rs
@@ -957,6 +957,23 @@ impl DomDocument for RinchDocument {
         caret_position_for_offset(self, node_id, byte_offset)
     }
 
+    fn query_selection_rects(
+        &self,
+        node_id: u64,
+        byte_a: usize,
+        byte_b: usize,
+    ) -> Vec<(f32, f32, f32, f32)> {
+        let Some(node) = self.tree.nodes.get(node_id as usize) else {
+            return Vec::new();
+        };
+        let layout = match (&node.text_layout, &node.cached_text_parley) {
+            (Some(inline), _) => &inline.layout,
+            (None, Some(layout)) => layout,
+            (None, None) => return Vec::new(),
+        };
+        crate::text_query::selection_rects_for_layout(layout, byte_a, byte_b)
+    }
+
     fn query_glyph_bounds(
         &self,
         node_id: u64,

--- a/crates/rinch-dom/src/text_query.rs
+++ b/crates/rinch-dom/src/text_query.rs
@@ -179,6 +179,36 @@ pub fn byte_offset_from_position(layout: &parley::layout::Layout<Brush>, x: f32,
     Cursor::from_point(layout, x, y).index()
 }
 
+/// Per-line selection rectangles `(x, y, width, height)` (layout-local) covering
+/// the byte range `[a, b)` in `layout`. One rect per visual line the range spans.
+/// Used to render a text selection's highlight.
+pub fn selection_rects_for_layout(
+    layout: &parley::layout::Layout<Brush>,
+    a: usize,
+    b: usize,
+) -> Vec<(f32, f32, f32, f32)> {
+    let (a, b) = if a <= b { (a, b) } else { (b, a) };
+    let mut rects = Vec::new();
+    for line in layout.lines() {
+        let range = line.text_range();
+        let start = a.max(range.start);
+        let end = b.min(range.end);
+        if start >= end {
+            continue;
+        }
+        let metrics = line.metrics();
+        let top = metrics.baseline - metrics.ascent;
+        let left = Cursor::from_byte_index(layout, start, Affinity::Downstream)
+            .geometry(layout, 0.0)
+            .x0 as f32;
+        let right = Cursor::from_byte_index(layout, end, Affinity::Downstream)
+            .geometry(layout, 0.0)
+            .x0 as f32;
+        rects.push((left, top, (right - left).max(1.0), metrics.line_height));
+    }
+    rects
+}
+
 // ── IFC ↔ DomCursor conversions ─────────────────────────────────────────
 
 /// Convert an IFC flat byte offset to a DOM cursor `(node_id, offset_within_node)`.

--- a/crates/rinch-dom/tests/virtualization_tests.rs
+++ b/crates/rinch-dom/tests/virtualization_tests.rs
@@ -1,0 +1,98 @@
+//! Isolation tests for the `estimated_height` block-collapse mechanism that
+//! block virtualization depends on.
+//!
+//! These reproduce the **new editor's** block structure — an element with a
+//! single text child, built directly through the `DomDocument` trait the way
+//! `RinchDomEditorView::ViewDesc::build` does (`<p data-pm-type="paragraph">` +
+//! a text child) — and verify rinch-dom honors `estimated_height` exactly the
+//! way `CeVirtualWindow` relies on. If a far off-screen editor paragraph keeps
+//! its full multi-line height after `estimated_height` is set, the collapse is
+//! broken at the layout layer (not in the driver). See the
+//! `project-editor-virtualization` handover.
+
+use rinch_core::dom::DomDocument;
+use rinch_dom::RinchDocument;
+
+/// Build a scroll container holding `n` paragraphs, each with text long enough
+/// to wrap onto several lines in a narrow (150px) column. Mirrors the editor's
+/// `<div data-pm-type="doc">` container with `<p data-pm-type="paragraph">`
+/// children. Returns `(container_id, block_ids)` (raw node ids).
+fn build_editor_like_doc(doc: &mut RinchDocument, n: usize) -> (usize, Vec<usize>) {
+    let body = doc.body();
+    let container = doc.create_element("div");
+    doc.set_attribute(container, "data-pm-type", "doc");
+    doc.set_attribute(
+        container,
+        "style",
+        "width: 150px; height: 300px; overflow-y: auto; position: relative",
+    );
+    doc.append_child(body, container);
+
+    let mut blocks = Vec::new();
+    for i in 0..n {
+        let p = doc.create_element("p");
+        doc.set_attribute(p, "data-pm-type", "paragraph");
+        doc.append_child(container, p);
+        let text = doc.create_text(&format!(
+            "Block {i} with plenty of words here so it wraps across at least two lines in a narrow column"
+        ));
+        doc.append_child(p, text);
+        blocks.push(p.0);
+    }
+    (container.0, blocks)
+}
+
+/// The editor `<p>` must be an IFC root — its text child carries
+/// `ifc_root == Some(<p>)`, which is what makes the `<p>` a
+/// `NodeContext::InlineRoot` Taffy leaf and lets the `estimated_height`
+/// short-circuit fire.
+#[test]
+fn editor_paragraph_text_child_points_at_its_ifc_root() {
+    let mut doc = RinchDocument::new();
+    let (_c, blocks) = build_editor_like_doc(&mut doc, 3);
+    doc.resolve_layout(400.0, 600.0);
+
+    for &p in &blocks {
+        let text_child = doc.tree.nodes[p].children[0];
+        assert_eq!(
+            doc.tree.nodes[text_child].ifc_root,
+            Some(p),
+            "the <p>'s text child must point at the <p> as its IFC root"
+        );
+    }
+}
+
+/// Setting `estimated_height` (with the same dirty markers `CeVirtualWindow`
+/// uses) on a far off-screen editor paragraph must collapse it to the estimate
+/// on the next layout pass.
+#[test]
+fn estimated_height_collapses_an_editor_paragraph() {
+    let mut doc = RinchDocument::new();
+    let (_c, blocks) = build_editor_like_doc(&mut doc, 80);
+    doc.resolve_layout(400.0, 600.0);
+
+    let probe = blocks[50];
+    let full_h = doc.tree.nodes[probe].layout.height;
+    assert!(
+        full_h > 30.0,
+        "expected a multi-line paragraph (>30px) before collapse, got {full_h}"
+    );
+
+    // Mimic CeVirtualWindow::new exactly: set the estimate + dirty markers.
+    for &b in &blocks[40..] {
+        doc.tree.nodes[b].estimated_height = Some(24.0);
+        doc.tree.style_dirty_nodes.push(b);
+    }
+    doc.tree.layout_dirty = true;
+    doc.tree.ifc_dirty = true;
+    doc.tree.styles_dirty = true;
+
+    doc.resolve_layout(400.0, 600.0);
+
+    let collapsed_h = doc.tree.nodes[probe].layout.height;
+    assert!(
+        (collapsed_h - 24.0).abs() < 1.0,
+        "block 50 should collapse to ~24px after estimated_height was set, \
+         got {collapsed_h} (full height was {full_h})"
+    );
+}

--- a/crates/rinch-editor-core/Cargo.toml
+++ b/crates/rinch-editor-core/Cargo.toml
@@ -7,12 +7,20 @@ description = "Pure, renderer-agnostic core of the Rinch rich-text editor: docum
 
 [dependencies]
 thiserror.workspace = true
-# NOTE (editor-rearchitecture milestones): regex (input rules, M4), serde (DocNode
-# wire shape, M3), and pulldown-cmark (markdown I/O, M3) are added by the milestone
-# that first needs them. M0 is schema-only. NO automerge / rinch-dom / winit ever.
+# Input rules (M4): markdown-shortcut pattern matching. Pure Rust, wasm-clean.
+regex = "1"
+# Total, attr-aware serialization (M3). Both optional and wasm-clean.
+# NO automerge / rinch-dom / winit ever.
+serde = { version = "1", optional = true, features = ["derive"] }
+pulldown-cmark = { version = "0.12", optional = true, default-features = false }
 
 [features]
 default = []
+# The durable, schema-derived DocNode wire shape (serialize/doc_json.rs).
+serde = ["dep:serde"]
+# Markdown I/O via pulldown-cmark (serialize/markdown.rs); benign, wasm-clean.
+markdown = ["dep:pulldown-cmark"]
 
 [dev-dependencies]
 pretty_assertions = "1"
+serde_json = "1"

--- a/crates/rinch-editor-core/src/command.rs
+++ b/crates/rinch-editor-core/src/command.rs
@@ -1,0 +1,55 @@
+//! [`Command`] — the unit of editing intent that toolbar buttons, keymap entries,
+//! and input rules resolve to.
+//!
+//! A command **queries the state and, if it applies, builds a transaction and
+//! dispatches it**, returning `true`. Called with `dispatch = None` it only reports
+//! applicability — which is exactly what a toolbar needs to enable/disable a
+//! button without performing the edit (design §5; amendment A20 fixes the command
+//! type to the closure form so a command can close over data like a heading level
+//! or a link href).
+//!
+//! ```ignore
+//! let toggle_bold: Command = Rc::new(|state, dispatch| {
+//!     // ... query state.selection / state.stored_marks ...
+//!     if let Some(dispatch) = dispatch { dispatch(tr); }
+//!     true
+//! });
+//! ```
+
+use crate::state::{EditorState, Transaction};
+use std::rc::Rc;
+
+/// The sink a command hands its built [`Transaction`] to. The runtime's dispatch
+/// is `|tr| new_state = state.apply(tr)`.
+pub type Dispatch<'a> = &'a mut dyn FnMut(Transaction);
+
+/// A command: `(state, Option<dispatch>) -> applied?`.
+///
+/// - With `Some(dispatch)`: if the command applies, it builds a transaction, calls
+///   `dispatch(tr)`, and returns `true`; otherwise returns `false` without
+///   dispatching.
+/// - With `None`: returns whether the command *would* apply (toolbar enablement),
+///   performing no edit.
+///
+/// `Transaction` owns its schema (no lifetime), so this is an ordinary
+/// `Fn` trait object — no lifetime parameter leaks into the alias.
+pub type Command = Rc<dyn Fn(&EditorState, Option<Dispatch>) -> bool>;
+
+/// Run two commands in sequence, stopping at the first that applies — the `chain`
+/// combinator from prosemirror-commands. Used to bind e.g. Backspace to
+/// "join-backward else delete-selection".
+pub fn chain(commands: Vec<Command>) -> Command {
+    Rc::new(move |state, dispatch| match dispatch {
+        Some(d) => {
+            for cmd in &commands {
+                // Reborrow `*d` for just this attempt (`Option<&mut _>` isn't Copy).
+                if cmd(state, Some(&mut *d)) {
+                    return true;
+                }
+            }
+            false
+        }
+        // Applicability query: any sub-command that would apply makes the chain apply.
+        None => commands.iter().any(|cmd| cmd(state, None)),
+    })
+}

--- a/crates/rinch-editor-core/src/commands/mod.rs
+++ b/crates/rinch-editor-core/src/commands/mod.rs
@@ -601,22 +601,107 @@ fn build_lift_after(state: &EditorState, cut: usize) -> Option<Transaction> {
     None
 }
 
+/// A wrapping chain of node types `[W1, .., Wn]` — PM `ContentMatch.findWrapping`
+/// adapted to the simplified content model — such that `before_type` can contain
+/// `W1`, each `Wi` can contain `Wi+1`, and `Wn` can contain `target_type`. A BFS
+/// over node types (edge `A → B` iff `A`'s content accepts `B`), depth-bounded.
+/// `None` if no chain exists. Used by [`wrap_into_before`] to move a block into a
+/// preceding container.
+fn find_wrapping(
+    schema: &crate::Schema,
+    before_type: &str,
+    target_type: &str,
+) -> Option<Vec<NodeType>> {
+    use std::collections::{HashSet, VecDeque};
+    // Deterministic candidate order (the node map is a HashMap).
+    let mut names: Vec<&str> = schema.nodes.keys().map(String::as_str).collect();
+    names.sort_unstable();
+    let is_container = |n: &str| schema.node_type(n).is_some_and(|t| !t.is_leaf());
+
+    let mut visited: HashSet<&str> = HashSet::new();
+    let mut queue: VecDeque<Vec<&str>> = VecDeque::new();
+    for &n in &names {
+        if schema.allows_child(before_type, n) && is_container(n) {
+            visited.insert(n);
+            queue.push_back(vec![n]);
+        }
+    }
+    while let Some(chain) = queue.pop_front() {
+        let last = *chain.last()?;
+        if schema.allows_child(last, target_type) {
+            return chain
+                .iter()
+                .map(|&n| schema.node_type(n).cloned())
+                .collect();
+        }
+        if chain.len() >= 4 {
+            continue; // depth bound — no real schema nests this deep
+        }
+        for &n in &names {
+            if !visited.contains(n) && schema.allows_child(last, n) && is_container(n) {
+                visited.insert(n);
+                let mut next = chain.clone();
+                next.push(n);
+                queue.push_back(next);
+            }
+        }
+    }
+    None
+}
+
+/// PM `deleteBarrier` find-wrapping branch: move the block just after `cut` into the
+/// container just before it, wrapped to fit — a paragraph after a bullet list
+/// becomes a new list item. `None` if the before-block isn't a container that can
+/// take the after-block (wrapped), or either side is isolating.
+fn wrap_into_before(state: &EditorState, cut: usize) -> Option<Transaction> {
+    let r_cut = state.doc.resolve(Pos(cut)).ok()?;
+    let before = r_cut.node_before()?;
+    let after = r_cut.node_after()?;
+    if before.node_type().spec().isolating || after.node_type().spec().isolating {
+        return None;
+    }
+    let conn = find_wrapping(state.schema(), before.type_name(), after.type_name())?;
+    // Build the wrapper chain innermost-first (`[list_item]` → `list_item(<gap>)`),
+    // then a copy of the `before` container around it, so the slice (open at the
+    // start) merges with the existing container. The gap (the after-block) fills the
+    // innermost wrapper via the `ReplaceAroundStep`.
+    let mut wrap = Fragment::empty();
+    for typ in conn.iter().rev() {
+        wrap = Fragment::from_node(Node::new_branch(typ.clone(), Attrs::default(), wrap));
+    }
+    let before_copy = before.copy_with_content(wrap);
+    let slice = crate::Slice::new(Fragment::from_node(before_copy), 1, 0);
+    let end = cut + after.node_size();
+    let mut tr = state.tr();
+    tr.step(Box::new(ReplaceAroundStep::new(
+        cut - 1,
+        end,
+        cut,
+        end,
+        slice,
+        conn.len(),
+        true,
+    )))
+    .ok()?;
+    tr.doc_changed().then_some(tr)
+}
+
 /// Backspace: delete the selection, else the char before the cursor, else — at the
-/// start of a textblock — join onto the previous block or lift this block out of
-/// its wrapper.
+/// start of a textblock — join onto the previous block, move into a preceding
+/// container, or lift this block out of its wrapper.
 ///
-/// At block start this is PM's `joinBackward`/`deleteBarrier` (the common cases):
-/// it joins across the nearest cut with a **structural** replace of the boundary
-/// token pair (its own undo group, never coalesced into typing), and when that
-/// crosses a wrapper boundary it cannot join directly — into a blockquote or list
-/// item — it instead **lifts** this block out of the wrapper, so a second
-/// Backspace then joins.
+/// At block start this is PM's `joinBackward`/`deleteBarrier`: it joins across the
+/// nearest cut with a **structural** replace of the boundary token pair (its own
+/// undo group, never coalesced into typing); when it cannot join directly but the
+/// block before the cut is a **container** that can take this block (wrapped) — a
+/// paragraph after a list — it **moves the block in** as a new item
+/// ([`wrap_into_before`], the find-wrapping branch); and when it crosses a wrapper
+/// boundary from *inside* — a block at the start of a blockquote / list item — it
+/// **lifts** this block out of the wrapper, so a second Backspace then joins.
 ///
-/// Not yet ported (the remaining `deleteBarrier` branches; they need
-/// `ContentMatch::find_wrapping`, and belong with the M5.6 keyboard integration):
-/// the **wrap-and-move** branch — Backspace at the start of a paragraph that
-/// *follows* a list moves the paragraph into the list as a new item (currently a
-/// no-op here) — and the **content-move** + select-node-backward branches.
+/// Not ported (rare `deleteBarrier` tails): the content-move `ReplaceAround` (merge
+/// into the before-container's last textblock) and select-node-backward (atom
+/// delete) branches.
 pub fn delete_char_backward() -> Command {
     command_tr(|state| {
         let sel = &state.selection;
@@ -636,7 +721,8 @@ pub fn delete_char_backward() -> Command {
             tr.delete(pos - 1, pos).ok()?;
             return tr.doc_changed().then_some(tr);
         }
-        // At block start: join across the nearest cut, else lift out of the wrapper.
+        // At block start: join across the nearest cut, else move into the preceding
+        // container, else lift out of the wrapper.
         if let Some(cut) = find_cut_before(&r) {
             let mut tr = state.tr();
             if tr
@@ -648,6 +734,11 @@ pub fn delete_char_backward() -> Command {
                 .is_ok()
                 && tr.doc_changed()
             {
+                return Some(tr);
+            }
+            // Could not join directly across the cut — try moving this block into
+            // the container before it (a paragraph after a list → a new list item).
+            if let Some(tr) = wrap_into_before(state, cut) {
                 return Some(tr);
             }
         }
@@ -878,6 +969,58 @@ mod tests {
         let back = list.run("toggleBulletList").expect("lift out of list");
         assert!(!in_node_type(&back, "bullet_list"));
         assert_eq!(back.doc.child(0).type_name(), "paragraph");
+    }
+
+    #[test]
+    fn backspace_at_paragraph_after_list_moves_it_into_the_list() {
+        // doc(bullet_list(li(p"a"), li(p"b")), paragraph "c"); Backspace at the start
+        // of "c" moves it into the list as a third item (PM deleteBarrier findWrapping).
+        let s = Rc::new(Schema::starter_kit());
+        let li = |t: &str| {
+            s.branch(
+                "list_item",
+                Fragment::from_node(
+                    s.branch("paragraph", Fragment::from_node(s.text(t).unwrap()))
+                        .unwrap(),
+                ),
+            )
+            .unwrap()
+        };
+        let list = s
+            .branch(
+                "bullet_list",
+                Fragment::from_children(vec![li("a"), li("b")]),
+            )
+            .unwrap();
+        let para = s
+            .branch("paragraph", Fragment::from_node(s.text("c").unwrap()))
+            .unwrap();
+        let doc = s
+            .branch("doc", Fragment::from_children(vec![list, para]))
+            .unwrap();
+        let mut state = EditorState::create(s, doc, vec![Rc::new(BaseCommandsPlugin)]);
+
+        // Cursor at the start of "c" — just inside the paragraph after the list.
+        let list_size = state.doc.child(0).node_size();
+        state.selection = Selection::cursor(Pos(list_size + 1));
+
+        let next = state
+            .run("deleteCharBackward")
+            .expect("backspace moves the paragraph into the list");
+        assert_eq!(
+            next.doc.child_count(),
+            1,
+            "only the list remains at top level"
+        );
+        let list = next.doc.child(0);
+        assert_eq!(list.type_name(), "bullet_list");
+        assert_eq!(list.child_count(), 3, "a third list item was added");
+        assert_eq!(list.child(2).type_name(), "list_item");
+        assert_eq!(list.child(2).child(0).type_name(), "paragraph");
+        assert_eq!(all_text(list.child(2)), "c");
+        // The first two items are untouched.
+        assert_eq!(all_text(list.child(0)), "a");
+        assert_eq!(all_text(list.child(1)), "b");
     }
 
     #[test]

--- a/crates/rinch-editor-core/src/commands/mod.rs
+++ b/crates/rinch-editor-core/src/commands/mod.rs
@@ -1,0 +1,1308 @@
+//! The built-in command catalogue (design §5 / amendment A6) and the toolbar
+//! queries that drive button enabled/active state — all reading **state**, never
+//! the DOM (the structural fix for the old `with_active_ce_api(...).has_active_mark`
+//! anti-pattern).
+//!
+//! Commands compose the [`Transaction`] gesture API; structural commands use the
+//! "attempt the steps, let the schema gate decide" pattern, so applicability and
+//! execution share one code path and an invalid edit is reported as inapplicable
+//! rather than producing a broken document.
+
+use std::rc::Rc;
+
+use crate::Fragment;
+use crate::command::{Command, chain};
+use crate::keymap::KeyBinding;
+use crate::model::{Attrs, Mark, MarkType, Node, NodeType};
+use crate::plugin::{Plugin, PluginKey};
+use crate::pos::{Pos, ResolvedPos};
+use crate::state::{EditorState, Transaction};
+use crate::transform::steps::{ReplaceAroundStep, ReplaceStep};
+use crate::transform::{block_range, block_range_simple};
+
+// ===================================================================
+// Toolbar queries — read state, never the host (A6)
+// ===================================================================
+
+/// The marks active at a position (what a character typed there would inherit).
+pub fn marks_at(state: &EditorState, pos: usize) -> Vec<Mark> {
+    state
+        .doc
+        .resolve(Pos(pos))
+        .map(|r| r.marks())
+        .unwrap_or_default()
+}
+
+/// True if any inline node in `from..to` carries a mark of `mark_type` (PM's
+/// `rangeHasMark`).
+pub fn range_has_mark(doc: &Node, from: usize, to: usize, mark_type: &MarkType) -> bool {
+    if to <= from {
+        return false;
+    }
+    let mut found = false;
+    doc.nodes_between(from, to, &mut |node, _pos, _parent| {
+        if !found && node.is_inline() && node.marks().iter().any(|m| &m.typ == mark_type) {
+            found = true;
+        }
+        !found
+    });
+    found
+}
+
+/// Whether `mark_type` is active for the current selection — for a collapsed cursor,
+/// whether it is in the stored/inherited marks; for a range, whether the range has
+/// the mark. Drives a toolbar button's "on" state.
+pub fn is_mark_active(state: &EditorState, mark_type: &MarkType) -> bool {
+    let sel = &state.selection;
+    if sel.is_empty() {
+        let marks = state
+            .stored_marks
+            .clone()
+            .unwrap_or_else(|| marks_at(state, sel.from().0));
+        marks.iter().any(|m| &m.typ == mark_type)
+    } else {
+        range_has_mark(&state.doc, sel.from().0, sel.to().0, mark_type)
+    }
+}
+
+/// The node type of the textblock at the selection head — drives the block-style
+/// dropdown's current value.
+pub fn current_block_type(state: &EditorState) -> Option<NodeType> {
+    let r = state.doc.resolve(state.selection.head()).ok()?;
+    Some(r.parent().node_type().clone())
+}
+
+/// Whether any ancestor of the selection head is of `type_name` — drives the
+/// List/Blockquote button active-state (A6: `current_block_type` alone can't,
+/// because the textblock stays `paragraph` inside a `list_item`).
+pub fn in_node_type(state: &EditorState, type_name: &str) -> bool {
+    if let Ok(r) = state.doc.resolve(state.selection.head()) {
+        for d in 0..=r.depth() {
+            if r.node(d).type_name() == type_name {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Whether the outdent (lift) command currently applies.
+pub fn can_lift(state: &EditorState) -> bool {
+    build_lift(state).is_some()
+}
+
+/// Whether the indent (sink list item) command currently applies.
+pub fn can_sink(state: &EditorState) -> bool {
+    build_sink(state, "list_item").is_some()
+}
+
+// ===================================================================
+// Command plumbing
+// ===================================================================
+
+/// Wrap a transaction-builder into a [`Command`]. The builder returns `Some(tr)`
+/// when the command applies (even a stored-marks-only transaction with no doc
+/// change), or `None` when it does not.
+fn command_tr(build: impl Fn(&EditorState) -> Option<Transaction> + 'static) -> Command {
+    Rc::new(move |state, dispatch| match build(state) {
+        Some(tr) => {
+            if let Some(d) = dispatch {
+                d(tr);
+            }
+            true
+        }
+        None => false,
+    })
+}
+
+// ===================================================================
+// Marks
+// ===================================================================
+
+/// Toggle a simple (attribute-less) mark: bold, italic, underline, strike, code,
+/// subscript, superscript, highlight. For a collapsed cursor this flips the stored
+/// marks (the "click bold then type" path); for a range it adds or removes the
+/// mark across it (remove if the range already has it anywhere — PM's toggle).
+pub fn toggle_mark(mark_type: &'static str) -> Command {
+    command_tr(move |state| {
+        let mt = state.schema().mark_type(mark_type)?.clone();
+        let sel = &state.selection;
+        let mut tr = state.tr();
+        if sel.is_empty() {
+            let marks = state
+                .stored_marks
+                .clone()
+                .unwrap_or_else(|| marks_at(state, sel.from().0));
+            let mark = Mark::simple(mt.clone());
+            if marks.iter().any(|m| m.typ == mt) {
+                tr.remove_stored_mark(&mark);
+            } else {
+                tr.add_stored_mark(mark);
+            }
+        } else {
+            let (from, to) = (sel.from().0, sel.to().0);
+            let mark = Mark::simple(mt.clone());
+            if range_has_mark(&state.doc, from, to, &mt) {
+                tr.remove_mark(from, to, mark).ok()?;
+            } else {
+                tr.add_mark(from, to, mark).ok()?;
+            }
+        }
+        Some(tr)
+    })
+}
+
+/// Apply a `link` mark with `href` across the selection (no-op for a collapsed
+/// cursor — a link needs a range). A builder (the href is supplied at call time).
+pub fn toggle_link(href: String) -> Command {
+    command_tr(move |state| {
+        let mt = state.schema().mark_type("link")?.clone();
+        let sel = &state.selection;
+        if sel.is_empty() {
+            return None;
+        }
+        let (from, to) = (sel.from().0, sel.to().0);
+        let mut tr = state.tr();
+        if range_has_mark(&state.doc, from, to, &mt) {
+            // Remove every link in the range, regardless of href.
+            remove_marks_of_type(&mut tr, &state.doc, from, to, &mt).ok()?;
+        } else {
+            let attrs = Attrs::from_iter([("href", crate::AttrValue::from(href.clone()))]);
+            tr.add_mark(from, to, Mark::new(mt.clone(), attrs)).ok()?;
+        }
+        Some(tr)
+    })
+}
+
+/// Remove all `link` marks from the selection.
+pub fn remove_link() -> Command {
+    command_tr(|state| {
+        let mt = state.schema().mark_type("link")?.clone();
+        let sel = &state.selection;
+        let (from, to) = (sel.from().0, sel.to().0);
+        if to <= from || !range_has_mark(&state.doc, from, to, &mt) {
+            return None;
+        }
+        let mut tr = state.tr();
+        remove_marks_of_type(&mut tr, &state.doc, from, to, &mt).ok()?;
+        Some(tr)
+    })
+}
+
+/// Remove every mark of `mark_type` (any attrs) from `from..to`.
+fn remove_marks_of_type(
+    tr: &mut Transaction,
+    doc: &Node,
+    from: usize,
+    to: usize,
+    mark_type: &MarkType,
+) -> Result<(), crate::transform::StepError> {
+    let mut targets: Vec<Mark> = Vec::new();
+    doc.nodes_between(from, to, &mut |node, _pos, _parent| {
+        for m in node.marks() {
+            if &m.typ == mark_type && !targets.contains(m) {
+                targets.push(m.clone());
+            }
+        }
+        true
+    });
+    for m in targets {
+        tr.remove_mark(from, to, m)?;
+    }
+    Ok(())
+}
+
+// ===================================================================
+// Block types
+// ===================================================================
+
+/// Set every textblock overlapping the selection to `node_type` with `attrs` —
+/// `setParagraph` / `setHeading{level}` / `setCodeBlock`. Applies only if some
+/// textblock in range does not already have that markup.
+pub fn set_block_type(node_type: &'static str, attrs: Attrs) -> Command {
+    command_tr(move |state| {
+        let ty = state.schema().node_type(node_type)?.clone();
+        if !ty.is_textblock() {
+            return None;
+        }
+        let (from, to) = (state.selection.from().0, state.selection.to().0);
+        let mut applies = false;
+        state
+            .doc
+            .nodes_between(from, to, &mut |node, _pos, _parent| {
+                if node.is_textblock() && !node.has_markup(&ty, &attrs) {
+                    applies = true;
+                }
+                true
+            });
+        if !applies {
+            return None;
+        }
+        let mut tr = state.tr();
+        tr.set_block_type(from, to, ty, attrs.clone()).ok()?;
+        tr.doc_changed().then_some(tr)
+    })
+}
+
+// ===================================================================
+// Wrapping: blockquote, lists, lift/sink
+// ===================================================================
+
+/// Wrap the selected block range in `node_type` (e.g. `wrapInBlockquote`).
+pub fn wrap_in(node_type: &'static str) -> Command {
+    command_tr(move |state| {
+        let ty = state.schema().node_type(node_type)?.clone();
+        let r_from = state.doc.resolve(state.selection.from()).ok()?;
+        let r_to = state.doc.resolve(state.selection.to()).ok()?;
+        let range = block_range_simple(&r_from, &r_to)?;
+        let mut tr = state.tr();
+        tr.wrap(&range, &[(ty, Attrs::new())]).ok()?;
+        tr.doc_changed().then_some(tr)
+    })
+}
+
+/// Toggle a list of `list_type` (`toggleBulletList` / `toggleOrderedList`): wrap
+/// the block range into `list > list_item` if not already in that list, or lift it
+/// out if it is. **Wrap/lift, NOT set_block_type** (A6).
+pub fn toggle_list(list_type: &'static str) -> Command {
+    command_tr(move |state| {
+        if in_node_type(state, list_type) {
+            build_lift(state)
+        } else {
+            build_wrap_in_list(state, list_type)
+        }
+    })
+}
+
+/// Build the wrap-into-list transaction.
+fn build_wrap_in_list(state: &EditorState, list_type: &str) -> Option<Transaction> {
+    let list_ty = state.schema().node_type(list_type)?.clone();
+    let item_name = if list_type == "task_list" {
+        "task_item"
+    } else {
+        "list_item"
+    };
+    let item_ty = state.schema().node_type(item_name)?.clone();
+    let r_from = state.doc.resolve(state.selection.from()).ok()?;
+    let r_to = state.doc.resolve(state.selection.to()).ok()?;
+    let range = block_range_simple(&r_from, &r_to)?;
+    let mut tr = state.tr();
+    tr.wrap(&range, &[(list_ty, Attrs::new()), (item_ty, Attrs::new())])
+        .ok()?;
+    tr.doc_changed().then_some(tr)
+}
+
+/// The outdent / lift command: lift the selected block range out of its enclosing
+/// wrapper (list, blockquote). Tries the deepest valid target first.
+pub fn lift() -> Command {
+    command_tr(build_lift)
+}
+
+/// Build the lift transaction, choosing the shallowest schema-valid target depth.
+fn build_lift(state: &EditorState) -> Option<Transaction> {
+    let r_from = state.doc.resolve(state.selection.from()).ok()?;
+    let r_to = state.doc.resolve(state.selection.to()).ok()?;
+    let range = block_range_simple(&r_from, &r_to)?;
+    if range.depth == 0 {
+        return None;
+    }
+    // Try lifting to each target from one level out (depth-1) down to the doc;
+    // the schema gate rejects invalid targets, so the first that applies wins.
+    for target in (0..range.depth).rev() {
+        let mut tr = state.tr();
+        if tr.lift(&range, target).is_ok() && tr.doc_changed() {
+            return Some(tr);
+        }
+    }
+    None
+}
+
+/// The indent / sink-list-item command: nest the current list item under its
+/// previous sibling. Port of PM's `sinkListItem` (without the `nestedBefore`
+/// merge optimization).
+pub fn sink_list_item(item_type: &'static str) -> Command {
+    command_tr(move |state| build_sink(state, item_type))
+}
+
+/// Build the sink (indent) transaction.
+fn build_sink(state: &EditorState, item_type: &str) -> Option<Transaction> {
+    let item_ty = state.schema().node_type(item_type)?.clone();
+    let r_from = state.doc.resolve(state.selection.from()).ok()?;
+    let r_to = state.doc.resolve(state.selection.to()).ok()?;
+    let range = block_range(&r_from, &r_to, |n| {
+        n.child_count() > 0 && n.child(0).node_type() == &item_ty
+    })?;
+    let start_index = range.start_index();
+    if start_index == 0 {
+        return None;
+    }
+    let parent = range.parent();
+    let node_before = parent.child(start_index - 1);
+    if node_before.node_type() != &item_ty {
+        return None;
+    }
+    // Build a `list_item(list())` shell; the ReplaceAroundStep drops the current
+    // item into the inner list, joining onto the previous item.
+    let list_ty = parent.node_type().clone();
+    let inner_list = Node::new_branch(list_ty, parent.attrs().clone(), Fragment::empty());
+    let new_item = Node::new_branch(
+        item_ty.clone(),
+        Attrs::new(),
+        Fragment::from_node(inner_list),
+    );
+    let slice = crate::Slice::new(Fragment::from_node(new_item), 1, 0);
+    let before = range.start();
+    let after = range.end();
+    let mut tr = state.tr();
+    tr.step(Box::new(ReplaceAroundStep::new(
+        before - 1,
+        after,
+        before,
+        after,
+        slice,
+        1,
+        true,
+    )))
+    .ok()?;
+    tr.doc_changed().then_some(tr)
+}
+
+// ===================================================================
+// Structure & deletion
+// ===================================================================
+
+/// Split the current textblock at the cursor (Enter). Deletes a non-empty
+/// selection first; at the end of a heading, the new block becomes a paragraph.
+pub fn split_block() -> Command {
+    command_tr(|state| {
+        let mut tr = state.tr();
+        if !state.selection.is_empty() {
+            tr.delete_selection().ok()?;
+        }
+        let pos = tr.selection().from().0;
+        let r = tr.doc().resolve(Pos(pos)).ok()?;
+        if r.depth() < 1 {
+            return None;
+        }
+        let parent = r.parent();
+        let at_end = r.parent_offset() == parent.content().size();
+        let types_after = if at_end && parent.type_name() == "heading" {
+            let para = state.schema().node_type("paragraph")?.clone();
+            Some(vec![Some((para, Attrs::new()))])
+        } else {
+            None
+        };
+        tr.split(pos, 1, types_after).ok()?;
+        Some(tr)
+    })
+}
+
+/// Split the current list item into a new one (Enter inside a list). Port of
+/// ProseMirror's `splitListItem`: when the cursor is in a textblock whose parent
+/// is `item_type` (e.g. `list_item`), split **two levels** so the text after the
+/// cursor moves into a fresh sibling item. Returns `None` (inapplicable) when not
+/// in a list item or when the item's textblock is empty — the [`split_block_or_list_item`]
+/// chain then falls through to [`lift_empty_block`] (which exits the list).
+pub fn split_list_item(item_type: &'static str) -> Command {
+    command_tr(move |state| {
+        let r_from = state.doc.resolve(state.selection.from()).ok()?;
+        let r_to = state.doc.resolve(state.selection.to()).ok()?;
+        // Need at least `… > item > textblock` so node(depth-1) is the item, and a
+        // selection contained within one textblock.
+        if r_from.depth() < 2
+            || r_from.depth() != r_to.depth()
+            || r_from.start(r_from.depth()) != r_to.start(r_to.depth())
+        {
+            return None;
+        }
+        if r_from.node(r_from.depth() - 1).type_name() != item_type {
+            return None;
+        }
+        // Empty textblock → not a split; let the chain lift it out of the list.
+        if r_from.parent().content().size() == 0 {
+            return None;
+        }
+        let mut tr = state.tr();
+        if !state.selection.is_empty() {
+            tr.delete_selection().ok()?;
+        }
+        let pos = tr.selection().from().0;
+        let r = tr.doc().resolve(Pos(pos)).ok()?;
+        // At the end of the textblock the new item starts with the list item's
+        // default content (a paragraph) rather than copying a heading/code block.
+        let at_end = r.parent_offset() == r.parent().content().size();
+        let types = if at_end {
+            let para = state.schema().node_type("paragraph")?.clone();
+            // [outer = item (keep its type), inner = the new default textblock]
+            Some(vec![None, Some((para, Attrs::new()))])
+        } else {
+            None
+        };
+        tr.split(pos, 2, types).ok()?;
+        Some(tr)
+    })
+}
+
+/// Lift an empty textblock out of its wrapper (PM `liftEmptyBlock`): pressing Enter
+/// in an empty list item / blockquote paragraph exits it. If the empty block is not
+/// the last child of its parent, split the parent before it instead.
+pub fn lift_empty_block() -> Command {
+    command_tr(|state| {
+        if !state.selection.is_empty() {
+            return None;
+        }
+        let r = state.doc.resolve(state.selection.from()).ok()?;
+        if r.parent().content().size() != 0 {
+            return None;
+        }
+        // Not the last child of its grandparent → split the grandparent before it.
+        if r.depth() >= 2
+            && r.after(r.depth()) != Some(r.end(r.depth() - 1))
+            && let Some(before) = r.before(r.depth())
+        {
+            let mut tr = state.tr();
+            if tr.split(before, 1, None).is_ok() && tr.doc_changed() {
+                return Some(tr);
+            }
+        }
+        // Otherwise lift the empty block out of its wrapper (exits a list, etc.).
+        build_lift(state)
+    })
+}
+
+/// The Enter handler (`splitBlock` is the toolbar/programmatic name; Enter binds
+/// here): split a list item into a new item, else lift an empty block out of its
+/// wrapper, else split the current block.
+pub fn split_block_or_list_item() -> Command {
+    chain(vec![
+        split_list_item("list_item"),
+        lift_empty_block(),
+        split_block(),
+    ])
+}
+
+/// Insert a hard break at the cursor (Shift+Enter).
+pub fn insert_hard_break() -> Command {
+    command_tr(|state| {
+        let hb = state
+            .schema()
+            .create_node("hard_break", Attrs::new(), Fragment::empty())
+            .ok()?;
+        let mut tr = state.tr();
+        tr.replace_selection_with(hb).ok()?;
+        Some(tr)
+    })
+}
+
+/// Insert a horizontal rule, replacing the selection.
+pub fn insert_horizontal_rule() -> Command {
+    command_tr(|state| {
+        let hr = state
+            .schema()
+            .create_node("horizontal_rule", Attrs::new(), Fragment::empty())
+            .ok()?;
+        let mut tr = state.tr();
+        tr.replace_selection_with(hr).ok()?;
+        Some(tr)
+    })
+}
+
+/// Insert an image with `src`/`alt`, replacing the selection. A builder.
+pub fn insert_image(src: String, alt: String) -> Command {
+    command_tr(move |state| {
+        let attrs = Attrs::from_iter([
+            ("src", crate::AttrValue::from(src.clone())),
+            ("alt", crate::AttrValue::from(alt.clone())),
+        ]);
+        let img = state
+            .schema()
+            .create_node("image", attrs, Fragment::empty())
+            .ok()?;
+        let mut tr = state.tr();
+        tr.replace_selection_with(img).ok()?;
+        Some(tr)
+    })
+}
+
+/// Delete the current selection (only applies when it is non-empty).
+pub fn delete_selection() -> Command {
+    command_tr(|state| {
+        if state.selection.is_empty() {
+            return None;
+        }
+        let mut tr = state.tr();
+        tr.delete_selection().ok()?;
+        Some(tr)
+    })
+}
+
+/// PM `findCutBefore`: the document position just before the nearest ancestor of
+/// the cursor (walking up from it) that has a sibling before it — the boundary a
+/// Backspace at block-start would join across. `None` when the cursor is at the
+/// very start of its top-level context (so Backspace should *lift*, not join).
+/// Stops at (and never crosses) an isolating boundary (e.g. a table cell, M7).
+fn find_cut_before(r: &ResolvedPos) -> Option<usize> {
+    if r.parent().node_type().spec().isolating {
+        return None;
+    }
+    let mut depth = r.depth() as isize - 1;
+    while depth >= 0 {
+        let d = depth as usize;
+        if r.index(d) > 0 {
+            return r.before(d + 1);
+        }
+        if r.node(d).node_type().spec().isolating {
+            break;
+        }
+        depth -= 1;
+    }
+    None
+}
+
+/// PM `findCutAfter`: the mirror of [`find_cut_before`] — the position just after
+/// the nearest ancestor that has a sibling after it, the boundary a forward-Delete
+/// at block-end joins across.
+fn find_cut_after(r: &ResolvedPos) -> Option<usize> {
+    if r.parent().node_type().spec().isolating {
+        return None;
+    }
+    let mut depth = r.depth() as isize - 1;
+    while depth >= 0 {
+        let d = depth as usize;
+        let parent = r.node(d);
+        if r.index(d) + 1 < parent.child_count() {
+            return r.after(d + 1);
+        }
+        if parent.node_type().spec().isolating {
+            break;
+        }
+        depth -= 1;
+    }
+    None
+}
+
+/// Lift the block that begins just after `cut` out of its wrapper (PM
+/// `deleteBarrier`'s lift path, used when a forward-Delete can't directly join
+/// across the barrier). Returns `None` if there is no liftable block there.
+fn build_lift_after(state: &EditorState, cut: usize) -> Option<Transaction> {
+    let sel_after = crate::selection::Selection::near(&state.doc, Pos(cut), 1);
+    let r_from = state.doc.resolve(sel_after.from()).ok()?;
+    let r_to = state.doc.resolve(sel_after.to()).ok()?;
+    let range = block_range_simple(&r_from, &r_to)?;
+    if range.depth == 0 {
+        return None;
+    }
+    for target in (0..range.depth).rev() {
+        let mut tr = state.tr();
+        if tr.lift(&range, target).is_ok() && tr.doc_changed() {
+            return Some(tr);
+        }
+    }
+    None
+}
+
+/// Backspace: delete the selection, else the char before the cursor, else — at the
+/// start of a textblock — join onto the previous block or lift this block out of
+/// its wrapper.
+///
+/// At block start this is PM's `joinBackward`/`deleteBarrier` (the common cases):
+/// it joins across the nearest cut with a **structural** replace of the boundary
+/// token pair (its own undo group, never coalesced into typing), and when that
+/// crosses a wrapper boundary it cannot join directly — into a blockquote or list
+/// item — it instead **lifts** this block out of the wrapper, so a second
+/// Backspace then joins.
+///
+/// Not yet ported (the remaining `deleteBarrier` branches; they need
+/// `ContentMatch::find_wrapping`, and belong with the M5.6 keyboard integration):
+/// the **wrap-and-move** branch — Backspace at the start of a paragraph that
+/// *follows* a list moves the paragraph into the list as a new item (currently a
+/// no-op here) — and the **content-move** + select-node-backward branches.
+pub fn delete_char_backward() -> Command {
+    command_tr(|state| {
+        let sel = &state.selection;
+        if !sel.is_empty() {
+            let mut tr = state.tr();
+            tr.delete_selection().ok()?;
+            return Some(tr);
+        }
+        let pos = sel.from().0;
+        if pos == 0 {
+            return None;
+        }
+        let r = state.doc.resolve(Pos(pos)).ok()?;
+        if r.parent_offset() > 0 {
+            // Mid-text: delete the char before the cursor.
+            let mut tr = state.tr();
+            tr.delete(pos - 1, pos).ok()?;
+            return tr.doc_changed().then_some(tr);
+        }
+        // At block start: join across the nearest cut, else lift out of the wrapper.
+        if let Some(cut) = find_cut_before(&r) {
+            let mut tr = state.tr();
+            if tr
+                .step(Box::new(ReplaceStep::structural(
+                    cut - 1,
+                    cut + 1,
+                    crate::Slice::empty(),
+                )))
+                .is_ok()
+                && tr.doc_changed()
+            {
+                return Some(tr);
+            }
+        }
+        build_lift(state)
+    })
+}
+
+/// Delete forward: delete the selection, else the char after the cursor, else — at
+/// the end of a textblock — join the next block onto this one, or lift the next
+/// block out of its wrapper across the barrier (PM `joinForward`/`deleteBarrier`;
+/// see [`delete_char_backward`]). Unlike Backspace there is no "no cut → lift"
+/// case: with nothing after, forward-Delete is a no-op.
+pub fn delete_char_forward() -> Command {
+    command_tr(|state| {
+        let sel = &state.selection;
+        if !sel.is_empty() {
+            let mut tr = state.tr();
+            tr.delete_selection().ok()?;
+            return Some(tr);
+        }
+        let pos = sel.from().0;
+        let r = state.doc.resolve(Pos(pos)).ok()?;
+        if r.parent_offset() < r.parent().content().size() {
+            // Mid-text: delete the char after the cursor.
+            let mut tr = state.tr();
+            tr.delete(pos, pos + 1).ok()?;
+            return tr.doc_changed().then_some(tr);
+        }
+        // At block end: join across the nearest cut, else lift the next block out.
+        let cut = find_cut_after(&r)?;
+        let mut tr = state.tr();
+        if tr
+            .step(Box::new(ReplaceStep::structural(
+                cut - 1,
+                cut + 1,
+                crate::Slice::empty(),
+            )))
+            .is_ok()
+            && tr.doc_changed()
+        {
+            return Some(tr);
+        }
+        build_lift_after(state, cut)
+    })
+}
+
+// ===================================================================
+// The base-editing plugin (commands + keymap)
+// ===================================================================
+
+/// Bundles the built-in command catalogue and its default key bindings as a
+/// [`Plugin`]. History (undo/redo) and markdown input rules are separate plugins.
+#[derive(Debug, Default)]
+pub struct BaseCommandsPlugin;
+
+impl Plugin for BaseCommandsPlugin {
+    fn key(&self) -> PluginKey {
+        PluginKey("base-commands")
+    }
+
+    fn commands(&self) -> Vec<(&'static str, Command)> {
+        let mut cmds: Vec<(&'static str, Command)> = vec![
+            ("toggleBold", toggle_mark("bold")),
+            ("toggleItalic", toggle_mark("italic")),
+            ("toggleUnderline", toggle_mark("underline")),
+            ("toggleStrike", toggle_mark("strike")),
+            ("toggleCode", toggle_mark("code")),
+            ("toggleSubscript", toggle_mark("subscript")),
+            ("toggleSuperscript", toggle_mark("superscript")),
+            ("toggleHighlight", toggle_mark("highlight")),
+            ("removeLink", remove_link()),
+            ("setParagraph", set_block_type("paragraph", Attrs::new())),
+            ("setCodeBlock", set_block_type("code_block", Attrs::new())),
+            ("toggleBulletList", toggle_list("bullet_list")),
+            ("toggleOrderedList", toggle_list("ordered_list")),
+            ("wrapInBlockquote", wrap_in("blockquote")),
+            ("liftListItem", lift()),
+            ("outdent", lift()),
+            ("sinkListItem", sink_list_item("list_item")),
+            ("indent", sink_list_item("list_item")),
+            ("insertHorizontalRule", insert_horizontal_rule()),
+            ("insertHardBreak", insert_hard_break()),
+            ("splitBlock", split_block()),
+            ("splitListItem", split_list_item("list_item")),
+            ("enter", split_block_or_list_item()),
+            ("deleteSelection", delete_selection()),
+            ("deleteCharBackward", delete_char_backward()),
+            ("deleteCharForward", delete_char_forward()),
+        ];
+        for level in 1..=6i64 {
+            let name: &'static str = match level {
+                1 => "setHeading1",
+                2 => "setHeading2",
+                3 => "setHeading3",
+                4 => "setHeading4",
+                5 => "setHeading5",
+                _ => "setHeading6",
+            };
+            let attrs = Attrs::from_iter([("level", crate::AttrValue::Int(level))]);
+            cmds.push((name, set_block_type("heading", attrs)));
+        }
+        cmds
+    }
+
+    fn keymap(&self) -> Vec<(KeyBinding, &'static str)> {
+        [
+            ("Mod-b", "toggleBold"),
+            ("Mod-i", "toggleItalic"),
+            ("Mod-u", "toggleUnderline"),
+            ("Mod-Shift-s", "toggleStrike"),
+            ("Mod-e", "toggleCode"),
+            ("Enter", "enter"),
+            ("Shift-Enter", "insertHardBreak"),
+            ("Backspace", "deleteCharBackward"),
+            ("Delete", "deleteCharForward"),
+            ("Tab", "sinkListItem"),
+            ("Shift-Tab", "liftListItem"),
+            ("Mod-Shift-8", "toggleBulletList"),
+            ("Mod-Shift-9", "toggleOrderedList"),
+            ("Mod-Shift-b", "wrapInBlockquote"),
+            ("Mod-Shift-0", "setParagraph"),
+            ("Mod-Alt-1", "setHeading1"),
+            ("Mod-Alt-2", "setHeading2"),
+            ("Mod-Alt-3", "setHeading3"),
+        ]
+        .into_iter()
+        .filter_map(|(b, cmd)| KeyBinding::parse(b).map(|kb| (kb, cmd)))
+        .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::selection::Selection;
+    use crate::{Schema, default_plugins};
+
+    fn editor(text: &str) -> EditorState {
+        let s = Rc::new(Schema::starter_kit());
+        let para = s
+            .branch("paragraph", Fragment::from_node(s.text(text).unwrap()))
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(para)).unwrap();
+        EditorState::create(s, doc, vec![Rc::new(BaseCommandsPlugin)])
+    }
+
+    fn all_text(node: &Node) -> String {
+        if let Some(t) = node.text() {
+            return t.to_string();
+        }
+        node.content().iter().map(all_text).collect()
+    }
+
+    #[test]
+    fn toggle_bold_over_range() {
+        let mut state = editor("abcd");
+        state.selection = Selection::text(Pos(1), Pos(5)); // whole "abcd"
+        let next = state.run("toggleBold").expect("toggleBold applies");
+        let bolded = next
+            .doc
+            .child(0)
+            .content()
+            .iter()
+            .all(|n| n.marks().iter().any(|m| m.type_name() == "bold"));
+        assert!(bolded, "whole range should be bold");
+        // toggling again removes it
+        let cleared = next.run("toggleBold").unwrap();
+        assert!(!range_has_mark(
+            &cleared.doc,
+            1,
+            5,
+            cleared.schema().mark_type("bold").unwrap()
+        ));
+    }
+
+    #[test]
+    fn cursor_bold_then_type_is_bold() {
+        // audit S2 — toggle bold at a collapsed cursor sets stored marks; typing applies them
+        let mut state = editor("ab");
+        state.selection = Selection::cursor(Pos(3)); // end of "ab"
+        let state = state
+            .run("toggleBold")
+            .expect("toggleBold (cursor) applies");
+        assert!(is_mark_active(
+            &state,
+            state.schema().mark_type("bold").unwrap()
+        ));
+        let mut tr = state.tr();
+        tr.insert_text("X").unwrap();
+        let state = state.apply(tr);
+        let x_is_bold =
+            state.doc.child(0).content().iter().any(|n| {
+                n.text() == Some("X") && n.marks().iter().any(|m| m.type_name() == "bold")
+            });
+        assert!(x_is_bold, "typed X after cursor-bold should be bold");
+    }
+
+    #[test]
+    fn set_heading_and_back_to_paragraph() {
+        let state = editor("title");
+        let h = state.run("setHeading2").expect("setHeading2 applies");
+        assert_eq!(h.doc.child(0).type_name(), "heading");
+        assert_eq!(h.doc.child(0).attrs().get_int("level"), Some(2));
+        // setHeading2 again is a no-op (already that markup) → not applicable
+        assert!(!h.can_run("setHeading2"));
+        let p = h.run("setParagraph").expect("setParagraph applies");
+        assert_eq!(p.doc.child(0).type_name(), "paragraph");
+    }
+
+    #[test]
+    fn wrap_blockquote_and_lift_back() {
+        let state = editor("x");
+        let bq = state.run("wrapInBlockquote").expect("wrap applies");
+        assert_eq!(bq.doc.child(0).type_name(), "blockquote");
+        assert!(in_node_type(&bq, "blockquote"));
+        let lifted = bq.run("liftListItem").expect("lift applies");
+        assert_eq!(lifted.doc.child(0).type_name(), "paragraph");
+    }
+
+    #[test]
+    fn toggle_bullet_list_and_back() {
+        let state = editor("item");
+        let list = state.run("toggleBulletList").expect("wrap into list");
+        assert_eq!(list.doc.child(0).type_name(), "bullet_list");
+        assert_eq!(list.doc.child(0).child(0).type_name(), "list_item");
+        assert!(in_node_type(&list, "bullet_list"));
+        // toggling again lifts out of the list
+        let back = list.run("toggleBulletList").expect("lift out of list");
+        assert!(!in_node_type(&back, "bullet_list"));
+        assert_eq!(back.doc.child(0).type_name(), "paragraph");
+    }
+
+    #[test]
+    fn sink_nests_second_list_item() {
+        // build doc(bullet_list(list_item(p"a"), list_item(p"b"))); cursor in 2nd item
+        let s = Rc::new(Schema::starter_kit());
+        let li = |t: &str| {
+            s.branch(
+                "list_item",
+                Fragment::from_node(
+                    s.branch("paragraph", Fragment::from_node(s.text(t).unwrap()))
+                        .unwrap(),
+                ),
+            )
+            .unwrap()
+        };
+        let list = s
+            .branch(
+                "bullet_list",
+                Fragment::from_children(vec![li("a"), li("b")]),
+            )
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(list)).unwrap();
+        let mut state = EditorState::create(s, doc, vec![Rc::new(BaseCommandsPlugin)]);
+        // positions: 0[ul 1[li 2[p 3 a 4]5]6 [li 7[p 8 b 9]10]11]12 ; cursor in 2nd item's text
+        state.selection = Selection::cursor(Pos(8));
+        assert!(can_sink(&state));
+        let nested = state.run("sinkListItem").expect("sink applies");
+        // the second item is now nested inside the first item's sublist
+        let outer_list = nested.doc.child(0);
+        assert_eq!(outer_list.type_name(), "bullet_list");
+        assert_eq!(
+            outer_list.child_count(),
+            1,
+            "second item nested under the first"
+        );
+        let first_item = outer_list.child(0);
+        // first item now holds: paragraph "a", bullet_list(list_item(p"b"))
+        let inner_list = first_item.child(first_item.child_count() - 1);
+        assert_eq!(inner_list.type_name(), "bullet_list");
+        assert_eq!(all_text(inner_list), "b");
+    }
+
+    #[test]
+    fn split_block_in_paragraph() {
+        let mut state = editor("ab");
+        state.selection = Selection::cursor(Pos(2)); // between a,b
+        let split = state.run("splitBlock").expect("split applies");
+        assert_eq!(split.doc.child_count(), 2);
+        assert_eq!(all_text(split.doc.child(0)), "a");
+        assert_eq!(all_text(split.doc.child(1)), "b");
+        // cursor is at the start of the second block
+        assert_eq!(split.selection, Selection::cursor(Pos(4)));
+    }
+
+    #[test]
+    fn split_at_end_of_heading_makes_paragraph() {
+        let s = Rc::new(Schema::starter_kit());
+        let h = s
+            .branch("heading", Fragment::from_node(s.text("T").unwrap()))
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(h)).unwrap();
+        let mut state = EditorState::create(s, doc, vec![Rc::new(BaseCommandsPlugin)]);
+        state.selection = Selection::cursor(Pos(2)); // end of heading "T"
+        let split = state.run("splitBlock").unwrap();
+        assert_eq!(split.doc.child(0).type_name(), "heading");
+        assert_eq!(split.doc.child(1).type_name(), "paragraph");
+    }
+
+    // ── Enter in lists (splitListItem / liftEmptyBlock) ───────────────────────
+
+    fn list_doc(s: &Schema, items: &[&str]) -> Node {
+        let lis: Vec<Node> = items.iter().map(|t| li_of(s, t)).collect();
+        let list = s
+            .branch("bullet_list", Fragment::from_children(lis))
+            .unwrap();
+        s.branch("doc", Fragment::from_node(list)).unwrap()
+    }
+
+    #[test]
+    fn enter_in_list_item_splits_into_new_item() {
+        // doc(bullet_list(list_item(p"ab"))); cursor between a,b. Positions are
+        // 0-based in doc content: list@0(c@1) item@1(c@2) p@2(c@3) "a"@3 "b"@4.
+        let s = Rc::new(Schema::starter_kit());
+        let state = state_of(list_doc(&s, &["ab"]), s, 4);
+        let next = state.run("enter").expect("enter splits the list item");
+        let list = next.doc.child(0);
+        assert_eq!(list.type_name(), "bullet_list");
+        assert_eq!(list.child_count(), 2, "split produced two list items");
+        assert_eq!(list.child(0).type_name(), "list_item");
+        assert_eq!(list.child(1).type_name(), "list_item");
+        assert_eq!(all_text(list.child(0)), "a");
+        assert_eq!(all_text(list.child(1)), "b");
+    }
+
+    #[test]
+    fn enter_at_end_of_list_item_makes_empty_item() {
+        // doc(bullet_list(list_item(p"ab"))); cursor at end of "ab" (after 'b').
+        let s = Rc::new(Schema::starter_kit());
+        let state = state_of(list_doc(&s, &["ab"]), s, 5);
+        let next = state.run("enter").expect("enter adds a new item");
+        let list = next.doc.child(0);
+        assert_eq!(list.child_count(), 2);
+        assert_eq!(all_text(list.child(0)), "ab");
+        assert_eq!(all_text(list.child(1)), "", "new item is empty");
+        assert_eq!(list.child(1).child(0).type_name(), "paragraph");
+    }
+
+    #[test]
+    fn enter_in_empty_trailing_list_item_exits_list() {
+        // doc(bullet_list(list_item(p"ab"), list_item(p""))); cursor in the empty
+        // 2nd item — Enter should lift it out of the list.
+        let s = Rc::new(Schema::starter_kit());
+        let empty_li = s
+            .branch(
+                "list_item",
+                Fragment::from_node(s.branch("paragraph", Fragment::empty()).unwrap()),
+            )
+            .unwrap();
+        let list = s
+            .branch(
+                "bullet_list",
+                Fragment::from_children(vec![li_of(&s, "ab"), empty_li]),
+            )
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(list)).unwrap();
+        // 0-based: list@0(c@1) li1@1(c@2) p"ab"@2(c@3) "ab"@3-5 li1.close@6 li2@7(c@8) p""@8(c@9)
+        let state = state_of(doc, s, 9);
+        let next = state.run("enter").expect("enter exits the empty item");
+        // The empty item left the list: a top-level paragraph now follows a
+        // single-item list (the paragraph is no longer inside any list).
+        assert!(
+            !in_node_type(&next, "bullet_list"),
+            "cursor block escaped the list"
+        );
+        assert_eq!(next.doc.child(0).type_name(), "bullet_list");
+        assert_eq!(
+            next.doc.child(0).child_count(),
+            1,
+            "list shrank to one item"
+        );
+        assert_eq!(next.doc.child(1).type_name(), "paragraph");
+    }
+
+    #[test]
+    fn enter_in_plain_paragraph_still_splits_block() {
+        // The chain falls through to split_block when not in a list item.
+        let mut state = editor("ab");
+        state.selection = Selection::cursor(Pos(2));
+        let next = state.run("enter").expect("enter splits the paragraph");
+        assert_eq!(next.doc.child_count(), 2);
+        assert_eq!(all_text(next.doc.child(0)), "a");
+        assert_eq!(all_text(next.doc.child(1)), "b");
+    }
+
+    #[test]
+    fn backspace_joins_blocks() {
+        let s = Rc::new(Schema::starter_kit());
+        let p = |t: &str| {
+            s.branch("paragraph", Fragment::from_node(s.text(t).unwrap()))
+                .unwrap()
+        };
+        let doc = s
+            .branch("doc", Fragment::from_children(vec![p("ab"), p("cd")]))
+            .unwrap();
+        let mut state = EditorState::create(s, doc, vec![Rc::new(BaseCommandsPlugin)]);
+        state.selection = Selection::cursor(Pos(5)); // start of second paragraph
+        let joined = state.run("deleteCharBackward").expect("join applies");
+        assert_eq!(joined.doc.child_count(), 1);
+        assert_eq!(all_text(&joined.doc), "abcd");
+    }
+
+    #[test]
+    fn delete_forward_joins_next_block() {
+        let s = Rc::new(Schema::starter_kit());
+        let p = |t: &str| {
+            s.branch("paragraph", Fragment::from_node(s.text(t).unwrap()))
+                .unwrap()
+        };
+        let doc = s
+            .branch("doc", Fragment::from_children(vec![p("ab"), p("cd")]))
+            .unwrap();
+        let mut state = EditorState::create(s, doc, vec![Rc::new(BaseCommandsPlugin)]);
+        state.selection = Selection::cursor(Pos(3)); // end of first paragraph
+        let joined = state
+            .run("deleteCharForward")
+            .expect("forward-join applies");
+        assert_eq!(joined.doc.child_count(), 1);
+        assert_eq!(all_text(&joined.doc), "abcd");
+        // at the very end of the doc, forward-delete does nothing
+        let mut at_end = editor("xy");
+        at_end.selection = Selection::cursor(Pos(3));
+        assert!(!at_end.can_run("deleteCharForward"));
+    }
+
+    #[test]
+    fn delete_forward_removes_char_mid_text() {
+        let mut state = editor("abc");
+        state.selection = Selection::cursor(Pos(2)); // between a,b
+        let next = state.run("deleteCharForward").unwrap();
+        assert_eq!(all_text(&next.doc), "ac");
+    }
+
+    #[test]
+    fn backspace_deletes_char_mid_text() {
+        let mut state = editor("abc");
+        state.selection = Selection::cursor(Pos(4)); // after "abc"
+        let next = state.run("deleteCharBackward").unwrap();
+        assert_eq!(all_text(&next.doc), "ab");
+    }
+
+    // ── cross-wrapper joins (M5.3 — the M4 `deleteBarrier` deferral) ──────────
+
+    fn p_of(s: &Schema, t: &str) -> Node {
+        s.branch("paragraph", Fragment::from_node(s.text(t).unwrap()))
+            .unwrap()
+    }
+    fn li_of(s: &Schema, t: &str) -> Node {
+        s.branch("list_item", Fragment::from_node(p_of(s, t)))
+            .unwrap()
+    }
+    fn state_of(doc: Node, schema: Rc<Schema>, cursor: usize) -> EditorState {
+        let mut state = EditorState::create(schema, doc, vec![Rc::new(BaseCommandsPlugin)]);
+        state.selection = Selection::cursor(Pos(cursor));
+        state
+    }
+
+    #[test]
+    fn backspace_lifts_paragraph_out_of_blockquote() {
+        // doc(blockquote(p"abc")); cursor at start of the paragraph (pos 2).
+        let s = Rc::new(Schema::starter_kit());
+        let bq = s
+            .branch("blockquote", Fragment::from_node(p_of(&s, "abc")))
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(bq)).unwrap();
+        let state = state_of(doc, s, 2);
+        let lifted = state.run("deleteCharBackward").expect("backspace lifts");
+        // The paragraph escaped the blockquote (the M4-deferred case is no longer a no-op).
+        assert!(!in_node_type(&lifted, "blockquote"));
+        assert_eq!(lifted.doc.child(0).type_name(), "paragraph");
+        assert_eq!(all_text(&lifted.doc), "abc");
+    }
+
+    #[test]
+    fn backspace_joins_sibling_paragraphs_inside_blockquote() {
+        // doc(blockquote(p"a", p"b")); cursor at start of the 2nd paragraph.
+        let s = Rc::new(Schema::starter_kit());
+        let bq = s
+            .branch(
+                "blockquote",
+                Fragment::from_children(vec![p_of(&s, "a"), p_of(&s, "b")]),
+            )
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(bq)).unwrap();
+        // positions: 0[bq 1[p 2 a 3]4[p 5 b 6]7]8 ; start of 2nd para = pos 5
+        let state = state_of(doc, s, 5);
+        let joined = state
+            .run("deleteCharBackward")
+            .expect("in-wrapper join applies");
+        let bq = joined.doc.child(0);
+        assert_eq!(bq.type_name(), "blockquote");
+        assert_eq!(bq.child_count(), 1, "the two paragraphs joined into one");
+        assert_eq!(all_text(&joined.doc), "ab");
+    }
+
+    #[test]
+    fn backspace_joins_adjacent_list_items() {
+        // doc(bullet_list(list_item(p"a"), list_item(p"b"))); cursor in 2nd item.
+        let s = Rc::new(Schema::starter_kit());
+        let ul = s
+            .branch(
+                "bullet_list",
+                Fragment::from_children(vec![li_of(&s, "a"), li_of(&s, "b")]),
+            )
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(ul)).unwrap();
+        // start of 2nd list item's paragraph = pos 8
+        let state = state_of(doc, s, 8);
+        let joined = state
+            .run("deleteCharBackward")
+            .expect("list-item join applies");
+        let ul = joined.doc.child(0);
+        assert_eq!(ul.type_name(), "bullet_list");
+        assert_eq!(ul.child_count(), 1, "the two items joined into one");
+        // PM-faithful: a depth-1 join of the two list items leaves their two
+        // paragraphs stacked inside the surviving item (NOT a single "ab"
+        // paragraph). A further Backspace would then join the paragraphs.
+        let item = ul.child(0);
+        assert_eq!(item.type_name(), "list_item");
+        assert_eq!(
+            item.child_count(),
+            2,
+            "both paragraphs survive inside the item"
+        );
+        assert_eq!(all_text(&joined.doc), "ab");
+    }
+
+    #[test]
+    fn forward_delete_near_block_atom_does_not_panic() {
+        // Regression (adversarial Finding 1): forward-Delete at the end of a
+        // paragraph followed by `blockquote(hr)` synthesizes a node-selection of
+        // the hr, whose block range is degenerate; the lift path must fail
+        // gracefully, never panic on an out-of-bounds path index.
+        let s = Rc::new(Schema::starter_kit());
+        let hr = s.branch("horizontal_rule", Fragment::empty()).unwrap();
+        let bq = s.branch("blockquote", Fragment::from_node(hr)).unwrap();
+        let doc = s
+            .branch("doc", Fragment::from_children(vec![p_of(&s, "a"), bq]))
+            .unwrap();
+        let state = state_of(doc, s, 2); // end of "a"
+        // Must return cleanly (a no-op here), not panic.
+        assert!(state.run("deleteCharForward").is_none());
+    }
+
+    #[test]
+    fn outdent_on_block_atom_node_selection_does_not_panic() {
+        // Regression (adversarial Finding 1): the `lift`/outdent path on a
+        // node-selection of a block atom must not panic.
+        use crate::selection::{NodeSelection, Selection as Sel};
+        let s = Rc::new(Schema::starter_kit());
+        let hr = s.branch("horizontal_rule", Fragment::empty()).unwrap();
+        let bq = s.branch("blockquote", Fragment::from_node(hr)).unwrap();
+        let doc = s.branch("doc", Fragment::from_node(bq)).unwrap();
+        let mut state = EditorState::create(s, doc, vec![Rc::new(BaseCommandsPlugin)]);
+        // Select the hr (positions: 0[bq 1[hr]2]3 → node selection 1..2).
+        state.selection = Sel::Node(NodeSelection {
+            anchor: Pos(1),
+            head: Pos(2),
+        });
+        // Should not panic; applicability/exec just reports inapplicable.
+        let _ = state.can_run("outdent");
+        let _ = state.run("outdent");
+    }
+
+    #[test]
+    fn backspace_at_start_of_first_block_in_doc_is_noop() {
+        // A top-level paragraph at the very start of the doc has nothing to join or lift.
+        let mut state = editor("abc");
+        state.selection = Selection::cursor(Pos(1)); // start of the only paragraph
+        assert!(!state.can_run("deleteCharBackward"));
+    }
+
+    #[test]
+    fn cross_wrapper_backspace_round_trips_under_undo() {
+        // The lift is a real, invertible transaction — undo restores the blockquote.
+        let s = Rc::new(Schema::starter_kit());
+        let bq = s
+            .branch("blockquote", Fragment::from_node(p_of(&s, "abc")))
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(bq.clone())).unwrap();
+        let mut state = EditorState::create(s, doc, default_plugins());
+        state.selection = Selection::cursor(Pos(2));
+        let lifted = state.run("deleteCharBackward").expect("lift");
+        assert!(!in_node_type(&lifted, "blockquote"));
+        let undone = lifted.run("undo").expect("undo applies");
+        assert!(in_node_type(&undone, "blockquote"));
+        assert_eq!(all_text(&undone.doc), "abc");
+    }
+
+    #[test]
+    fn insert_hard_break_and_hr() {
+        let mut state = editor("ab");
+        state.selection = Selection::cursor(Pos(2));
+        let hb = state.run("insertHardBreak").unwrap();
+        assert!(
+            hb.doc
+                .child(0)
+                .content()
+                .iter()
+                .any(|n| n.type_name() == "hard_break")
+        );
+
+        let mut state2 = editor("ab");
+        state2.selection = Selection::cursor(Pos(3)); // end of "ab"
+        // hr inserts at a block gap; place cursor at the doc-level gap after the para
+        state2.selection = Selection::text(Pos(4), Pos(4));
+        let hr = state2.run("insertHorizontalRule").unwrap();
+        assert!(
+            hr.doc
+                .content()
+                .iter()
+                .any(|n| n.type_name() == "horizontal_rule")
+        );
+    }
+
+    #[test]
+    fn link_command_adds_and_removes() {
+        let mut state = editor("abcd");
+        state.selection = Selection::text(Pos(1), Pos(5));
+        let cmd = toggle_link("https://x.test".into());
+        let linked = state.run_command(&cmd).expect("link applies");
+        let has_link = linked.doc.child(0).content().iter().any(|n| {
+            n.marks().iter().any(|m| {
+                m.type_name() == "link" && m.attrs.get_str("href") == Some("https://x.test")
+            })
+        });
+        assert!(has_link);
+        let unlinked = linked.run("removeLink").expect("removeLink applies");
+        assert!(!range_has_mark(
+            &unlinked.doc,
+            1,
+            5,
+            unlinked.schema().mark_type("link").unwrap()
+        ));
+    }
+
+    #[test]
+    fn toolbar_queries_read_state() {
+        let mut state = editor("abcd");
+        state.selection = Selection::text(Pos(1), Pos(5));
+        let bold = state.run("toggleBold").unwrap();
+        assert!(is_mark_active(
+            &bold,
+            bold.schema().mark_type("bold").unwrap()
+        ));
+        assert_eq!(
+            current_block_type(&bold).map(|t| t.name().to_string()),
+            Some("paragraph".to_string())
+        );
+        let listed = bold.run("toggleBulletList").unwrap();
+        assert!(in_node_type(&listed, "bullet_list"));
+        // inside a list the textblock is still a paragraph (A6's point)
+        assert_eq!(
+            current_block_type(&listed).map(|t| t.name().to_string()),
+            Some("paragraph".to_string())
+        );
+    }
+}

--- a/crates/rinch-editor-core/src/decoration.rs
+++ b/crates/rinch-editor-core/src/decoration.rs
@@ -1,0 +1,196 @@
+//! Decorations — view-side annotations that are **rendered but never part of the
+//! document**.
+//!
+//! The placeholder shown in an empty editor (design A8), the IME composition
+//! preedit (M6), a search highlight, and a remote collaborator's caret (M9) are
+//! all decorations: they are computed *from* [`EditorState`] but live outside the
+//! `doc`, so they never flow through a [`Step`](crate::transform::Step) and never
+//! corrupt the model. The view treats the [`DecorationSet`] as a first-class
+//! input and diffs `prev` vs `next` decorations **independently of the document
+//! diff** (design A4) — a transaction that changes only decorations (an IME
+//! preedit keystroke) still produces a visible update with zero document churn.
+//!
+//! Plugins contribute decorations through
+//! [`Plugin::decorations`](crate::plugin::Plugin::decorations); the state
+//! aggregates them in
+//! [`EditorState::decorations`](crate::state::EditorState::decorations).
+//!
+//! **Scope (M5):** only [`Widget`] decorations exist, because the placeholder is
+//! the only thing M5 renders this way. Inline decorations (preedit underline,
+//! search highlight — `Inline { from, to, attrs }`) land in M6 and node
+//! decorations in M7; adding those variants now would be unconstructed and trip
+//! the crate's no-dead-code gate.
+//!
+//! [`EditorState`]: crate::state::EditorState
+
+use crate::pos::Pos;
+use std::rc::Rc;
+
+/// One decoration. Currently always a [`Decoration::Widget`]; the inline and node
+/// kinds arrive with later milestones (see the module docs).
+#[derive(Clone, Debug, PartialEq)]
+pub enum Decoration {
+    /// A widget anchored at a single document position, drawn *between* content
+    /// and never selectable. Used for the empty-editor placeholder now, and for
+    /// the IME preedit / collaborator carets in later milestones.
+    Widget {
+        /// The document position the widget is anchored at.
+        pos: Pos,
+        /// Draw bias when content or another widget shares this position: a
+        /// negative `side` draws before, a positive `side` after. Mirrors
+        /// ProseMirror's widget `side`.
+        side: i32,
+        /// The renderer-agnostic widget payload.
+        widget: Widget,
+    },
+}
+
+impl Decoration {
+    /// A [`Decoration::Widget`] at `pos`.
+    pub fn widget(pos: Pos, side: i32, widget: Widget) -> Decoration {
+        Decoration::Widget { pos, side, widget }
+    }
+
+    /// The (single) document position this decoration is anchored at. For a
+    /// widget, the position it is drawn at.
+    pub fn pos(&self) -> Pos {
+        match self {
+            Decoration::Widget { pos, .. } => *pos,
+        }
+    }
+
+    /// This decoration's placeholder prompt text, if it is a
+    /// [`Widget::Placeholder`]; `None` otherwise (other widget kinds and the
+    /// inline/node decoration kinds added in later milestones). Lets the view pull
+    /// the placeholder out of a [`DecorationSet`] without matching the enum.
+    pub fn as_placeholder(&self) -> Option<&str> {
+        match self {
+            Decoration::Widget {
+                widget: Widget::Placeholder(text),
+                ..
+            } => Some(text),
+        }
+    }
+}
+
+/// The renderer-agnostic content of a [`Decoration::Widget`]. The view maps each
+/// variant onto host nodes; the core never references a renderer. Grows in later
+/// milestones (M6 IME preedit, M9 collaborator caret).
+#[derive(Clone, Debug, PartialEq)]
+pub enum Widget {
+    /// Dimmed prompt text shown when the editor is empty (design A8). Shared from
+    /// the placeholder plugin's config, so cloning a `DecorationSet` is cheap.
+    Placeholder(Rc<str>),
+}
+
+/// An ordered collection of [`Decoration`]s for one editor state — the view's
+/// decoration input. Cheap to clone and compare (`PartialEq`) so the view can
+/// diff `prev` against `next`.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct DecorationSet {
+    decorations: Vec<Decoration>,
+}
+
+impl DecorationSet {
+    /// The empty set.
+    pub fn empty() -> DecorationSet {
+        DecorationSet::default()
+    }
+
+    /// A set wrapping the given decorations (in draw order).
+    pub fn new(decorations: Vec<Decoration>) -> DecorationSet {
+        DecorationSet { decorations }
+    }
+
+    /// True if there are no decorations.
+    pub fn is_empty(&self) -> bool {
+        self.decorations.is_empty()
+    }
+
+    /// The number of decorations.
+    pub fn len(&self) -> usize {
+        self.decorations.len()
+    }
+
+    /// Iterate the decorations in draw order.
+    pub fn iter(&self) -> std::slice::Iter<'_, Decoration> {
+        self.decorations.iter()
+    }
+
+    /// Append one decoration.
+    pub fn push(&mut self, decoration: Decoration) {
+        self.decorations.push(decoration);
+    }
+
+    /// Merge `other`'s decorations into this set (used to aggregate plugins'
+    /// contributions in [`EditorState::decorations`](crate::state::EditorState::decorations)).
+    pub fn merge(&mut self, other: DecorationSet) {
+        self.decorations.extend(other.decorations);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_set_has_no_decorations() {
+        let set = DecorationSet::empty();
+        assert!(set.is_empty());
+        assert_eq!(set.len(), 0);
+        assert_eq!(set.iter().count(), 0);
+    }
+
+    #[test]
+    fn widget_decoration_records_pos_and_payload() {
+        let d = Decoration::widget(Pos(1), 0, Widget::Placeholder(Rc::from("Type here…")));
+        assert_eq!(d.pos(), Pos(1));
+        match &d {
+            Decoration::Widget { widget, side, .. } => {
+                assert_eq!(*side, 0);
+                assert_eq!(*widget, Widget::Placeholder(Rc::from("Type here…")));
+            }
+        }
+    }
+
+    #[test]
+    fn push_and_merge_accumulate_in_order() {
+        let mut set = DecorationSet::empty();
+        set.push(Decoration::widget(
+            Pos(1),
+            0,
+            Widget::Placeholder(Rc::from("a")),
+        ));
+        let mut other = DecorationSet::empty();
+        other.push(Decoration::widget(
+            Pos(2),
+            -1,
+            Widget::Placeholder(Rc::from("b")),
+        ));
+        set.merge(other);
+        assert_eq!(set.len(), 2);
+        let positions: Vec<Pos> = set.iter().map(|d| d.pos()).collect();
+        assert_eq!(positions, vec![Pos(1), Pos(2)]);
+    }
+
+    #[test]
+    fn sets_compare_structurally_for_diffing() {
+        let a = DecorationSet::new(vec![Decoration::widget(
+            Pos(1),
+            0,
+            Widget::Placeholder(Rc::from("x")),
+        )]);
+        let b = DecorationSet::new(vec![Decoration::widget(
+            Pos(1),
+            0,
+            Widget::Placeholder(Rc::from("x")),
+        )]);
+        let c = DecorationSet::new(vec![Decoration::widget(
+            Pos(2),
+            0,
+            Widget::Placeholder(Rc::from("x")),
+        )]);
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+}

--- a/crates/rinch-editor-core/src/input_rules.rs
+++ b/crates/rinch-editor-core/src/input_rules.rs
@@ -1,0 +1,283 @@
+//! Input rules — markdown-style shortcuts that rewrite text as you type.
+//!
+//! An [`InputRule`] pairs a `$`-anchored [`Regex`] (matched against the text before
+//! the cursor in the current textblock) with a handler that, on a match, returns a
+//! [`Transaction`] performing the rewrite (e.g. `"## "` → an `<h2>`, `"- "` → a
+//! bullet list). Rules are contributed by plugins and aggregated into the editor
+//! config; the view runs [`apply_input_rules`] on each text input *before* the
+//! plain insert, and dispatches the rule's transaction instead when one fires.
+//!
+//! Faithful in shape to ProseMirror's `prosemirror-inputrules` (the salvaged
+//! `rules.rs`), rebound to return `Option<Transaction>`.
+
+use crate::model::{AttrValue, Attrs, Node};
+use crate::pos::Pos;
+use crate::state::{EditorState, Transaction};
+use crate::transform::block_range_simple;
+use regex::{Captures, Regex};
+use std::rc::Rc;
+
+/// How many characters before the cursor are considered for a match (PM's
+/// `MAX_MATCH`). Keeps long paragraphs from re-matching `^`-anchored rules.
+const MAX_MATCH: usize = 500;
+
+/// The handler half of an [`InputRule`]: given the state, the regex captures, and
+/// the document range `start..end` the match covers, build the rewrite
+/// transaction (or `None` to decline).
+pub type InputRuleHandler =
+    Rc<dyn Fn(&EditorState, &Captures, usize, usize) -> Option<Transaction>>;
+
+/// A single input rule: a pattern plus its handler.
+#[derive(Clone)]
+pub struct InputRule {
+    /// The pattern, matched against the text before the cursor (should be anchored
+    /// at the end with `$`, and usually at the start with `^`).
+    pub pattern: Regex,
+    handler: InputRuleHandler,
+}
+
+impl InputRule {
+    /// Build a rule from a pattern string and a handler.
+    ///
+    /// # Panics
+    /// Panics if `pattern` is not a valid regex (patterns are compile-time
+    /// constants in plugin code, so a bad pattern is a programming error).
+    pub fn new(
+        pattern: &str,
+        handler: impl Fn(&EditorState, &Captures, usize, usize) -> Option<Transaction> + 'static,
+    ) -> InputRule {
+        InputRule {
+            pattern: Regex::new(pattern).expect("input rule pattern must be a valid regex"),
+            handler: Rc::new(handler),
+        }
+    }
+}
+
+impl std::fmt::Debug for InputRule {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InputRule")
+            .field("pattern", &self.pattern.as_str())
+            .finish_non_exhaustive()
+    }
+}
+
+/// The text of `parent`'s inline content from `start_offset` to `end_offset`
+/// (char offsets), with non-text inline leaves rendered as `\u{fffc}` (the object
+/// replacement char, as PM does) so positions line up.
+fn text_between(parent: &Node, start_offset: usize, end_offset: usize) -> String {
+    let mut out = String::new();
+    let mut pos = 0usize;
+    for child in parent.content().iter() {
+        if pos >= end_offset {
+            break;
+        }
+        let len = if child.is_text() { child.text_len() } else { 1 };
+        let child_end = pos + len;
+        if child_end > start_offset {
+            if let Some(t) = child.text() {
+                let take_start = start_offset.saturating_sub(pos);
+                let take_end = (end_offset - pos).min(len);
+                out.extend(t.chars().skip(take_start).take(take_end - take_start));
+            } else {
+                out.push('\u{fffc}');
+            }
+        }
+        pos = child_end;
+    }
+    out
+}
+
+/// Try each rule against the text before the (collapsed) cursor at `pos` plus the
+/// just-typed `text`, returning the first rule's rewrite transaction. The caller
+/// inserts `text` normally only when this returns `None`. Mirrors PM's
+/// `inputRules` plugin `handleTextInput`.
+///
+/// `pos` is the position where `text` is about to be inserted (the selection must
+/// be a collapsed cursor for a rule to fire).
+pub fn apply_input_rules(
+    state: &EditorState,
+    rules: &[InputRule],
+    pos: usize,
+    text: &str,
+) -> Option<Transaction> {
+    let r = state.doc.resolve(Pos(pos)).ok()?;
+    let parent = r.parent();
+    // No input rules inside code blocks (raw text — PM checks `spec.code`).
+    if parent.type_name() == "code_block" {
+        return None;
+    }
+    let parent_offset = r.parent_offset();
+    let from_offset = parent_offset.saturating_sub(MAX_MATCH);
+    let mut before = text_between(parent, from_offset, parent_offset);
+    before.push_str(text);
+
+    let text_chars = text.chars().count();
+    for rule in rules {
+        if let Some(caps) = rule.pattern.captures(&before) {
+            let whole = caps.get(0).unwrap();
+            let match_chars = whole.as_str().chars().count();
+            // The match's document start: walk back `match_chars - text_chars`
+            // chars (the marker text that is already in the doc) from `pos`.
+            let start = pos.saturating_sub(match_chars.saturating_sub(text_chars));
+            let end = pos;
+            if let Some(tr) = (rule.handler)(state, &caps, start, end) {
+                return Some(tr);
+            }
+        }
+    }
+    None
+}
+
+// -- rule builders (PM-style) -------------------------------------------------
+
+/// A rule that turns the current textblock into `node_type` when `pattern` matches
+/// at the block start — e.g. `"## "` → heading. `attrs_from` derives the new node's
+/// attributes from the match (e.g. heading level from the `#` count).
+pub fn textblock_type_input_rule(
+    pattern: &str,
+    node_type: &'static str,
+    attrs_from: impl Fn(&Captures) -> Attrs + 'static,
+) -> InputRule {
+    InputRule::new(pattern, move |state, caps, start, end| {
+        let ty = state.schema().node_type(node_type)?.clone();
+        if !ty.is_textblock() {
+            return None;
+        }
+        let attrs = attrs_from(caps);
+        let mut tr = state.tr();
+        tr.delete(start, end).ok()?;
+        tr.set_block_type(start, start, ty, attrs).ok()?;
+        Some(tr)
+    })
+}
+
+/// A rule that wraps the current block in `node_type` (a list/blockquote) when
+/// `pattern` matches at the block start — e.g. `"- "` → bullet list. For list
+/// wrappers an inner `list_item` is added automatically.
+pub fn wrapping_input_rule(
+    pattern: &str,
+    node_type: &'static str,
+    attrs_from: impl Fn(&Captures) -> Attrs + 'static,
+) -> InputRule {
+    InputRule::new(pattern, move |state, caps, start, end| {
+        let wrap_ty = state.schema().node_type(node_type)?.clone();
+        let attrs = attrs_from(caps);
+        let mut tr = state.tr();
+        tr.delete(start, end).ok()?;
+        let r_from = tr.doc().resolve(Pos(start)).ok()?;
+        let range = block_range_simple(&r_from, &r_from)?;
+        // A list wraps its blocks in list_item; a blockquote wraps them directly.
+        let needs_item = matches!(node_type, "bullet_list" | "ordered_list" | "task_list");
+        if needs_item {
+            let item_name = if node_type == "task_list" {
+                "task_item"
+            } else {
+                "list_item"
+            };
+            let item_ty = state.schema().node_type(item_name)?.clone();
+            tr.wrap(&range, &[(wrap_ty, attrs), (item_ty, Attrs::new())])
+                .ok()?;
+        } else {
+            tr.wrap(&range, &[(wrap_ty, attrs)]).ok()?;
+        }
+        Some(tr)
+    })
+}
+
+/// The default markdown-shortcut input rules (heading, blockquote, bullet/ordered
+/// list, code block). Contributed by the markdown-rules plugin.
+pub fn markdown_input_rules() -> Vec<InputRule> {
+    vec![
+        // `# ` … `###### ` → heading levels 1–6
+        textblock_type_input_rule(r"^(#{1,6})\s$", "heading", |caps| {
+            let level = caps.get(1).map_or(1, |m| m.as_str().len()) as i64;
+            Attrs::from_iter([("level", AttrValue::Int(level))])
+        }),
+        // ``` ``` ``` → code block
+        textblock_type_input_rule(r"^```$", "code_block", |_| Attrs::new()),
+        // `> ` → blockquote
+        wrapping_input_rule(r"^\s*>\s$", "blockquote", |_| Attrs::new()),
+        // `- ` / `* ` / `+ ` → bullet list
+        wrapping_input_rule(r"^\s*([-+*])\s$", "bullet_list", |_| Attrs::new()),
+        // `1. ` → ordered list (start = the typed number)
+        wrapping_input_rule(r"^(\d+)\.\s$", "ordered_list", |caps| {
+            let start = caps
+                .get(1)
+                .and_then(|m| m.as_str().parse::<i64>().ok())
+                .unwrap_or(1);
+            Attrs::from_iter([("start", AttrValue::Int(start))])
+        }),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Schema;
+    use crate::model::Fragment;
+    use crate::plugin::{Plugin, PluginKey};
+    use std::rc::Rc;
+
+    struct MdRules;
+    impl Plugin for MdRules {
+        fn key(&self) -> PluginKey {
+            PluginKey("markdown-input-rules")
+        }
+        fn input_rules(&self) -> Vec<InputRule> {
+            markdown_input_rules()
+        }
+    }
+
+    fn state_with(text: &str) -> EditorState {
+        let s = Rc::new(Schema::starter_kit());
+        let para = s
+            .branch("paragraph", Fragment::from_node(s.text(text).unwrap()))
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(para)).unwrap();
+        EditorState::create(s, doc, vec![Rc::new(MdRules)])
+    }
+
+    #[test]
+    fn heading_rule_fires_on_hash_space() {
+        // paragraph "#"; cursor after '#' at pos 2; type ' '
+        let state = state_with("#");
+        let rules = state.input_rules();
+        let tr = apply_input_rules(&state, rules, 2, " ").expect("heading rule should fire");
+        let next = state.apply(tr);
+        assert_eq!(next.doc.child(0).type_name(), "heading");
+        assert_eq!(next.doc.child(0).attrs().get_int("level"), Some(1));
+        // the "#" marker was removed
+        assert_eq!(next.doc.child(0).content().size(), 0);
+    }
+
+    #[test]
+    fn heading_level_from_hash_count() {
+        let state = state_with("###");
+        let rules = state.input_rules();
+        // cursor after "###" at pos 4; type ' '
+        let tr = apply_input_rules(&state, rules, 4, " ").expect("h3 rule should fire");
+        let next = state.apply(tr);
+        assert_eq!(next.doc.child(0).type_name(), "heading");
+        assert_eq!(next.doc.child(0).attrs().get_int("level"), Some(3));
+    }
+
+    #[test]
+    fn bullet_list_rule_wraps() {
+        let state = state_with("-");
+        let rules = state.input_rules();
+        // cursor after "-" at pos 2; type ' '
+        let tr = apply_input_rules(&state, rules, 2, " ").expect("bullet rule should fire");
+        let next = state.apply(tr);
+        assert_eq!(next.doc.child(0).type_name(), "bullet_list");
+        assert_eq!(next.doc.child(0).child(0).type_name(), "list_item");
+        assert_eq!(next.doc.child(0).child(0).child(0).type_name(), "paragraph");
+    }
+
+    #[test]
+    fn no_rule_fires_mid_word() {
+        // "ab#"; cursor after at pos 4; typing space should NOT match ^# (not at start)
+        let state = state_with("ab#");
+        let rules = state.input_rules();
+        assert!(apply_input_rules(&state, rules, 4, " ").is_none());
+    }
+}

--- a/crates/rinch-editor-core/src/keymap.rs
+++ b/crates/rinch-editor-core/src/keymap.rs
@@ -1,0 +1,242 @@
+//! Platform-agnostic key bindings.
+//!
+//! The core speaks an abstract keyboard vocabulary — [`Key`] + [`Modifiers`] —
+//! that carries no `winit`/`web_sys` types. A platform view translates its native
+//! key event into a [`KeyBinding`], looks it up in the aggregated [`Keymap`], and
+//! runs the bound command (design §5; salvages the `normalize_key` *logic* from the
+//! old `shortcuts.rs` but consumes events at the platform edge, not here).
+//!
+//! ## "Mod" / the primary accelerator
+//!
+//! Bindings are written with `Mod` (e.g. `"Mod-b"`) meaning *the platform's primary
+//! accelerator* — Ctrl on Windows/Linux, Cmd on macOS. The core collapses
+//! Ctrl/Cmd/Meta/Mod into a single [`Modifiers::primary`] flag; the platform view
+//! decides which physical modifier maps to `primary` for the host OS. This keeps
+//! one binding table correct on every platform.
+
+use std::collections::HashMap;
+
+/// An abstract key — a named editing key or a printable character (lower-cased;
+/// case is carried by [`Modifiers::shift`]).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Key {
+    /// A printable character, lower-cased (`'b'` for both `b` and `Shift-B`).
+    Char(char),
+    /// Return / Enter.
+    Enter,
+    /// Backspace.
+    Backspace,
+    /// Forward delete.
+    Delete,
+    /// Tab.
+    Tab,
+    /// Escape.
+    Escape,
+    /// Space (distinct from `Char(' ')` so `"Space"` parses).
+    Space,
+    /// Left arrow.
+    ArrowLeft,
+    /// Right arrow.
+    ArrowRight,
+    /// Up arrow.
+    ArrowUp,
+    /// Down arrow.
+    ArrowDown,
+    /// Home.
+    Home,
+    /// End.
+    End,
+    /// Page up.
+    PageUp,
+    /// Page down.
+    PageDown,
+}
+
+impl Key {
+    /// Parse a key token (`"Enter"`, `"ArrowLeft"`, `"b"`, `" "`). Names are
+    /// case-insensitive; a single character becomes a lower-cased [`Key::Char`].
+    pub fn parse(s: &str) -> Option<Key> {
+        let named = match s.to_ascii_lowercase().as_str() {
+            "enter" | "return" => Some(Key::Enter),
+            "backspace" => Some(Key::Backspace),
+            "delete" | "del" => Some(Key::Delete),
+            "tab" => Some(Key::Tab),
+            "escape" | "esc" => Some(Key::Escape),
+            "space" => Some(Key::Space),
+            "arrowleft" | "left" => Some(Key::ArrowLeft),
+            "arrowright" | "right" => Some(Key::ArrowRight),
+            "arrowup" | "up" => Some(Key::ArrowUp),
+            "arrowdown" | "down" => Some(Key::ArrowDown),
+            "home" => Some(Key::Home),
+            "end" => Some(Key::End),
+            "pageup" => Some(Key::PageUp),
+            "pagedown" => Some(Key::PageDown),
+            _ => None,
+        };
+        if named.is_some() {
+            return named;
+        }
+        if s == " " {
+            return Some(Key::Space);
+        }
+        let mut chars = s.chars();
+        let c = chars.next()?;
+        if chars.next().is_some() {
+            return None; // more than one char and not a known name
+        }
+        Some(Key::Char(c.to_ascii_lowercase()))
+    }
+}
+
+/// Modifier flags. `primary` is the OS accelerator (Ctrl / Cmd); `shift` and `alt`
+/// are literal.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct Modifiers {
+    /// The platform's primary accelerator (Ctrl on Windows/Linux, Cmd on macOS).
+    pub primary: bool,
+    /// Shift.
+    pub shift: bool,
+    /// Alt / Option.
+    pub alt: bool,
+}
+
+/// A key plus its modifiers — the lookup key for a [`Keymap`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct KeyBinding {
+    /// The key.
+    pub key: Key,
+    /// The modifiers held.
+    pub mods: Modifiers,
+}
+
+impl KeyBinding {
+    /// A binding from a key and modifiers.
+    pub fn new(key: Key, mods: Modifiers) -> KeyBinding {
+        KeyBinding { key, mods }
+    }
+
+    /// Parse a binding string like `"Mod-b"`, `"Shift-Enter"`, `"Mod-Shift-z"`,
+    /// `"Mod--"` (primary + minus). Modifier tokens (case-insensitive): `Mod`,
+    /// `Primary`, `Ctrl`/`Control`, `Cmd`/`Meta`/`Super` → `primary`; `Shift`;
+    /// `Alt`/`Option`. The final token is the key.
+    pub fn parse(s: &str) -> Option<KeyBinding> {
+        let mut mods = Modifiers::default();
+        let mut rest = s;
+        loop {
+            let Some(idx) = rest.find('-') else {
+                return Some(KeyBinding::new(Key::parse(rest)?, mods));
+            };
+            let tok = &rest[..idx];
+            let after = &rest[idx + 1..];
+            match tok.to_ascii_lowercase().as_str() {
+                "mod" | "primary" | "ctrl" | "control" | "cmd" | "meta" | "super" => {
+                    mods.primary = true;
+                    rest = after;
+                }
+                "shift" => {
+                    mods.shift = true;
+                    rest = after;
+                }
+                "alt" | "option" => {
+                    mods.alt = true;
+                    rest = after;
+                }
+                // Not a modifier token → `rest` (which still includes any internal
+                // '-', e.g. the key "-") is the key.
+                _ => return Some(KeyBinding::new(Key::parse(rest)?, mods)),
+            }
+        }
+    }
+}
+
+/// A binding → command-name lookup table, aggregated from all plugins.
+#[derive(Debug, Default, Clone)]
+pub struct Keymap {
+    map: HashMap<KeyBinding, String>,
+}
+
+impl Keymap {
+    /// An empty keymap.
+    pub fn new() -> Keymap {
+        Keymap {
+            map: HashMap::new(),
+        }
+    }
+
+    /// Bind `binding` to the command named `command`. Later bindings override
+    /// earlier ones for the same key.
+    pub fn add(&mut self, binding: KeyBinding, command: impl Into<String>) {
+        self.map.insert(binding, command.into());
+    }
+
+    /// Bind a parsed string (`"Mod-b"`) to a command; ignored if the string does
+    /// not parse.
+    pub fn bind(&mut self, binding: &str, command: impl Into<String>) {
+        if let Some(b) = KeyBinding::parse(binding) {
+            self.add(b, command);
+        }
+    }
+
+    /// The command name bound to `binding`, if any.
+    pub fn command_for(&self, binding: &KeyBinding) -> Option<&str> {
+        self.map.get(binding).map(String::as_str)
+    }
+
+    /// Number of bindings.
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    /// True if no bindings.
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_mod_letter() {
+        let b = KeyBinding::parse("Mod-b").unwrap();
+        assert_eq!(b.key, Key::Char('b'));
+        assert!(b.mods.primary);
+        assert!(!b.mods.shift && !b.mods.alt);
+    }
+
+    #[test]
+    fn parses_named_and_combos() {
+        assert_eq!(KeyBinding::parse("Shift-Enter").unwrap().key, Key::Enter);
+        let z = KeyBinding::parse("Mod-Shift-z").unwrap();
+        assert_eq!(z.key, Key::Char('z'));
+        assert!(z.mods.primary && z.mods.shift);
+        // case-insensitive modifiers + uppercase letter folds to lower
+        let b = KeyBinding::parse("mod-B").unwrap();
+        assert_eq!(b.key, Key::Char('b'));
+    }
+
+    #[test]
+    fn parses_minus_key() {
+        let b = KeyBinding::parse("Mod--").unwrap();
+        assert_eq!(b.key, Key::Char('-'));
+        assert!(b.mods.primary);
+    }
+
+    #[test]
+    fn ctrl_cmd_meta_all_map_to_primary() {
+        for s in ["Ctrl-a", "Cmd-a", "Meta-a", "Primary-a"] {
+            assert!(KeyBinding::parse(s).unwrap().mods.primary, "{s}");
+        }
+    }
+
+    #[test]
+    fn keymap_lookup() {
+        let mut km = Keymap::new();
+        km.bind("Mod-b", "toggleBold");
+        let b = KeyBinding::parse("Mod-b").unwrap();
+        assert_eq!(km.command_for(&b), Some("toggleBold"));
+        let other = KeyBinding::parse("Mod-i").unwrap();
+        assert_eq!(km.command_for(&other), None);
+    }
+}

--- a/crates/rinch-editor-core/src/lib.rs
+++ b/crates/rinch-editor-core/src/lib.rs
@@ -11,20 +11,63 @@
 //! `rinch-editor-collab`.
 //!
 //! See `docs/design/editor-rearchitecture.md` for the full design and the
-//! milestone plan. This is **M0**: the crate scaffold plus the schema, lifted
-//! from the old `rinch-editor` crate (dyn `Node`/`Mark` traits and the
-//! Automerge error variant dropped). The concrete `Node`/`Mark`/`Fragment`/
-//! `Slice` value model, `Pos`, the `Step`/`Transaction` engine, and typed
-//! attrs (`AttrValue`) arrive in M1+.
+//! milestone plan. Implemented through **M4**: the schema (M0), the value model +
+//! positions + `ContentMatch` (M1), the transform/`Step` engine (M2), total
+//! schema-driven serialization — the durable `DocNode` JSON wire shape, HTML, and
+//! markdown (M3) — and the state layer: [`EditorState`]/[`Transaction`],
+//! [`Selection`], [`Plugin`]s, the [`Command`] catalogue, the [`keymap`], input
+//! rules, and the Step-based undo/redo [`plugins::HistoryPlugin`] (M4). The
+//! platform view seams (M5+) follow.
 
+use std::rc::Rc;
+
+pub mod command;
+pub mod commands;
+pub mod decoration;
 pub mod error;
+pub mod input_rules;
+pub mod keymap;
 pub mod model;
+pub mod plugin;
+pub mod plugins;
 pub mod pos;
 pub mod schema;
+pub mod selection;
+pub mod serialize;
+pub mod state;
+pub mod transform;
+pub mod view;
 
+pub use command::{Command, Dispatch, chain};
+pub use commands::BaseCommandsPlugin;
+pub use decoration::{Decoration, DecorationSet, Widget};
 pub use error::EditorError;
+pub use input_rules::{InputRule, apply_input_rules};
+pub use keymap::{Key, KeyBinding, Keymap, Modifiers};
 pub use model::{AttrValue, Attrs, Fragment, Mark, MarkType, Node, NodeType, Slice};
+pub use plugin::{Plugin, PluginKey};
+pub use plugins::{HistoryPlugin, MarkdownInputRulesPlugin, PlaceholderPlugin};
 pub use pos::{Pos, ResolvedPos};
 pub use schema::{
     AttrSpec, MarkSet, MarkSpec, MarkSpecBuilder, NodeSpec, NodeSpecBuilder, Schema, SchemaBuilder,
 };
+pub use selection::{NodeSelection, Selection, TextSelection};
+pub use state::{EditorState, Transaction};
+pub use transform::{
+    AddMarkStep, MapResult, Mapping, NodeRange, RemoveMarkStep, ReplaceAroundStep, ReplaceStep,
+    SetDocAttrStep, SetNodeAttrStep, Step, StepError, StepMap, Transform, block_range,
+    block_range_simple,
+};
+pub use view::{EditorView, ViewRequest};
+
+/// The default plugin set for a standard rich-text editor: the built-in command
+/// catalogue + keymap ([`BaseCommandsPlugin`]), markdown input rules
+/// ([`MarkdownInputRulesPlugin`]), and Step-based undo/redo ([`HistoryPlugin`]).
+/// Pass to [`EditorState::create`].
+pub fn default_plugins() -> Vec<Rc<dyn Plugin>> {
+    vec![
+        Rc::new(BaseCommandsPlugin),
+        Rc::new(MarkdownInputRulesPlugin),
+        Rc::new(HistoryPlugin::new()),
+    ]
+}

--- a/crates/rinch-editor-core/src/model/fragment.rs
+++ b/crates/rinch-editor-core/src/model/fragment.rs
@@ -107,6 +107,103 @@ impl Fragment {
         // Unreachable for an in-range `pos`, but stay total.
         (self.0.children.len(), self.0.size)
     }
+
+    /// Internal constructor with a pre-computed size (avoids the O(n) re-sum when
+    /// the caller already knows the size — every content-surgery primitive does).
+    fn from_parts(children: Vec<Node>, size: usize) -> Fragment {
+        debug_assert_eq!(
+            size,
+            children.iter().map(Node::node_size).sum::<usize>(),
+            "from_parts size mismatch"
+        );
+        Fragment(Rc::new(FragmentInner { children, size }))
+    }
+
+    /// Cut the content between two **content positions** `from..to`, slicing
+    /// through text nodes and one level into non-text nodes where the boundary
+    /// falls inside a child. A faithful port of ProseMirror's `Fragment.cut`.
+    ///
+    /// `from`/`to` are positions in this fragment's content space
+    /// (`0..=self.size()`); the result is the content that lies strictly between
+    /// them.
+    pub fn cut(&self, from: usize, to: usize) -> Fragment {
+        if from == 0 && to == self.0.size {
+            return self.clone();
+        }
+        let mut result: Vec<Node> = Vec::new();
+        let mut size = 0usize;
+        if to > from {
+            let mut pos = 0usize;
+            for child in &self.0.children {
+                if pos >= to {
+                    break;
+                }
+                let end = pos + child.node_size();
+                if end > from {
+                    let piece = if pos < from || end > to {
+                        if child.is_text() {
+                            // char offsets within the text node
+                            child.cut(from.saturating_sub(pos), (to - pos).min(child.text_len()))
+                        } else {
+                            // content offsets within the child (skip its open token)
+                            child.cut(
+                                from.saturating_sub(pos + 1),
+                                (to - pos - 1).min(child.content_size()),
+                            )
+                        }
+                    } else {
+                        child.clone()
+                    };
+                    size += piece.node_size();
+                    result.push(piece);
+                }
+                pos = end;
+            }
+        }
+        Fragment::from_parts(result, size)
+    }
+
+    /// Concatenate `other` onto the end of this fragment, merging the boundary
+    /// pair if both are text nodes with identical markup (so adjacent runs never
+    /// fragment). Faithful port of ProseMirror's `Fragment.append`.
+    pub fn append(&self, other: &Fragment) -> Fragment {
+        if other.is_empty() {
+            return self.clone();
+        }
+        if self.is_empty() {
+            return other.clone();
+        }
+        let mut content = self.0.children.clone();
+        let first = &other.0.children[0];
+        // `content` is non-empty (we returned early when `self` is empty), so the
+        // last child always exists.
+        let last_idx = content.len() - 1;
+        let mut start = 0usize;
+        if content[last_idx].is_text() && first.is_text() && content[last_idx].same_markup(first) {
+            let merged = format!(
+                "{}{}",
+                content[last_idx].text().unwrap(),
+                first.text().unwrap()
+            );
+            content[last_idx] = content[last_idx].with_text(merged.into());
+            start = 1;
+        }
+        content.extend(other.0.children[start..].iter().cloned());
+        Fragment::from_parts(content, self.0.size + other.0.size)
+    }
+
+    /// Return a copy with the child at `index` replaced by `node` (the rest
+    /// structurally shared). Faithful port of `Fragment.replaceChild`.
+    pub fn replace_child(&self, index: usize, node: Node) -> Fragment {
+        let current = &self.0.children[index];
+        if current.same_ref(&node) {
+            return self.clone();
+        }
+        let size = self.0.size + node.node_size() - current.node_size();
+        let mut copy = self.0.children.clone();
+        copy[index] = node;
+        Fragment::from_parts(copy, size)
+    }
 }
 
 impl PartialEq for Fragment {
@@ -126,5 +223,111 @@ impl fmt::Debug for Fragment {
 impl Default for Fragment {
     fn default() -> Self {
         Fragment::empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Schema;
+    use crate::model::{Fragment, Mark};
+
+    /// paragraph("abcd") — content size 4.
+    fn para_abcd(s: &Schema) -> Fragment {
+        s.branch("paragraph", Fragment::from_node(s.text("abcd").unwrap()))
+            .unwrap()
+            .content()
+            .clone()
+    }
+
+    #[test]
+    fn cut_text_within_a_single_run() {
+        let s = Schema::starter_kit();
+        let frag = para_abcd(&s); // [text "abcd"]
+        // cut content positions 1..3 -> "bc"
+        let c = frag.cut(1, 3);
+        assert_eq!(c.size(), 2);
+        assert_eq!(c.child(0).text(), Some("bc"));
+    }
+
+    #[test]
+    fn cut_whole_is_identity_ref() {
+        let s = Schema::starter_kit();
+        let frag = para_abcd(&s);
+        let c = frag.cut(0, frag.size());
+        assert!(std::rc::Rc::ptr_eq(&frag.0, &c.0)); // shares the Rc
+    }
+
+    #[test]
+    fn cut_empty_range_is_empty() {
+        let s = Schema::starter_kit();
+        let frag = para_abcd(&s);
+        assert!(frag.cut(2, 2).is_empty());
+    }
+
+    #[test]
+    fn cut_spanning_two_blocks_opens_them() {
+        // doc content = [paragraph "ab" (0..4), paragraph "cd" (4..8)]
+        let s = Schema::starter_kit();
+        let p1 = s
+            .branch("paragraph", Fragment::from_node(s.text("ab").unwrap()))
+            .unwrap();
+        let p2 = s
+            .branch("paragraph", Fragment::from_node(s.text("cd").unwrap()))
+            .unwrap();
+        let doc_content = Fragment::from_children(vec![p1, p2]);
+        // cut 2..6 -> "b" from p1 and "c" from p2 (each block kept, sliced)
+        let c = doc_content.cut(2, 6);
+        assert_eq!(c.child_count(), 2);
+        assert_eq!(c.child(0).child(0).text(), Some("b"));
+        assert_eq!(c.child(1).child(0).text(), Some("c"));
+    }
+
+    #[test]
+    fn append_merges_adjacent_text_with_same_marks() {
+        let s = Schema::starter_kit();
+        let a = Fragment::from_node(s.text("foo").unwrap());
+        let b = Fragment::from_node(s.text("bar").unwrap());
+        let merged = a.append(&b);
+        assert_eq!(merged.child_count(), 1);
+        assert_eq!(merged.child(0).text(), Some("foobar"));
+        assert_eq!(merged.size(), 6);
+    }
+
+    #[test]
+    fn append_does_not_merge_text_with_different_marks() {
+        let s = Schema::starter_kit();
+        let bold = Mark::simple(s.mark_type("bold").unwrap().clone());
+        let a = Fragment::from_node(s.text("foo").unwrap());
+        let b = Fragment::from_node(s.text_with_marks("bar", vec![bold]).unwrap());
+        let merged = a.append(&b);
+        assert_eq!(merged.child_count(), 2);
+        assert_eq!(merged.size(), 6);
+    }
+
+    #[test]
+    fn append_with_empty_is_identity() {
+        let s = Schema::starter_kit();
+        let a = Fragment::from_node(s.text("x").unwrap());
+        assert!(std::rc::Rc::ptr_eq(&a.append(&Fragment::empty()).0, &a.0));
+        assert!(std::rc::Rc::ptr_eq(&Fragment::empty().append(&a).0, &a.0));
+    }
+
+    #[test]
+    fn replace_child_preserves_size_accounting() {
+        let s = Schema::starter_kit();
+        let p1 = s
+            .branch("paragraph", Fragment::from_node(s.text("ab").unwrap()))
+            .unwrap();
+        let p2 = s
+            .branch("paragraph", Fragment::from_node(s.text("cde").unwrap()))
+            .unwrap();
+        let frag = Fragment::from_children(vec![p1, p2]); // 4 + 5 = 9
+        assert_eq!(frag.size(), 9);
+        let new_p = s
+            .branch("paragraph", Fragment::from_node(s.text("z").unwrap()))
+            .unwrap(); // size 3
+        let replaced = frag.replace_child(0, new_p);
+        assert_eq!(replaced.size(), 3 + 5);
+        assert_eq!(replaced.child(0).child(0).text(), Some("z"));
     }
 }

--- a/crates/rinch-editor-core/src/model/mark.rs
+++ b/crates/rinch-editor-core/src/model/mark.rs
@@ -44,4 +44,46 @@ impl Mark {
     pub fn is_in(&self, set: &[Mark]) -> bool {
         set.contains(self)
     }
+
+    /// Add this mark to `set`, returning the new set. If an existing mark equals
+    /// this one the set is returned unchanged; marks this one *excludes* are
+    /// dropped; if an existing mark excludes this one the set is returned unchanged
+    /// (the mark cannot be added). Port of ProseMirror's `Mark.addToSet` (without
+    /// the rank-based ordering — the new mark is appended, which preserves set
+    /// membership; ordering is not load-bearing for our value model).
+    pub fn add_to_set(&self, set: &[Mark]) -> Vec<Mark> {
+        let mut copy: Option<Vec<Mark>> = None;
+        for (i, other) in set.iter().enumerate() {
+            if self == other {
+                return set.to_vec();
+            }
+            if self.typ.excludes(other.type_name()) {
+                // this excludes other → drop other
+                if copy.is_none() {
+                    copy = Some(set[..i].to_vec());
+                }
+            } else if other.typ.excludes(self.type_name()) {
+                // other excludes this → cannot add
+                return set.to_vec();
+            } else if let Some(c) = copy.as_mut() {
+                c.push(other.clone());
+            }
+        }
+        let mut copy = copy.unwrap_or_else(|| set.to_vec());
+        copy.push(self.clone());
+        copy
+    }
+
+    /// Remove this mark from `set`, returning the new set (unchanged if absent).
+    /// Port of `Mark.removeFromSet`.
+    pub fn remove_from_set(&self, set: &[Mark]) -> Vec<Mark> {
+        match set.iter().position(|m| m == self) {
+            Some(i) => {
+                let mut v = set[..i].to_vec();
+                v.extend_from_slice(&set[i + 1..]);
+                v
+            }
+            None => set.to_vec(),
+        }
+    }
 }

--- a/crates/rinch-editor-core/src/model/node.rs
+++ b/crates/rinch-editor-core/src/model/node.rs
@@ -122,6 +122,29 @@ impl Node {
         self.0.typ.is_atom()
     }
 
+    /// True if this is a textblock (block-level node with inline content).
+    pub fn is_textblock(&self) -> bool {
+        self.0.typ.is_textblock()
+    }
+
+    /// True if this node already has the given type and attributes — used by
+    /// `set_block_type` to skip nodes that need no change. Port of `Node.hasMarkup`
+    /// (restricted to type + attrs).
+    pub fn has_markup(&self, typ: &NodeType, attrs: &Attrs) -> bool {
+        self.0.typ == *typ && self.0.attrs == *attrs
+    }
+
+    /// Visit every descendant node whose range overlaps `from..to`, calling
+    /// `f(node, pos, parent)` with the node's document position and its parent.
+    /// Returning `false` from `f` skips descending into that node's content. Port
+    /// of `Node.nodesBetween`.
+    pub fn nodes_between<F>(&self, from: usize, to: usize, f: &mut F)
+    where
+        F: FnMut(&Node, usize, Option<&Node>) -> bool,
+    {
+        nodes_between_frag(&self.0.content, from, to, 0, Some(self), f);
+    }
+
     /// Number of children.
     pub fn child_count(&self) -> usize {
         self.0.content.child_count()
@@ -162,6 +185,162 @@ impl Node {
     /// Pointer-identity check — the view-diff fast path.
     pub fn same_ref(&self, other: &Node) -> bool {
         Rc::ptr_eq(&self.0, &other.0)
+    }
+
+    /// True if `self` and `other` have the same type, attrs and marks — i.e. they
+    /// differ only (possibly) in content. Used to decide whether two adjacent text
+    /// runs may be merged. Port of ProseMirror's `Node.sameMarkup`.
+    pub fn same_markup(&self, other: &Node) -> bool {
+        self.0.typ == other.0.typ && self.0.attrs == other.0.attrs && self.0.marks == other.0.marks
+    }
+
+    /// A copy of this **non-text** node with new content, preserving type, attrs
+    /// and marks (the persistent-tree `copy` primitive). The transform engine
+    /// builds every new tree out of `copy_with_content` over shared subtrees.
+    pub fn copy_with_content(&self, content: Fragment) -> Node {
+        debug_assert!(!self.is_text(), "copy_with_content on a text node");
+        Node(Rc::new(NodeInner {
+            typ: self.0.typ.clone(),
+            attrs: self.0.attrs.clone(),
+            content,
+            marks: self.0.marks.clone(),
+            text: None,
+            text_len: 0,
+        }))
+    }
+
+    /// A copy of this **text** node carrying `text` in place of its own, keeping
+    /// the same marks. Port of `TextNode.withText`.
+    pub(crate) fn with_text(&self, text: Box<str>) -> Node {
+        debug_assert!(self.is_text(), "with_text on a non-text node");
+        Node::new_text(self.0.typ.clone(), text, self.0.marks.clone())
+    }
+
+    /// Cut this node to a sub-range, slicing its text (text node, char offsets) or
+    /// its content (non-text node, content offsets). Port of `Node.cut` /
+    /// `TextNode.cut`.
+    pub fn cut(&self, from: usize, to: usize) -> Node {
+        if self.is_text() {
+            if from == 0 && to == self.0.text_len {
+                return self.clone();
+            }
+            let sliced: String = self
+                .text()
+                .unwrap()
+                .chars()
+                .skip(from)
+                .take(to - from)
+                .collect();
+            return self.with_text(sliced.into());
+        }
+        if from == 0 && to == self.content_size() {
+            return self.clone();
+        }
+        self.copy_with_content(self.0.content.cut(from, to))
+    }
+
+    /// The node that *starts* at `pos` (or the text node `pos` falls inside),
+    /// interpreting `self` as the document root. `None` if `pos` is at the end of a
+    /// parent's content. Port of `Node.nodeAt`.
+    pub fn node_at(&self, pos: usize) -> Option<Node> {
+        let mut node = self.clone();
+        let mut pos = pos;
+        loop {
+            let (index, offset) = node.content().find_index(pos);
+            let child = node.content().maybe_child(index)?.clone();
+            if offset == pos || child.is_text() {
+                return Some(child);
+            }
+            pos -= offset + 1;
+            node = child;
+        }
+    }
+
+    /// A copy of this node with the given mark list (text node keeps its text,
+    /// non-text node keeps its content). Port of `Node.mark`.
+    pub(crate) fn mark(&self, marks: Vec<Mark>) -> Node {
+        if self.is_text() {
+            Node::new_text(self.0.typ.clone(), self.0.text.clone().unwrap(), marks)
+        } else {
+            Node(Rc::new(NodeInner {
+                typ: self.0.typ.clone(),
+                attrs: self.0.attrs.clone(),
+                content: self.0.content.clone(),
+                marks,
+                text: None,
+                text_len: 0,
+            }))
+        }
+    }
+
+    /// A copy of this **non-text** node with replaced attrs, keeping content and
+    /// marks. The attr-step primitive.
+    pub(crate) fn with_attrs(&self, attrs: Attrs) -> Node {
+        debug_assert!(!self.is_text(), "with_attrs on a text node");
+        Node(Rc::new(NodeInner {
+            typ: self.0.typ.clone(),
+            attrs,
+            content: self.0.content.clone(),
+            marks: self.0.marks.clone(),
+            text: None,
+            text_len: 0,
+        }))
+    }
+
+    /// Extract a [`Slice`] of the content between two positions (interpreting
+    /// `self` as the document root), recording the open depths at each end. Port of
+    /// `Node.slice`. Used by `ReplaceStep::invert` to recover the replaced content.
+    pub fn slice(&self, from: usize, to: usize) -> Result<crate::model::Slice, EditorError> {
+        use crate::model::Slice;
+        if from == to {
+            return Ok(Slice::empty());
+        }
+        let r_from = self.resolve(Pos(from))?;
+        let r_to = self.resolve(Pos(to))?;
+        let depth = r_from.shared_depth(Pos(to));
+        let start = r_from.start(depth);
+        let node = r_from.node(depth);
+        let content = node.content().cut(from - start, to - start);
+        Ok(Slice::new(
+            content,
+            r_from.depth() - depth,
+            r_to.depth() - depth,
+        ))
+    }
+}
+
+/// Recursive worker for [`Node::nodes_between`].
+fn nodes_between_frag<F>(
+    frag: &Fragment,
+    from: usize,
+    to: usize,
+    node_start: usize,
+    parent: Option<&Node>,
+    f: &mut F,
+) where
+    F: FnMut(&Node, usize, Option<&Node>) -> bool,
+{
+    let mut pos = 0usize;
+    for child in frag.children() {
+        if pos >= to {
+            break;
+        }
+        let end = pos + child.node_size();
+        if end > from {
+            let descend = f(child, node_start + pos, parent) && child.content_size() > 0;
+            if descend {
+                let start = pos + 1;
+                nodes_between_frag(
+                    child.content(),
+                    from.saturating_sub(start),
+                    (to.saturating_sub(start)).min(child.content_size()),
+                    node_start + start,
+                    Some(child),
+                    f,
+                );
+            }
+        }
+        pos = end;
     }
 }
 
@@ -467,6 +646,92 @@ mod tests {
         assert_eq!(g.depth(), 1);
         assert_eq!(g.parent().type_name(), "blockquote");
         assert_eq!(g.index(1), 1);
+    }
+
+    #[test]
+    fn slice_within_one_textblock_is_flat() {
+        // doc(paragraph("abcd")); slice 2..3 = "b"? positions: 0 open p,1 a,2 b,3 c,4 d,5 close
+        let s = Schema::starter_kit();
+        let para = s
+            .branch("paragraph", Fragment::from_node(s.text("abcd").unwrap()))
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(para)).unwrap();
+        // pos 2..4 -> chars "bc", inside the single paragraph -> open depths 0
+        let slice = doc.slice(2, 4).unwrap();
+        assert_eq!(slice.open_start, 0);
+        assert_eq!(slice.open_end, 0);
+        assert_eq!(slice.content.child(0).text(), Some("bc"));
+        assert_eq!(slice.size(), 2);
+    }
+
+    #[test]
+    fn slice_spanning_two_paragraphs_is_open_on_both_sides() {
+        // doc(paragraph("ab"), paragraph("cd")); positions:
+        // 0 [p1 1 a 2 b 3] 4 [p2 5 c 6 d 7] 8 -- content size 8
+        let s = Schema::starter_kit();
+        let p1 = s
+            .branch("paragraph", Fragment::from_node(s.text("ab").unwrap()))
+            .unwrap();
+        let p2 = s
+            .branch("paragraph", Fragment::from_node(s.text("cd").unwrap()))
+            .unwrap();
+        let doc = s
+            .branch("doc", Fragment::from_children(vec![p1, p2]))
+            .unwrap();
+        // slice 2..6 : "b" .. "c", crossing the paragraph boundary -> open 1/1
+        let slice = doc.slice(2, 6).unwrap();
+        assert_eq!((slice.open_start, slice.open_end), (1, 1));
+        assert_eq!(slice.content.child_count(), 2);
+        assert_eq!(slice.content.child(0).child(0).text(), Some("b"));
+        assert_eq!(slice.content.child(1).child(0).text(), Some("c"));
+        // slice.size() = content.size() - open_start - open_end
+        assert_eq!(slice.size(), slice.content.size() - 2);
+    }
+
+    #[test]
+    fn slice_empty_range_is_empty() {
+        let s = Schema::starter_kit();
+        let para = s
+            .branch("paragraph", Fragment::from_node(s.text("abcd").unwrap()))
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(para)).unwrap();
+        assert!(doc.slice(2, 2).unwrap().is_empty());
+    }
+
+    #[test]
+    fn resolved_text_offset_and_neighbors() {
+        // doc(paragraph("abcd"))
+        let s = Schema::starter_kit();
+        let para = s
+            .branch("paragraph", Fragment::from_node(s.text("abcd").unwrap()))
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(para)).unwrap();
+        let r = doc.resolve(Pos(3)).unwrap(); // between b and c (offset 2 into text)
+        assert_eq!(r.text_offset(), 2);
+        // node_before -> "ab", node_after -> "cd"
+        assert_eq!(r.node_before().unwrap().text(), Some("ab"));
+        assert_eq!(r.node_after().unwrap().text(), Some("cd"));
+    }
+
+    #[test]
+    fn resolved_neighbors_at_block_boundary() {
+        // doc(paragraph("ab"), paragraph("cd")); pos 4 = the gap between paragraphs
+        let s = Schema::starter_kit();
+        let p1 = s
+            .branch("paragraph", Fragment::from_node(s.text("ab").unwrap()))
+            .unwrap();
+        let p2 = s
+            .branch("paragraph", Fragment::from_node(s.text("cd").unwrap()))
+            .unwrap();
+        let doc = s
+            .branch("doc", Fragment::from_children(vec![p1, p2]))
+            .unwrap();
+        let r = doc.resolve(Pos(4)).unwrap();
+        assert_eq!(r.text_offset(), 0);
+        assert_eq!(r.node_before().unwrap().type_name(), "paragraph");
+        assert_eq!(r.node_after().unwrap().type_name(), "paragraph");
+        // shared_depth between pos 4 and a pos inside p2 is the doc (0)
+        assert_eq!(r.shared_depth(Pos(6)), 0);
     }
 
     #[test]

--- a/crates/rinch-editor-core/src/model/slice.rs
+++ b/crates/rinch-editor-core/src/model/slice.rs
@@ -9,7 +9,7 @@
 //! The transform engine (M2) uses `Slice` as the payload of `ReplaceStep`; copy
 //! and paste (M6) serialize to/from it.
 
-use crate::model::Fragment;
+use crate::model::{Fragment, Node};
 
 /// A slice of document content with open boundary depths.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -64,6 +64,74 @@ impl Slice {
     pub fn is_empty(&self) -> bool {
         self.content.is_empty()
     }
+
+    /// Insert `fragment` into this slice's content at the (content) offset `pos`,
+    /// descending into open nodes as needed. Returns `None` if it cannot fit.
+    /// Used by `ReplaceAroundStep` to drop the preserved gap content into the
+    /// wrapping slice. Port of `Slice.insertAt`.
+    pub fn insert_at(&self, pos: usize, fragment: &Fragment) -> Option<Slice> {
+        let content = insert_into(&self.content, pos + self.open_start, fragment)?;
+        Some(Slice::new(content, self.open_start, self.open_end))
+    }
+
+    /// Remove the (content) range `from..to` from this slice's content, descending
+    /// into open nodes. The range must be flat (not cross a node boundary at an
+    /// unequal depth). Used by `ReplaceAroundStep::invert`. Port of
+    /// `Slice.removeBetween`.
+    pub fn remove_between(&self, from: usize, to: usize) -> Slice {
+        Slice::new(
+            remove_range(&self.content, from + self.open_start, to + self.open_start),
+            self.open_start,
+            self.open_end,
+        )
+    }
+}
+
+/// Recursive helper for [`Slice::insert_at`]. Port of `insertInto` (the `parent`
+/// argument is always absent in this call chain, so the `canReplace` check PM
+/// guards with it is a no-op and omitted; schema validity is enforced later by the
+/// replace's `close`).
+fn insert_into(content: &Fragment, dist: usize, insert: &Fragment) -> Option<Fragment> {
+    let (index, offset) = content.find_index(dist);
+    let child = content.maybe_child(index);
+    if offset == dist || child.is_some_and(Node::is_text) {
+        Some(
+            content
+                .cut(0, dist)
+                .append(insert)
+                .append(&content.cut(dist, content.size())),
+        )
+    } else {
+        let child = child?;
+        let inner = insert_into(child.content(), dist - offset - 1, insert)?;
+        Some(content.replace_child(index, child.copy_with_content(inner)))
+    }
+}
+
+/// Recursive helper for [`Slice::remove_between`]. Port of `removeRange`.
+fn remove_range(content: &Fragment, from: usize, to: usize) -> Fragment {
+    let (index, offset) = content.find_index(from);
+    let child = content.maybe_child(index);
+    let (index_to, offset_to) = content.find_index(to);
+    if offset == from || child.is_some_and(Node::is_text) {
+        debug_assert!(
+            offset_to == to || content.child(index_to).is_text(),
+            "remove_range: non-flat range"
+        );
+        return content
+            .cut(0, from)
+            .append(&content.cut(to, content.size()));
+    }
+    debug_assert!(index == index_to, "remove_range: non-flat range");
+    let child = content.child(index);
+    content.replace_child(
+        index,
+        child.copy_with_content(remove_range(
+            child.content(),
+            from - offset - 1,
+            to - offset - 1,
+        )),
+    )
 }
 
 impl Default for Slice {

--- a/crates/rinch-editor-core/src/model/types.rs
+++ b/crates/rinch-editor-core/src/model/types.rs
@@ -12,10 +12,51 @@
 //! Handles from two *different* `Schema` instances are never equal, which is the
 //! correct behavior — you cannot mix nodes across schemas.
 
+use crate::EditorError;
+use crate::model::{AttrValue, Attrs};
 use crate::schema::content_match::ContentMatch;
-use crate::schema::{MarkSpec, NodeSpec};
+use crate::schema::{AttrSpec, MarkSpec, NodeSpec};
+use std::collections::BTreeMap;
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
+
+/// Compute the full, typed attribute set for a node/mark of the given spec from a
+/// (possibly partial) set of `provided` attributes — the port of ProseMirror's
+/// `computeAttrs`. For each attribute the type *declares*:
+///
+/// - if `provided` carries it, keep that value;
+/// - else if the spec has a default, fill the default;
+/// - else (a required attribute with no default) return
+///   [`EditorError::SchemaValidation`].
+///
+/// Attributes present in `provided` but **not declared** by the spec are dropped
+/// (PM behavior) — a node never carries undeclared attrs, which keeps the model,
+/// equality, and serialization clean. The result is total (every declared attr is
+/// present) and deterministic (keys are ordered by [`Attrs`]'s `BTreeMap`), and
+/// the function is idempotent: `compute(compute(x)) == compute(x)`.
+fn compute_attrs(
+    specs: &BTreeMap<String, AttrSpec>,
+    provided: &Attrs,
+    kind: &str,
+    type_name: &str,
+) -> Result<Attrs, EditorError> {
+    if specs.is_empty() {
+        return Ok(Attrs::new());
+    }
+    let mut pairs: Vec<(Box<str>, AttrValue)> = Vec::with_capacity(specs.len());
+    for (name, spec) in specs {
+        if let Some(v) = provided.get(name) {
+            pairs.push((name.as_str().into(), v.clone()));
+        } else if let Some(default) = &spec.default {
+            pairs.push((name.as_str().into(), default.clone()));
+        } else {
+            return Err(EditorError::SchemaValidation(format!(
+                "missing required attribute '{name}' on {kind} '{type_name}'"
+            )));
+        }
+    }
+    Ok(Attrs::from_iter(pairs))
+}
 
 struct NodeTypeInner {
     name: Box<str>,
@@ -87,6 +128,29 @@ impl NodeType {
     pub fn group(&self) -> Option<&str> {
         self.0.spec.group.as_deref()
     }
+
+    /// Whether content of this type may be joined with content of `other` — true
+    /// for identical types, or when their content expressions share at least one
+    /// acceptable child type. Used by the replace algorithm when merging the open
+    /// ancestors of two positions. Port of `NodeType.compatibleContent`.
+    pub fn compatible_content(&self, other: &NodeType) -> bool {
+        self == other || self.0.content_match.compatible(&other.0.content_match)
+    }
+
+    /// A *textblock* is a block-level type whose content is inline (paragraph,
+    /// heading, code_block) — the unit that `set_block_type`, `wrap`, and `lift`
+    /// operate over. Approximates ProseMirror's `isTextblock`
+    /// (`isBlock && inlineContent`) via "accepts a text child".
+    pub fn is_textblock(&self) -> bool {
+        self.is_block() && self.0.content_match.accepts("text")
+    }
+
+    /// Fill defaults and validate required attributes for this node type, given a
+    /// (possibly partial) `provided` attribute set. See [`compute_attrs`]. Used by
+    /// serialization (M3) and, in M4, by `Step::apply`.
+    pub fn compute_attrs(&self, provided: &Attrs) -> Result<Attrs, EditorError> {
+        compute_attrs(&self.0.spec.attrs, provided, "node", &self.0.name)
+    }
 }
 
 impl PartialEq for NodeType {
@@ -134,6 +198,12 @@ impl MarkType {
     pub fn excludes(&self, other: &str) -> bool {
         self.0.spec.excludes_mark(other)
     }
+
+    /// Fill defaults and validate required attributes for this mark type, given a
+    /// (possibly partial) `provided` attribute set. See [`compute_attrs`].
+    pub fn compute_attrs(&self, provided: &Attrs) -> Result<Attrs, EditorError> {
+        compute_attrs(&self.0.spec.attrs, provided, "mark", &self.0.name)
+    }
 }
 
 impl PartialEq for MarkType {
@@ -150,5 +220,105 @@ impl Hash for MarkType {
 impl std::fmt::Debug for MarkType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "MarkType({})", self.0.name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Schema;
+    use crate::model::{AttrValue, Attrs};
+
+    #[test]
+    fn compute_attrs_fills_defaults() {
+        let s = Schema::starter_kit();
+        // heading.level defaults to Int(1)
+        let heading = s.node_type("heading").unwrap();
+        let computed = heading.compute_attrs(&Attrs::new()).unwrap();
+        assert_eq!(computed.get_int("level"), Some(1));
+        // task_item.checked defaults to Bool(false), ordered_list.start to Int(1)
+        assert_eq!(
+            s.node_type("task_item")
+                .unwrap()
+                .compute_attrs(&Attrs::new())
+                .unwrap()
+                .get_bool("checked"),
+            Some(false)
+        );
+        assert_eq!(
+            s.node_type("ordered_list")
+                .unwrap()
+                .compute_attrs(&Attrs::new())
+                .unwrap()
+                .get_int("start"),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn compute_attrs_keeps_provided_over_default() {
+        let s = Schema::starter_kit();
+        let provided = Attrs::from_iter([("level", AttrValue::Int(3))]);
+        let computed = s
+            .node_type("heading")
+            .unwrap()
+            .compute_attrs(&provided)
+            .unwrap();
+        assert_eq!(computed.get_int("level"), Some(3));
+    }
+
+    #[test]
+    fn compute_attrs_errors_on_missing_required() {
+        let s = Schema::starter_kit();
+        // image.src is required (no default)
+        assert!(
+            s.node_type("image")
+                .unwrap()
+                .compute_attrs(&Attrs::new())
+                .is_err()
+        );
+        // link.href is required
+        assert!(
+            s.mark_type("link")
+                .unwrap()
+                .compute_attrs(&Attrs::new())
+                .is_err()
+        );
+        // text_color.color is required
+        assert!(
+            s.mark_type("text_color")
+                .unwrap()
+                .compute_attrs(&Attrs::new())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn compute_attrs_drops_undeclared_and_is_idempotent() {
+        let s = Schema::starter_kit();
+        let heading = s.node_type("heading").unwrap();
+        // an undeclared attr is dropped; the declared one survives
+        let provided = Attrs::from_iter([
+            ("level", AttrValue::Int(2)),
+            ("bogus", AttrValue::from("x")),
+        ]);
+        let once = heading.compute_attrs(&provided).unwrap();
+        assert_eq!(once.get_int("level"), Some(2));
+        assert_eq!(once.get("bogus"), None);
+        // idempotent: computing again yields the same set
+        let twice = heading.compute_attrs(&once).unwrap();
+        assert_eq!(once, twice);
+    }
+
+    #[test]
+    fn compute_attrs_empty_for_attrless_type() {
+        let s = Schema::starter_kit();
+        // paragraph declares no attrs → empty result even if junk is provided
+        let provided = Attrs::from_iter([("junk", AttrValue::Bool(true))]);
+        let computed = s
+            .node_type("paragraph")
+            .unwrap()
+            .compute_attrs(&provided)
+            .unwrap();
+        assert!(computed.is_empty());
     }
 }

--- a/crates/rinch-editor-core/src/plugin.rs
+++ b/crates/rinch-editor-core/src/plugin.rs
@@ -1,0 +1,77 @@
+//! [`Plugin`] — the extension seam. History, input rules, tables (M7), collab
+//! (M9) and IME-preedit decorations (M6) are **all plugins**; nothing is
+//! special-cased in the state core (design §5).
+//!
+//! A plugin contributes commands (and, once those layers land, keymap entries and
+//! input rules), optionally holds **plugin state** that is folded forward on every
+//! transaction ([`Plugin::apply`]), and is keyed by a unique [`PluginKey`] so its
+//! state can be looked up from [`EditorState`](crate::state::EditorState).
+
+use crate::command::Command;
+use crate::decoration::DecorationSet;
+use crate::input_rules::InputRule;
+use crate::keymap::KeyBinding;
+use crate::model::Node;
+use crate::state::{EditorState, Transaction};
+use std::any::Any;
+use std::rc::Rc;
+
+/// A stable identity for a plugin, used to store and look up its state. Two
+/// plugins in one state must not share a key.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct PluginKey(pub &'static str);
+
+/// An editor extension: commands, keymap, input rules, and optional folded state.
+///
+/// All methods have defaults, so a plugin overrides only what it contributes.
+pub trait Plugin {
+    /// This plugin's unique key.
+    fn key(&self) -> PluginKey;
+
+    /// Named commands this plugin contributes (aggregated into the state's command
+    /// registry).
+    fn commands(&self) -> Vec<(&'static str, Command)> {
+        Vec::new()
+    }
+
+    /// Key bindings this plugin contributes, as `(binding, command name)` pairs.
+    fn keymap(&self) -> Vec<(KeyBinding, &'static str)> {
+        Vec::new()
+    }
+
+    /// Input rules (markdown-style shortcuts) this plugin contributes.
+    fn input_rules(&self) -> Vec<InputRule> {
+        Vec::new()
+    }
+
+    /// Build this plugin's initial state for a fresh document. `None` if the plugin
+    /// is stateless.
+    fn init_state(&self, _doc: &Node) -> Option<Rc<dyn Any>> {
+        None
+    }
+
+    /// Fold this plugin's state forward across a transaction. Called on **every**
+    /// applied transaction with the previous state value (`prev`), the old editor
+    /// state, and the new document. Returns the new plugin-state value, or `None`
+    /// to leave no state. A stateless plugin keeps the default (no state).
+    fn apply(
+        &self,
+        _tr: &Transaction,
+        _old: &EditorState,
+        _new_doc: &Node,
+        _prev: Option<&dyn Any>,
+    ) -> Option<Rc<dyn Any>> {
+        None
+    }
+
+    /// View-facing: the decorations this plugin wants rendered for `state` — the
+    /// empty-editor placeholder ([`PlaceholderPlugin`](crate::plugins::PlaceholderPlugin)),
+    /// and (in later milestones) the IME preedit, search highlights, and
+    /// collaborator carets. The state aggregates these across all plugins in
+    /// [`EditorState::decorations`](crate::state::EditorState::decorations), and the
+    /// view diffs the result independently of the document (design A4). Default:
+    /// no decorations.
+    fn decorations(&self, _state: &EditorState) -> DecorationSet {
+        DecorationSet::empty()
+    }
+}

--- a/crates/rinch-editor-core/src/plugins/history.rs
+++ b/crates/rinch-editor-core/src/plugins/history.rs
@@ -1,0 +1,514 @@
+//! The history plugin — a single, Step-based, grouped, typing-merged undo/redo.
+//!
+//! This is the **only** undo system (design §5; it replaces the old engine's two
+//! competing interpreters). History stores **inverted Steps**, not byte positions:
+//! a recorded event is "the steps that, applied in reverse, revert this edit",
+//! plus the selection to restore and a timestamp. Undo applies an event's inverse
+//! steps as a transaction (`addToHistory=false`); redo re-applies the forward
+//! steps. The same event machinery serves both branches.
+//!
+//! Grouping: consecutive **typing** transactions within a time window merge into a
+//! single undo step (so a word is one undo, not one-per-keystroke); any non-typing
+//! transaction (a mark, a block change, a split) is its own group, and an explicit
+//! caret move breaks the current group. The time window is driven by
+//! [`Transaction::set_time`]; with times unset (`0`), consecutive typing merges
+//! (the default headless behavior), which tests pin by spacing timestamps apart.
+
+use std::any::Any;
+use std::rc::Rc;
+
+use crate::command::Command;
+use crate::keymap::KeyBinding;
+use crate::model::Node;
+use crate::plugin::{Plugin, PluginKey};
+use crate::selection::Selection;
+use crate::state::{EditorState, Transaction};
+use crate::transform::step::Step;
+use crate::transform::steps::ReplaceStep;
+
+/// The history plugin's key.
+pub const HISTORY_KEY: PluginKey = PluginKey("history");
+/// Transaction meta key marking an undo/redo (so the plugin shifts branches
+/// instead of recording a new event).
+const HISTORY_META: &str = "history";
+
+/// Marks a transaction as an undo or redo for the history plugin.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum HistoryAction {
+    Undo,
+    Redo,
+}
+
+/// One undo/redo step: the inverse steps (forward-collected; applied in reverse to
+/// revert), the selection to restore, a timestamp, and whether it is a typing
+/// group (mergeable).
+#[derive(Clone)]
+struct HistoryEvent {
+    steps: Vec<Box<dyn Step>>,
+    selection: Selection,
+    time: u64,
+    typing: bool,
+}
+
+/// One side of the history (the undo stack or the redo stack).
+#[derive(Clone, Default)]
+struct Branch {
+    events: Vec<HistoryEvent>,
+}
+
+/// The history plugin's folded state.
+#[derive(Clone, Default)]
+pub struct HistoryState {
+    done: Branch,
+    undone: Branch,
+    /// Set by a caret-only transaction; suppresses the next typing merge.
+    break_group: bool,
+}
+
+impl HistoryState {
+    /// Number of available undo steps.
+    pub fn undo_depth(&self) -> usize {
+        self.done.events.len()
+    }
+    /// Number of available redo steps.
+    pub fn redo_depth(&self) -> usize {
+        self.undone.events.len()
+    }
+}
+
+/// Build a history event from a transaction's steps (inverting each against its
+/// pre-step document) plus the selection of the state *before* the transaction.
+fn event_from(tr: &Transaction, old: &EditorState) -> HistoryEvent {
+    let mut steps = Vec::with_capacity(tr.steps().len());
+    for (i, step) in tr.steps().iter().enumerate() {
+        steps.push(step.invert(&tr.docs()[i]));
+    }
+    HistoryEvent {
+        steps,
+        selection: old.selection.clone(),
+        time: tr.time(),
+        typing: is_typing(tr),
+    }
+}
+
+/// A transaction is "typing" if all its steps are non-structural replaces (text
+/// insert/delete) — the class that should coalesce into one undo group.
+fn is_typing(tr: &Transaction) -> bool {
+    !tr.steps().is_empty()
+        && tr.steps().iter().all(|s| {
+            s.as_any()
+                .downcast_ref::<ReplaceStep>()
+                .is_some_and(|r| !r.structure)
+        })
+}
+
+/// Whether a new typing event should merge into the last recorded done event.
+fn should_merge(hist: &HistoryState, event: &HistoryEvent, delay: u64) -> bool {
+    if hist.break_group || !event.typing {
+        return false;
+    }
+    match hist.done.events.last() {
+        Some(last) => last.typing && event.time >= last.time && event.time - last.time < delay,
+        None => false,
+    }
+}
+
+/// Append `event` onto the end of the last group (combine their inverse steps).
+fn merge_into_last(branch: &mut Branch, event: HistoryEvent) {
+    let last = branch.events.last_mut().expect("merge with no prior event");
+    last.steps.extend(event.steps);
+    last.time = event.time; // slide the window forward; keep the group's selection
+}
+
+/// The history plugin. `new_group_delay` is the typing-merge window in
+/// milliseconds; `depth` caps the number of retained undo events.
+#[derive(Debug)]
+pub struct HistoryPlugin {
+    new_group_delay: u64,
+    depth: usize,
+}
+
+impl Default for HistoryPlugin {
+    fn default() -> Self {
+        HistoryPlugin {
+            new_group_delay: 500,
+            depth: 200,
+        }
+    }
+}
+
+impl HistoryPlugin {
+    /// A history plugin with default grouping (500ms window, depth 200).
+    pub fn new() -> HistoryPlugin {
+        HistoryPlugin::default()
+    }
+
+    /// Override the typing-merge window (ms) and the retained-event cap.
+    pub fn with(new_group_delay: u64, depth: usize) -> HistoryPlugin {
+        HistoryPlugin {
+            new_group_delay,
+            depth,
+        }
+    }
+}
+
+impl Plugin for HistoryPlugin {
+    fn key(&self) -> PluginKey {
+        HISTORY_KEY
+    }
+
+    fn commands(&self) -> Vec<(&'static str, Command)> {
+        vec![("undo", undo()), ("redo", redo())]
+    }
+
+    fn keymap(&self) -> Vec<(KeyBinding, &'static str)> {
+        [
+            ("Mod-z", "undo"),
+            ("Mod-y", "redo"),
+            ("Mod-Shift-z", "redo"),
+        ]
+        .into_iter()
+        .filter_map(|(b, c)| KeyBinding::parse(b).map(|kb| (kb, c)))
+        .collect()
+    }
+
+    fn init_state(&self, _doc: &Node) -> Option<Rc<dyn Any>> {
+        Some(Rc::new(HistoryState::default()))
+    }
+
+    fn apply(
+        &self,
+        tr: &Transaction,
+        old: &EditorState,
+        _new_doc: &Node,
+        prev: Option<&dyn Any>,
+    ) -> Option<Rc<dyn Any>> {
+        let mut hist = prev
+            .and_then(|p| p.downcast_ref::<HistoryState>())
+            .cloned()
+            .unwrap_or_default();
+
+        match tr.get_meta_as::<HistoryAction>(HISTORY_META) {
+            Some(HistoryAction::Undo) => {
+                // The undo command reverted `done.last`; record the redo event.
+                // Inherit the reverted event's `typing` classification rather than
+                // recomputing it: an event's inverse steps are always non-structural
+                // (PM's `ReplaceStep.invert` drops the structure flag), so a redone
+                // structural edit (e.g. a split) must NOT be reclassified as typing
+                // and merged with the next keystroke.
+                let reverted = hist.done.events.pop();
+                let mut event = event_from(tr, old);
+                if let Some(prev) = &reverted {
+                    event.typing = prev.typing;
+                }
+                hist.undone.events.push(event);
+            }
+            Some(HistoryAction::Redo) => {
+                let reverted = hist.undone.events.pop();
+                let mut event = event_from(tr, old);
+                if let Some(prev) = &reverted {
+                    event.typing = prev.typing;
+                }
+                hist.done.events.push(event);
+            }
+            None => {
+                if tr.add_to_history() && tr.doc_changed() {
+                    let event = event_from(tr, old);
+                    if should_merge(&hist, &event, self.new_group_delay) {
+                        merge_into_last(&mut hist.done, event);
+                    } else {
+                        hist.done.events.push(event);
+                    }
+                    hist.break_group = false;
+                    hist.undone.events.clear(); // a fresh edit invalidates redo
+                } else if (tr.selection_set() || tr.stored_marks_set()) && !tr.doc_changed() {
+                    // A caret-only move or a stored-mark toggle (e.g. cursor-bold)
+                    // ends the current typing group, matching PM's storedMarksSet
+                    // group break.
+                    hist.break_group = true;
+                }
+            }
+        }
+
+        // Cap retained undo history.
+        while hist.done.events.len() > self.depth {
+            hist.done.events.remove(0);
+        }
+        Some(Rc::new(hist))
+    }
+}
+
+/// Apply an event's inverse steps (in reverse) as a transaction, restoring the
+/// event's selection and tagging it with `action` so the plugin shifts branches.
+fn apply_event(
+    state: &EditorState,
+    event: &HistoryEvent,
+    action: HistoryAction,
+) -> Option<Transaction> {
+    let mut tr = state.tr();
+    for step in event.steps.iter().rev() {
+        tr.step(step.clone()).ok()?;
+    }
+    tr.set_selection(event.selection.clone());
+    tr.set_add_to_history(false);
+    tr.set_meta(HISTORY_META, action);
+    Some(tr)
+}
+
+/// The undo command: revert the most recent recorded event.
+pub fn undo() -> Command {
+    Rc::new(|state: &EditorState, dispatch| {
+        // Build the transaction eagerly so the applicability query (`dispatch ==
+        // None`) and the dispatch path share one code path (no "reports applicable
+        // but then fails to dispatch" divergence — matching the `command_tr`
+        // discipline elsewhere in the catalogue).
+        let Some(hist) = state.plugin_state::<HistoryState>(HISTORY_KEY) else {
+            return false;
+        };
+        let Some(event) = hist.done.events.last() else {
+            return false;
+        };
+        let Some(tr) = apply_event(state, event, HistoryAction::Undo) else {
+            return false;
+        };
+        if let Some(dispatch) = dispatch {
+            dispatch(tr);
+        }
+        true
+    })
+}
+
+/// The redo command: re-apply the most recently undone event.
+pub fn redo() -> Command {
+    Rc::new(|state: &EditorState, dispatch| {
+        let Some(hist) = state.plugin_state::<HistoryState>(HISTORY_KEY) else {
+            return false;
+        };
+        let Some(event) = hist.undone.events.last() else {
+            return false;
+        };
+        let Some(tr) = apply_event(state, event, HistoryAction::Redo) else {
+            return false;
+        };
+        if let Some(dispatch) = dispatch {
+            dispatch(tr);
+        }
+        true
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Schema;
+    use crate::commands::BaseCommandsPlugin;
+    use crate::model::Fragment;
+    use crate::pos::Pos;
+
+    fn editor(text: &str) -> EditorState {
+        let s = Rc::new(Schema::starter_kit());
+        let para = s
+            .branch("paragraph", Fragment::from_node(s.text(text).unwrap()))
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(para)).unwrap();
+        EditorState::create(
+            s,
+            doc,
+            vec![Rc::new(BaseCommandsPlugin), Rc::new(HistoryPlugin::new())],
+        )
+    }
+
+    fn all_text(node: &Node) -> String {
+        if let Some(t) = node.text() {
+            return t.to_string();
+        }
+        node.content().iter().map(all_text).collect()
+    }
+
+    fn type_char(state: &EditorState, text: &str, time: u64) -> EditorState {
+        let mut tr = state.tr();
+        tr.set_time(time);
+        tr.insert_text(text).unwrap();
+        state.apply(tr)
+    }
+
+    #[test]
+    fn undo_and_redo_a_single_edit() {
+        let state = editor("ab");
+        let typed = type_char(&state, "X", 0); // cursor at start (pos 1) → "Xab"
+        assert_eq!(all_text(&typed.doc), "Xab");
+        let undone = typed.run("undo").expect("undo applies");
+        assert_eq!(all_text(&undone.doc), "ab");
+        let redone = undone.run("redo").expect("redo applies");
+        assert_eq!(all_text(&redone.doc), "Xab");
+    }
+
+    #[test]
+    fn typing_coalesces_into_one_undo_group() {
+        // three chars typed within the window merge into a single undo
+        let state = editor("");
+        let s1 = type_char(&state, "a", 0);
+        let s2 = type_char(&s1, "b", 10);
+        let s3 = type_char(&s2, "c", 20);
+        assert_eq!(all_text(&s3.doc), "abc");
+        let undone = s3.run("undo").expect("undo applies");
+        assert_eq!(
+            all_text(&undone.doc),
+            "",
+            "one undo reverts all coalesced typing"
+        );
+        // and a single redo restores all of it
+        let redone = undone.run("redo").unwrap();
+        assert_eq!(all_text(&redone.doc), "abc");
+    }
+
+    #[test]
+    fn time_gap_breaks_typing_group() {
+        let state = editor("");
+        let s1 = type_char(&state, "a", 0);
+        let s2 = type_char(&s1, "b", 1000); // beyond the 500ms window
+        assert_eq!(all_text(&s2.doc), "ab");
+        let u1 = s2.run("undo").unwrap();
+        assert_eq!(all_text(&u1.doc), "a", "second char is its own group");
+        let u2 = u1.run("undo").unwrap();
+        assert_eq!(all_text(&u2.doc), "");
+    }
+
+    #[test]
+    fn type_then_bold_undo_reverts_bold_only() {
+        // design M4 test: typing then a mark are separate groups
+        let state = editor("ab");
+        let typed = type_char(&state, "X", 0); // "Xab", cursor at 2
+        let mut bolded_state = typed.clone();
+        bolded_state.selection = Selection::text(Pos(1), Pos(4)); // select "Xab"
+        let bolded = bolded_state.run("toggleBold").expect("bold applies");
+        assert!(
+            bolded
+                .doc
+                .child(0)
+                .content()
+                .iter()
+                .all(|n| n.marks().iter().any(|m| m.type_name() == "bold"))
+        );
+        // first undo removes the bold (its own group), text remains
+        let u1 = bolded.run("undo").expect("undo bold");
+        assert_eq!(all_text(&u1.doc), "Xab");
+        assert!(!range_has_bold(&u1));
+        // second undo removes the typed X
+        let u2 = u1.run("undo").expect("undo typing");
+        assert_eq!(all_text(&u2.doc), "ab");
+    }
+
+    fn range_has_bold(state: &EditorState) -> bool {
+        let bold = state.schema().mark_type("bold").unwrap();
+        crate::commands::range_has_mark(&state.doc, 0, state.doc.content_size(), bold)
+    }
+
+    #[test]
+    fn new_edit_clears_redo() {
+        let state = editor("");
+        let s1 = type_char(&state, "a", 0);
+        let undone = s1.run("undo").unwrap();
+        assert!(undone.run("redo").is_some());
+        // typing again should drop the redo stack
+        let s2 = type_char(&undone, "b", 0);
+        assert!(s2.run("redo").is_none(), "a fresh edit invalidates redo");
+        assert_eq!(all_text(&s2.doc), "b");
+    }
+
+    #[test]
+    fn undo_restores_selection() {
+        let state = editor("ab");
+        let mut s0 = state.clone();
+        s0.selection = Selection::cursor(Pos(3)); // end of "ab"
+        let typed = {
+            let mut tr = s0.tr();
+            tr.insert_text("Z").unwrap();
+            s0.apply(tr)
+        };
+        assert_eq!(typed.selection, Selection::cursor(Pos(4)));
+        let undone = typed.run("undo").unwrap();
+        // selection restored to where it was before the edit (pos 3)
+        assert_eq!(undone.selection, Selection::cursor(Pos(3)));
+    }
+
+    #[test]
+    fn undo_unavailable_on_empty_history() {
+        let state = editor("ab");
+        assert!(!state.can_run("undo"));
+        assert!(!state.can_run("redo"));
+    }
+
+    #[test]
+    fn redone_split_does_not_merge_with_later_typing() {
+        // verification finding #1: a redone structural edit (split) must keep its
+        // non-typing classification so a following keystroke is its own undo group.
+        let mut state = editor("ab");
+        state.selection = Selection::cursor(Pos(2)); // a|b
+        let split = state.run("splitBlock").expect("split");
+        assert_eq!(split.doc.child_count(), 2);
+        let undone = split.run("undo").expect("undo split");
+        assert_eq!(undone.doc.child_count(), 1);
+        let redone = undone.run("redo").expect("redo split");
+        assert_eq!(redone.doc.child_count(), 2);
+        // type after the redone split, within the merge window
+        let typed = type_char(&redone, "Z", 0);
+        let after = typed.run("undo").expect("undo typing");
+        assert_eq!(
+            after.doc.child_count(),
+            2,
+            "undo reverts only the typing, not the redone split"
+        );
+    }
+
+    #[test]
+    fn stored_mark_toggle_breaks_typing_group() {
+        // verification finding #2: a cursor mark toggle between keystrokes ends the
+        // typing group (PM storedMarksSet group break).
+        let mut state = editor("");
+        state.selection = Selection::cursor(Pos(1));
+        let s1 = type_char(&state, "a", 0);
+        let s2 = s1.run("toggleBold").expect("cursor bold (stored marks)");
+        let s3 = type_char(&s2, "b", 10); // within the window
+        assert_eq!(all_text(&s3.doc), "ab");
+        let undone = s3.run("undo").expect("undo");
+        assert_eq!(
+            all_text(&undone.doc),
+            "a",
+            "only 'b' reverted, not the whole word"
+        );
+    }
+
+    #[test]
+    fn block_join_starts_new_undo_group() {
+        // verification finding #4: a structural block join is its own undo group and
+        // does not coalesce into preceding typing.
+        let s = Rc::new(Schema::starter_kit());
+        let p = |t: &str| {
+            s.branch("paragraph", Fragment::from_node(s.text(t).unwrap()))
+                .unwrap()
+        };
+        let doc = s
+            .branch("doc", Fragment::from_children(vec![p("ab"), p("cd")]))
+            .unwrap();
+        let mut state = EditorState::create(
+            s,
+            doc,
+            vec![Rc::new(BaseCommandsPlugin), Rc::new(HistoryPlugin::new())],
+        );
+        state.selection = Selection::cursor(Pos(3)); // end of first paragraph
+        let typed = type_char(&state, "Z", 0); // "abZ" / "cd"
+        assert_eq!(typed.doc.child_count(), 2);
+        let joined = typed.run("deleteCharForward").expect("forward join");
+        assert_eq!(joined.doc.child_count(), 1);
+        assert_eq!(all_text(&joined.doc), "abZcd");
+        // undo reverts ONLY the join, keeping the typed Z
+        let after = joined.run("undo").expect("undo join");
+        assert_eq!(after.doc.child_count(), 2, "join is its own undo group");
+        assert_eq!(
+            all_text(&after.doc),
+            "abZcd",
+            "the typed Z survives the undo"
+        );
+    }
+}

--- a/crates/rinch-editor-core/src/plugins/markdown.rs
+++ b/crates/rinch-editor-core/src/plugins/markdown.rs
@@ -1,0 +1,19 @@
+//! The markdown-shortcut input rules as a [`Plugin`] (`## ` → heading, `- ` →
+//! bullet list, `> ` → blockquote, `1. ` → ordered list, ` ``` ` → code block).
+
+use crate::input_rules::{InputRule, markdown_input_rules};
+use crate::plugin::{Plugin, PluginKey};
+
+/// Contributes the default markdown input rules.
+#[derive(Debug, Default)]
+pub struct MarkdownInputRulesPlugin;
+
+impl Plugin for MarkdownInputRulesPlugin {
+    fn key(&self) -> PluginKey {
+        PluginKey("markdown-input-rules")
+    }
+
+    fn input_rules(&self) -> Vec<InputRule> {
+        markdown_input_rules()
+    }
+}

--- a/crates/rinch-editor-core/src/plugins/mod.rs
+++ b/crates/rinch-editor-core/src/plugins/mod.rs
@@ -1,0 +1,12 @@
+//! Built-in plugins: history (undo/redo), markdown input rules, and the
+//! empty-editor placeholder (M5). Tables (M7), accessibility (M7b), collaboration
+//! (M9), and IME-preedit decorations (M6) join here (or in their own crates) as
+//! later milestones land.
+
+pub mod history;
+pub mod markdown;
+pub mod placeholder;
+
+pub use history::{HISTORY_KEY, HistoryPlugin, HistoryState};
+pub use markdown::MarkdownInputRulesPlugin;
+pub use placeholder::{PLACEHOLDER_KEY, PlaceholderPlugin};

--- a/crates/rinch-editor-core/src/plugins/placeholder.rs
+++ b/crates/rinch-editor-core/src/plugins/placeholder.rs
@@ -1,0 +1,155 @@
+//! The empty-editor placeholder as a [`Plugin`] (design A8).
+//!
+//! When the document is a single empty textblock, this plugin contributes one
+//! [`Widget::Placeholder`] decoration carrying the configured prompt text. The
+//! decoration is **not** part of the document — it flows through the same
+//! decoration-diff path the view uses for the IME preedit (M6), so the
+//! placeholder appears and disappears purely as a function of `state.doc`.
+//!
+//! This plugin is **not** in [`default_plugins`](crate::default_plugins): the
+//! prompt text is per-editor, so the desktop view (M5.7) constructs it from the
+//! `Editor { placeholder: … }` prop.
+
+use crate::decoration::{Decoration, DecorationSet, Widget};
+use crate::model::Node;
+use crate::plugin::{Plugin, PluginKey};
+use crate::pos::Pos;
+use crate::state::EditorState;
+use std::rc::Rc;
+
+/// The stable key for the placeholder plugin's slot.
+pub const PLACEHOLDER_KEY: PluginKey = PluginKey("placeholder");
+
+/// Shows a dimmed prompt while the editor is empty (design A8).
+#[derive(Debug, Clone)]
+pub struct PlaceholderPlugin {
+    text: Rc<str>,
+}
+
+impl PlaceholderPlugin {
+    /// A placeholder showing `text` when the document is empty.
+    pub fn new(text: impl Into<Rc<str>>) -> PlaceholderPlugin {
+        PlaceholderPlugin { text: text.into() }
+    }
+
+    /// The configured prompt text.
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+}
+
+impl Plugin for PlaceholderPlugin {
+    fn key(&self) -> PluginKey {
+        PLACEHOLDER_KEY
+    }
+
+    fn decorations(&self, state: &EditorState) -> DecorationSet {
+        if doc_is_empty(&state.doc) {
+            // The single empty textblock is `doc.child(0)`; its inline content
+            // begins at position 1 (just inside its opening boundary).
+            DecorationSet::new(vec![Decoration::widget(
+                Pos(1),
+                0,
+                Widget::Placeholder(self.text.clone()),
+            )])
+        } else {
+            DecorationSet::empty()
+        }
+    }
+}
+
+/// True when `doc` is a single, empty textblock (e.g. one empty paragraph) — the
+/// canonical "nothing typed yet" shape the placeholder targets.
+fn doc_is_empty(doc: &Node) -> bool {
+    doc.child_count() == 1 && {
+        let only = doc.child(0);
+        only.is_textblock() && only.child_count() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Schema;
+    use crate::model::Fragment;
+    use std::rc::Rc;
+
+    fn state_with_doc(doc: Node) -> EditorState {
+        let schema = Rc::new(Schema::starter_kit());
+        EditorState::create(
+            schema,
+            doc,
+            vec![Rc::new(PlaceholderPlugin::new("Write something…"))],
+        )
+    }
+
+    fn empty_doc(s: &Schema) -> Node {
+        s.branch(
+            "doc",
+            Fragment::from_node(s.branch("paragraph", Fragment::empty()).unwrap()),
+        )
+        .unwrap()
+    }
+
+    fn nonempty_doc(s: &Schema) -> Node {
+        s.branch(
+            "doc",
+            Fragment::from_node(
+                s.branch("paragraph", Fragment::from_node(s.text("hi").unwrap()))
+                    .unwrap(),
+            ),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn placeholder_shows_for_empty_doc() {
+        let s = Schema::starter_kit();
+        let state = state_with_doc(empty_doc(&s));
+        let decos = state.decorations();
+        assert_eq!(decos.len(), 1);
+        let d = decos.iter().next().unwrap();
+        assert_eq!(d.pos(), Pos(1));
+        match d {
+            Decoration::Widget { widget, .. } => {
+                assert_eq!(*widget, Widget::Placeholder(Rc::from("Write something…")));
+            }
+        }
+    }
+
+    #[test]
+    fn placeholder_hidden_once_content_exists() {
+        let s = Schema::starter_kit();
+        let state = state_with_doc(nonempty_doc(&s));
+        assert!(state.decorations().is_empty());
+    }
+
+    #[test]
+    fn placeholder_hidden_for_non_textblock_first_child() {
+        // A doc whose only child is a horizontal rule is not "empty text".
+        let s = Schema::starter_kit();
+        let doc = s
+            .branch(
+                "doc",
+                Fragment::from_node(s.branch("horizontal_rule", Fragment::empty()).unwrap()),
+            )
+            .unwrap();
+        let state = state_with_doc(doc);
+        assert!(state.decorations().is_empty());
+    }
+
+    #[test]
+    fn doc_is_empty_rejects_multiple_blocks() {
+        let s = Schema::starter_kit();
+        let doc = s
+            .branch(
+                "doc",
+                Fragment::from_children(vec![
+                    s.branch("paragraph", Fragment::empty()).unwrap(),
+                    s.branch("paragraph", Fragment::empty()).unwrap(),
+                ]),
+            )
+            .unwrap();
+        assert!(!doc_is_empty(&doc));
+    }
+}

--- a/crates/rinch-editor-core/src/pos/resolved.rs
+++ b/crates/rinch-editor-core/src/pos/resolved.rs
@@ -8,7 +8,7 @@
 //! within it, and the positions before/after/inside any ancestor.
 
 use crate::EditorError;
-use crate::model::Node;
+use crate::model::{Mark, Node};
 use crate::pos::Pos;
 
 /// One level of the resolved path.
@@ -107,6 +107,18 @@ impl ResolvedPos {
         self.path[depth].index
     }
 
+    /// The child index *after* the position within the node at `depth`. Equal to
+    /// [`Self::index`] except at the deepest level when the position sits inside a
+    /// text node (then it is the next index). Port of `ResolvedPos.indexAfter`.
+    pub fn index_after(&self, depth: usize) -> usize {
+        self.index(depth)
+            + if depth == self.depth && self.text_offset() == 0 {
+                0
+            } else {
+                1
+            }
+    }
+
     /// The offset of the position within its immediate parent's content (within a
     /// text node, the char offset).
     pub fn parent_offset(&self) -> usize {
@@ -140,6 +152,87 @@ impl ResolvedPos {
     /// The document position directly after the node at `depth`. `None` at depth 0.
     pub fn after(&self, depth: usize) -> Option<usize> {
         self.before(depth).map(|b| b + self.node(depth).node_size())
+    }
+
+    /// The offset of the position within the deepest child boundary — i.e. the
+    /// char offset into the text node the position sits in, or `0` at a non-text
+    /// boundary. Port of `ResolvedPos.textOffset`.
+    pub fn text_offset(&self) -> usize {
+        self.pos.0 - self.path[self.depth].before
+    }
+
+    /// The node directly after the position within its parent, cut at the position
+    /// if it falls inside a text node; `None` at the parent's end. Port of
+    /// `ResolvedPos.nodeAfter`.
+    pub fn node_after(&self) -> Option<Node> {
+        let parent = self.parent();
+        let index = self.index(self.depth);
+        if index == parent.child_count() {
+            return None;
+        }
+        let d_off = self.text_offset();
+        let child = parent.child(index);
+        if d_off > 0 {
+            let to = if child.is_text() {
+                child.text_len()
+            } else {
+                child.content_size()
+            };
+            Some(child.cut(d_off, to))
+        } else {
+            Some(child.clone())
+        }
+    }
+
+    /// The node directly before the position within its parent, cut at the
+    /// position if it falls inside a text node; `None` at the parent's start. Port
+    /// of `ResolvedPos.nodeBefore`.
+    pub fn node_before(&self) -> Option<Node> {
+        let index = self.index(self.depth);
+        let d_off = self.text_offset();
+        if d_off > 0 {
+            Some(self.parent().child(index).cut(0, d_off))
+        } else if index == 0 {
+            None
+        } else {
+            Some(self.parent().child(index - 1).clone())
+        }
+    }
+
+    /// The deepest ancestor whose content range contains both this position and
+    /// `pos` — the depth at which a slice between the two stays closed. Port of
+    /// `ResolvedPos.sharedDepth`.
+    pub fn shared_depth(&self, pos: Pos) -> usize {
+        let p = pos.0;
+        let mut depth = self.depth;
+        while depth > 0 {
+            if self.start(depth) <= p && self.end(depth) >= p {
+                return depth;
+            }
+            depth -= 1;
+        }
+        0
+    }
+
+    /// The set of marks active *at* this position — the marks a character typed
+    /// here would inherit. Inside a text node, the node's own marks; at a boundary,
+    /// the marks of the node immediately before (or, if none, the node after). Port
+    /// of `ResolvedPos.marks` (without the `inclusive` spec flag, which this engine
+    /// does not model — every mark behaves as inclusive).
+    pub fn marks(&self) -> Vec<Mark> {
+        let parent = self.parent();
+        if parent.content().size() == 0 {
+            return Vec::new();
+        }
+        if self.text_offset() > 0 {
+            return parent.child(self.index(self.depth)).marks().to_vec();
+        }
+        let index = self.index(self.depth);
+        let before = index
+            .checked_sub(1)
+            .and_then(|i| parent.content().maybe_child(i));
+        let main = before.or_else(|| parent.content().maybe_child(index));
+        main.map(|n| n.marks().to_vec()).unwrap_or_default()
     }
 
     /// If the position is inside (or at the left edge of) a text node, return that

--- a/crates/rinch-editor-core/src/schema/content_match.rs
+++ b/crates/rinch-editor-core/src/schema/content_match.rs
@@ -102,6 +102,15 @@ impl ContentMatch {
         ContentMatch { parts }
     }
 
+    /// Do this and `other` accept at least one node type in common? The replace
+    /// algorithm uses this to decide whether two nodes' contents may be joined.
+    /// Port (over the part list) of `ContentMatch.compatible`.
+    pub fn compatible(&self, other: &ContentMatch) -> bool {
+        self.parts
+            .iter()
+            .any(|p| other.parts.iter().any(|q| !p.types.is_disjoint(&q.types)))
+    }
+
     /// Does any part of this expression accept a child of type `name`?
     ///
     /// This answers "can node type X ever appear as a child here" — the basis for

--- a/crates/rinch-editor-core/src/schema/mark.rs
+++ b/crates/rinch-editor-core/src/schema/mark.rs
@@ -1,7 +1,7 @@
 //! Mark types and specifications.
 
 use super::node::AttrSpec;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 // NOTE: the old dyn `Mark` trait was dropped in the rearchitecture (M0). The
 // concrete `Mark` value type lives in `crate::model` (M1); the schema only deals
@@ -14,7 +14,7 @@ pub struct MarkSpec {
     pub name: String,
 
     /// Mark attributes
-    pub attrs: HashMap<String, AttrSpec>,
+    pub attrs: BTreeMap<String, AttrSpec>,
 
     /// Whether this mark spans across nodes
     pub spanning: bool,
@@ -34,7 +34,7 @@ impl MarkSpec {
     pub fn simple(name: &str) -> Self {
         Self {
             name: name.to_string(),
-            attrs: HashMap::new(),
+            attrs: BTreeMap::new(),
             spanning: true,
             excludes: None,
             parse_html_tags: Vec::new(),
@@ -42,7 +42,7 @@ impl MarkSpec {
     }
 
     /// Create a mark with attributes.
-    pub fn with_attrs(name: &str, attrs: HashMap<String, AttrSpec>) -> Self {
+    pub fn with_attrs(name: &str, attrs: BTreeMap<String, AttrSpec>) -> Self {
         Self {
             name: name.to_string(),
             attrs,
@@ -126,7 +126,7 @@ mod tests {
 
     #[test]
     fn with_attrs_constructor() {
-        let mut attrs = HashMap::new();
+        let mut attrs = BTreeMap::new();
         attrs.insert("href".to_string(), AttrSpec::required());
         attrs.insert("title".to_string(), AttrSpec::optional(""));
         let spec = MarkSpec::with_attrs("link", attrs);

--- a/crates/rinch-editor-core/src/schema/mod.rs
+++ b/crates/rinch-editor-core/src/schema/mod.rs
@@ -12,9 +12,10 @@ pub mod validation;
 pub use mark::{MarkSpec, MarkSpecBuilder};
 pub use node::{AttrSpec, MarkSet, NodeSpec, NodeSpecBuilder};
 
+use crate::model::AttrValue;
 use crate::model::types::{MarkType, NodeType};
 use content_match::ContentMatch;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 /// Schema defines the valid structure of a document.
 ///
@@ -85,7 +86,7 @@ impl Schema {
             NodeSpec::builder("heading")
                 .content("inline*")
                 .group("block")
-                .attr("level", AttrSpec::optional("1"))
+                .attr("level", AttrSpec::optional(AttrValue::Int(1)))
                 .parse_html(vec![
                     "h1".into(),
                     "h2".into(),
@@ -135,7 +136,7 @@ impl Schema {
             NodeSpec::builder("ordered_list")
                 .content("list_item+")
                 .group("block")
-                .attr("start", AttrSpec::optional("1"))
+                .attr("start", AttrSpec::optional(AttrValue::Int(1)))
                 .parse_html(vec!["ol".into()])
                 .build(),
         );
@@ -163,7 +164,7 @@ impl Schema {
             "task_item",
             NodeSpec::builder("task_item")
                 .content("block+")
-                .attr("checked", AttrSpec::optional("false"))
+                .attr("checked", AttrSpec::optional(AttrValue::Bool(false)))
                 .build(),
         );
 
@@ -231,7 +232,7 @@ impl Schema {
         builder = builder.mark("code", code);
 
         // link
-        let mut link_attrs = HashMap::new();
+        let mut link_attrs = BTreeMap::new();
         link_attrs.insert("href".into(), AttrSpec::required());
         link_attrs.insert("title".into(), AttrSpec::optional(""));
         link_attrs.insert("target".into(), AttrSpec::optional(""));
@@ -240,14 +241,14 @@ impl Schema {
         builder = builder.mark("link", link);
 
         // highlight
-        let mut hl_attrs = HashMap::new();
+        let mut hl_attrs = BTreeMap::new();
         hl_attrs.insert("color".into(), AttrSpec::optional(""));
         let mut highlight = MarkSpec::with_attrs("highlight", hl_attrs);
         highlight.parse_html_tags = vec!["mark".into()];
         builder = builder.mark("highlight", highlight);
 
         // text_color
-        let mut tc_attrs = HashMap::new();
+        let mut tc_attrs = BTreeMap::new();
         tc_attrs.insert("color".into(), AttrSpec::required());
         let text_color = MarkSpec::with_attrs("text_color", tc_attrs);
         builder = builder.mark("text_color", text_color);
@@ -699,7 +700,7 @@ mod tests {
         let schema = Schema::starter_kit();
         let heading = schema.node("heading").unwrap();
         assert!(heading.attrs.contains_key("level"));
-        assert_eq!(heading.attrs["level"].default, Some("1".to_string()));
+        assert_eq!(heading.attrs["level"].default, Some(AttrValue::Int(1)));
     }
 
     #[test]

--- a/crates/rinch-editor-core/src/schema/node.rs
+++ b/crates/rinch-editor-core/src/schema/node.rs
@@ -1,6 +1,7 @@
 //! Node types and specifications.
 
-use std::collections::HashMap;
+use crate::model::AttrValue;
+use std::collections::BTreeMap;
 
 // NOTE: the old dyn `Node` trait was dropped in the rearchitecture (M0). The
 // concrete `Node` value type lives in `crate::model` (M1); the schema only deals
@@ -39,7 +40,7 @@ pub struct NodeSpec {
     pub isolating: bool,
 
     /// Node attributes with their defaults
-    pub attrs: HashMap<String, AttrSpec>,
+    pub attrs: BTreeMap<String, AttrSpec>,
 
     /// HTML tags to parse as this node (e.g., ["p"], ["h1", "h2", "h3"...])
     pub parse_html_tags: Vec<String>,
@@ -63,7 +64,7 @@ impl NodeSpec {
             selectable: true,
             draggable: false,
             isolating: false,
-            attrs: HashMap::new(),
+            attrs: BTreeMap::new(),
             parse_html_tags: Vec::new(),
         }
     }
@@ -80,7 +81,7 @@ impl NodeSpec {
             selectable: false,
             draggable: false,
             isolating: false,
-            attrs: HashMap::new(),
+            attrs: BTreeMap::new(),
             parse_html_tags: Vec::new(),
         }
     }
@@ -97,7 +98,7 @@ impl NodeSpec {
             selectable: true,
             draggable: false,
             isolating: false,
-            attrs: HashMap::new(),
+            attrs: BTreeMap::new(),
             parse_html_tags: Vec::new(),
         }
     }
@@ -133,20 +134,26 @@ impl MarkSet {
     }
 }
 
-/// Attribute specification with optional default value.
-#[derive(Debug, Clone)]
+/// Attribute specification with an optional, **typed** default value.
+///
+/// The default is an [`AttrValue`] (not a string) so that `heading.level`
+/// defaults to `Int(1)` and `task_item.checked` to `Bool(false)` — the typed
+/// model the document tree carries (amendment A11). `default == None` marks a
+/// required attribute (no default; absence is a schema-validation error at the
+/// serialization / Step boundary via [`NodeType::compute_attrs`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AttrSpec {
     /// Default value (None = required attribute)
-    pub default: Option<String>,
+    pub default: Option<AttrValue>,
     /// Whether this attribute is required
     pub required: bool,
 }
 
 impl AttrSpec {
-    /// Create an optional attribute with a default value.
-    pub fn optional(default: &str) -> Self {
+    /// Create an optional attribute with a typed default value.
+    pub fn optional(default: impl Into<AttrValue>) -> Self {
         Self {
-            default: Some(default.to_string()),
+            default: Some(default.into()),
             required: false,
         }
     }
@@ -180,7 +187,7 @@ impl NodeSpecBuilder {
                 selectable: true,
                 draggable: false,
                 isolating: false,
-                attrs: HashMap::new(),
+                attrs: BTreeMap::new(),
                 parse_html_tags: Vec::new(),
             },
         }
@@ -298,7 +305,7 @@ mod tests {
         let spec = NodeSpec::builder("heading")
             .content("inline*")
             .group("block")
-            .attr("level", AttrSpec::optional("1"))
+            .attr("level", AttrSpec::optional(AttrValue::Int(1)))
             .parse_html(vec!["h1".into(), "h2".into()])
             .build();
 
@@ -306,7 +313,7 @@ mod tests {
         assert_eq!(spec.content, Some("inline*".to_string()));
         assert_eq!(spec.group, Some("block".to_string()));
         assert!(spec.attrs.contains_key("level"));
-        assert_eq!(spec.attrs["level"].default, Some("1".to_string()));
+        assert_eq!(spec.attrs["level"].default, Some(AttrValue::Int(1)));
         assert_eq!(spec.parse_html_tags.len(), 2);
     }
 
@@ -339,9 +346,12 @@ mod tests {
 
     #[test]
     fn attrspec_optional_has_default() {
-        let attr = AttrSpec::optional("1");
-        assert_eq!(attr.default, Some("1".to_string()));
+        let attr = AttrSpec::optional(AttrValue::Int(1));
+        assert_eq!(attr.default, Some(AttrValue::Int(1)));
         assert!(!attr.required);
+        // string defaults still work via the `Into<AttrValue>` bound
+        let s = AttrSpec::optional("");
+        assert_eq!(s.default, Some(AttrValue::Str("".into())));
     }
 
     #[test]

--- a/crates/rinch-editor-core/src/selection.rs
+++ b/crates/rinch-editor-core/src/selection.rs
@@ -1,0 +1,373 @@
+//! [`Selection`] — the editor's caret/range, part of [`EditorState`].
+//!
+//! Selection is **first-class state** (design §5, non-negotiable principle #3):
+//! the caret is rendered from `state.selection`, never from a second DOM-side
+//! cursor model. A selection is one of:
+//!
+//! - [`TextSelection`] — a text range `anchor..head` (a collapsed cursor when
+//!   `anchor == head`); `anchor` is the fixed end, `head` the moving end.
+//! - [`NodeSelection`] — a whole non-text node selected (an image, a horizontal
+//!   rule).
+//!
+//! A `Cell` selection (table rectangles) is intentionally **not** here yet — it
+//! lands with the tables plugin in M7, so adding a dead variant now would trip the
+//! crate's "no dead code" gate.
+//!
+//! Every transaction maps its selection forward through the accumulated
+//! [`Mapping`], so the caret follows content as it shifts. A faithful port of the
+//! relevant parts of ProseMirror's `prosemirror-state/src/selection.ts`.
+//!
+//! [`EditorState`]: crate::state::EditorState
+
+use crate::model::Node;
+use crate::pos::Pos;
+use crate::transform::step_map::Mapping;
+
+/// The editor selection: a caret, a text range, or a selected node.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Selection {
+    /// A text range (collapsed when `anchor == head`).
+    Text(TextSelection),
+    /// A whole non-text node selected.
+    Node(NodeSelection),
+}
+
+/// A text selection: `anchor` is fixed, `head` moves (e.g. while shift-arrowing).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TextSelection {
+    /// The fixed end of the selection.
+    pub anchor: Pos,
+    /// The moving end of the selection (where the caret is drawn).
+    pub head: Pos,
+}
+
+/// A node selection: the node that *starts* at `anchor` is selected whole.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct NodeSelection {
+    /// The position immediately before the selected node.
+    pub anchor: Pos,
+    /// The position immediately after the selected node (`anchor + node_size`).
+    pub head: Pos,
+}
+
+impl TextSelection {
+    /// A text selection from `anchor` to `head`.
+    pub fn new(anchor: Pos, head: Pos) -> TextSelection {
+        TextSelection { anchor, head }
+    }
+
+    /// A collapsed cursor at `pos`.
+    pub fn cursor(pos: Pos) -> TextSelection {
+        TextSelection {
+            anchor: pos,
+            head: pos,
+        }
+    }
+}
+
+impl Selection {
+    /// A collapsed text cursor at `pos`.
+    pub fn cursor(pos: Pos) -> Selection {
+        Selection::Text(TextSelection::cursor(pos))
+    }
+
+    /// A text selection from `anchor` to `head`.
+    pub fn text(anchor: Pos, head: Pos) -> Selection {
+        Selection::Text(TextSelection::new(anchor, head))
+    }
+
+    /// The lower bound of the selection (its leftmost position).
+    pub fn from(&self) -> Pos {
+        match self {
+            Selection::Text(t) => Pos(t.anchor.0.min(t.head.0)),
+            Selection::Node(n) => n.anchor,
+        }
+    }
+
+    /// The upper bound of the selection (its rightmost position).
+    pub fn to(&self) -> Pos {
+        match self {
+            Selection::Text(t) => Pos(t.anchor.0.max(t.head.0)),
+            Selection::Node(n) => n.head,
+        }
+    }
+
+    /// The fixed end of the selection.
+    pub fn anchor(&self) -> Pos {
+        match self {
+            Selection::Text(t) => t.anchor,
+            Selection::Node(n) => n.anchor,
+        }
+    }
+
+    /// The moving end of the selection (the caret).
+    pub fn head(&self) -> Pos {
+        match self {
+            Selection::Text(t) => t.head,
+            Selection::Node(n) => n.head,
+        }
+    }
+
+    /// True if the selection covers no content (a collapsed text cursor). A node
+    /// selection is never empty.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Selection::Text(t) => t.anchor == t.head,
+            Selection::Node(_) => false,
+        }
+    }
+
+    /// True if the selection is a **collapsed text cursor** — the condition under
+    /// which `stored_marks` survive into the next state (design §5).
+    pub fn is_text_cursor(&self) -> bool {
+        matches!(self, Selection::Text(t) if t.anchor == t.head)
+    }
+
+    /// Map this selection forward through `mapping`, re-resolving against `doc`
+    /// (the document *after* the steps). If the mapped head no longer sits in
+    /// inline content (e.g. its textblock was removed), fall back to the nearest
+    /// valid selection. Port of `Selection.map` / `TextSelection.map` /
+    /// `NodeSelection.map`.
+    pub fn map(&self, doc: &Node, mapping: &Mapping) -> Selection {
+        match self {
+            Selection::Text(t) => {
+                let head = mapping.map(t.head.0, 1);
+                let r_head = match doc.resolve(Pos(head)) {
+                    Ok(r) => r,
+                    Err(_) => return Selection::near(doc, Pos(head.min(doc.content_size())), 1),
+                };
+                if !r_head.parent().is_textblock() {
+                    return Selection::near(doc, Pos(head), 1);
+                }
+                let anchor = mapping.map(t.anchor.0, 1);
+                let anchor_inline = doc
+                    .resolve(Pos(anchor))
+                    .map(|r| r.parent().is_textblock())
+                    .unwrap_or(false);
+                Selection::text(Pos(if anchor_inline { anchor } else { head }), Pos(head))
+            }
+            Selection::Node(n) => {
+                let result = mapping.map_result(n.anchor.0, 1);
+                let pos = Pos(result.pos);
+                if result.deleted() {
+                    return Selection::near(doc, pos, 1);
+                }
+                match node_selection_at(doc, pos) {
+                    Some(sel) => sel,
+                    None => Selection::near(doc, pos, 1),
+                }
+            }
+        }
+    }
+
+    /// The nearest valid selection to `pos`, searching first in `bias`'s direction
+    /// then the other, and finally falling back to a collapsed cursor at a clamped
+    /// position. Port of `Selection.near` (without `AllSelection`; the fallback is
+    /// a clamped text cursor, which is total for the starter-kit schemas).
+    pub fn near(doc: &Node, pos: Pos, bias: i32) -> Selection {
+        find_from(doc, pos, bias, false)
+            .or_else(|| find_from(doc, pos, -bias, false))
+            .unwrap_or_else(|| Selection::cursor(Pos(pos.0.min(doc.content_size()))))
+    }
+
+    /// A selection at the very start of the document's first textblock.
+    pub fn at_start(doc: &Node) -> Selection {
+        find_from(doc, Pos(0), 1, false).unwrap_or_else(|| Selection::cursor(Pos(0)))
+    }
+
+    /// A selection at the very end of the document's last textblock.
+    pub fn at_end(doc: &Node) -> Selection {
+        find_from(doc, Pos(doc.content_size()), -1, false)
+            .unwrap_or_else(|| Selection::cursor(Pos(doc.content_size())))
+    }
+
+    /// The selected node, for a [`NodeSelection`]; `None` for a text selection.
+    pub fn node(&self, doc: &Node) -> Option<Node> {
+        match self {
+            Selection::Node(n) => doc.node_at(n.anchor.0),
+            Selection::Text(_) => None,
+        }
+    }
+}
+
+/// Build a [`NodeSelection`] for the node starting at `pos`, if one is there and is
+/// selectable; otherwise `None`.
+fn node_selection_at(doc: &Node, pos: Pos) -> Option<Selection> {
+    let r = doc.resolve(pos).ok()?;
+    let node = r.node_after()?;
+    if node.is_text() || !node.node_type().spec().selectable {
+        return None;
+    }
+    Some(Selection::Node(NodeSelection {
+        anchor: pos,
+        head: Pos(pos.0 + node.node_size()),
+    }))
+}
+
+/// Find the nearest selection from `pos` in direction `dir` (`+1`/`-1`). Port of
+/// `Selection.findFrom`.
+fn find_from(doc: &Node, pos: Pos, dir: i32, text_only: bool) -> Option<Selection> {
+    let r = doc.resolve(pos).ok()?;
+    let inner = if r.parent().is_textblock() {
+        Some(Selection::cursor(pos))
+    } else {
+        find_selection_in(r.parent(), pos.0, r.index(r.depth()), dir, text_only)
+    };
+    if let Some(sel) = inner {
+        return Some(sel);
+    }
+    let mut depth = r.depth() as isize - 1;
+    while depth >= 0 {
+        let d = depth as usize;
+        let found = if dir < 0 {
+            find_selection_in(r.node(d), r.before(d + 1)?, r.index(d), dir, text_only)
+        } else {
+            find_selection_in(r.node(d), r.after(d + 1)?, r.index(d) + 1, dir, text_only)
+        };
+        if found.is_some() {
+            return found;
+        }
+        depth -= 1;
+    }
+    None
+}
+
+/// Search inside `node` (whose content begins at document position `pos`, child
+/// index `index`) for a selectable position in direction `dir`. Port of
+/// `findSelectionIn`.
+fn find_selection_in(
+    node: &Node,
+    mut pos: usize,
+    index: usize,
+    dir: i32,
+    text_only: bool,
+) -> Option<Selection> {
+    if node.is_textblock() {
+        return Some(Selection::cursor(Pos(pos)));
+    }
+    let count = node.child_count();
+    // Starting index: for dir>0 begin at `index`, for dir<0 at `index - 1`.
+    let mut i: isize = if dir > 0 {
+        index as isize
+    } else {
+        index as isize - 1
+    };
+    while (dir > 0 && (i as usize) < count) || (dir < 0 && i >= 0) {
+        let child = node.child(i as usize);
+        if !child.is_atom() {
+            let inner_index = if dir < 0 { child.child_count() } else { 0 };
+            let inner = find_selection_in(
+                child,
+                (pos as isize + dir as isize) as usize,
+                inner_index,
+                dir,
+                text_only,
+            );
+            if inner.is_some() {
+                return inner;
+            }
+        } else if !text_only && child.node_type().spec().selectable {
+            let node_pos = if dir < 0 {
+                pos - child.node_size()
+            } else {
+                pos
+            };
+            return Some(Selection::Node(NodeSelection {
+                anchor: Pos(node_pos),
+                head: Pos(node_pos + child.node_size()),
+            }));
+        }
+        pos = (pos as isize + child.node_size() as isize * dir as isize) as usize;
+        i += dir as isize;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Schema;
+    use crate::model::Fragment;
+
+    fn sk() -> Schema {
+        Schema::starter_kit()
+    }
+    fn para(s: &Schema, t: &str) -> Node {
+        s.branch("paragraph", Fragment::from_node(s.text(t).unwrap()))
+            .unwrap()
+    }
+    fn doc(s: &Schema, blocks: Vec<Node>) -> Node {
+        s.branch("doc", Fragment::from_children(blocks)).unwrap()
+    }
+
+    #[test]
+    fn from_to_anchor_head() {
+        let sel = Selection::text(Pos(5), Pos(2));
+        assert_eq!(sel.from(), Pos(2));
+        assert_eq!(sel.to(), Pos(5));
+        assert_eq!(sel.anchor(), Pos(5));
+        assert_eq!(sel.head(), Pos(2));
+        assert!(!sel.is_empty());
+        let cur = Selection::cursor(Pos(3));
+        assert!(cur.is_empty());
+        assert!(cur.is_text_cursor());
+    }
+
+    #[test]
+    fn at_start_and_end_land_in_textblocks() {
+        let s = sk();
+        let d = doc(&s, vec![para(&s, "ab"), para(&s, "cd")]);
+        // positions: 0[p1 1 a 2 b 3]4[p2 5 c 6 d 7]8
+        // first textblock content begins at pos 1
+        assert_eq!(Selection::at_start(&d), Selection::cursor(Pos(1)));
+        // last textblock content ends at pos 7 (after "cd", before p2's close token)
+        assert_eq!(Selection::at_end(&d), Selection::cursor(Pos(7)));
+    }
+
+    #[test]
+    fn map_cursor_through_insert_advances() {
+        // cursor at pos 1, insert 2 chars before it → maps to 3 (assoc 1)
+        let s = sk();
+        let d = doc(&s, vec![para(&s, "ab")]);
+        let mut m = Mapping::new();
+        m.append_map(crate::transform::StepMap::new(vec![1, 0, 2]));
+        let sel = Selection::cursor(Pos(1));
+        assert_eq!(sel.map(&d, &m), Selection::cursor(Pos(3)));
+    }
+
+    #[test]
+    fn near_falls_into_adjacent_textblock() {
+        // doc(hr, paragraph "x"): pos 1 is between hr and paragraph; near→ into the para
+        let s = sk();
+        let hr = s.branch("horizontal_rule", Fragment::empty()).unwrap();
+        let d = doc(&s, vec![hr, para(&s, "x")]);
+        // hr occupies 0..1; paragraph 1..4, its inline content at pos 2
+        let sel = Selection::near(&d, Pos(1), 1);
+        assert_eq!(sel, Selection::cursor(Pos(2)));
+    }
+
+    #[test]
+    fn find_from_selects_atom_node() {
+        // doc(paragraph(text, image)) — image is a selectable inline atom
+        let s = sk();
+        let img = s
+            .create_node(
+                "image",
+                crate::model::Attrs::from_iter([("src", crate::model::AttrValue::from("a.png"))]),
+                Fragment::empty(),
+            )
+            .unwrap();
+        let p = s
+            .branch(
+                "paragraph",
+                Fragment::from_children(vec![s.text("a").unwrap(), img]),
+            )
+            .unwrap();
+        let d = doc(&s, vec![p]);
+        // positions: 0[p 1 a 2 (img) 3]4 ; the paragraph is a textblock so find_from
+        // at the doc level resolves to a text cursor — node-selection of inline
+        // atoms is exercised by the command layer, here we assert near() is total.
+        let sel = Selection::near(&d, Pos(2), 1);
+        assert!(matches!(sel, Selection::Text(_)));
+    }
+}

--- a/crates/rinch-editor-core/src/selection.rs
+++ b/crates/rinch-editor-core/src/selection.rs
@@ -170,6 +170,16 @@ impl Selection {
             .unwrap_or_else(|| Selection::cursor(Pos(pos.0.min(doc.content_size()))))
     }
 
+    /// The nearest **text cursor** to `pos` (searching `bias`'s direction then the
+    /// other), **skipping** any selectable block atoms in the way. Unlike
+    /// [`Self::near`], this never returns a [`Selection::Node`] — it is the
+    /// vertical-caret-movement primitive, which steps *over* an atom (a horizontal
+    /// rule) rather than selecting it. `None` if there is no text cursor on either
+    /// side.
+    pub fn near_text(doc: &Node, pos: Pos, bias: i32) -> Option<Selection> {
+        find_from(doc, pos, bias, true).or_else(|| find_from(doc, pos, -bias, true))
+    }
+
     /// A selection at the very start of the document's first textblock.
     pub fn at_start(doc: &Node) -> Selection {
         find_from(doc, Pos(0), 1, false).unwrap_or_else(|| Selection::cursor(Pos(0)))
@@ -187,6 +197,22 @@ impl Selection {
             Selection::Node(n) => doc.node_at(n.anchor.0),
             Selection::Text(_) => None,
         }
+    }
+
+    /// A [`NodeSelection`] of the node that *starts* at `pos`, if there is one and
+    /// it is a selectable **leaf atom** (an image or horizontal rule). `None` for a
+    /// text node, a non-leaf container (a paragraph / list — `selectable` in the
+    /// schema but never node-selected this way), an unselectable node, or no node at
+    /// `pos`. The pointer and keyboard layers use this to node-select a leaf the
+    /// user clicks or arrows onto (design §6 node-views).
+    pub fn node_at(doc: &Node, pos: Pos) -> Option<Selection> {
+        let sel = node_selection_at(doc, pos)?;
+        // Restrict to leaf atoms — `node_selection_at` (shared with selection
+        // mapping) only checks `selectable`, which is `true` for block containers.
+        if !sel.node(doc)?.node_type().is_leaf() {
+            return None;
+        }
+        Some(sel)
     }
 }
 
@@ -344,6 +370,53 @@ mod tests {
         // hr occupies 0..1; paragraph 1..4, its inline content at pos 2
         let sel = Selection::near(&d, Pos(1), 1);
         assert_eq!(sel, Selection::cursor(Pos(2)));
+    }
+
+    #[test]
+    fn node_at_selects_block_atom_and_rejects_text() {
+        // doc(paragraph "ab", hr): the hr is a selectable block atom.
+        let s = sk();
+        let hr = s.branch("horizontal_rule", Fragment::empty()).unwrap();
+        let d = doc(&s, vec![para(&s, "ab"), hr]);
+        // positions: 0[p 1 a 2 b 3]4 <hr 4..5> 5 ; the hr starts at pos 4.
+        let sel = Selection::node_at(&d, Pos(4)).expect("hr is selectable");
+        assert_eq!(sel.from(), Pos(4));
+        assert_eq!(sel.to(), Pos(5));
+        assert!(matches!(sel, Selection::Node(_)));
+        // A position before a text run is not a node selection.
+        assert!(Selection::node_at(&d, Pos(1)).is_none());
+        // Out of range / no node after → None (total, no panic).
+        assert!(Selection::node_at(&d, Pos(5)).is_none());
+        // A selectable *container* (the paragraph, `selectable: true` by default)
+        // is NOT node-selectable via `node_at` — only leaf atoms are.
+        assert!(
+            Selection::node_at(&d, Pos(0)).is_none(),
+            "a paragraph container must not node-select"
+        );
+    }
+
+    #[test]
+    fn node_at_selects_inline_image() {
+        // doc(paragraph(text "a", image)) — the image is a selectable inline atom.
+        let s = sk();
+        let img = s
+            .create_node(
+                "image",
+                crate::model::Attrs::from_iter([("src", crate::model::AttrValue::from("a.png"))]),
+                Fragment::empty(),
+            )
+            .unwrap();
+        let p = s
+            .branch(
+                "paragraph",
+                Fragment::from_children(vec![s.text("a").unwrap(), img]),
+            )
+            .unwrap();
+        let d = doc(&s, vec![p]);
+        // positions: 0[p 1 a 2 (img) 3]4 ; the image starts at pos 2.
+        let sel = Selection::node_at(&d, Pos(2)).expect("image is selectable");
+        assert_eq!(sel.from(), Pos(2));
+        assert_eq!(sel.to(), Pos(3));
     }
 
     #[test]

--- a/crates/rinch-editor-core/src/serialize/doc_json.rs
+++ b/crates/rinch-editor-core/src/serialize/doc_json.rs
@@ -1,0 +1,569 @@
+//! The durable, schema-derived JSON wire shape (`DocNode`) — feature `serde`.
+//!
+//! This replaces the old flat `BlockData`/`InlineRunData`/`InlineMarkData`
+//! interchange (which could not express lists, tables, or atoms, and dropped
+//! marks — #59). The shape is **recursive** (nesting works), **typed**
+//! (attributes carry their `AttrValue` kind, not stringly values), and **total**:
+//!
+//! - **Serialize** ([`Node::to_doc`]) walks the schema, applies attribute
+//!   defaults, and would fail (not silently emit garbage) on a node missing a
+//!   required attribute.
+//! - **Deserialize** ([`Schema::node_from_doc`]) consults the schema: an unknown
+//!   node or mark type is a hard [`EditorError::SchemaValidation`], never a silent
+//!   drop, and a missing required attribute is an error. The boundary either
+//!   round-trips a thing faithfully or rejects it.
+//!
+//! The snake_case key conventions (`type`, `attrs`, `content`, `text`, `marks`)
+//! are kept for familiarity and wire stability.
+
+use crate::EditorError;
+use crate::model::{AttrValue, Attrs, Fragment, Mark, Node};
+use crate::schema::Schema;
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::BTreeMap;
+use std::fmt;
+
+/// A single attribute value on the wire. A thin, serde-friendly mirror of
+/// [`AttrValue`] (uses `String` rather than `Box<str>`), kept distinct from the
+/// model type so the durable wire format is decoupled from the in-memory model.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum JsonAttr {
+    /// JSON `null` — explicit absence (distinct from "key not present").
+    Null,
+    /// JSON boolean.
+    Bool(bool),
+    /// JSON integer.
+    Int(i64),
+    /// JSON string.
+    Str(String),
+}
+
+impl From<&AttrValue> for JsonAttr {
+    fn from(v: &AttrValue) -> Self {
+        match v {
+            AttrValue::Null => JsonAttr::Null,
+            AttrValue::Bool(b) => JsonAttr::Bool(*b),
+            AttrValue::Int(i) => JsonAttr::Int(*i),
+            AttrValue::Str(s) => JsonAttr::Str(s.to_string()),
+        }
+    }
+}
+
+impl From<&JsonAttr> for AttrValue {
+    fn from(v: &JsonAttr) -> Self {
+        match v {
+            JsonAttr::Null => AttrValue::Null,
+            JsonAttr::Bool(b) => AttrValue::Bool(*b),
+            JsonAttr::Int(i) => AttrValue::Int(*i),
+            JsonAttr::Str(s) => AttrValue::Str(s.as_str().into()),
+        }
+    }
+}
+
+// Manual serde so a `JsonAttr` serializes as a *bare* JSON scalar (`null`, `true`,
+// `42`, `"x"`) rather than a tagged enum — the natural, stable wire form — and so
+// the crate needs no `serde_json` dependency (we use `deserialize_any`, which all
+// self-describing formats including JSON support).
+impl Serialize for JsonAttr {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            JsonAttr::Null => serializer.serialize_unit(),
+            JsonAttr::Bool(b) => serializer.serialize_bool(*b),
+            JsonAttr::Int(i) => serializer.serialize_i64(*i),
+            JsonAttr::Str(s) => serializer.serialize_str(s),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for JsonAttr {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct AttrVisitor;
+        impl<'de> Visitor<'de> for AttrVisitor {
+            type Value = JsonAttr;
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                f.write_str("a null, boolean, integer, or string attribute value")
+            }
+            fn visit_bool<E: de::Error>(self, v: bool) -> Result<JsonAttr, E> {
+                Ok(JsonAttr::Bool(v))
+            }
+            fn visit_i64<E: de::Error>(self, v: i64) -> Result<JsonAttr, E> {
+                Ok(JsonAttr::Int(v))
+            }
+            fn visit_u64<E: de::Error>(self, v: u64) -> Result<JsonAttr, E> {
+                i64::try_from(v)
+                    .map(JsonAttr::Int)
+                    .map_err(|_| E::custom("integer attribute value out of i64 range"))
+            }
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<JsonAttr, E> {
+                Ok(JsonAttr::Str(v.to_string()))
+            }
+            fn visit_string<E: de::Error>(self, v: String) -> Result<JsonAttr, E> {
+                Ok(JsonAttr::Str(v))
+            }
+            fn visit_unit<E: de::Error>(self) -> Result<JsonAttr, E> {
+                Ok(JsonAttr::Null)
+            }
+            fn visit_none<E: de::Error>(self) -> Result<JsonAttr, E> {
+                Ok(JsonAttr::Null)
+            }
+        }
+        deserializer.deserialize_any(AttrVisitor)
+    }
+}
+
+/// The durable wire shape for a document node. Recursive, so nesting (lists,
+/// blockquotes, tables) is expressible; total, so every node carries its schema
+/// type name and (defaults-applied) typed attributes.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct DocNode {
+    /// The schema node-type name (`paragraph`, `heading`, `text`, …). Always present.
+    #[serde(rename = "type")]
+    pub node_type: String,
+    /// Typed attributes, defaults applied. Omitted from JSON when empty.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub attrs: BTreeMap<String, JsonAttr>,
+    /// Child nodes (recursive). Omitted from JSON when empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub content: Vec<DocNode>,
+    /// The string of a text node. Omitted for non-text nodes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    /// Marks on a text node or inline leaf. Omitted from JSON when empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub marks: Vec<DocMark>,
+}
+
+/// The durable wire shape for a mark.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct DocMark {
+    /// The schema mark-type name (`bold`, `link`, …).
+    #[serde(rename = "type")]
+    pub mark_type: String,
+    /// Typed mark attributes, defaults applied. Omitted from JSON when empty.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub attrs: BTreeMap<String, JsonAttr>,
+}
+
+impl Node {
+    /// Serialize this node (and its subtree) to the durable [`DocNode`] wire shape.
+    ///
+    /// Attribute defaults are applied so the wire is total. Returns
+    /// [`EditorError::SchemaValidation`] if any node is missing a required
+    /// attribute (such a node was never a valid document and must not be silently
+    /// persisted).
+    pub fn to_doc(&self) -> Result<DocNode, EditorError> {
+        doc_from_node(self)
+    }
+}
+
+impl Schema {
+    /// Deserialize a [`DocNode`] into a model [`Node`], validated against this
+    /// schema. Unknown node/mark types and missing required attributes are hard
+    /// errors — the structural fix for #59.
+    pub fn node_from_doc(&self, doc: &DocNode) -> Result<Node, EditorError> {
+        node_from_doc_node(self, doc)
+    }
+}
+
+fn attrs_to_wire(attrs: &Attrs) -> BTreeMap<String, JsonAttr> {
+    attrs
+        .iter()
+        .map(|(k, v)| (k.to_string(), JsonAttr::from(v)))
+        .collect()
+}
+
+fn wire_to_attrs(wire: &BTreeMap<String, JsonAttr>) -> Attrs {
+    wire.iter()
+        .map(|(k, v)| (k.clone(), AttrValue::from(v)))
+        .collect()
+}
+
+fn doc_from_node(node: &Node) -> Result<DocNode, EditorError> {
+    let marks = node
+        .marks()
+        .iter()
+        .map(doc_from_mark)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    if let Some(text) = node.text() {
+        return Ok(DocNode {
+            node_type: node.type_name().to_string(),
+            attrs: BTreeMap::new(),
+            content: Vec::new(),
+            text: Some(text.to_string()),
+            marks,
+        });
+    }
+
+    let attrs = node.node_type().compute_attrs(node.attrs())?;
+    let content = node
+        .content()
+        .children()
+        .iter()
+        .map(doc_from_node)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(DocNode {
+        node_type: node.type_name().to_string(),
+        attrs: attrs_to_wire(&attrs),
+        content,
+        text: None,
+        marks,
+    })
+}
+
+fn doc_from_mark(mark: &Mark) -> Result<DocMark, EditorError> {
+    let attrs = mark.typ.compute_attrs(&mark.attrs)?;
+    Ok(DocMark {
+        mark_type: mark.type_name().to_string(),
+        attrs: attrs_to_wire(&attrs),
+    })
+}
+
+fn node_from_doc_node(schema: &Schema, doc: &DocNode) -> Result<Node, EditorError> {
+    if let Some(text) = &doc.text {
+        let nt = schema.node_type(&doc.node_type).ok_or_else(|| {
+            EditorError::SchemaValidation(format!("unknown node type '{}'", doc.node_type))
+        })?;
+        if !nt.is_text() {
+            return Err(EditorError::SchemaValidation(format!(
+                "node '{}' carries text but is not a text node type",
+                doc.node_type
+            )));
+        }
+        // A text node may not also carry content or attrs — reject rather than
+        // silently discard them (totality; the #59 contract for the durable path).
+        if !doc.content.is_empty() {
+            return Err(EditorError::SchemaValidation(format!(
+                "text node '{}' must not carry content",
+                doc.node_type
+            )));
+        }
+        if !doc.attrs.is_empty() {
+            return Err(EditorError::SchemaValidation(format!(
+                "text node '{}' must not carry attributes",
+                doc.node_type
+            )));
+        }
+        let marks = doc
+            .marks
+            .iter()
+            .map(|m| mark_from_doc_mark(schema, m))
+            .collect::<Result<Vec<_>, _>>()?;
+        return Ok(Node::new_text(nt.clone(), text.as_str().into(), marks));
+    }
+
+    let nt = schema
+        .node_type(&doc.node_type)
+        .ok_or_else(|| {
+            EditorError::SchemaValidation(format!("unknown node type '{}'", doc.node_type))
+        })?
+        .clone();
+    let attrs = nt.compute_attrs(&wire_to_attrs(&doc.attrs))?;
+    let children = doc
+        .content
+        .iter()
+        .map(|c| node_from_doc_node(schema, c))
+        .collect::<Result<Vec<_>, _>>()?;
+    let marks = doc
+        .marks
+        .iter()
+        .map(|m| mark_from_doc_mark(schema, m))
+        .collect::<Result<Vec<_>, _>>()?;
+    let node = Node::new_branch(nt, attrs, Fragment::from_children(children));
+    Ok(if marks.is_empty() {
+        node
+    } else {
+        node.mark(marks)
+    })
+}
+
+fn mark_from_doc_mark(schema: &Schema, doc: &DocMark) -> Result<Mark, EditorError> {
+    let mt = schema
+        .mark_type(&doc.mark_type)
+        .ok_or_else(|| {
+            EditorError::SchemaValidation(format!("unknown mark type '{}'", doc.mark_type))
+        })?
+        .clone();
+    let attrs = mt.compute_attrs(&wire_to_attrs(&doc.attrs))?;
+    Ok(Mark::new(mt, attrs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Schema;
+
+    /// Build a normalized (defaults-applied) non-text node.
+    fn node(s: &Schema, ty: &str, attrs: Attrs, content: Fragment) -> Node {
+        let nt = s.node_type(ty).unwrap().clone();
+        let attrs = nt.compute_attrs(&attrs).unwrap();
+        Node::new_branch(nt, attrs, content)
+    }
+
+    /// Build a normalized mark.
+    fn mark(s: &Schema, ty: &str, attrs: Attrs) -> Mark {
+        let mt = s.mark_type(ty).unwrap().clone();
+        let attrs = mt.compute_attrs(&attrs).unwrap();
+        Mark::new(mt, attrs)
+    }
+
+    fn attrs(pairs: &[(&str, AttrValue)]) -> Attrs {
+        Attrs::from_iter(pairs.iter().map(|(k, v)| (*k, v.clone())))
+    }
+
+    /// A rich document touching every starter-kit node and mark with attrs.
+    fn rich_doc(s: &Schema) -> Node {
+        let frag = Fragment::from_children;
+
+        let heading = node(
+            s,
+            "heading",
+            attrs(&[("level", AttrValue::Int(2))]),
+            frag(vec![s.text("Title").unwrap()]),
+        );
+
+        let para = node(
+            s,
+            "paragraph",
+            Attrs::new(),
+            frag(vec![
+                s.text("plain ").unwrap(),
+                s.text_with_marks("bold", vec![mark(s, "bold", Attrs::new())])
+                    .unwrap(),
+                s.text(" ").unwrap(),
+                s.text_with_marks(
+                    "linked",
+                    vec![mark(
+                        s,
+                        "link",
+                        attrs(&[("href", AttrValue::from("https://example.com"))]),
+                    )],
+                )
+                .unwrap(),
+                s.text_with_marks(
+                    "hi",
+                    vec![mark(
+                        s,
+                        "highlight",
+                        attrs(&[("color", AttrValue::from("yellow"))]),
+                    )],
+                )
+                .unwrap(),
+                s.text_with_marks(
+                    "colored",
+                    vec![mark(
+                        s,
+                        "text_color",
+                        attrs(&[("color", AttrValue::from("#f00"))]),
+                    )],
+                )
+                .unwrap(),
+                node(
+                    s,
+                    "image",
+                    attrs(&[("src", AttrValue::from("a.png"))]),
+                    Fragment::empty(),
+                ),
+                node(s, "hard_break", Attrs::new(), Fragment::empty()),
+            ]),
+        );
+
+        let bq = node(
+            s,
+            "blockquote",
+            Attrs::new(),
+            frag(vec![node(
+                s,
+                "paragraph",
+                Attrs::new(),
+                frag(vec![s.text("quote").unwrap()]),
+            )]),
+        );
+
+        let list = node(
+            s,
+            "bullet_list",
+            Attrs::new(),
+            frag(vec![node(
+                s,
+                "list_item",
+                Attrs::new(),
+                frag(vec![node(
+                    s,
+                    "paragraph",
+                    Attrs::new(),
+                    frag(vec![s.text("item").unwrap()]),
+                )]),
+            )]),
+        );
+
+        let code = node(
+            s,
+            "code_block",
+            attrs(&[("language", AttrValue::from("rust"))]),
+            frag(vec![s.text("fn main() {}").unwrap()]),
+        );
+
+        let hr = node(s, "horizontal_rule", Attrs::new(), Fragment::empty());
+
+        node(
+            s,
+            "doc",
+            Attrs::new(),
+            frag(vec![heading, para, bq, list, code, hr]),
+        )
+    }
+
+    #[test]
+    fn round_trip_identity_for_rich_doc() {
+        let s = Schema::starter_kit();
+        let doc = rich_doc(&s);
+        let wire = doc.to_doc().unwrap();
+        let back = s.node_from_doc(&wire).unwrap();
+        assert_eq!(doc, back, "Node -> DocNode -> Node must be identity");
+    }
+
+    #[test]
+    fn round_trip_through_json_string() {
+        let s = Schema::starter_kit();
+        let doc = rich_doc(&s);
+        let wire = doc.to_doc().unwrap();
+        let json = serde_json::to_string(&wire).unwrap();
+        let parsed: DocNode = serde_json::from_str(&json).unwrap();
+        assert_eq!(wire, parsed);
+        let back = s.node_from_doc(&parsed).unwrap();
+        assert_eq!(doc, back);
+    }
+
+    #[test]
+    fn wire_uses_snake_case_and_type_key() {
+        let s = Schema::starter_kit();
+        let heading = node(
+            &s,
+            "heading",
+            attrs(&[("level", AttrValue::Int(2))]),
+            Fragment::from_node(s.text("Hi").unwrap()),
+        );
+        let json = serde_json::to_string(&heading.to_doc().unwrap()).unwrap();
+        // `type` key (not `node_type`), `level` as a bare number, snake_case text key.
+        assert!(json.contains(r#""type":"heading""#), "json: {json}");
+        assert!(json.contains(r#""level":2"#), "json: {json}");
+        assert!(json.contains(r#""type":"text""#), "json: {json}");
+        assert!(json.contains(r#""text":"Hi""#), "json: {json}");
+    }
+
+    #[test]
+    fn unknown_node_type_is_error_not_silent_drop() {
+        let s = Schema::starter_kit();
+        let wire = DocNode {
+            node_type: "marquee".to_string(),
+            attrs: BTreeMap::new(),
+            content: vec![],
+            text: None,
+            marks: vec![],
+        };
+        assert!(s.node_from_doc(&wire).is_err());
+    }
+
+    #[test]
+    fn unknown_mark_type_is_error() {
+        let s = Schema::starter_kit();
+        let wire = DocNode {
+            node_type: "text".to_string(),
+            attrs: BTreeMap::new(),
+            content: vec![],
+            text: Some("x".to_string()),
+            marks: vec![DocMark {
+                mark_type: "blink".to_string(),
+                attrs: BTreeMap::new(),
+            }],
+        };
+        assert!(s.node_from_doc(&wire).is_err());
+    }
+
+    #[test]
+    fn missing_required_attr_is_error() {
+        let s = Schema::starter_kit();
+        // image with no `src` (required)
+        let wire = DocNode {
+            node_type: "image".to_string(),
+            attrs: BTreeMap::new(),
+            content: vec![],
+            text: None,
+            marks: vec![],
+        };
+        assert!(s.node_from_doc(&wire).is_err());
+    }
+
+    #[test]
+    fn deserialize_fills_optional_defaults() {
+        let s = Schema::starter_kit();
+        // heading with no `level` on the wire → default Int(1) on the node
+        let wire = DocNode {
+            node_type: "heading".to_string(),
+            attrs: BTreeMap::new(),
+            content: vec![],
+            text: None,
+            marks: vec![],
+        };
+        let node = s.node_from_doc(&wire).unwrap();
+        assert_eq!(node.attrs().get_int("level"), Some(1));
+    }
+
+    #[test]
+    fn text_field_on_non_text_type_is_error() {
+        let s = Schema::starter_kit();
+        let wire = DocNode {
+            node_type: "paragraph".to_string(),
+            attrs: BTreeMap::new(),
+            content: vec![],
+            text: Some("oops".to_string()),
+            marks: vec![],
+        };
+        assert!(s.node_from_doc(&wire).is_err());
+    }
+
+    #[test]
+    fn text_node_with_content_is_error() {
+        let s = Schema::starter_kit();
+        let wire = DocNode {
+            node_type: "text".to_string(),
+            attrs: BTreeMap::new(),
+            content: vec![DocNode {
+                node_type: "text".to_string(),
+                attrs: BTreeMap::new(),
+                content: vec![],
+                text: Some("inner".to_string()),
+                marks: vec![],
+            }],
+            text: Some("outer".to_string()),
+            marks: vec![],
+        };
+        // Must reject, not silently drop the `inner` child (the #59 totality contract).
+        assert!(s.node_from_doc(&wire).is_err());
+    }
+
+    #[test]
+    fn text_node_with_attrs_is_error() {
+        let s = Schema::starter_kit();
+        let wire = DocNode {
+            node_type: "text".to_string(),
+            attrs: attrs_to_wire(&Attrs::from_iter([("level", AttrValue::Int(9))])),
+            content: vec![],
+            text: Some("x".to_string()),
+            marks: vec![],
+        };
+        assert!(s.node_from_doc(&wire).is_err());
+    }
+
+    #[test]
+    fn null_attr_round_trips_through_json() {
+        // A Null attribute value survives a JSON round-trip as JSON `null`.
+        let attr = JsonAttr::Null;
+        let json = serde_json::to_string(&attr).unwrap();
+        assert_eq!(json, "null");
+        let back: JsonAttr = serde_json::from_str(&json).unwrap();
+        assert_eq!(attr, back);
+    }
+}

--- a/crates/rinch-editor-core/src/serialize/html.rs
+++ b/crates/rinch-editor-core/src/serialize/html.rs
@@ -1,0 +1,1551 @@
+//! Schema-driven HTML serialization (copy-out) and parsing (paste-in).
+//!
+//! Both directions are driven by the schema's `parse_html_tags` (on `NodeSpec` and
+//! `MarkSpec`) — one table, used both ways — unifying the old engine's three
+//! divergent hardcoded tag maps (`wrap_mark`, `block_type_to_tag`,
+//! `mark_type_to_tag`). A few genuinely attr-dependent cases (heading level,
+//! ordered-list `start`, `<span style>` → `text_color`/`highlight`) are handled
+//! explicitly, mirroring ProseMirror's per-type `toDOM`/`parseDOM`.
+//!
+//! HTML is a **lossy clipboard interchange** — the durable, total format is
+//! [`super::doc_json`]. The parse direction is a **whitelist**: unknown tags,
+//! marks, and attributes are dropped; `<script>`/`<iframe>`/`<object>`/`<embed>`
+//! never materialize; `javascript:`/`vbscript:` URLs are stripped. This kills the
+//! audit's raw-DOM-paste hole.
+//!
+//! The zero-dependency tokenizer is salvaged from `rinch/src/app/html_parser.rs`.
+
+use crate::EditorError;
+use crate::model::{AttrValue, Attrs, Fragment, Mark, MarkType, Node, NodeType, Slice};
+use crate::schema::Schema;
+use std::collections::HashMap;
+
+// ─── Copy-out: model → HTML ──────────────────────────────────────────────────
+
+/// Serialize a node (and its subtree) to HTML. A `doc` node emits its block
+/// children with no wrapper; any other node emits its own element.
+pub fn node_to_html(node: &Node) -> String {
+    let mut out = String::new();
+    if node.type_name() == "doc" {
+        for child in node.content().children() {
+            write_node(child, &mut out);
+        }
+    } else {
+        write_node(node, &mut out);
+    }
+    out
+}
+
+/// Serialize a [`Slice`]'s content to an HTML fragment — the clipboard copy-out.
+///
+/// The slice's open depths are **not** encoded in the markup; they are re-derived
+/// on paste by [`slice_from_html`]'s open-depth heuristic. So a within-block copy
+/// (whose `content` is the bare inline runs) round-trips back into a textblock, and
+/// a multi-block copy emits its `<p>`/`<h1>`/… children directly.
+pub fn slice_to_html(slice: &Slice) -> String {
+    let mut out = String::new();
+    for child in slice.content.children() {
+        write_node(child, &mut out);
+    }
+    out
+}
+
+fn write_node(node: &Node, out: &mut String) {
+    // Text node: escaped text wrapped in its marks (innermost = marks[0]).
+    if let Some(text) = node.text() {
+        let mut s = escape_text(text);
+        for mark in node.marks() {
+            s = wrap_mark(mark, &s);
+        }
+        out.push_str(&s);
+        return;
+    }
+    // Leaf non-text node (atom: hr / image / hard_break) → void element.
+    if node.is_leaf() {
+        let mut s = void_element(node);
+        for mark in node.marks() {
+            s = wrap_mark(mark, &s);
+        }
+        out.push_str(&s);
+        return;
+    }
+    // Container element.
+    let (open, close) = block_tags(node);
+    out.push_str(&open);
+    for child in node.content().children() {
+        write_node(child, out);
+    }
+    out.push_str(&close);
+}
+
+/// The open/close tag pair for a container node — schema-derived, with the
+/// attr-dependent specials handled explicitly.
+fn block_tags(node: &Node) -> (String, String) {
+    match node.type_name() {
+        "heading" => {
+            let level = node.attrs().get_int("level").unwrap_or(1).clamp(1, 6);
+            (format!("<h{level}>"), format!("</h{level}>"))
+        }
+        "ordered_list" => {
+            let start = node.attrs().get_int("start").unwrap_or(1);
+            if start != 1 {
+                (format!("<ol start=\"{start}\">"), "</ol>".to_string())
+            } else {
+                ("<ol>".to_string(), "</ol>".to_string())
+            }
+        }
+        "code_block" => ("<pre>".to_string(), "</pre>".to_string()),
+        _ => {
+            let tag = primary_tag(node.node_type());
+            (format!("<{tag}>"), format!("</{tag}>"))
+        }
+    }
+}
+
+/// A void/self-closing element (hr, img, br) with its declared string attrs.
+fn void_element(node: &Node) -> String {
+    let tag = primary_tag(node.node_type());
+    let mut s = format!("<{tag}");
+    for (k, v) in node.attrs().iter() {
+        if let Some(val) = v.as_str()
+            && !val.is_empty()
+        {
+            s.push_str(&format!(" {k}=\"{}\"", escape_attr(val)));
+        }
+    }
+    s.push('>');
+    s
+}
+
+/// The DOM element tag name a **non-text** node renders to — the schema's
+/// `parse_html_tags`, with the attr-dependent specials (`heading` → `h{level}`,
+/// `code_block` → `pre`). The desktop view (M5) uses this for its incremental
+/// node→element projection, so the host tag is the *same* schema-derived table
+/// copy-out HTML uses. Other attrs (`ordered_list.start`, `image.src/alt`) are set
+/// by the view as element attributes, not encoded in the tag.
+pub fn node_dom_tag(node: &Node) -> String {
+    match node.type_name() {
+        "heading" => {
+            let level = node.attrs().get_int("level").unwrap_or(1).clamp(1, 6);
+            format!("h{level}")
+        }
+        "code_block" => "pre".to_string(),
+        _ => primary_tag(node.node_type()),
+    }
+}
+
+/// The DOM element tag name a mark wraps its content in — the schema's
+/// `parse_html_tags`, with the attr-bearing specials (`link` → `a`, `text_color`
+/// → `span`, `highlight` → `mark`). `None` for a mark type with no HTML tag (it
+/// renders without a wrapper — lossy by design, matching copy-out HTML). The
+/// desktop view (M5) uses this for its incremental inline mark wrappers; the
+/// attr-bearing marks set their own attributes (`href`, inline `style`).
+pub fn mark_dom_tag(mark: &Mark) -> Option<String> {
+    match mark.type_name() {
+        "link" => Some("a".to_string()),
+        "text_color" => Some("span".to_string()),
+        "highlight" => Some("mark".to_string()),
+        _ => mark.typ.spec().parse_html_tags.first().cloned(),
+    }
+}
+
+/// The HTML tag a node type serializes to: its first `parse_html_tags` entry, or
+/// a group-based fallback (`div` for blocks, `span` otherwise) for types with no
+/// declared tags (e.g. `task_list`). HTML is lossy here by design; DocNode is not.
+fn primary_tag(nt: &NodeType) -> String {
+    if let Some(tag) = nt.spec().parse_html_tags.first() {
+        return tag.clone();
+    }
+    if nt.is_block() {
+        "div".to_string()
+    } else {
+        "span".to_string()
+    }
+}
+
+/// Wrap `inner` in the HTML for `mark`. Schema-derived for simple marks; explicit
+/// for the attr-bearing ones (`link`, `text_color`, `highlight`).
+fn wrap_mark(mark: &Mark, inner: &str) -> String {
+    match mark.type_name() {
+        "link" => {
+            let href = mark.attrs.get_str("href").unwrap_or("");
+            let mut s = format!("<a href=\"{}\"", escape_attr(href));
+            if let Some(t) = mark.attrs.get_str("title")
+                && !t.is_empty()
+            {
+                s.push_str(&format!(" title=\"{}\"", escape_attr(t)));
+            }
+            if let Some(tg) = mark.attrs.get_str("target")
+                && !tg.is_empty()
+            {
+                s.push_str(&format!(" target=\"{}\"", escape_attr(tg)));
+                // Guard against reverse-tabnabbing on HTML export.
+                if tg != "_self" {
+                    s.push_str(" rel=\"noopener noreferrer\"");
+                }
+            }
+            s.push_str(&format!(">{inner}</a>"));
+            s
+        }
+        "text_color" => {
+            let color = mark.attrs.get_str("color").unwrap_or("");
+            format!(
+                "<span style=\"color:{}\">{}</span>",
+                escape_attr(color),
+                inner
+            )
+        }
+        "highlight" => {
+            let color = mark.attrs.get_str("color").unwrap_or("");
+            if color.is_empty() {
+                format!("<mark>{inner}</mark>")
+            } else {
+                format!(
+                    "<mark style=\"background-color:{}\">{}</mark>",
+                    escape_attr(color),
+                    inner
+                )
+            }
+        }
+        _ => match mark.typ.spec().parse_html_tags.first() {
+            Some(tag) => format!("<{tag}>{inner}</{tag}>"),
+            None => inner.to_string(),
+        },
+    }
+}
+
+/// Escape text content (`&`, `<`, `>`).
+fn escape_text(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+/// Escape a double-quoted attribute value.
+fn escape_attr(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+// ─── Paste-in: HTML → Slice (whitelist) ──────────────────────────────────────
+
+/// Parse an HTML fragment into a sanitized [`Slice`] against `schema`.
+///
+/// The result is a structurally valid slice with an open-depth heuristic suitable
+/// for `replaceSelection` (M6): the first/last block is "open" when it is a
+/// textblock, so pasted leading/trailing paragraphs merge inline at the insertion
+/// point. Unknown tags/marks/attrs are dropped; dangerous elements never
+/// materialize.
+pub fn slice_from_html(schema: &Schema, html: &str) -> Result<Slice, EditorError> {
+    let forest = parse_html_fragment(html);
+    let parser = HtmlParser::new(schema)?;
+    let blocks = parser.parse_blocks(&forest)?;
+    if blocks.is_empty() {
+        return Ok(Slice::empty());
+    }
+    let open_start = usize::from(blocks.first().is_some_and(Node::is_textblock));
+    let open_end = usize::from(blocks.last().is_some_and(Node::is_textblock));
+    Ok(Slice::new(
+        Fragment::from_children(blocks),
+        open_start,
+        open_end,
+    ))
+}
+
+/// Holds the schema and the reverse tag→type lookup tables, built once per parse.
+struct HtmlParser<'a> {
+    schema: &'a Schema,
+    /// Block-level HTML tag → node type (`p`→paragraph, `h1`→heading, …).
+    block: HashMap<&'a str, &'a NodeType>,
+    /// Inline-leaf HTML tag → node type (`img`→image, `br`→hard_break).
+    inline_leaf: HashMap<&'a str, &'a NodeType>,
+    /// Inline HTML tag → mark type (`strong`/`b`→bold, `a`→link, `mark`→highlight, …).
+    marks: HashMap<&'a str, &'a MarkType>,
+    paragraph: &'a NodeType,
+    list_item: &'a NodeType,
+}
+
+impl<'a> HtmlParser<'a> {
+    fn new(schema: &'a Schema) -> Result<Self, EditorError> {
+        let mut block = HashMap::new();
+        let mut inline_leaf = HashMap::new();
+        for (name, spec) in &schema.nodes {
+            let nt = schema.node_type(name).expect("compiled node type");
+            for tag in &spec.parse_html_tags {
+                if nt.is_inline() && nt.is_leaf() {
+                    inline_leaf.insert(tag.as_str(), nt);
+                } else if nt.is_block() {
+                    block.insert(tag.as_str(), nt);
+                }
+            }
+        }
+        let mut marks = HashMap::new();
+        for (name, spec) in &schema.marks {
+            let mt = schema.mark_type(name).expect("compiled mark type");
+            for tag in &spec.parse_html_tags {
+                marks.insert(tag.as_str(), mt);
+            }
+        }
+        let paragraph = schema
+            .node_type("paragraph")
+            .ok_or_else(|| EditorError::HtmlParse("schema has no 'paragraph' type".into()))?;
+        let list_item = schema
+            .node_type("list_item")
+            .ok_or_else(|| EditorError::HtmlParse("schema has no 'list_item' type".into()))?;
+        Ok(Self {
+            schema,
+            block,
+            inline_leaf,
+            marks,
+            paragraph,
+            list_item,
+        })
+    }
+
+    /// True if `tag` should be parsed as inline content at block level.
+    fn is_inline_tag(&self, tag: &str) -> bool {
+        self.inline_leaf.contains_key(tag)
+            || self.marks.contains_key(tag)
+            || matches!(
+                tag,
+                "span"
+                    | "font"
+                    | "abbr"
+                    | "cite"
+                    | "q"
+                    | "small"
+                    | "big"
+                    | "var"
+                    | "kbd"
+                    | "samp"
+                    | "time"
+                    | "bdi"
+                    | "bdo"
+            )
+    }
+
+    fn parse_blocks(&self, nodes: &[ParsedNode]) -> Result<Vec<Node>, EditorError> {
+        let mut blocks: Vec<Node> = Vec::new();
+        let mut loose: Vec<Node> = Vec::new();
+
+        for n in nodes {
+            match n {
+                ParsedNode::Text(t) => {
+                    // Inter-block whitespace is dropped; meaningful text accumulates.
+                    if !t.trim().is_empty() {
+                        self.parse_inline(std::slice::from_ref(n), &[], &mut loose)?;
+                    }
+                }
+                ParsedNode::Element { tag, children, .. } => {
+                    if is_dropped(tag) {
+                        continue;
+                    }
+                    if let Some(nt) = self.block.get(tag.as_str()) {
+                        self.flush_loose(&mut loose, &mut blocks)?;
+                        blocks.push(self.build_block(nt, tag, n)?);
+                    } else if self.is_inline_tag(tag) {
+                        self.parse_inline(std::slice::from_ref(n), &[], &mut loose)?;
+                    } else {
+                        // Unknown container (div, section, …): recurse as blocks.
+                        let inner = self.parse_blocks(children)?;
+                        if inner.is_empty() {
+                            self.parse_inline(children, &[], &mut loose)?;
+                        } else {
+                            self.flush_loose(&mut loose, &mut blocks)?;
+                            blocks.extend(inner);
+                        }
+                    }
+                }
+            }
+        }
+        self.flush_loose(&mut loose, &mut blocks)?;
+        Ok(blocks)
+    }
+
+    /// Flush accumulated inline content as a paragraph block.
+    fn flush_loose(
+        &self,
+        loose: &mut Vec<Node>,
+        blocks: &mut Vec<Node>,
+    ) -> Result<(), EditorError> {
+        if loose.is_empty() {
+            return Ok(());
+        }
+        let content = Fragment::from_children(std::mem::take(loose));
+        blocks.push(self.make_node(self.paragraph, Attrs::new(), content)?);
+        Ok(())
+    }
+
+    fn build_block(
+        &self,
+        nt: &NodeType,
+        tag: &str,
+        element: &ParsedNode,
+    ) -> Result<Node, EditorError> {
+        let (attributes, children) = match element {
+            ParsedNode::Element {
+                attributes,
+                children,
+                ..
+            } => (attributes.as_slice(), children.as_slice()),
+            ParsedNode::Text(_) => (&[][..], &[][..]),
+        };
+        match nt.name() {
+            "heading" => {
+                let level = heading_level(tag);
+                let content = self.parse_inline_children(children)?;
+                self.make_node(
+                    nt,
+                    Attrs::from_iter([("level", AttrValue::Int(level))]),
+                    content,
+                )
+            }
+            "code_block" => {
+                let mut text = String::new();
+                collect_text(children, &mut text);
+                let content = if text.is_empty() {
+                    Fragment::empty()
+                } else {
+                    Fragment::from_node(self.schema.text(&text)?)
+                };
+                self.make_node(nt, Attrs::new(), content)
+            }
+            "blockquote" => {
+                let inner = self.ensure_block_plus(self.parse_blocks(children)?)?;
+                self.make_node(nt, Attrs::new(), Fragment::from_children(inner))
+            }
+            "bullet_list" | "ordered_list" => {
+                let mut items = self.parse_list_items(children)?;
+                if items.is_empty() {
+                    items.push(self.empty_list_item()?);
+                }
+                let attrs = if nt.name() == "ordered_list" {
+                    let start = attr(attributes, "start")
+                        .and_then(|s| s.parse::<i64>().ok())
+                        .unwrap_or(1);
+                    Attrs::from_iter([("start", AttrValue::Int(start))])
+                } else {
+                    Attrs::new()
+                };
+                self.make_node(nt, attrs, Fragment::from_children(items))
+            }
+            "list_item" => {
+                let inner = self.ensure_block_plus(self.parse_blocks(children)?)?;
+                self.make_node(nt, Attrs::new(), Fragment::from_children(inner))
+            }
+            "horizontal_rule" => self.make_node(nt, Attrs::new(), Fragment::empty()),
+            _ => {
+                // Any other textblock-ish block: treat content as inline.
+                let _ = attributes;
+                let content = self.parse_inline_children(children)?;
+                self.make_node(nt, Attrs::new(), content)
+            }
+        }
+    }
+
+    fn parse_list_items(&self, children: &[ParsedNode]) -> Result<Vec<Node>, EditorError> {
+        let mut items = Vec::new();
+        for child in children {
+            // Only <li> children become items; whitespace / stray tags are dropped.
+            let ParsedNode::Element {
+                tag,
+                children: li_children,
+                ..
+            } = child
+            else {
+                continue;
+            };
+            if tag != "li" || is_dropped(tag) {
+                continue;
+            }
+            let inner = self.ensure_block_plus(self.parse_blocks(li_children)?)?;
+            items.push(self.make_node(
+                self.list_item,
+                Attrs::new(),
+                Fragment::from_children(inner),
+            )?);
+        }
+        Ok(items)
+    }
+
+    /// Ensure a `block+` content list is non-empty (insert an empty paragraph).
+    fn ensure_block_plus(&self, mut blocks: Vec<Node>) -> Result<Vec<Node>, EditorError> {
+        if blocks.is_empty() {
+            blocks.push(self.make_node(self.paragraph, Attrs::new(), Fragment::empty())?);
+        }
+        Ok(blocks)
+    }
+
+    fn empty_list_item(&self) -> Result<Node, EditorError> {
+        let para = self.make_node(self.paragraph, Attrs::new(), Fragment::empty())?;
+        self.make_node(self.list_item, Attrs::new(), Fragment::from_node(para))
+    }
+
+    fn parse_inline_children(&self, children: &[ParsedNode]) -> Result<Fragment, EditorError> {
+        let mut out = Vec::new();
+        self.parse_inline(children, &[], &mut out)?;
+        Ok(Fragment::from_children(out))
+    }
+
+    fn parse_inline(
+        &self,
+        nodes: &[ParsedNode],
+        active: &[Mark],
+        out: &mut Vec<Node>,
+    ) -> Result<(), EditorError> {
+        for n in nodes {
+            match n {
+                ParsedNode::Text(t) => {
+                    if !t.is_empty() {
+                        out.push(self.schema.text_with_marks(t, active.to_vec())?);
+                    }
+                }
+                ParsedNode::Element {
+                    tag,
+                    attributes,
+                    children,
+                } => {
+                    if is_dropped(tag) {
+                        continue;
+                    }
+                    // Inline leaves (br, img).
+                    if let Some(nt) = self.inline_leaf.get(tag.as_str()) {
+                        if let Some(leaf) = self.build_inline_leaf(nt, attributes, active)? {
+                            out.push(leaf);
+                        }
+                        continue;
+                    }
+                    // Mark-bearing tags (strong, em, a, mark, …).
+                    if self.marks.contains_key(tag.as_str()) {
+                        if let Some(mark) = self.mark_for(tag, attributes)? {
+                            let next = mark.add_to_set(active);
+                            self.parse_inline(children, &next, out)?;
+                        } else {
+                            // e.g. <a> with no/unsafe href → transparent, keep text.
+                            self.parse_inline(children, active, out)?;
+                        }
+                        continue;
+                    }
+                    // <span style>: style-derived marks (color → text_color, bg → highlight).
+                    if tag == "span" {
+                        let next = self.span_marks(attributes, active)?;
+                        self.parse_inline(children, &next, out)?;
+                        continue;
+                    }
+                    // Any other inline element (font, etc.) → transparent.
+                    self.parse_inline(children, active, out)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn build_inline_leaf(
+        &self,
+        nt: &NodeType,
+        attributes: &[(String, String)],
+        active: &[Mark],
+    ) -> Result<Option<Node>, EditorError> {
+        match nt.name() {
+            "hard_break" => Ok(Some(self.make_node(nt, Attrs::new(), Fragment::empty())?)),
+            "image" => {
+                let Some(src) = attr(attributes, "src") else {
+                    return Ok(None);
+                };
+                if !is_safe_url(src, true) {
+                    return Ok(None);
+                }
+                let mut pairs: Vec<(&str, AttrValue)> = vec![("src", AttrValue::from(src))];
+                if let Some(alt) = attr(attributes, "alt") {
+                    pairs.push(("alt", AttrValue::from(alt)));
+                }
+                if let Some(title) = attr(attributes, "title") {
+                    pairs.push(("title", AttrValue::from(title)));
+                }
+                let img = self.make_node(nt, Attrs::from_iter(pairs), Fragment::empty())?;
+                Ok(Some(if active.is_empty() {
+                    img
+                } else {
+                    img.mark(active.to_vec())
+                }))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Resolve a mark-bearing tag to a `Mark`, or `None` if it cannot be formed
+    /// (e.g. a link with no safe href → transparent passthrough).
+    fn mark_for(
+        &self,
+        tag: &str,
+        attributes: &[(String, String)],
+    ) -> Result<Option<Mark>, EditorError> {
+        let Some(mt) = self.marks.get(tag).copied() else {
+            return Ok(None);
+        };
+        match mt.name() {
+            "link" => {
+                let Some(href) = attr(attributes, "href") else {
+                    return Ok(None);
+                };
+                if !is_safe_url(href, false) {
+                    return Ok(None);
+                }
+                let mut pairs: Vec<(&str, AttrValue)> = vec![("href", AttrValue::from(href))];
+                if let Some(title) = attr(attributes, "title")
+                    && !title.is_empty()
+                {
+                    pairs.push(("title", AttrValue::from(title)));
+                }
+                if let Some(target) = attr(attributes, "target")
+                    && !target.is_empty()
+                {
+                    pairs.push(("target", AttrValue::from(target)));
+                }
+                let attrs = mt.compute_attrs(&Attrs::from_iter(pairs))?;
+                Ok(Some(Mark::new(mt.clone(), attrs)))
+            }
+            "highlight" => {
+                let mut pairs: Vec<(&str, AttrValue)> = Vec::new();
+                if let Some(style) = attr(attributes, "style")
+                    && let Some(bg) =
+                        parse_style(style, "background-color").filter(|c| is_safe_css_color(c))
+                {
+                    pairs.push(("color", AttrValue::from(bg)));
+                }
+                let attrs = mt.compute_attrs(&Attrs::from_iter(pairs))?;
+                Ok(Some(Mark::new(mt.clone(), attrs)))
+            }
+            _ => {
+                let attrs = mt.compute_attrs(&Attrs::new())?;
+                Ok(Some(Mark::new(mt.clone(), attrs)))
+            }
+        }
+    }
+
+    /// Marks contributed by a `<span style>`: `color` → `text_color`,
+    /// `background-color` → `highlight`. Returns the new active mark set.
+    fn span_marks(
+        &self,
+        attributes: &[(String, String)],
+        active: &[Mark],
+    ) -> Result<Vec<Mark>, EditorError> {
+        let mut next = active.to_vec();
+        let Some(style) = attr(attributes, "style") else {
+            return Ok(next);
+        };
+        if let (Some(color), Some(mt)) = (
+            parse_style(style, "color").filter(|c| is_safe_css_color(c)),
+            self.schema.mark_type("text_color"),
+        ) {
+            let attrs = mt.compute_attrs(&Attrs::from_iter([("color", AttrValue::from(color))]))?;
+            next = Mark::new(mt.clone(), attrs).add_to_set(&next);
+        }
+        if let (Some(bg), Some(mt)) = (
+            parse_style(style, "background-color").filter(|c| is_safe_css_color(c)),
+            self.schema.mark_type("highlight"),
+        ) {
+            let attrs = mt.compute_attrs(&Attrs::from_iter([("color", AttrValue::from(bg))]))?;
+            next = Mark::new(mt.clone(), attrs).add_to_set(&next);
+        }
+        Ok(next)
+    }
+
+    fn make_node(
+        &self,
+        nt: &NodeType,
+        attrs: Attrs,
+        content: Fragment,
+    ) -> Result<Node, EditorError> {
+        let attrs = nt.compute_attrs(&attrs)?;
+        Ok(Node::new_branch(nt.clone(), attrs, content))
+    }
+}
+
+/// Tags whose entire subtree is dropped on paste (never materialize).
+fn is_dropped(tag: &str) -> bool {
+    matches!(
+        tag,
+        "script"
+            | "style"
+            | "meta"
+            | "link"
+            | "head"
+            | "title"
+            | "iframe"
+            | "object"
+            | "embed"
+            | "noscript"
+            | "base"
+            | "form"
+            | "input"
+            | "button"
+            | "select"
+            | "textarea"
+            | "svg"
+            | "math"
+            | "applet"
+            | "frame"
+            | "frameset"
+    )
+}
+
+/// The heading level encoded in an `h1`..`h6` tag (defaults to 1).
+fn heading_level(tag: &str) -> i64 {
+    tag.strip_prefix('h')
+        .and_then(|d| d.parse::<i64>().ok())
+        .filter(|l| (1..=6).contains(l))
+        .unwrap_or(1)
+}
+
+/// Recursively gather text content (ignoring tags) — used for code blocks.
+fn collect_text(nodes: &[ParsedNode], out: &mut String) {
+    for n in nodes {
+        match n {
+            ParsedNode::Text(t) => out.push_str(t),
+            ParsedNode::Element { tag, children, .. } => {
+                if !is_dropped(tag) {
+                    collect_text(children, out);
+                }
+            }
+        }
+    }
+}
+
+/// Find an attribute value (case-insensitive name) in a parsed attribute list.
+fn attr<'b>(attributes: &'b [(String, String)], name: &str) -> Option<&'b str> {
+    attributes
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case(name))
+        .map(|(_, v)| v.as_str())
+}
+
+/// Extract a single CSS property value from an inline `style` attribute.
+fn parse_style(style: &str, property: &str) -> Option<String> {
+    for decl in style.split(';') {
+        if let Some((k, v)) = decl.split_once(':')
+            && k.trim().eq_ignore_ascii_case(property)
+        {
+            let value = v.trim();
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Reject dangerous URL schemes. `javascript:`/`vbscript:` are always rejected;
+/// `data:` is rejected for links and allowed only for **raster** image data URIs
+/// (`data:image/svg+xml` is excluded — SVG can carry `<script>`). Whitespace
+/// (including embedded newlines/tabs) is stripped before the scheme check to defeat
+/// `java\nscript:`-style obfuscation. Shared with the markdown ingress path.
+pub(crate) fn is_safe_url(url: &str, allow_data_image: bool) -> bool {
+    let normalized: String = url
+        .trim()
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect::<String>()
+        .to_ascii_lowercase();
+    if normalized.starts_with("javascript:") || normalized.starts_with("vbscript:") {
+        return false;
+    }
+    if normalized.starts_with("data:") {
+        if !allow_data_image {
+            return false;
+        }
+        return [
+            "data:image/png",
+            "data:image/jpeg",
+            "data:image/jpg",
+            "data:image/gif",
+            "data:image/webp",
+            "data:image/avif",
+            "data:image/bmp",
+        ]
+        .iter()
+        .any(|prefix| normalized.starts_with(prefix));
+    }
+    true
+}
+
+/// Whitelist for CSS color values accepted from pasted `style` attributes. Allows
+/// only named colors (letters), hex (`#rgb`/`#rgba`/`#rrggbb`/`#rrggbbaa`), and the
+/// numeric color functions `rgb()/rgba()/hsl()/hsla()`. Everything else — notably
+/// `expression(...)`, `url(...)`, and anything carrying `;`/`@` — is rejected, so a
+/// pasted color can never smuggle arbitrary CSS into the model or HTML copy-out.
+pub(crate) fn is_safe_css_color(value: &str) -> bool {
+    let v = value.trim();
+    if v.is_empty() || v.len() > 64 {
+        return false;
+    }
+    if let Some(hex) = v.strip_prefix('#') {
+        return matches!(hex.len(), 3 | 4 | 6 | 8) && hex.bytes().all(|b| b.is_ascii_hexdigit());
+    }
+    if let Some(open) = v.find('(') {
+        let name = v[..open].trim().to_ascii_lowercase();
+        if !matches!(name.as_str(), "rgb" | "rgba" | "hsl" | "hsla") || !v.ends_with(')') {
+            return false;
+        }
+        let args = &v[open + 1..v.len() - 1];
+        return args
+            .bytes()
+            .all(|b| b.is_ascii_digit() || matches!(b, b'.' | b',' | b'%' | b' ' | b'/'));
+    }
+    v.bytes().all(|b| b.is_ascii_alphabetic())
+}
+
+// ─── Salvaged zero-dependency HTML tokenizer ─────────────────────────────────
+//
+// Ported from `rinch/src/app/html_parser.rs`. Produces a tree of `ParsedNode`s
+// from a (possibly messy, clipboard-sourced) HTML fragment. Strips
+// `<html>/<head>/<body>` wrappers and `<script>/<style>/<meta>/<link>/<title>`
+// subtrees; attribute whitelisting drops `on*` handlers and anything not needed
+// by the schema mapper.
+
+/// A parsed HTML node.
+#[derive(Debug, Clone)]
+enum ParsedNode {
+    Text(String),
+    Element {
+        tag: String,
+        attributes: Vec<(String, String)>,
+        children: Vec<ParsedNode>,
+    },
+}
+
+fn parse_html_fragment(html: &str) -> Vec<ParsedNode> {
+    let mut parser = HtmlFragmentParser::new(html);
+    let nodes = parser.parse();
+    unwrap_body(nodes)
+}
+
+fn unwrap_body(nodes: Vec<ParsedNode>) -> Vec<ParsedNode> {
+    if nodes.len() == 1
+        && let ParsedNode::Element {
+            ref tag,
+            ref children,
+            ..
+        } = nodes[0]
+        && (tag == "html" || tag == "body")
+    {
+        return unwrap_body(children.clone());
+    }
+    let mut result = Vec::new();
+    let mut found_wrapper = false;
+    for node in &nodes {
+        if let ParsedNode::Element { tag, children, .. } = node {
+            if tag == "html" || tag == "body" {
+                result.extend(unwrap_body(children.clone()));
+                found_wrapper = true;
+            } else if tag == "head" || tag == "meta" || tag == "style" || tag == "script" {
+                found_wrapper = true;
+            } else {
+                result.push(node.clone());
+            }
+        } else {
+            result.push(node.clone());
+        }
+    }
+    if found_wrapper && !result.is_empty() {
+        return result;
+    }
+    nodes
+}
+
+struct HtmlFragmentParser<'a> {
+    input: &'a str,
+    pos: usize,
+}
+
+impl<'a> HtmlFragmentParser<'a> {
+    fn new(input: &'a str) -> Self {
+        Self { input, pos: 0 }
+    }
+
+    fn parse(&mut self) -> Vec<ParsedNode> {
+        self.parse_nodes(None)
+    }
+
+    fn parse_nodes(&mut self, end_tag: Option<&str>) -> Vec<ParsedNode> {
+        let mut nodes = Vec::new();
+        while self.pos < self.input.len() {
+            if let Some(end) = end_tag
+                && self.looking_at_close_tag(end)
+            {
+                self.consume_close_tag();
+                break;
+            }
+            if self.peek() == Some('<') {
+                if self.input[self.pos..].starts_with("<!--") {
+                    self.skip_comment();
+                    continue;
+                }
+                if self.input[self.pos..].starts_with("</") {
+                    if end_tag.is_none() {
+                        self.skip_to('>');
+                    }
+                    break;
+                }
+                if let Some(element) = self.parse_element() {
+                    nodes.push(element);
+                }
+            } else {
+                let text = self.parse_text();
+                if !text.is_empty() {
+                    nodes.push(ParsedNode::Text(text));
+                }
+            }
+        }
+        nodes
+    }
+
+    fn parse_element(&mut self) -> Option<ParsedNode> {
+        self.advance(); // consume '<'
+        let tag = self.parse_tag_name()?.to_ascii_lowercase();
+        if matches!(
+            tag.as_str(),
+            "script" | "style" | "meta" | "link" | "head" | "title"
+        ) {
+            self.skip_until_close_tag(&tag);
+            return None;
+        }
+        let attributes = self.parse_attributes();
+        self.skip_whitespace();
+        let self_closing = self.peek() == Some('/');
+        if self_closing {
+            self.advance();
+        }
+        if self.peek() == Some('>') {
+            self.advance();
+        }
+        let is_void = is_void_tag(&tag);
+        if self_closing || is_void {
+            return Some(ParsedNode::Element {
+                tag,
+                attributes: filter_attributes(attributes),
+                children: Vec::new(),
+            });
+        }
+        let children = self.parse_nodes(Some(&tag));
+        Some(ParsedNode::Element {
+            tag,
+            attributes: filter_attributes(attributes),
+            children,
+        })
+    }
+
+    fn parse_tag_name(&mut self) -> Option<String> {
+        let start = self.pos;
+        while self.pos < self.input.len() {
+            let ch = self.input.as_bytes()[self.pos];
+            if ch.is_ascii_alphanumeric() || ch == b'-' || ch == b'_' {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+        if self.pos > start {
+            Some(self.input[start..self.pos].to_string())
+        } else {
+            self.skip_to('>');
+            None
+        }
+    }
+
+    fn parse_attributes(&mut self) -> Vec<(String, String)> {
+        let mut attrs = Vec::new();
+        loop {
+            self.skip_whitespace();
+            let ch = self.peek();
+            if ch == Some('>') || ch == Some('/') || ch.is_none() {
+                break;
+            }
+            let name_start = self.pos;
+            while self.pos < self.input.len() {
+                let ch = self.input.as_bytes()[self.pos];
+                if ch == b'=' || ch == b'>' || ch == b'/' || ch.is_ascii_whitespace() {
+                    break;
+                }
+                self.pos += 1;
+            }
+            let name = self.input[name_start..self.pos].to_ascii_lowercase();
+            if name.is_empty() {
+                self.advance();
+                continue;
+            }
+            self.skip_whitespace();
+            if self.peek() == Some('=') {
+                self.advance();
+                self.skip_whitespace();
+                let value = if self.peek() == Some('"') {
+                    self.advance();
+                    let v = self.consume_until('"');
+                    self.advance();
+                    decode_entities(&v)
+                } else if self.peek() == Some('\'') {
+                    self.advance();
+                    let v = self.consume_until('\'');
+                    self.advance();
+                    decode_entities(&v)
+                } else {
+                    let v_start = self.pos;
+                    while self.pos < self.input.len() {
+                        let ch = self.input.as_bytes()[self.pos];
+                        if ch.is_ascii_whitespace() || ch == b'>' || ch == b'/' {
+                            break;
+                        }
+                        self.pos += 1;
+                    }
+                    decode_entities(&self.input[v_start..self.pos])
+                };
+                attrs.push((name, value));
+            } else {
+                attrs.push((name, String::new()));
+            }
+        }
+        attrs
+    }
+
+    fn parse_text(&mut self) -> String {
+        let start = self.pos;
+        while self.pos < self.input.len() && self.input.as_bytes()[self.pos] != b'<' {
+            self.pos += 1;
+        }
+        decode_entities(&self.input[start..self.pos])
+    }
+
+    fn peek(&self) -> Option<char> {
+        self.input[self.pos..].chars().next()
+    }
+
+    fn advance(&mut self) {
+        if self.pos < self.input.len() {
+            self.pos += self.input[self.pos..]
+                .chars()
+                .next()
+                .map_or(1, |c| c.len_utf8());
+        }
+    }
+
+    fn skip_whitespace(&mut self) {
+        while self.pos < self.input.len() && self.input.as_bytes()[self.pos].is_ascii_whitespace() {
+            self.pos += 1;
+        }
+    }
+
+    fn skip_to(&mut self, ch: char) {
+        while self.pos < self.input.len() && self.input.as_bytes()[self.pos] != ch as u8 {
+            self.pos += 1;
+        }
+        if self.pos < self.input.len() {
+            self.pos += 1;
+        }
+    }
+
+    fn consume_until(&mut self, ch: char) -> String {
+        let start = self.pos;
+        while self.pos < self.input.len() && self.input.as_bytes()[self.pos] != ch as u8 {
+            self.pos += 1;
+        }
+        self.input[start..self.pos].to_string()
+    }
+
+    fn looking_at_close_tag(&self, tag: &str) -> bool {
+        // Compare on bytes: `self.pos` is a char boundary here (parse_nodes only
+        // reaches this with `pos` at a `<`), but `tag.len()` may land mid-char if
+        // the close tag's name is multibyte, so never str-slice by `tag.len()`.
+        let remaining = &self.input.as_bytes()[self.pos..];
+        if !remaining.starts_with(b"</") {
+            return false;
+        }
+        let after = &remaining[2..];
+        if after.len() < tag.len() {
+            return false;
+        }
+        after[..tag.len()].eq_ignore_ascii_case(tag.as_bytes())
+            && after
+                .get(tag.len())
+                .is_none_or(|&b| b == b'>' || b.is_ascii_whitespace())
+    }
+
+    fn consume_close_tag(&mut self) {
+        self.skip_to('>');
+    }
+
+    fn skip_comment(&mut self) {
+        self.pos += 4; // skip "<!--"
+        // Scan on bytes: `pos` is advanced one byte at a time, so it may land
+        // inside a multibyte char — comparing `&str` slices there would panic.
+        let bytes = self.input.as_bytes();
+        while self.pos < bytes.len() {
+            if bytes[self.pos..].starts_with(b"-->") {
+                self.pos += 3;
+                return;
+            }
+            self.pos += 1;
+        }
+        self.pos = self.input.len();
+    }
+
+    fn skip_until_close_tag(&mut self, tag: &str) {
+        let close = format!("</{tag}");
+        let close_bytes = close.as_bytes();
+        // Byte-level, case-insensitive scan — `pos` advances byte-by-byte and may
+        // sit mid-char in non-ASCII element bodies (e.g. `<style>café</style>`).
+        let bytes = self.input.as_bytes();
+        while self.pos < bytes.len() {
+            if bytes[self.pos..].len() >= close_bytes.len()
+                && bytes[self.pos..self.pos + close_bytes.len()].eq_ignore_ascii_case(close_bytes)
+            {
+                self.skip_to('>');
+                return;
+            }
+            self.pos += 1;
+        }
+    }
+}
+
+fn is_void_tag(tag: &str) -> bool {
+    matches!(
+        tag,
+        "br" | "hr"
+            | "img"
+            | "input"
+            | "meta"
+            | "link"
+            | "wbr"
+            | "area"
+            | "base"
+            | "col"
+            | "embed"
+            | "source"
+            | "track"
+    )
+}
+
+/// Keep only the safe, schema-relevant attributes — drops `on*` event handlers
+/// and everything else.
+fn filter_attributes(attrs: Vec<(String, String)>) -> Vec<(String, String)> {
+    attrs
+        .into_iter()
+        .filter(|(name, _)| {
+            matches!(
+                name.as_str(),
+                "href" | "src" | "alt" | "title" | "target" | "start" | "style" | "class"
+            )
+        })
+        .collect()
+}
+
+fn decode_entities(s: &str) -> String {
+    s.replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&apos;", "'")
+        .replace("&#39;", "'")
+        .replace("&nbsp;", "\u{00A0}")
+        .replace("&amp;", "&")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s() -> Schema {
+        Schema::starter_kit()
+    }
+
+    /// Serialize HTML, parse it back to a slice, wrap in a doc, re-serialize.
+    fn reserialize_via_slice(schema: &Schema, html: &str) -> String {
+        let slice = slice_from_html(schema, html).unwrap();
+        let doc = Node::new_branch(
+            schema.node_type("doc").unwrap().clone(),
+            Attrs::new(),
+            slice.content.clone(),
+        );
+        node_to_html(&doc)
+    }
+
+    #[test]
+    fn serialize_heading_and_paragraph() {
+        let schema = s();
+        let heading = Node::new_branch(
+            schema.node_type("heading").unwrap().clone(),
+            Attrs::from_iter([("level", AttrValue::Int(2))]),
+            Fragment::from_node(schema.text("Title").unwrap()),
+        );
+        let para = Node::new_branch(
+            schema.node_type("paragraph").unwrap().clone(),
+            Attrs::new(),
+            Fragment::from_node(schema.text("Body").unwrap()),
+        );
+        let doc = Node::new_branch(
+            schema.node_type("doc").unwrap().clone(),
+            Attrs::new(),
+            Fragment::from_children(vec![heading, para]),
+        );
+        assert_eq!(node_to_html(&doc), "<h2>Title</h2><p>Body</p>");
+    }
+
+    #[test]
+    fn serialize_marks_nested_per_run() {
+        let schema = s();
+        let bold = Mark::new(schema.mark_type("bold").unwrap().clone(), Attrs::new());
+        let link = Mark::new(
+            schema.mark_type("link").unwrap().clone(),
+            schema
+                .mark_type("link")
+                .unwrap()
+                .compute_attrs(&Attrs::from_iter([(
+                    "href",
+                    AttrValue::from("https://x.io"),
+                )]))
+                .unwrap(),
+        );
+        let para = Node::new_branch(
+            schema.node_type("paragraph").unwrap().clone(),
+            Attrs::new(),
+            Fragment::from_children(vec![
+                schema.text_with_marks("a", vec![bold]).unwrap(),
+                schema.text_with_marks("b", vec![link]).unwrap(),
+            ]),
+        );
+        assert_eq!(
+            node_to_html(&para),
+            r#"<p><strong>a</strong><a href="https://x.io">b</a></p>"#
+        );
+    }
+
+    #[test]
+    fn serialize_list_items_with_combined_marks() {
+        // A bullet list whose items carry bold, italic, and bold+italic runs —
+        // each run wraps innermost-first (marks[0] innermost), matching copy-out
+        // HTML. Combined marks nest: [bold, italic] → <em><strong>…</strong></em>.
+        let schema = s();
+        let bold = || Mark::new(schema.mark_type("bold").unwrap().clone(), Attrs::new());
+        let italic = || Mark::new(schema.mark_type("italic").unwrap().clone(), Attrs::new());
+        let item = |run: Node| {
+            let p = Node::new_branch(
+                schema.node_type("paragraph").unwrap().clone(),
+                Attrs::new(),
+                Fragment::from_node(run),
+            );
+            Node::new_branch(
+                schema.node_type("list_item").unwrap().clone(),
+                Attrs::new(),
+                Fragment::from_node(p),
+            )
+        };
+        let list = Node::new_branch(
+            schema.node_type("bullet_list").unwrap().clone(),
+            Attrs::new(),
+            Fragment::from_children(vec![
+                item(schema.text_with_marks("a", vec![bold()]).unwrap()),
+                item(schema.text_with_marks("b", vec![italic()]).unwrap()),
+                item(schema.text_with_marks("c", vec![bold(), italic()]).unwrap()),
+            ]),
+        );
+        assert_eq!(
+            node_to_html(&list),
+            "<ul><li><p><strong>a</strong></p></li>\
+             <li><p><em>b</em></p></li>\
+             <li><p><em><strong>c</strong></em></p></li></ul>"
+        );
+    }
+
+    #[test]
+    fn serialize_escapes_text_and_attrs() {
+        let schema = s();
+        let link = Mark::new(
+            schema.mark_type("link").unwrap().clone(),
+            schema
+                .mark_type("link")
+                .unwrap()
+                .compute_attrs(&Attrs::from_iter([(
+                    "href",
+                    AttrValue::from("https://x.io/?a=1&b=2"),
+                )]))
+                .unwrap(),
+        );
+        let para = Node::new_branch(
+            schema.node_type("paragraph").unwrap().clone(),
+            Attrs::new(),
+            Fragment::from_children(vec![
+                schema.text("a < b & c > d").unwrap(),
+                schema.text_with_marks("link", vec![link]).unwrap(),
+            ]),
+        );
+        let html = node_to_html(&para);
+        assert!(html.contains("a &lt; b &amp; c &gt; d"), "{html}");
+        assert!(
+            html.contains(r#"href="https://x.io/?a=1&amp;b=2""#),
+            "{html}"
+        );
+    }
+
+    #[test]
+    fn serialize_void_elements() {
+        let schema = s();
+        let img = Node::new_branch(
+            schema.node_type("image").unwrap().clone(),
+            schema
+                .node_type("image")
+                .unwrap()
+                .compute_attrs(&Attrs::from_iter([("src", AttrValue::from("a.png"))]))
+                .unwrap(),
+            Fragment::empty(),
+        );
+        let para = Node::new_branch(
+            schema.node_type("paragraph").unwrap().clone(),
+            Attrs::new(),
+            Fragment::from_children(vec![
+                img,
+                Node::new_branch(
+                    schema.node_type("hard_break").unwrap().clone(),
+                    Attrs::new(),
+                    Fragment::empty(),
+                ),
+            ]),
+        );
+        assert_eq!(node_to_html(&para), r#"<p><img src="a.png"><br></p>"#);
+    }
+
+    #[test]
+    fn parse_drops_script_and_iframe() {
+        let schema = s();
+        let out = reserialize_via_slice(
+            &schema,
+            "<p>safe</p><script>alert(1)</script><iframe src=\"evil\"></iframe><p>after</p>",
+        );
+        assert!(!out.contains("alert"), "{out}");
+        assert!(!out.contains("iframe"), "{out}");
+        assert!(out.contains("safe"));
+        assert!(out.contains("after"));
+    }
+
+    #[test]
+    fn parse_drops_event_handler_attrs() {
+        let schema = s();
+        let slice = slice_from_html(&schema, r#"<p onclick="steal()">hi</p>"#).unwrap();
+        let html = node_to_html(&Node::new_branch(
+            schema.node_type("doc").unwrap().clone(),
+            Attrs::new(),
+            slice.content,
+        ));
+        assert!(!html.contains("onclick"), "{html}");
+        assert!(html.contains("hi"));
+    }
+
+    #[test]
+    fn parse_span_style_to_text_color() {
+        let schema = s();
+        let slice =
+            slice_from_html(&schema, r#"<p><span style="color: red">x</span></p>"#).unwrap();
+        // dig into doc > paragraph > text
+        let para = slice.content.child(0);
+        let text = para.child(0);
+        assert_eq!(text.text(), Some("x"));
+        assert!(
+            text.marks()
+                .iter()
+                .any(|m| m.type_name() == "text_color" && m.attrs.get_str("color") == Some("red")),
+            "marks: {:?}",
+            text.marks()
+        );
+    }
+
+    #[test]
+    fn parse_preserves_bold_link_marks() {
+        let schema = s();
+        let slice =
+            slice_from_html(&schema, r#"<p><b><a href="https://x.io">hi</a></b></p>"#).unwrap();
+        let text = slice.content.child(0).child(0);
+        let names: Vec<&str> = text.marks().iter().map(|m| m.type_name()).collect();
+        assert!(names.contains(&"bold"), "{names:?}");
+        assert!(names.contains(&"link"), "{names:?}");
+        assert_eq!(
+            text.marks()
+                .iter()
+                .find(|m| m.type_name() == "link")
+                .and_then(|m| m.attrs.get_str("href")),
+            Some("https://x.io")
+        );
+    }
+
+    #[test]
+    fn parse_strips_javascript_url_link() {
+        let schema = s();
+        let slice =
+            slice_from_html(&schema, r#"<p><a href="javascript:alert(1)">x</a></p>"#).unwrap();
+        let text = slice.content.child(0).child(0);
+        assert_eq!(text.text(), Some("x"));
+        assert!(
+            text.marks().is_empty(),
+            "javascript: link must be dropped, got {:?}",
+            text.marks()
+        );
+    }
+
+    #[test]
+    fn parse_nested_list() {
+        let schema = s();
+        let slice = slice_from_html(&schema, "<ul><li>one</li><li>two</li></ul>").unwrap();
+        let list = slice.content.child(0);
+        assert_eq!(list.type_name(), "bullet_list");
+        assert_eq!(list.child_count(), 2);
+        let item0 = list.child(0);
+        assert_eq!(item0.type_name(), "list_item");
+        assert_eq!(item0.child(0).type_name(), "paragraph");
+        assert_eq!(item0.child(0).child(0).text(), Some("one"));
+    }
+
+    #[test]
+    fn parse_blockquote_wraps_inline() {
+        let schema = s();
+        let slice = slice_from_html(&schema, "<blockquote>quoted</blockquote>").unwrap();
+        let bq = slice.content.child(0);
+        assert_eq!(bq.type_name(), "blockquote");
+        assert_eq!(bq.child(0).type_name(), "paragraph");
+        assert_eq!(bq.child(0).child(0).text(), Some("quoted"));
+    }
+
+    #[test]
+    fn parse_bare_inline_is_open_slice() {
+        let schema = s();
+        let slice = slice_from_html(&schema, "<strong>hi</strong>").unwrap();
+        assert_eq!(slice.content.child_count(), 1);
+        assert_eq!(slice.content.child(0).type_name(), "paragraph");
+        // textblock first & last → open 1/1 so it merges inline on paste.
+        assert_eq!((slice.open_start, slice.open_end), (1, 1));
+    }
+
+    #[test]
+    fn parse_then_serialize_round_trips_common_html() {
+        let schema = s();
+        let html = "<h1>Title</h1><p>Some <strong>bold</strong> and <em>italic</em>.</p>";
+        assert_eq!(reserialize_via_slice(&schema, html), html);
+    }
+
+    #[test]
+    fn parse_ordered_list_start() {
+        let schema = s();
+        let slice = slice_from_html(&schema, r#"<ol start="3"><li>x</li></ol>"#).unwrap();
+        let list = slice.content.child(0);
+        assert_eq!(list.type_name(), "ordered_list");
+        assert_eq!(list.attrs().get_int("start"), Some(3));
+    }
+
+    #[test]
+    fn parse_code_block() {
+        let schema = s();
+        let slice = slice_from_html(&schema, "<pre>fn main() {}</pre>").unwrap();
+        let code = slice.content.child(0);
+        assert_eq!(code.type_name(), "code_block");
+        assert_eq!(code.child(0).text(), Some("fn main() {}"));
+    }
+
+    #[test]
+    fn parse_multibyte_comment_does_not_panic() {
+        // Regression: the tokenizer byte-advanced then str-sliced inside comments.
+        let schema = s();
+        let slice = slice_from_html(&schema, "<!--é comment 🎉--><p>after</p>").unwrap();
+        assert_eq!(slice.content.child(0).child(0).text(), Some("after"));
+        // unterminated comment with multibyte must also be safe
+        assert!(slice_from_html(&schema, "<!--café no closer 🎉").is_ok());
+    }
+
+    #[test]
+    fn parse_multibyte_in_dropped_tag_does_not_panic() {
+        // Regression: skip_until_close_tag byte-advanced then str-sliced (case-fold).
+        let schema = s();
+        let slice = slice_from_html(&schema, "<style>café {}</style><p>hi</p>").unwrap();
+        assert_eq!(slice.content.child(0).child(0).text(), Some("hi"));
+        assert!(slice_from_html(&schema, "<script>let x='ünïcödé';</script><p>y</p>").is_ok());
+    }
+
+    #[test]
+    fn parse_rejects_unsafe_css_color() {
+        let schema = s();
+        let slice = slice_from_html(
+            &schema,
+            r#"<p><span style="color: expression(alert(1))">x</span></p>"#,
+        )
+        .unwrap();
+        let text = slice.content.child(0).child(0);
+        assert_eq!(text.text(), Some("x"));
+        assert!(
+            text.marks().is_empty(),
+            "expression() color must be rejected, got {:?}",
+            text.marks()
+        );
+        // a legitimate color is still accepted
+        let ok =
+            slice_from_html(&schema, r#"<p><span style="color:#ff0000">y</span></p>"#).unwrap();
+        assert!(
+            ok.content
+                .child(0)
+                .child(0)
+                .marks()
+                .iter()
+                .any(|m| m.type_name() == "text_color")
+        );
+    }
+
+    #[test]
+    fn parse_image_data_uri_svg_rejected_raster_allowed() {
+        let schema = s();
+        // svg+xml can carry script → dropped
+        let svg = slice_from_html(
+            &schema,
+            r#"<p><img src="data:image/svg+xml,<svg onload=alert(1)>"></p>"#,
+        )
+        .unwrap();
+        assert!(
+            !svg.content
+                .child(0)
+                .content()
+                .children()
+                .iter()
+                .any(|n| n.type_name() == "image"),
+            "data:image/svg+xml must be dropped"
+        );
+        // a raster data URI is allowed
+        let png =
+            slice_from_html(&schema, r#"<p><img src="data:image/png;base64,AAAA"></p>"#).unwrap();
+        assert!(
+            png.content
+                .child(0)
+                .content()
+                .children()
+                .iter()
+                .any(|n| n.type_name() == "image")
+        );
+    }
+
+    #[test]
+    fn serialize_target_blank_link_adds_rel_noopener() {
+        let schema = s();
+        let mt = schema.mark_type("link").unwrap();
+        let attrs = mt
+            .compute_attrs(&Attrs::from_iter([
+                ("href", AttrValue::from("https://x.io")),
+                ("target", AttrValue::from("_blank")),
+            ]))
+            .unwrap();
+        let para = Node::new_branch(
+            schema.node_type("paragraph").unwrap().clone(),
+            Attrs::new(),
+            Fragment::from_node(
+                schema
+                    .text_with_marks("x", vec![Mark::new(mt.clone(), attrs)])
+                    .unwrap(),
+            ),
+        );
+        let html = node_to_html(&para);
+        assert!(html.contains(r#"target="_blank""#), "{html}");
+        assert!(html.contains(r#"rel="noopener noreferrer""#), "{html}");
+    }
+}

--- a/crates/rinch-editor-core/src/serialize/markdown.rs
+++ b/crates/rinch-editor-core/src/serialize/markdown.rs
@@ -1,0 +1,706 @@
+//! Markdown I/O via `pulldown-cmark` — feature `markdown`.
+//!
+//! Salvaged from the old `rinch-editor` `document/fragment.rs`, but rebound to the
+//! real [`Node`] model and producing **properly nested** structure (a markdown
+//! bullet list becomes one `bullet_list` node containing `list_item`s, each with a
+//! `paragraph` — not the old flat "one block per item"). Markdown is a lossy
+//! interchange: marks without a markdown equivalent (underline, highlight,
+//! text_color, sub/superscript) serialize as plain text. The durable, total
+//! format is [`super::doc_json`].
+
+use crate::EditorError;
+use crate::model::{AttrValue, Attrs, Fragment, Mark, Node};
+use crate::schema::Schema;
+use crate::serialize::html::is_safe_url;
+use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+
+// ─── markdown → doc ──────────────────────────────────────────────────────────
+
+/// Parse a markdown string into a `doc` node, validated against `schema`.
+pub fn doc_from_markdown(schema: &Schema, md: &str) -> Result<Node, EditorError> {
+    let mut options = Options::empty();
+    options.insert(Options::ENABLE_STRIKETHROUGH);
+    options.insert(Options::ENABLE_TABLES);
+
+    let mut builder = MdBuilder::new(schema);
+    for event in Parser::new_ext(md, options) {
+        builder.handle(event)?;
+    }
+    builder.finish()
+}
+
+/// A container being assembled (doc, blockquote, list, list_item).
+struct Container {
+    type_name: &'static str,
+    attrs: Attrs,
+    children: Vec<Node>,
+}
+
+/// A textblock being assembled (paragraph, heading, code_block).
+struct TextBlock {
+    type_name: &'static str,
+    attrs: Attrs,
+    content: Vec<Node>,
+    is_code: bool,
+}
+
+struct MdBuilder<'a> {
+    schema: &'a Schema,
+    /// Container stack; `containers[0]` is always the `doc`.
+    containers: Vec<Container>,
+    /// The open textblock, if any.
+    inline: Option<TextBlock>,
+    /// Active inline marks.
+    marks: Vec<Mark>,
+    /// In-progress image: `(src, title, alt-accumulator)`.
+    image: Option<(String, String, String)>,
+}
+
+impl<'a> MdBuilder<'a> {
+    fn new(schema: &'a Schema) -> Self {
+        Self {
+            schema,
+            containers: vec![Container {
+                type_name: "doc",
+                attrs: Attrs::new(),
+                children: Vec::new(),
+            }],
+            inline: None,
+            marks: Vec::new(),
+            image: None,
+        }
+    }
+
+    fn handle(&mut self, event: Event<'_>) -> Result<(), EditorError> {
+        match event {
+            Event::Start(tag) => self.start(tag)?,
+            Event::End(tag_end) => self.end(tag_end)?,
+            Event::Text(t) => self.push_text(&t)?,
+            Event::Code(t) => self.push_code(&t)?,
+            Event::SoftBreak => self.push_text(" ")?,
+            Event::HardBreak => self.push_hard_break()?,
+            Event::Rule => self.push_rule()?,
+            _ => {} // raw HTML, footnotes, math, task markers: ignored
+        }
+        Ok(())
+    }
+
+    fn start(&mut self, tag: Tag<'_>) -> Result<(), EditorError> {
+        match tag {
+            Tag::Heading { level, .. } => {
+                self.flush_inline()?;
+                let attrs = Attrs::from_iter([("level", AttrValue::Int(heading_level(level)))]);
+                self.open_inline("heading", attrs, false);
+            }
+            Tag::Paragraph => {
+                self.flush_inline()?;
+                self.open_inline("paragraph", Attrs::new(), false);
+            }
+            Tag::CodeBlock(kind) => {
+                self.flush_inline()?;
+                let attrs = match kind {
+                    CodeBlockKind::Fenced(lang) if !lang.is_empty() => {
+                        Attrs::from_iter([("language", AttrValue::from(lang.to_string()))])
+                    }
+                    _ => Attrs::new(),
+                };
+                self.open_inline("code_block", attrs, true);
+            }
+            Tag::BlockQuote(_) => {
+                self.flush_inline()?;
+                self.push_container("blockquote", Attrs::new());
+            }
+            Tag::List(start) => {
+                self.flush_inline()?;
+                match start {
+                    Some(s) => self.push_container(
+                        "ordered_list",
+                        Attrs::from_iter([("start", AttrValue::Int(s as i64))]),
+                    ),
+                    None => self.push_container("bullet_list", Attrs::new()),
+                }
+            }
+            Tag::Item => {
+                self.flush_inline()?;
+                self.push_container("list_item", Attrs::new());
+            }
+            Tag::Strong => self.add_mark("bold", Attrs::new())?,
+            Tag::Emphasis => self.add_mark("italic", Attrs::new())?,
+            Tag::Strikethrough => self.add_mark("strike", Attrs::new())?,
+            Tag::Link {
+                dest_url, title, ..
+            } => {
+                // Mirror the HTML ingress whitelist: a javascript:/vbscript:/data:
+                // href never enters the model. On rejection the link mark is simply
+                // not pushed (children parse transparently); the matching End(Link)
+                // `remove_mark("link")` is then a harmless no-op.
+                if is_safe_url(&dest_url, false) {
+                    let mut pairs: Vec<(&str, AttrValue)> =
+                        vec![("href", AttrValue::from(dest_url.to_string()))];
+                    if !title.is_empty() {
+                        pairs.push(("title", AttrValue::from(title.to_string())));
+                    }
+                    self.add_mark("link", Attrs::from_iter(pairs))?;
+                }
+            }
+            Tag::Image {
+                dest_url, title, ..
+            } => {
+                self.image = Some((dest_url.to_string(), title.to_string(), String::new()));
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn end(&mut self, tag_end: TagEnd) -> Result<(), EditorError> {
+        match tag_end {
+            TagEnd::Heading(_) | TagEnd::Paragraph | TagEnd::CodeBlock => self.flush_inline()?,
+            TagEnd::BlockQuote(_) | TagEnd::List(_) | TagEnd::Item => {
+                self.flush_inline()?;
+                self.pop_container()?;
+            }
+            TagEnd::Image => {
+                if let Some((src, title, alt)) = self.image.take() {
+                    // Unsafe src → drop the image entirely. The alt text was captured
+                    // into the image buffer (not leaked into the paragraph) so nothing
+                    // dangerous and nothing stray remains.
+                    if is_safe_url(&src, true) {
+                        self.push_image(&src, &title, &alt)?;
+                    }
+                }
+            }
+            TagEnd::Strong => self.remove_mark("bold"),
+            TagEnd::Emphasis => self.remove_mark("italic"),
+            TagEnd::Strikethrough => self.remove_mark("strike"),
+            TagEnd::Link => self.remove_mark("link"),
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn open_inline(&mut self, type_name: &'static str, attrs: Attrs, is_code: bool) {
+        self.inline = Some(TextBlock {
+            type_name,
+            attrs,
+            content: Vec::new(),
+            is_code,
+        });
+    }
+
+    fn ensure_inline(&mut self) {
+        if self.inline.is_none() {
+            self.open_inline("paragraph", Attrs::new(), false);
+        }
+    }
+
+    fn flush_inline(&mut self) -> Result<(), EditorError> {
+        let Some(tb) = self.inline.take() else {
+            return Ok(());
+        };
+        let content = if tb.is_code {
+            let mut text = String::new();
+            for n in &tb.content {
+                text.push_str(n.text().unwrap_or(""));
+            }
+            // pulldown appends a trailing newline to code blocks.
+            if text.ends_with('\n') {
+                text.pop();
+            }
+            if text.is_empty() {
+                Fragment::empty()
+            } else {
+                Fragment::from_node(self.schema.text(&text)?)
+            }
+        } else {
+            Fragment::from_children(tb.content)
+        };
+        let node = self.make_node(tb.type_name, tb.attrs, content)?;
+        self.top_mut().children.push(node);
+        Ok(())
+    }
+
+    fn push_container(&mut self, type_name: &'static str, attrs: Attrs) {
+        self.containers.push(Container {
+            type_name,
+            attrs,
+            children: Vec::new(),
+        });
+    }
+
+    fn pop_container(&mut self) -> Result<(), EditorError> {
+        // Never pop the root doc container.
+        if self.containers.len() <= 1 {
+            return Ok(());
+        }
+        let c = self.containers.pop().expect("non-root container");
+        let node = self.build_container(c)?;
+        self.top_mut().children.push(node);
+        Ok(())
+    }
+
+    fn push_text(&mut self, t: &str) -> Result<(), EditorError> {
+        if let Some((_, _, alt)) = &mut self.image {
+            alt.push_str(t);
+            return Ok(());
+        }
+        if t.is_empty() {
+            return Ok(());
+        }
+        self.ensure_inline();
+        let node = self.schema.text_with_marks(t, self.marks.clone())?;
+        self.inline
+            .as_mut()
+            .expect("inline open")
+            .content
+            .push(node);
+        Ok(())
+    }
+
+    fn push_code(&mut self, t: &str) -> Result<(), EditorError> {
+        if self.image.is_some() {
+            return Ok(());
+        }
+        self.ensure_inline();
+        let marks = match self.schema.mark_type("code") {
+            Some(mt) => {
+                Mark::new(mt.clone(), mt.compute_attrs(&Attrs::new())?).add_to_set(&self.marks)
+            }
+            None => self.marks.clone(),
+        };
+        let node = self.schema.text_with_marks(t, marks)?;
+        self.inline
+            .as_mut()
+            .expect("inline open")
+            .content
+            .push(node);
+        Ok(())
+    }
+
+    fn push_hard_break(&mut self) -> Result<(), EditorError> {
+        if self.image.is_some() {
+            return Ok(());
+        }
+        self.ensure_inline();
+        let node = self.make_node("hard_break", Attrs::new(), Fragment::empty())?;
+        self.inline
+            .as_mut()
+            .expect("inline open")
+            .content
+            .push(node);
+        Ok(())
+    }
+
+    fn push_rule(&mut self) -> Result<(), EditorError> {
+        self.flush_inline()?;
+        let hr = self.make_node("horizontal_rule", Attrs::new(), Fragment::empty())?;
+        self.top_mut().children.push(hr);
+        Ok(())
+    }
+
+    fn push_image(&mut self, src: &str, title: &str, alt: &str) -> Result<(), EditorError> {
+        self.ensure_inline();
+        let mut pairs: Vec<(&str, AttrValue)> = vec![("src", AttrValue::from(src.to_string()))];
+        if !alt.is_empty() {
+            pairs.push(("alt", AttrValue::from(alt.to_string())));
+        }
+        if !title.is_empty() {
+            pairs.push(("title", AttrValue::from(title.to_string())));
+        }
+        let img = self.make_node("image", Attrs::from_iter(pairs), Fragment::empty())?;
+        self.inline.as_mut().expect("inline open").content.push(img);
+        Ok(())
+    }
+
+    fn add_mark(&mut self, name: &str, attrs: Attrs) -> Result<(), EditorError> {
+        if let Some(mt) = self.schema.mark_type(name) {
+            let mark = Mark::new(mt.clone(), mt.compute_attrs(&attrs)?);
+            self.marks = mark.add_to_set(&self.marks);
+        }
+        Ok(())
+    }
+
+    fn remove_mark(&mut self, name: &str) {
+        self.marks.retain(|m| m.type_name() != name);
+    }
+
+    fn top_mut(&mut self) -> &mut Container {
+        self.containers.last_mut().expect("doc container")
+    }
+
+    fn build_container(&self, c: Container) -> Result<Node, EditorError> {
+        match c.type_name {
+            "blockquote" | "list_item" => {
+                let children = self.ensure_block_plus(c.children)?;
+                self.make_node(c.type_name, c.attrs, Fragment::from_children(children))
+            }
+            "bullet_list" | "ordered_list" => {
+                let items = if c.children.is_empty() {
+                    vec![self.empty_list_item()?]
+                } else {
+                    c.children
+                };
+                self.make_node(c.type_name, c.attrs, Fragment::from_children(items))
+            }
+            _ => self.make_node(c.type_name, c.attrs, Fragment::from_children(c.children)),
+        }
+    }
+
+    fn ensure_block_plus(&self, mut blocks: Vec<Node>) -> Result<Vec<Node>, EditorError> {
+        if blocks.is_empty() {
+            blocks.push(self.make_node("paragraph", Attrs::new(), Fragment::empty())?);
+        }
+        Ok(blocks)
+    }
+
+    fn empty_list_item(&self) -> Result<Node, EditorError> {
+        let para = self.make_node("paragraph", Attrs::new(), Fragment::empty())?;
+        self.make_node("list_item", Attrs::new(), Fragment::from_node(para))
+    }
+
+    fn make_node(
+        &self,
+        type_name: &str,
+        attrs: Attrs,
+        content: Fragment,
+    ) -> Result<Node, EditorError> {
+        let nt = self
+            .schema
+            .node_type(type_name)
+            .ok_or_else(|| EditorError::UnknownNodeType(type_name.to_string()))?;
+        let attrs = nt.compute_attrs(&attrs)?;
+        Ok(Node::new_branch(nt.clone(), attrs, content))
+    }
+
+    fn finish(mut self) -> Result<Node, EditorError> {
+        self.flush_inline()?;
+        // Close any containers the (malformed) input left open.
+        while self.containers.len() > 1 {
+            self.pop_container()?;
+        }
+        let doc = self.containers.pop().expect("doc container");
+        let children = self.ensure_block_plus(doc.children)?;
+        self.make_node("doc", Attrs::new(), Fragment::from_children(children))
+    }
+}
+
+fn heading_level(level: HeadingLevel) -> i64 {
+    match level {
+        HeadingLevel::H1 => 1,
+        HeadingLevel::H2 => 2,
+        HeadingLevel::H3 => 3,
+        HeadingLevel::H4 => 4,
+        HeadingLevel::H5 => 5,
+        HeadingLevel::H6 => 6,
+    }
+}
+
+// ─── doc → markdown ──────────────────────────────────────────────────────────
+
+/// Serialize a `doc` node to a markdown string.
+pub fn doc_to_markdown(doc: &Node) -> String {
+    let md = blocks_to_md(doc.content().children());
+    md.trim_end().to_string()
+}
+
+fn blocks_to_md(blocks: &[Node]) -> String {
+    let mut out = String::new();
+    for b in blocks {
+        out.push_str(&block_to_md(b));
+    }
+    out
+}
+
+fn block_to_md(node: &Node) -> String {
+    match node.type_name() {
+        "heading" => {
+            let level = node.attrs().get_int("level").unwrap_or(1).clamp(1, 6) as usize;
+            format!("{} {}\n\n", "#".repeat(level), inline_to_md(node))
+        }
+        "code_block" => {
+            let lang = node.attrs().get_str("language").unwrap_or("");
+            format!("```{lang}\n{}\n```\n\n", block_text(node))
+        }
+        "blockquote" => {
+            let inner = blocks_to_md(node.content().children());
+            format!("{}\n\n", prefix_lines(inner.trim_end(), "> "))
+        }
+        "bullet_list" => list_to_md(node, None),
+        "ordered_list" => list_to_md(node, Some(node.attrs().get_int("start").unwrap_or(1))),
+        "horizontal_rule" => "---\n\n".to_string(),
+        // paragraph and any other textblock-ish node.
+        _ => format!("{}\n\n", inline_to_md(node)),
+    }
+}
+
+fn list_to_md(list: &Node, start: Option<i64>) -> String {
+    let mut out = String::new();
+    for (i, item) in list.content().children().iter().enumerate() {
+        let item_md = blocks_to_md(item.content().children());
+        let marker = match start {
+            Some(s) => format!("{}. ", s + i as i64),
+            None => "- ".to_string(),
+        };
+        let indent = " ".repeat(marker.len());
+        out.push_str(&prefix_first_then_rest(
+            item_md.trim_end(),
+            &marker,
+            &indent,
+        ));
+        out.push('\n');
+    }
+    out.push('\n');
+    out
+}
+
+/// Inline markdown for a textblock's content.
+fn inline_to_md(block: &Node) -> String {
+    let mut out = String::new();
+    for inline in block.content().children() {
+        if let Some(text) = inline.text() {
+            let mut s = text.to_string();
+            for mark in inline.marks() {
+                s = wrap_mark_md(mark, &s);
+            }
+            out.push_str(&s);
+        } else if inline.type_name() == "hard_break" {
+            out.push_str("  \n");
+        } else if inline.type_name() == "image" {
+            let src = inline.attrs().get_str("src").unwrap_or("");
+            let alt = inline.attrs().get_str("alt").unwrap_or("");
+            let title = inline.attrs().get_str("title").unwrap_or("");
+            if title.is_empty() {
+                out.push_str(&format!("![{alt}]({src})"));
+            } else {
+                out.push_str(&format!("![{alt}]({src} \"{title}\")"));
+            }
+        }
+    }
+    out
+}
+
+fn wrap_mark_md(mark: &Mark, text: &str) -> String {
+    match mark.type_name() {
+        "bold" => format!("**{text}**"),
+        "italic" => format!("*{text}*"),
+        "strike" => format!("~~{text}~~"),
+        "code" => format!("`{text}`"),
+        "link" => {
+            let href = mark.attrs.get_str("href").unwrap_or("");
+            let title = mark.attrs.get_str("title").unwrap_or("");
+            if title.is_empty() {
+                format!("[{text}]({href})")
+            } else {
+                format!("[{text}]({href} \"{title}\")")
+            }
+        }
+        // underline, highlight, text_color, subscript, superscript: no markdown
+        // equivalent → emit plain (lossy; the lossless format is DocNode).
+        _ => text.to_string(),
+    }
+}
+
+/// Concatenate all descendant text (used for code blocks).
+fn block_text(node: &Node) -> String {
+    let mut out = String::new();
+    collect(node, &mut out);
+    fn collect(node: &Node, out: &mut String) {
+        if let Some(t) = node.text() {
+            out.push_str(t);
+        } else {
+            for child in node.content().children() {
+                collect(child, out);
+            }
+        }
+    }
+    out
+}
+
+fn prefix_lines(text: &str, prefix: &str) -> String {
+    text.lines()
+        .map(|line| format!("{prefix}{line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn prefix_first_then_rest(text: &str, first: &str, rest: &str) -> String {
+    let mut out = String::new();
+    for (i, line) in text.lines().enumerate() {
+        if i == 0 {
+            out.push_str(&format!("{first}{line}"));
+        } else {
+            out.push('\n');
+            out.push_str(&format!("{rest}{line}"));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s() -> Schema {
+        Schema::starter_kit()
+    }
+
+    #[test]
+    fn heading_round_trips() {
+        let schema = s();
+        let doc = doc_from_markdown(&schema, "## Title").unwrap();
+        let h = doc.child(0);
+        assert_eq!(h.type_name(), "heading");
+        assert_eq!(h.attrs().get_int("level"), Some(2));
+        assert_eq!(h.child(0).text(), Some("Title"));
+        assert_eq!(doc_to_markdown(&doc), "## Title");
+    }
+
+    #[test]
+    fn bold_and_italic() {
+        let schema = s();
+        let doc = doc_from_markdown(&schema, "This is **bold** and *italic*.").unwrap();
+        let md = doc_to_markdown(&doc);
+        assert!(md.contains("**bold**"), "{md}");
+        assert!(md.contains("*italic*"), "{md}");
+    }
+
+    #[test]
+    fn nested_bullet_list_structure() {
+        let schema = s();
+        let doc = doc_from_markdown(&schema, "- one\n- two").unwrap();
+        // doc > bullet_list > [list_item > paragraph > text] x2
+        let list = doc.child(0);
+        assert_eq!(list.type_name(), "bullet_list");
+        assert_eq!(list.child_count(), 2);
+        let item0 = list.child(0);
+        assert_eq!(item0.type_name(), "list_item");
+        assert_eq!(item0.child(0).type_name(), "paragraph");
+        assert_eq!(item0.child(0).child(0).text(), Some("one"));
+        // round-trips to bullets
+        let md = doc_to_markdown(&doc);
+        assert!(md.contains("- one"), "{md}");
+        assert!(md.contains("- two"), "{md}");
+    }
+
+    #[test]
+    fn ordered_list_start_and_numbering() {
+        let schema = s();
+        let doc = doc_from_markdown(&schema, "3. a\n4. b").unwrap();
+        let list = doc.child(0);
+        assert_eq!(list.type_name(), "ordered_list");
+        assert_eq!(list.attrs().get_int("start"), Some(3));
+        let md = doc_to_markdown(&doc);
+        assert!(md.contains("3. a"), "{md}");
+        assert!(md.contains("4. b"), "{md}");
+    }
+
+    #[test]
+    fn code_block_with_language() {
+        let schema = s();
+        let doc = doc_from_markdown(&schema, "```rust\nfn main() {}\n```").unwrap();
+        let cb = doc.child(0);
+        assert_eq!(cb.type_name(), "code_block");
+        assert_eq!(cb.attrs().get_str("language"), Some("rust"));
+        assert_eq!(cb.child(0).text(), Some("fn main() {}"));
+        let md = doc_to_markdown(&doc);
+        assert!(md.contains("```rust"), "{md}");
+        assert!(md.contains("fn main() {}"), "{md}");
+    }
+
+    #[test]
+    fn blockquote_structure_and_prefix() {
+        let schema = s();
+        let doc = doc_from_markdown(&schema, "> quoted text").unwrap();
+        let bq = doc.child(0);
+        assert_eq!(bq.type_name(), "blockquote");
+        assert_eq!(bq.child(0).type_name(), "paragraph");
+        assert_eq!(bq.child(0).child(0).text(), Some("quoted text"));
+        let md = doc_to_markdown(&doc);
+        assert!(md.contains("> quoted text"), "{md}");
+    }
+
+    #[test]
+    fn link_round_trips() {
+        let schema = s();
+        let doc = doc_from_markdown(&schema, "[click](https://example.com)").unwrap();
+        let text = doc.child(0).child(0);
+        assert_eq!(text.text(), Some("click"));
+        assert!(
+            text.marks().iter().any(|m| m.type_name() == "link"
+                && m.attrs.get_str("href") == Some("https://example.com")),
+            "marks: {:?}",
+            text.marks()
+        );
+        let md = doc_to_markdown(&doc);
+        assert!(md.contains("[click](https://example.com)"), "{md}");
+    }
+
+    #[test]
+    fn horizontal_rule() {
+        let schema = s();
+        let doc = doc_from_markdown(&schema, "---").unwrap();
+        assert_eq!(doc.child(0).type_name(), "horizontal_rule");
+        assert_eq!(doc_to_markdown(&doc), "---");
+    }
+
+    #[test]
+    fn image_round_trips() {
+        let schema = s();
+        let doc = doc_from_markdown(&schema, "![logo](a.png)").unwrap();
+        let img = doc.child(0).child(0);
+        assert_eq!(img.type_name(), "image");
+        assert_eq!(img.attrs().get_str("src"), Some("a.png"));
+        assert_eq!(img.attrs().get_str("alt"), Some("logo"));
+        let md = doc_to_markdown(&doc);
+        assert!(md.contains("![logo](a.png)"), "{md}");
+    }
+
+    #[test]
+    fn empty_input_is_one_empty_paragraph() {
+        let schema = s();
+        let doc = doc_from_markdown(&schema, "").unwrap();
+        assert_eq!(doc.child_count(), 1);
+        assert_eq!(doc.child(0).type_name(), "paragraph");
+    }
+
+    #[test]
+    fn inline_code() {
+        let schema = s();
+        let doc = doc_from_markdown(&schema, "use `Vec` here").unwrap();
+        let para = doc.child(0);
+        let has_code = para
+            .content()
+            .children()
+            .iter()
+            .any(|n| n.marks().iter().any(|m| m.type_name() == "code"));
+        assert!(has_code, "expected a code-marked run");
+        assert!(doc_to_markdown(&doc).contains("`Vec`"));
+    }
+
+    #[test]
+    fn javascript_link_is_dropped() {
+        let schema = s();
+        let doc = doc_from_markdown(&schema, "[click](javascript:alert(1))").unwrap();
+        let text = doc.child(0).child(0);
+        assert_eq!(text.text(), Some("click"));
+        assert!(
+            text.marks().is_empty(),
+            "javascript: link must not enter the model, got {:?}",
+            text.marks()
+        );
+    }
+
+    #[test]
+    fn javascript_image_is_dropped() {
+        let schema = s();
+        let doc = doc_from_markdown(&schema, "![x](javascript:alert(1))").unwrap();
+        // No image node should exist; the alt text must not leak as a stray run.
+        let has_image = doc
+            .child(0)
+            .content()
+            .children()
+            .iter()
+            .any(|n| n.type_name() == "image");
+        assert!(!has_image, "javascript: image must be dropped");
+    }
+}

--- a/crates/rinch-editor-core/src/serialize/mod.rs
+++ b/crates/rinch-editor-core/src/serialize/mod.rs
@@ -1,0 +1,26 @@
+//! Total, attr-aware serialization of the document model.
+//!
+//! Everything here is **schema-derived** and **total**: a node or mark either
+//! round-trips faithfully, or the boundary returns an error — content is never
+//! silently dropped or rendered to a garbage tag. This structurally closes #59
+//! and its whole class (the old serializer dropped marks, had no hr/image, and
+//! modelled `hard_break` as a string).
+//!
+//! - [`doc_json`] (feature `serde`): the durable [`DocNode`] save/load wire shape.
+//! - [`html`]: schema-driven HTML serialize (copy) / parse (paste), whitelist-driven.
+//! - [`markdown`] (feature `markdown`): markdown I/O via pulldown-cmark.
+//! - [`text`]: plain-text clipboard interchange (the lossy `text/plain` fall-back).
+
+#[cfg(feature = "serde")]
+pub mod doc_json;
+pub mod html;
+#[cfg(feature = "markdown")]
+pub mod markdown;
+pub mod text;
+
+#[cfg(feature = "serde")]
+pub use doc_json::{DocMark, DocNode, JsonAttr};
+pub use html::{mark_dom_tag, node_dom_tag, node_to_html, slice_from_html, slice_to_html};
+#[cfg(feature = "markdown")]
+pub use markdown::{doc_from_markdown, doc_to_markdown};
+pub use text::{slice_from_text, slice_to_text};

--- a/crates/rinch-editor-core/src/serialize/text.rs
+++ b/crates/rinch-editor-core/src/serialize/text.rs
@@ -1,0 +1,220 @@
+//! Plain-text clipboard interchange for [`Slice`]s.
+//!
+//! Plain text is the lossy fall-back the rich [`super::html`] path complements:
+//! [`slice_to_text`] is the `text/plain` alternative placed alongside `text/html`
+//! on copy, and [`slice_from_text`] turns an OS plain-text paste (which has no
+//! markup) into paragraph-per-line content for insertion. Block boundaries map to
+//! newlines and vice-versa; inline marks are dropped (there is nowhere to put them
+//! in plain text — lossy by design, like the markdown path).
+
+use crate::EditorError;
+use crate::model::{Fragment, Node, Slice};
+use crate::schema::Schema;
+
+/// Serialize a [`Slice`]'s content to plain text — the `text/plain` clipboard
+/// alternative. Block boundaries become newlines; `hard_break`s become newlines;
+/// inline runs (a within-block copy) concatenate with no separator; other leaves
+/// contribute nothing.
+pub fn slice_to_text(slice: &Slice) -> String {
+    let mut out = String::new();
+    write_fragment(slice.content.children(), &mut out);
+    out
+}
+
+/// Write a fragment's children, inserting a newline only across a block boundary
+/// (so inline runs concatenate but adjacent blocks are line-separated).
+fn write_fragment(children: &[Node], out: &mut String) {
+    let mut prev_block = false;
+    for (i, child) in children.iter().enumerate() {
+        let is_block = child.is_block();
+        if i > 0 && (is_block || prev_block) {
+            out.push('\n');
+        }
+        write_text(child, out);
+        prev_block = is_block;
+    }
+}
+
+/// Append `node`'s plain-text content to `out`. Textblocks concatenate their
+/// inline text; block containers newline-separate their block children; a
+/// `hard_break` is a newline; other leaves are empty.
+fn write_text(node: &Node, out: &mut String) {
+    if let Some(text) = node.text() {
+        out.push_str(text);
+        return;
+    }
+    if node.is_leaf() {
+        if node.type_name() == "hard_break" {
+            out.push('\n');
+        }
+        return;
+    }
+    write_fragment(node.content().children(), out);
+}
+
+/// Parse plain text into a [`Slice`] of one paragraph per line (an empty line →
+/// an empty paragraph) — used for an OS plain-text paste. The first and last
+/// blocks are "open" (`open_start == open_end == 1`), matching [`super::html`]'s
+/// heuristic, so a single-line paste merges inline at the cursor and a multi-line
+/// paste splits the surrounding block.
+pub fn slice_from_text(schema: &Schema, text: &str) -> Result<Slice, EditorError> {
+    if text.is_empty() {
+        return Ok(Slice::empty());
+    }
+    let normalized = text.replace("\r\n", "\n").replace('\r', "\n");
+    // Drop a single trailing newline: copying a whole line usually carries its
+    // terminating '\n', and pasting that should not append an empty paragraph.
+    // Interior and leading blank lines are preserved.
+    let body = normalized.strip_suffix('\n').unwrap_or(&normalized);
+    let mut blocks = Vec::new();
+    for line in body.split('\n') {
+        let content = if line.is_empty() {
+            Fragment::empty()
+        } else {
+            Fragment::from_node(schema.text(line)?)
+        };
+        blocks.push(schema.branch("paragraph", content)?);
+    }
+    Ok(Slice::new(Fragment::from_children(blocks), 1, 1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Fragment, Mark};
+    use crate::schema::Schema;
+
+    fn schema() -> Schema {
+        Schema::starter_kit()
+    }
+
+    fn para(s: &Schema, t: &str) -> Node {
+        s.branch("paragraph", Fragment::from_node(s.text(t).unwrap()))
+            .unwrap()
+    }
+
+    #[test]
+    fn within_block_slice_is_bare_text() {
+        // A cursor-range copy inside one paragraph yields bare inline runs.
+        let s = schema();
+        let doc = s
+            .branch("doc", Fragment::from_node(para(&s, "hello world")))
+            .unwrap();
+        let slice = doc.slice(2, 7).unwrap(); // "ello "
+        assert_eq!(slice_to_text(&slice), "ello ");
+    }
+
+    #[test]
+    fn multi_block_slice_is_newline_separated() {
+        let s = schema();
+        let doc = s
+            .branch(
+                "doc",
+                Fragment::from_children(vec![para(&s, "one"), para(&s, "two")]),
+            )
+            .unwrap();
+        // Whole document content: 0[p 1 one 4]5[p 6 two 9]10.
+        let slice = doc.slice(1, 9).unwrap();
+        assert_eq!(slice_to_text(&slice), "one\ntwo");
+    }
+
+    #[test]
+    fn hard_break_becomes_newline() {
+        let s = schema();
+        let hb = s
+            .create_node("hard_break", Default::default(), Fragment::empty())
+            .unwrap();
+        let p = s
+            .branch(
+                "paragraph",
+                Fragment::from_children(vec![s.text("a").unwrap(), hb, s.text("b").unwrap()]),
+            )
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(p)).unwrap();
+        let slice = doc.slice(1, 4).unwrap(); // a, br, b
+        assert_eq!(slice_to_text(&slice), "a\nb");
+    }
+
+    #[test]
+    fn from_text_single_line_open_paragraph() {
+        let s = schema();
+        let slice = slice_from_text(&s, "hello").unwrap();
+        assert_eq!(slice.content.child_count(), 1);
+        assert_eq!(slice.open_start, 1);
+        assert_eq!(slice.open_end, 1);
+        assert_eq!(slice.content.child(0).type_name(), "paragraph");
+        assert_eq!(slice_to_text(&slice), "hello");
+    }
+
+    #[test]
+    fn from_text_multiline_splits_paragraphs_crlf() {
+        let s = schema();
+        let slice = slice_from_text(&s, "a\r\nb\r\nc").unwrap();
+        assert_eq!(slice.content.child_count(), 3);
+        assert_eq!(slice_to_text(&slice), "a\nb\nc");
+    }
+
+    #[test]
+    fn from_text_blank_line_is_empty_paragraph() {
+        let s = schema();
+        let slice = slice_from_text(&s, "a\n\nb").unwrap();
+        assert_eq!(slice.content.child_count(), 3);
+        assert_eq!(
+            slice.content.child(1).child_count(),
+            0,
+            "middle paragraph is empty"
+        );
+    }
+
+    #[test]
+    fn from_text_strips_single_trailing_newline() {
+        let s = schema();
+        // Copying a whole line carries its terminating newline — don't append an
+        // empty paragraph for it.
+        let one = slice_from_text(&s, "line\n").unwrap();
+        assert_eq!(
+            one.content.child_count(),
+            1,
+            "single trailing newline trimmed"
+        );
+        assert_eq!(slice_to_text(&one), "line");
+        // Only ONE trailing newline is dropped — a deliberate blank line survives.
+        let two = slice_from_text(&s, "line\n\n").unwrap();
+        assert_eq!(two.content.child_count(), 2);
+        assert_eq!(
+            two.content.child(1).child_count(),
+            0,
+            "trailing blank line kept"
+        );
+    }
+
+    #[test]
+    fn empty_text_is_empty_slice() {
+        let s = schema();
+        let slice = slice_from_text(&s, "").unwrap();
+        assert_eq!(slice, Slice::empty());
+    }
+
+    #[test]
+    fn round_trip_through_text_preserves_lines() {
+        let s = schema();
+        let original = "first line\nsecond line";
+        let slice = slice_from_text(&s, original).unwrap();
+        assert_eq!(slice_to_text(&slice), original);
+    }
+
+    #[test]
+    fn marks_are_dropped_in_plain_text() {
+        let s = schema();
+        let bold = Mark::new(s.mark_type("bold").unwrap().clone(), Default::default());
+        let p = s
+            .branch(
+                "paragraph",
+                Fragment::from_node(s.text_with_marks("bold", vec![bold]).unwrap()),
+            )
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(p)).unwrap();
+        let slice = doc.slice(1, 5).unwrap();
+        assert_eq!(slice_to_text(&slice), "bold");
+    }
+}

--- a/crates/rinch-editor-core/src/state/mod.rs
+++ b/crates/rinch-editor-core/src/state/mod.rs
@@ -1,0 +1,214 @@
+//! Editor state: the single source of truth, and the transaction that evolves it.
+//!
+//! [`EditorState`] is an immutable value `{ doc, selection, stored_marks, plugin
+//! state }`; the only way to change it is to [`apply`](EditorState::apply) a
+//! [`Transaction`], producing a *new* state. This is design §5's non-negotiable
+//! principle #1 (single source of truth) and #2 (all changes are steps). `apply`
+//! is **pure and side-effect-free**: no DOM, no window, no thread-locals.
+
+pub mod transaction;
+
+pub use transaction::{ADD_TO_HISTORY, Transaction};
+
+use crate::command::{Command, Dispatch};
+use crate::decoration::DecorationSet;
+use crate::input_rules::InputRule;
+use crate::keymap::Keymap;
+use crate::model::{Mark, Node};
+use crate::plugin::{Plugin, PluginKey};
+use crate::schema::Schema;
+use crate::selection::Selection;
+use std::any::Any;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+/// The immutable, shared configuration of an editor: its schema, plugins, and the
+/// command / keymap / input-rule tables aggregated from those plugins once at
+/// construction. Shared (via `Rc`) by every state derived from the initial one, so
+/// applying a transaction never re-walks the plugin list to rebuild these.
+struct Config {
+    schema: Rc<Schema>,
+    plugins: Vec<Rc<dyn Plugin>>,
+    commands: HashMap<String, Command>,
+    keymap: Keymap,
+    input_rules: Vec<InputRule>,
+}
+
+/// The editor's entire state at one instant: the document, the selection, the
+/// pending stored marks, and each plugin's folded state. Immutable —
+/// [`apply`](EditorState::apply) returns a *new* `EditorState`.
+#[derive(Clone)]
+pub struct EditorState {
+    config: Rc<Config>,
+    /// The document (root node).
+    pub doc: Node,
+    /// The current selection (the caret is rendered from here, never from the host).
+    pub selection: Selection,
+    /// Marks the next typed text will carry (the "click bold then type" tri-state):
+    /// `None` = inherit, `Some(vec![])` = explicitly none, `Some([bold])` = bold.
+    pub stored_marks: Option<Vec<Mark>>,
+    plugin_state: HashMap<PluginKey, Rc<dyn Any>>,
+}
+
+impl EditorState {
+    /// Create a fresh state for `doc` with `plugins`, placing the selection at the
+    /// start of the document and aggregating the plugins' commands / keymap / input
+    /// rules into the shared config.
+    pub fn create(schema: Rc<Schema>, doc: Node, plugins: Vec<Rc<dyn Plugin>>) -> EditorState {
+        let mut commands: HashMap<String, Command> = HashMap::new();
+        let mut keymap = Keymap::new();
+        let mut input_rules: Vec<InputRule> = Vec::new();
+        for p in &plugins {
+            for (name, cmd) in p.commands() {
+                commands.insert(name.to_string(), cmd);
+            }
+            for (binding, command) in p.keymap() {
+                keymap.add(binding, command);
+            }
+            input_rules.extend(p.input_rules());
+        }
+
+        let mut plugin_state: HashMap<PluginKey, Rc<dyn Any>> = HashMap::new();
+        for p in &plugins {
+            if let Some(st) = p.init_state(&doc) {
+                plugin_state.insert(p.key(), st);
+            }
+        }
+
+        let selection = Selection::at_start(&doc);
+        let config = Rc::new(Config {
+            schema,
+            plugins,
+            commands,
+            keymap,
+            input_rules,
+        });
+        EditorState {
+            config,
+            doc,
+            selection,
+            stored_marks: None,
+            plugin_state,
+        }
+    }
+
+    /// A fresh [`Transaction`] starting from this state.
+    pub fn tr(&self) -> Transaction {
+        Transaction::new(
+            self.config.schema.clone(),
+            self.doc.clone(),
+            self.selection.clone(),
+            self.stored_marks.clone(),
+        )
+    }
+
+    /// Apply a transaction, returning a **new** state. Pure: runs no I/O. The new
+    /// document/selection come from the transaction; stored marks survive only into
+    /// a collapsed text cursor (design §5); each plugin folds its state forward.
+    pub fn apply(&self, tr: Transaction) -> EditorState {
+        let new_doc = tr.doc().clone();
+        let new_selection = tr.selection();
+        // Stored marks survive only if the resulting selection is a bare cursor.
+        let stored_marks = if new_selection.is_text_cursor() {
+            tr.stored_marks().cloned()
+        } else {
+            None
+        };
+
+        let mut plugin_state: HashMap<PluginKey, Rc<dyn Any>> = HashMap::new();
+        for p in &self.config.plugins {
+            let prev = self.plugin_state.get(&p.key()).map(|r| r.as_ref());
+            if let Some(next) = p.apply(&tr, self, &new_doc, prev) {
+                plugin_state.insert(p.key(), next);
+            }
+        }
+
+        EditorState {
+            config: self.config.clone(),
+            doc: new_doc,
+            selection: new_selection,
+            stored_marks,
+            plugin_state,
+        }
+    }
+
+    /// The schema.
+    pub fn schema(&self) -> &Schema {
+        &self.config.schema
+    }
+
+    /// A named command from the aggregated registry.
+    pub fn command(&self, name: &str) -> Option<Command> {
+        self.config.commands.get(name).cloned()
+    }
+
+    /// The aggregated keymap.
+    pub fn keymap(&self) -> &Keymap {
+        &self.config.keymap
+    }
+
+    /// The aggregated input rules.
+    pub fn input_rules(&self) -> &[InputRule] {
+        &self.config.input_rules
+    }
+
+    /// The decorations to render for this state, aggregated across every plugin
+    /// (design A4/A8). These are view-side annotations — the empty-editor
+    /// placeholder, later the IME preedit and collaborator carets — that are
+    /// rendered but are **not** part of the document. The view diffs this against
+    /// the previous state's set independently of the document diff.
+    pub fn decorations(&self) -> DecorationSet {
+        let mut set = DecorationSet::empty();
+        for p in &self.config.plugins {
+            set.merge(p.decorations(self));
+        }
+        set
+    }
+
+    /// A plugin's folded state, downcast to `T`.
+    pub fn plugin_state<T: 'static>(&self, key: PluginKey) -> Option<&T> {
+        self.plugin_state
+            .get(&key)
+            .and_then(|r| r.as_ref().downcast_ref::<T>())
+    }
+
+    /// Run `cmd` against this state, returning the resulting state if it applied
+    /// and dispatched, else `None`. The standard "command → apply" glue.
+    pub fn run_command(&self, cmd: &Command) -> Option<EditorState> {
+        let mut result: Option<EditorState> = None;
+        let applied = {
+            let mut dispatch = |tr: Transaction| {
+                result = Some(self.apply(tr));
+            };
+            let dispatch: Dispatch = &mut dispatch;
+            cmd(self, Some(dispatch))
+        };
+        if applied { result } else { None }
+    }
+
+    /// Run the command named `name`; `None` if no such command or it did not apply.
+    pub fn run(&self, name: &str) -> Option<EditorState> {
+        let cmd = self.command(name)?;
+        self.run_command(&cmd)
+    }
+
+    /// Whether `cmd` would apply (toolbar enablement) — no edit performed.
+    pub fn command_applies(&self, cmd: &Command) -> bool {
+        cmd(self, None)
+    }
+
+    /// Whether the named command would apply.
+    pub fn can_run(&self, name: &str) -> bool {
+        self.command(name).is_some_and(|cmd| cmd(self, None))
+    }
+}
+
+impl std::fmt::Debug for EditorState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EditorState")
+            .field("doc", &self.doc)
+            .field("selection", &self.selection)
+            .field("stored_marks", &self.stored_marks)
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/rinch-editor-core/src/state/transaction.rs
+++ b/crates/rinch-editor-core/src/state/transaction.rs
@@ -1,0 +1,537 @@
+//! [`Transaction`] — a state-level edit: a [`Transform`] plus selection, stored
+//! marks, and plugin metadata.
+//!
+//! A `Transaction` is what a command builds and a runtime applies
+//! ([`EditorState::apply`](crate::state::EditorState::apply)). It extends the pure
+//! [`Transform`] (steps + mapping) with the *editor* concerns the transform layer
+//! deliberately omits: the [`Selection`] (mapped forward as steps are added),
+//! `stored_marks` (the "click bold then type" tri-state), a `time` stamp (history
+//! grouping), and a free-form `meta` map (e.g. `addToHistory=false`, the history
+//! plugin's undo/redo marker).
+//!
+//! ## Ownership
+//!
+//! Unlike `Transform<'a>` (which borrows `&Schema`), a `Transaction` **owns** an
+//! `Rc<Schema>` and has no lifetime parameter — so a [`Command`] can be a plain
+//! `Fn(&EditorState, Option<&mut dyn FnMut(Transaction)>)` with no lifetime
+//! gymnastics. Each gesture borrows a local `&Schema` out of the `Rc` for the
+//! duration of the call ([`Transform::from_parts`]/`into_parts`), keeping the
+//! gesture logic single-sourced in the transform layer.
+//!
+//! [`Command`]: crate::command::Command
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+use crate::model::{AttrValue, Attrs, Fragment, Mark, NodeType};
+use crate::model::{Node, Slice};
+use crate::pos::Pos;
+use crate::schema::Schema;
+use crate::selection::Selection;
+use crate::transform::Transform;
+use crate::transform::node_range::NodeRange;
+use crate::transform::step::{Step, StepError};
+use crate::transform::step_map::Mapping;
+
+/// Meta key: when set to `false`, the history plugin will not record this
+/// transaction (used by undo/redo themselves).
+pub const ADD_TO_HISTORY: &str = "addToHistory";
+
+/// A single state-level edit. Build it from [`EditorState::tr`], mutate it with the
+/// gesture/selection/mark methods, then hand it to
+/// [`EditorState::apply`](crate::state::EditorState::apply).
+///
+/// [`EditorState::tr`]: crate::state::EditorState::tr
+pub struct Transaction {
+    schema: Rc<Schema>,
+    // --- transform accumulation (mirrors `Transform`'s fields) ---
+    doc: Node,
+    steps: Vec<Box<dyn Step>>,
+    docs: Vec<Node>,
+    mapping: Mapping,
+    // --- editor concerns ---
+    cur_selection: Selection,
+    /// The step index at which `cur_selection` was last set/mapped — `cur_selection`
+    /// is mapped forward from here through any steps added since.
+    cur_selection_for: usize,
+    selection_set: bool,
+    stored_marks: Option<Vec<Mark>>,
+    stored_marks_set: bool,
+    meta: HashMap<&'static str, Rc<dyn Any>>,
+    time: u64,
+}
+
+impl Transaction {
+    /// Construct a transaction from the pieces of an [`EditorState`]. Crate-internal:
+    /// callers use [`EditorState::tr`](crate::state::EditorState::tr).
+    pub(crate) fn new(
+        schema: Rc<Schema>,
+        doc: Node,
+        selection: Selection,
+        stored_marks: Option<Vec<Mark>>,
+    ) -> Transaction {
+        Transaction {
+            schema,
+            doc,
+            steps: Vec::new(),
+            docs: Vec::new(),
+            mapping: Mapping::new(),
+            cur_selection: selection,
+            cur_selection_for: 0,
+            selection_set: false,
+            stored_marks,
+            stored_marks_set: false,
+            meta: HashMap::new(),
+            time: 0,
+        }
+    }
+
+    // -- accessors -------------------------------------------------------
+
+    /// The current document (after all steps applied so far).
+    pub fn doc(&self) -> &Node {
+        &self.doc
+    }
+
+    /// The current selection (already mapped forward through every step added).
+    pub fn selection(&self) -> Selection {
+        self.cur_selection.clone()
+    }
+
+    /// The transaction's stored marks (the marks the next typed text will carry).
+    pub fn stored_marks(&self) -> Option<&Vec<Mark>> {
+        self.stored_marks.as_ref()
+    }
+
+    /// True if `set_selection` was called explicitly on this transaction.
+    pub fn selection_set(&self) -> bool {
+        self.selection_set
+    }
+
+    /// The accumulated steps.
+    pub fn steps(&self) -> &[Box<dyn Step>] {
+        &self.steps
+    }
+
+    /// `docs()[i]` is the document *before* step `i` — used to invert the steps.
+    pub fn docs(&self) -> &[Node] {
+        &self.docs
+    }
+
+    /// The accumulated position mapping.
+    pub fn mapping(&self) -> &Mapping {
+        &self.mapping
+    }
+
+    /// True if any step changed the document.
+    pub fn doc_changed(&self) -> bool {
+        !self.steps.is_empty()
+    }
+
+    /// The transaction's timestamp (history grouping). Defaults to `0`; the
+    /// platform sets it via [`Transaction::set_time`].
+    pub fn time(&self) -> u64 {
+        self.time
+    }
+
+    // -- the transform bridge --------------------------------------------
+
+    /// Run `f` against a real [`Transform`] borrowing a local `&Schema`, then take
+    /// the accumulation back and fold the selection / stored marks forward.
+    fn with_transform<R>(&mut self, f: impl FnOnce(&mut Transform) -> R) -> R {
+        let schema = self.schema.clone();
+        let mut tf = Transform::from_parts(
+            &schema,
+            self.doc.clone(),
+            std::mem::take(&mut self.steps),
+            std::mem::take(&mut self.docs),
+            std::mem::take(&mut self.mapping),
+        );
+        let steps_before = tf.steps().len();
+        let r = f(&mut tf);
+        let added = tf.steps().len() - steps_before;
+        let (doc, steps, docs, mapping) = tf.into_parts();
+        self.doc = doc;
+        self.steps = steps;
+        self.docs = docs;
+        self.mapping = mapping;
+        if added > 0 {
+            self.map_selection_to_end();
+            // A content change consumes any pending stored marks (PM addStep).
+            self.stored_marks = None;
+            self.stored_marks_set = false;
+        }
+        r
+    }
+
+    /// Map `cur_selection` forward through every step added since it was last set.
+    fn map_selection_to_end(&mut self) {
+        let total = self.mapping.maps().len();
+        if self.cur_selection_for < total {
+            let sub = self.mapping.slice(self.cur_selection_for, total);
+            self.cur_selection = self.cur_selection.map(&self.doc, &sub);
+            self.cur_selection_for = total;
+        }
+    }
+
+    /// Apply a raw step.
+    pub fn step(&mut self, step: Box<dyn Step>) -> Result<&mut Self, StepError> {
+        self.with_transform(|tf| tf.step(step).map(|_| ()))?;
+        Ok(self)
+    }
+
+    // -- position-based gestures (delegated to `Transform`) --------------
+
+    /// Replace `from..to` with `slice`.
+    pub fn replace(
+        &mut self,
+        from: usize,
+        to: usize,
+        slice: Slice,
+    ) -> Result<&mut Self, StepError> {
+        self.with_transform(|tf| tf.replace(from, to, slice).map(|_| ()))?;
+        Ok(self)
+    }
+
+    /// Replace `from..to` with `content`.
+    pub fn replace_with(
+        &mut self,
+        from: usize,
+        to: usize,
+        content: Fragment,
+    ) -> Result<&mut Self, StepError> {
+        self.with_transform(|tf| tf.replace_with(from, to, content).map(|_| ()))?;
+        Ok(self)
+    }
+
+    /// Delete `from..to`.
+    pub fn delete(&mut self, from: usize, to: usize) -> Result<&mut Self, StepError> {
+        self.with_transform(|tf| tf.delete(from, to).map(|_| ()))?;
+        Ok(self)
+    }
+
+    /// Split the node(s) at `pos`, `depth` levels deep.
+    pub fn split(
+        &mut self,
+        pos: usize,
+        depth: usize,
+        types_after: Option<Vec<Option<(NodeType, Attrs)>>>,
+    ) -> Result<&mut Self, StepError> {
+        self.with_transform(|tf| tf.split(pos, depth, types_after).map(|_| ()))?;
+        Ok(self)
+    }
+
+    /// Change the block type of every textblock overlapping `from..to`.
+    pub fn set_block_type(
+        &mut self,
+        from: usize,
+        to: usize,
+        typ: NodeType,
+        attrs: Attrs,
+    ) -> Result<&mut Self, StepError> {
+        self.with_transform(|tf| tf.set_block_type(from, to, typ, attrs).map(|_| ()))?;
+        Ok(self)
+    }
+
+    /// Wrap the block range in the given nested wrappers (outermost first).
+    pub fn wrap(
+        &mut self,
+        range: &NodeRange,
+        wrappers: &[(NodeType, Attrs)],
+    ) -> Result<&mut Self, StepError> {
+        self.with_transform(|tf| tf.wrap(range, wrappers).map(|_| ()))?;
+        Ok(self)
+    }
+
+    /// Lift the block range out to depth `target`.
+    pub fn lift(&mut self, range: &NodeRange, target: usize) -> Result<&mut Self, StepError> {
+        self.with_transform(|tf| tf.lift(range, target).map(|_| ()))?;
+        Ok(self)
+    }
+
+    /// Add `mark` across the inline range `from..to`.
+    pub fn add_mark(&mut self, from: usize, to: usize, mark: Mark) -> Result<&mut Self, StepError> {
+        self.with_transform(|tf| tf.add_mark(from, to, mark).map(|_| ()))?;
+        Ok(self)
+    }
+
+    /// Remove `mark` across the inline range `from..to`.
+    pub fn remove_mark(
+        &mut self,
+        from: usize,
+        to: usize,
+        mark: Mark,
+    ) -> Result<&mut Self, StepError> {
+        self.with_transform(|tf| tf.remove_mark(from, to, mark).map(|_| ()))?;
+        Ok(self)
+    }
+
+    /// Set the attribute `attr` of the node at `pos`.
+    pub fn set_node_attr(
+        &mut self,
+        pos: usize,
+        attr: impl Into<String>,
+        value: AttrValue,
+    ) -> Result<&mut Self, StepError> {
+        self.with_transform(|tf| tf.set_node_attr(pos, attr, value).map(|_| ()))?;
+        Ok(self)
+    }
+
+    /// Set a document-level attribute.
+    pub fn set_doc_attr(
+        &mut self,
+        attr: impl Into<String>,
+        value: AttrValue,
+    ) -> Result<&mut Self, StepError> {
+        self.with_transform(|tf| tf.set_doc_attr(attr, value).map(|_| ()))?;
+        Ok(self)
+    }
+
+    // -- selection-aware gestures ----------------------------------------
+
+    /// Type `text` at the current selection: replace the selected range with a text
+    /// node carrying the transaction's `stored_marks` (or the marks inherited at the
+    /// insertion point), then place the cursor after it. The typing path.
+    pub fn insert_text(&mut self, text: &str) -> Result<&mut Self, StepError> {
+        if text.is_empty() {
+            return Ok(self);
+        }
+        let from = self.cur_selection.from().0;
+        let to = self.cur_selection.to().0;
+        let marks = self
+            .stored_marks
+            .clone()
+            .unwrap_or_else(|| self.marks_at(from));
+        let node = self
+            .schema
+            .text_with_marks(text, marks)
+            .map_err(|e| StepError::new(e.to_string()))?;
+        let len = node.text_len();
+        self.replace_with(from, to, Fragment::from_node(node))?;
+        self.set_selection(Selection::cursor(Pos(from + len)));
+        Ok(self)
+    }
+
+    /// Replace the current selection with a single node (e.g. a hard break, image,
+    /// or horizontal rule), placing the cursor after it.
+    pub fn replace_selection_with(&mut self, node: Node) -> Result<&mut Self, StepError> {
+        let from = self.cur_selection.from().0;
+        let to = self.cur_selection.to().0;
+        let size = node.node_size();
+        self.replace_with(from, to, Fragment::from_node(node))?;
+        let after = Selection::near(&self.doc, Pos(from + size), 1);
+        self.set_selection(after);
+        Ok(self)
+    }
+
+    /// Delete the current (non-empty) selection. A no-op for a collapsed cursor.
+    pub fn delete_selection(&mut self) -> Result<&mut Self, StepError> {
+        let from = self.cur_selection.from().0;
+        let to = self.cur_selection.to().0;
+        if from == to {
+            return Ok(self);
+        }
+        self.delete(from, to)?;
+        Ok(self)
+    }
+
+    /// The marks active at document position `pos` (in this transaction's current
+    /// doc) — what a character typed there would inherit.
+    fn marks_at(&self, pos: usize) -> Vec<Mark> {
+        self.doc
+            .resolve(Pos(pos))
+            .map(|r| r.marks())
+            .unwrap_or_default()
+    }
+
+    // -- selection / stored marks / meta ---------------------------------
+
+    /// Set the selection explicitly. Clears any pending stored marks (moving the
+    /// caret resets the "click bold then type" state, PM `setSelection`).
+    pub fn set_selection(&mut self, selection: Selection) -> &mut Self {
+        self.cur_selection = selection;
+        self.cur_selection_for = self.steps.len();
+        self.selection_set = true;
+        self.stored_marks = None;
+        self.stored_marks_set = false;
+        self
+    }
+
+    /// Set the stored marks (`None` = inherit on next insert; `Some(vec![])` =
+    /// explicitly no marks).
+    pub fn set_stored_marks(&mut self, marks: Option<Vec<Mark>>) -> &mut Self {
+        self.stored_marks = marks;
+        self.stored_marks_set = true;
+        self
+    }
+
+    /// Add `mark` to the stored-mark set (seeded from the marks at the cursor when
+    /// no stored marks are pending).
+    pub fn add_stored_mark(&mut self, mark: Mark) -> &mut Self {
+        let base = self
+            .stored_marks
+            .clone()
+            .unwrap_or_else(|| self.marks_at(self.cur_selection.from().0));
+        let next = mark.add_to_set(&base);
+        self.set_stored_marks(Some(next))
+    }
+
+    /// Remove `mark` from the stored-mark set.
+    pub fn remove_stored_mark(&mut self, mark: &Mark) -> &mut Self {
+        let base = self
+            .stored_marks
+            .clone()
+            .unwrap_or_else(|| self.marks_at(self.cur_selection.from().0));
+        let next = mark.remove_from_set(&base);
+        self.set_stored_marks(Some(next))
+    }
+
+    /// True if [`Transaction::set_stored_marks`] (or a derived stored-mark mutation)
+    /// was called on this transaction.
+    pub fn stored_marks_set(&self) -> bool {
+        self.stored_marks_set
+    }
+
+    /// Set the transaction timestamp (history grouping window).
+    pub fn set_time(&mut self, time: u64) -> &mut Self {
+        self.time = time;
+        self
+    }
+
+    /// Attach plugin metadata under `key`.
+    pub fn set_meta(&mut self, key: &'static str, value: impl Any + 'static) -> &mut Self {
+        self.meta.insert(key, Rc::new(value));
+        self
+    }
+
+    /// Read plugin metadata at `key`.
+    pub fn get_meta(&self, key: &str) -> Option<&dyn Any> {
+        self.meta.get(key).map(|r| r.as_ref() as &dyn Any)
+    }
+
+    /// Convenience: typed read of a `Copy` metadata value.
+    pub fn get_meta_as<T: Copy + 'static>(&self, key: &str) -> Option<T> {
+        self.get_meta(key)
+            .and_then(|a| a.downcast_ref::<T>())
+            .copied()
+    }
+
+    /// Set `addToHistory` (false suppresses history recording, e.g. undo/redo).
+    pub fn set_add_to_history(&mut self, value: bool) -> &mut Self {
+        self.set_meta(ADD_TO_HISTORY, value)
+    }
+
+    /// Whether this transaction should be recorded by the history plugin (default
+    /// `true`).
+    pub fn add_to_history(&self) -> bool {
+        self.get_meta_as::<bool>(ADD_TO_HISTORY).unwrap_or(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Schema;
+
+    fn sk() -> Rc<Schema> {
+        Rc::new(Schema::starter_kit())
+    }
+    fn para(s: &Schema, t: &str) -> Node {
+        s.branch("paragraph", Fragment::from_node(s.text(t).unwrap()))
+            .unwrap()
+    }
+    fn doc(s: &Schema, blocks: Vec<Node>) -> Node {
+        s.branch("doc", Fragment::from_children(blocks)).unwrap()
+    }
+    fn all_text(node: &Node) -> String {
+        if let Some(t) = node.text() {
+            return t.to_string();
+        }
+        node.content().iter().map(all_text).collect()
+    }
+
+    #[test]
+    fn insert_text_advances_cursor_and_carries_no_marks_by_default() {
+        let s = sk();
+        let d = doc(&s, vec![para(&s, "ab")]);
+        let mut tr = Transaction::new(s.clone(), d, Selection::cursor(Pos(2)), None);
+        tr.insert_text("X").unwrap();
+        assert_eq!(all_text(tr.doc()), "aXb");
+        // cursor was at 2 (between a,b); after inserting one char → 3
+        assert_eq!(tr.selection(), Selection::cursor(Pos(3)));
+        assert!(tr.doc_changed());
+    }
+
+    #[test]
+    fn insert_text_consumes_stored_marks() {
+        let s = sk();
+        let d = doc(&s, vec![para(&s, "ab")]);
+        let bold = Mark::simple(s.mark_type("bold").unwrap().clone());
+        let mut tr = Transaction::new(s.clone(), d, Selection::cursor(Pos(2)), Some(vec![bold]));
+        tr.insert_text("X").unwrap();
+        // the inserted "X" carries bold; stored marks were consumed
+        let p = tr.doc().child(0);
+        let bolded_x = p
+            .content()
+            .iter()
+            .any(|n| n.text() == Some("X") && n.marks().iter().any(|m| m.type_name() == "bold"));
+        assert!(bolded_x, "inserted text should carry the stored bold mark");
+        assert!(
+            tr.stored_marks().is_none(),
+            "stored marks consumed by the insert"
+        );
+    }
+
+    #[test]
+    fn selection_maps_forward_through_a_leading_insert() {
+        let s = sk();
+        let d = doc(&s, vec![para(&s, "ab")]);
+        // cursor at the end of "ab" (pos 3)
+        let mut tr = Transaction::new(s.clone(), d, Selection::cursor(Pos(3)), None);
+        // insert "YY" at the start of the text (pos 1) via a position gesture
+        let yy = s.text("YY").unwrap();
+        tr.replace_with(1, 1, Fragment::from_node(yy)).unwrap();
+        assert_eq!(all_text(tr.doc()), "YYab");
+        // the cursor at 3 shifts by +2 → 5
+        assert_eq!(tr.selection(), Selection::cursor(Pos(5)));
+    }
+
+    #[test]
+    fn set_selection_clears_stored_marks() {
+        let s = sk();
+        let d = doc(&s, vec![para(&s, "ab")]);
+        let bold = Mark::simple(s.mark_type("bold").unwrap().clone());
+        let mut tr = Transaction::new(s.clone(), d, Selection::cursor(Pos(2)), None);
+        tr.set_stored_marks(Some(vec![bold]));
+        assert!(tr.stored_marks().is_some());
+        tr.set_selection(Selection::cursor(Pos(1)));
+        assert!(tr.stored_marks().is_none());
+    }
+
+    #[test]
+    fn delete_selection_collapses_cursor() {
+        let s = sk();
+        let d = doc(&s, vec![para(&s, "abcd")]);
+        let mut tr = Transaction::new(s.clone(), d, Selection::text(Pos(2), Pos(4)), None);
+        tr.delete_selection().unwrap();
+        assert_eq!(all_text(tr.doc()), "ad");
+        assert_eq!(tr.selection(), Selection::cursor(Pos(2)));
+    }
+
+    #[test]
+    fn meta_and_add_to_history() {
+        let s = sk();
+        let d = doc(&s, vec![para(&s, "x")]);
+        let mut tr = Transaction::new(s.clone(), d, Selection::cursor(Pos(1)), None);
+        assert!(tr.add_to_history());
+        tr.set_add_to_history(false);
+        assert!(!tr.add_to_history());
+        tr.set_meta("origin", "remote".to_string());
+        assert_eq!(
+            tr.get_meta("origin")
+                .and_then(|a| a.downcast_ref::<String>()),
+            Some(&"remote".to_string())
+        );
+    }
+}

--- a/crates/rinch-editor-core/src/transform/build.rs
+++ b/crates/rinch-editor-core/src/transform/build.rs
@@ -1,0 +1,425 @@
+//! [`Transform`] — the builder that turns editing gestures into [`Step`]s.
+//!
+//! A `Transform` starts from a document and accumulates steps; each gesture
+//! helper (`insert_text`, `delete`, `split`, `set_block_type`, `add_mark`, …)
+//! appends one or more steps, keeping a [`Mapping`] of every position shift and a
+//! per-step snapshot of the document for inversion. This is ProseMirror's
+//! `Transform`; the state-layer `Transaction` (selection, stored marks, plugin
+//! meta) extends it in M4.
+//!
+//! Helpers return `Result<&mut Self, StepError>` so failures (schema-invalid
+//! steps) surface and chain with `?` — `tr.insert_text(..)?.delete(..)?`.
+
+use crate::Slice;
+use crate::model::{AttrValue, Attrs, Fragment, Mark, Node, NodeType};
+use crate::pos::Pos;
+use crate::schema::Schema;
+use crate::transform::node_range::NodeRange;
+use crate::transform::step::{Step, StepError};
+use crate::transform::step_map::Mapping;
+use crate::transform::steps::{
+    AddMarkStep, RemoveMarkStep, ReplaceAroundStep, ReplaceStep, SetDocAttrStep, SetNodeAttrStep,
+};
+
+/// An abstraction over a document that accumulates [`Step`]s.
+pub struct Transform<'a> {
+    schema: &'a Schema,
+    /// The current document (after all steps applied so far).
+    pub doc: Node,
+    steps: Vec<Box<dyn Step>>,
+    docs: Vec<Node>,
+    mapping: Mapping,
+}
+
+impl<'a> Transform<'a> {
+    /// Start a transform from `doc` (which must belong to `schema`).
+    pub fn new(schema: &'a Schema, doc: Node) -> Transform<'a> {
+        Transform {
+            schema,
+            doc,
+            steps: Vec::new(),
+            docs: Vec::new(),
+            mapping: Mapping::new(),
+        }
+    }
+
+    /// Reconstitute a transform from previously-extracted parts. Paired with
+    /// [`Transform::into_parts`] so the state-layer
+    /// [`Transaction`](crate::state::Transaction) — which owns an `Rc<Schema>`
+    /// rather than a borrow — can borrow a local `&Schema` for the duration of one
+    /// gesture, run it through the shared gesture logic here, then take the
+    /// accumulation back. This avoids duplicating every gesture on `Transaction`.
+    pub(crate) fn from_parts(
+        schema: &'a Schema,
+        doc: Node,
+        steps: Vec<Box<dyn Step>>,
+        docs: Vec<Node>,
+        mapping: Mapping,
+    ) -> Transform<'a> {
+        Transform {
+            schema,
+            doc,
+            steps,
+            docs,
+            mapping,
+        }
+    }
+
+    /// Extract the accumulated state (the inverse of [`Transform::from_parts`]).
+    pub(crate) fn into_parts(self) -> (Node, Vec<Box<dyn Step>>, Vec<Node>, Mapping) {
+        (self.doc, self.steps, self.docs, self.mapping)
+    }
+
+    /// The document before any step was applied.
+    pub fn before(&self) -> &Node {
+        self.docs.first().unwrap_or(&self.doc)
+    }
+
+    /// The accumulated steps.
+    pub fn steps(&self) -> &[Box<dyn Step>] {
+        &self.steps
+    }
+
+    /// The per-step document snapshots: `docs()[i]` is the document *before* step
+    /// `i` was applied. Used to invert a whole transform (undo) and by collab.
+    pub fn docs(&self) -> &[Node] {
+        &self.docs
+    }
+
+    /// The accumulated position mapping.
+    pub fn mapping(&self) -> &Mapping {
+        &self.mapping
+    }
+
+    /// True if any step changed the document.
+    pub fn doc_changed(&self) -> bool {
+        !self.steps.is_empty()
+    }
+
+    /// Apply `step`, recording it (and its map and the pre-step doc). Returns the
+    /// step error if it fails to apply (e.g. the result would be schema-invalid),
+    /// leaving the transform unchanged.
+    pub fn step(&mut self, step: Box<dyn Step>) -> Result<&mut Self, StepError> {
+        let new_doc = step.apply(&self.doc)?;
+        self.docs.push(self.doc.clone());
+        self.mapping.append_map(step.get_map());
+        self.steps.push(step);
+        self.doc = new_doc;
+        Ok(self)
+    }
+
+    // -- replace family --------------------------------------------------
+
+    /// Replace `from..to` with `slice`.
+    pub fn replace(
+        &mut self,
+        from: usize,
+        to: usize,
+        slice: Slice,
+    ) -> Result<&mut Self, StepError> {
+        self.step(Box::new(ReplaceStep::new(from, to, slice)))
+    }
+
+    /// Replace `from..to` with the (flat) `content`.
+    pub fn replace_with(
+        &mut self,
+        from: usize,
+        to: usize,
+        content: Fragment,
+    ) -> Result<&mut Self, StepError> {
+        self.replace(from, to, Slice::from_fragment(content))
+    }
+
+    /// Delete the range `from..to`.
+    pub fn delete(&mut self, from: usize, to: usize) -> Result<&mut Self, StepError> {
+        self.replace(from, to, Slice::empty())
+    }
+
+    /// Insert `text` replacing `from..to` (collapsed when `from == to`).
+    pub fn insert_text(
+        &mut self,
+        from: usize,
+        to: usize,
+        text: &str,
+    ) -> Result<&mut Self, StepError> {
+        let node = self
+            .schema
+            .text(text)
+            .map_err(|e| StepError::new(e.to_string()))?;
+        self.replace(from, to, Slice::from_fragment(Fragment::from_node(node)))
+    }
+
+    // -- structure -------------------------------------------------------
+
+    /// Split the node(s) at `pos`, `depth` levels deep. `types_after` optionally
+    /// gives the type+attrs of the block(s) created after the split (e.g. Enter at
+    /// the end of a heading making a paragraph). Port of `Transform.split`.
+    pub fn split(
+        &mut self,
+        pos: usize,
+        depth: usize,
+        types_after: Option<Vec<Option<(NodeType, Attrs)>>>,
+    ) -> Result<&mut Self, StepError> {
+        let r = self
+            .doc
+            .resolve(Pos(pos))
+            .map_err(|e| StepError::new(e.to_string()))?;
+        // A split deeper than the position is impossible — ProseMirror would build
+        // a too-deep slice that `replace` then rejects; we reject up front (and
+        // avoid the usize underflow `r.depth() - depth` would otherwise cause).
+        if depth > r.depth() {
+            return Err(StepError::new(
+                "split depth exceeds the depth of the split position",
+            ));
+        }
+        let mut before = Fragment::empty();
+        let mut after = Fragment::empty();
+        let e = r.depth() - depth;
+        let mut d = r.depth();
+        let mut i = depth as isize - 1;
+        while d > e {
+            before = Fragment::from_node(r.node(d).copy_with_content(before));
+            let type_after = types_after
+                .as_ref()
+                .and_then(|v| v.get(i as usize).cloned().flatten());
+            let after_node = match type_after {
+                Some((typ, attrs)) => Node::new_branch(typ, attrs, after),
+                None => r.node(d).copy_with_content(after),
+            };
+            after = Fragment::from_node(after_node);
+            d -= 1;
+            i -= 1;
+        }
+        let slice = Slice::new(before.append(&after), depth, depth);
+        self.step(Box::new(ReplaceStep::structural(pos, pos, slice)))
+    }
+
+    /// Change the type (and attrs) of every textblock overlapping `from..to`.
+    /// Port of `Transform.setBlockType` (size-preserving, so no remapping needed).
+    pub fn set_block_type(
+        &mut self,
+        from: usize,
+        to: usize,
+        typ: NodeType,
+        attrs: Attrs,
+    ) -> Result<&mut Self, StepError> {
+        if !typ.is_textblock() {
+            return Err(StepError::new("set_block_type target must be a textblock"));
+        }
+        let mut conversions: Vec<(usize, usize, Vec<Mark>)> = Vec::new();
+        self.doc.nodes_between(from, to, &mut |node, pos, _parent| {
+            if node.is_textblock() && !node.has_markup(&typ, &attrs) {
+                conversions.push((pos, node.node_size(), node.marks().to_vec()));
+            }
+            true
+        });
+        for (pos, size, marks) in conversions {
+            let new_block =
+                Node::new_branch(typ.clone(), attrs.clone(), Fragment::empty()).mark(marks);
+            let slice = Slice::new(Fragment::from_node(new_block), 0, 0);
+            self.step(Box::new(ReplaceAroundStep::new(
+                pos,
+                pos + size,
+                pos + 1,
+                pos + size - 1,
+                slice,
+                1,
+                true,
+            )))?;
+        }
+        Ok(self)
+    }
+
+    /// Wrap the block range in the given nested wrappers (outermost first). Port
+    /// of `Transform.wrap`.
+    pub fn wrap(
+        &mut self,
+        range: &NodeRange,
+        wrappers: &[(NodeType, Attrs)],
+    ) -> Result<&mut Self, StepError> {
+        let mut content = Fragment::empty();
+        for (typ, attrs) in wrappers.iter().rev() {
+            content = Fragment::from_node(Node::new_branch(typ.clone(), attrs.clone(), content));
+        }
+        let start = range.start();
+        let end = range.end();
+        let slice = Slice::new(content, 0, 0);
+        self.step(Box::new(ReplaceAroundStep::new(
+            start,
+            end,
+            start,
+            end,
+            slice,
+            wrappers.len(),
+            true,
+        )))
+    }
+
+    /// Lift the block range out to depth `target` (un-wrap one or more levels of
+    /// list/blockquote). Port of `Transform.lift`.
+    pub fn lift(&mut self, range: &NodeRange, target: usize) -> Result<&mut Self, StepError> {
+        let from = &range.from;
+        let to = &range.to;
+        let depth = range.depth;
+        // A liftable range has both endpoints nested **strictly below** its common
+        // depth, so a `depth+1` ancestor exists in each path. A degenerate range —
+        // e.g. a node-selection of a block atom (an `hr` inside a blockquote) where
+        // an endpoint resolves *at* the common depth — has no such boundary;
+        // `after(depth+1)`/`node(depth+1)` would then index the path out of bounds
+        // and panic. Fail closed instead. (Reached via outdent on a node-selection
+        // and via forward-delete's `build_lift_after`.)
+        if from.depth() <= depth || to.depth() <= depth {
+            return Err(StepError::new(
+                "lift: range endpoints are not nested below its depth",
+            ));
+        }
+        let gap_start = from
+            .before(depth + 1)
+            .expect("guarded: from.depth() > depth");
+        let gap_end = to.after(depth + 1).expect("guarded: to.depth() > depth");
+
+        let mut start = gap_start;
+        let mut before = Fragment::empty();
+        let mut open_start = 0usize;
+        {
+            let mut splitting = false;
+            let mut d = depth;
+            while d > target {
+                if splitting || from.index(d) > 0 {
+                    splitting = true;
+                    before = Fragment::from_node(from.node(d).copy_with_content(before));
+                    open_start += 1;
+                } else {
+                    start -= 1;
+                }
+                d -= 1;
+            }
+        }
+
+        let mut end = gap_end;
+        let mut after = Fragment::empty();
+        let mut open_end = 0usize;
+        {
+            let mut splitting = false;
+            let mut d = depth;
+            while d > target {
+                // `d <= depth < to.depth()`, ensured by the guard above, so every
+                // `to.after(d + 1)` / `to.node(d)` access here is in bounds.
+                let after_d = to.after(d + 1).expect("guarded: d < to.depth()");
+                if splitting || after_d < to.end(d) {
+                    splitting = true;
+                    after = Fragment::from_node(to.node(d).copy_with_content(after));
+                    open_end += 1;
+                } else {
+                    end += 1;
+                }
+                d -= 1;
+            }
+        }
+
+        let insert = before.size() - open_start;
+        let slice = Slice::new(before.append(&after), open_start, open_end);
+        self.step(Box::new(ReplaceAroundStep::new(
+            start, end, gap_start, gap_end, slice, insert, true,
+        )))
+    }
+
+    // -- marks -----------------------------------------------------------
+
+    /// Add `mark` across the inline range `from..to`, first removing any marks the
+    /// new mark excludes. Port of `Transform.addMark`.
+    pub fn add_mark(&mut self, from: usize, to: usize, mark: Mark) -> Result<&mut Self, StepError> {
+        let mut removed: Vec<RemoveMarkStep> = Vec::new();
+        let mut added: Vec<AddMarkStep> = Vec::new();
+        self.doc.nodes_between(from, to, &mut |node, pos, parent| {
+            if !node.is_inline() {
+                return true;
+            }
+            let Some(parent) = parent else { return true };
+            if !mark.is_in(node.marks()) && parent.node_type().spec().marks.allows(mark.type_name())
+            {
+                let start = pos.max(from);
+                let end = (pos + node.node_size()).min(to);
+                let new_set = mark.add_to_set(node.marks());
+                for m in node.marks() {
+                    if m.is_in(&new_set) {
+                        continue;
+                    }
+                    let coalesced =
+                        matches!(removed.last(), Some(last) if last.to == start && last.mark == *m);
+                    if coalesced {
+                        removed.last_mut().unwrap().to = end;
+                    } else {
+                        removed.push(RemoveMarkStep::new(start, end, m.clone()));
+                    }
+                }
+                let coalesced = matches!(added.last(), Some(last) if last.to == start);
+                if coalesced {
+                    added.last_mut().unwrap().to = end;
+                } else {
+                    added.push(AddMarkStep::new(start, end, mark.clone()));
+                }
+            }
+            true
+        });
+        for s in removed {
+            self.step(Box::new(s))?;
+        }
+        for s in added {
+            self.step(Box::new(s))?;
+        }
+        Ok(self)
+    }
+
+    /// Remove `mark` across the inline range `from..to`. Port of
+    /// `Transform.removeMark` for a concrete mark.
+    pub fn remove_mark(
+        &mut self,
+        from: usize,
+        to: usize,
+        mark: Mark,
+    ) -> Result<&mut Self, StepError> {
+        let mut matched: Vec<(usize, usize)> = Vec::new();
+        self.doc.nodes_between(from, to, &mut |node, pos, _parent| {
+            if !node.is_inline() {
+                return true;
+            }
+            if mark.is_in(node.marks()) {
+                let start = pos.max(from);
+                let end = (pos + node.node_size()).min(to);
+                let coalesced = matches!(matched.last(), Some(last) if last.1 == start);
+                if coalesced {
+                    matched.last_mut().unwrap().1 = end;
+                } else {
+                    matched.push((start, end));
+                }
+            }
+            true
+        });
+        for (f, t) in matched {
+            self.step(Box::new(RemoveMarkStep::new(f, t, mark.clone())))?;
+        }
+        Ok(self)
+    }
+
+    // -- attrs -----------------------------------------------------------
+
+    /// Set the attribute `attr` of the node at `pos`.
+    pub fn set_node_attr(
+        &mut self,
+        pos: usize,
+        attr: impl Into<String>,
+        value: AttrValue,
+    ) -> Result<&mut Self, StepError> {
+        self.step(Box::new(SetNodeAttrStep::new(pos, attr, value)))
+    }
+
+    /// Set a document-level attribute.
+    pub fn set_doc_attr(
+        &mut self,
+        attr: impl Into<String>,
+        value: AttrValue,
+    ) -> Result<&mut Self, StepError> {
+        self.step(Box::new(SetDocAttrStep::new(attr, value)))
+    }
+}

--- a/crates/rinch-editor-core/src/transform/mod.rs
+++ b/crates/rinch-editor-core/src/transform/mod.rs
@@ -1,0 +1,24 @@
+//! The transform engine: invertible, mappable [`Step`](step::Step)s.
+//!
+//! Every change to a document is expressed as one or more `Step`s. A small,
+//! deliberately minimal step set — `ReplaceStep`, `ReplaceAroundStep`,
+//! `AddMarkStep`/`RemoveMarkStep`, `SetNodeAttrStep`/`SetDocAttrStep` — expresses
+//! every editing gesture; nothing is added per gesture. Steps are **invertible**
+//! (undo), **mappable** (redo, collab rebase), and **schema-enforcing** (an
+//! invalid step is rejected by [`apply`](step::Step::apply), never silently
+//! written). This is a faithful port of ProseMirror's `prosemirror-transform`.
+
+pub mod build;
+pub mod node_range;
+pub mod replace;
+pub mod step;
+pub mod step_map;
+pub mod steps;
+
+pub use build::Transform;
+pub use node_range::{NodeRange, block_range, block_range_simple};
+pub use step::{Step, StepError};
+pub use step_map::{MapResult, Mapping, StepMap};
+pub use steps::{
+    AddMarkStep, RemoveMarkStep, ReplaceAroundStep, ReplaceStep, SetDocAttrStep, SetNodeAttrStep,
+};

--- a/crates/rinch-editor-core/src/transform/node_range.rs
+++ b/crates/rinch-editor-core/src/transform/node_range.rs
@@ -1,0 +1,94 @@
+//! [`NodeRange`] — a range of sibling block nodes, the unit `wrap`/`lift` act on.
+//!
+//! A `NodeRange` is two resolved positions that share a common ancestor at a
+//! given `depth`; the range covers the children of that ancestor between the two
+//! positions. [`block_range`] finds the shallowest such range satisfying a
+//! predicate. Port of ProseMirror's `NodeRange` and `ResolvedPos.blockRange`.
+
+use crate::model::Node;
+use crate::pos::ResolvedPos;
+
+/// A contiguous range of sibling nodes within a common parent.
+#[derive(Clone, Debug)]
+pub struct NodeRange {
+    /// The resolved start position.
+    pub from: ResolvedPos,
+    /// The resolved end position.
+    pub to: ResolvedPos,
+    /// The depth of the common parent.
+    pub depth: usize,
+}
+
+impl NodeRange {
+    /// The document position before the first node in the range.
+    ///
+    /// Total: if `from` resolves shallower than `depth + 1` (a degenerate range
+    /// whose `from` lands on a boundary above the common depth), this falls back to
+    /// `from.pos()` rather than indexing the resolved path out of bounds. A
+    /// well-formed block range (both endpoints inside content) never hits the
+    /// fallback.
+    pub fn start(&self) -> usize {
+        if self.depth + 1 > self.from.depth() {
+            self.from.pos().0
+        } else {
+            self.from.before(self.depth + 1).expect("node range start")
+        }
+    }
+
+    /// The document position after the last node in the range.
+    ///
+    /// Total: if `to` resolves shallower than `depth + 1` (e.g. the selection head
+    /// lands on a gap above the common depth), this falls back to `to.pos()` rather
+    /// than indexing the resolved path out of bounds.
+    pub fn end(&self) -> usize {
+        if self.depth + 1 > self.to.depth() {
+            self.to.pos().0
+        } else {
+            self.to.after(self.depth + 1).expect("node range end")
+        }
+    }
+
+    /// The common parent node.
+    pub fn parent(&self) -> &Node {
+        self.from.node(self.depth)
+    }
+
+    /// The index of the first node in the parent.
+    pub fn start_index(&self) -> usize {
+        self.from.index(self.depth)
+    }
+
+    /// The index just past the last node in the parent.
+    pub fn end_index(&self) -> usize {
+        self.to.index_after(self.depth)
+    }
+}
+
+/// Find the shallowest [`NodeRange`] containing both positions whose parent
+/// satisfies `pred`. `from`/`to` must already be ordered (`from.pos <= to.pos`).
+/// Port of `ResolvedPos.blockRange`.
+pub fn block_range(
+    from: &ResolvedPos,
+    to: &ResolvedPos,
+    pred: impl Fn(&Node) -> bool,
+) -> Option<NodeRange> {
+    let adjust = usize::from(from.parent().is_textblock() || from.pos() == to.pos());
+    let mut d = from.depth() as isize - adjust as isize;
+    while d >= 0 {
+        let du = d as usize;
+        if to.pos().0 <= from.end(du) && pred(from.node(du)) {
+            return Some(NodeRange {
+                from: from.clone(),
+                to: to.clone(),
+                depth: du,
+            });
+        }
+        d -= 1;
+    }
+    None
+}
+
+/// Convenience: the shallowest block range covering both positions (no predicate).
+pub fn block_range_simple(from: &ResolvedPos, to: &ResolvedPos) -> Option<NodeRange> {
+    block_range(from, to, |_| true)
+}

--- a/crates/rinch-editor-core/src/transform/replace.rs
+++ b/crates/rinch-editor-core/src/transform/replace.rs
@@ -1,0 +1,286 @@
+//! The replace algorithm — the engine underneath `ReplaceStep`.
+//!
+//! Replacing the document range `from..to` with a [`Slice`] is the single
+//! operation that expresses text insertion, deletion, splitting, joining, and
+//! paste. The algorithm is delicate because the cut endpoints and the slice's
+//! open boundaries can sit at different depths: the content on the left of `from`
+//! must be re-joined to the slice's open-start, the slice's open-end re-joined to
+//! the content on the right of `to`, and any ancestors that the cut passes
+//! through reconstructed. This is a faithful port of ProseMirror's
+//! `transform/src/replace.ts`; **schema enforcement** (decision G) lives in
+//! [`close`], which rejects any reconstructed node whose children violate its
+//! content expression — so an invalid step never produces a document.
+
+use crate::Slice;
+use crate::model::{Fragment, Node};
+use crate::pos::{Pos, ResolvedPos};
+use crate::transform::step::StepError;
+
+/// Resolve `from`/`to` against `doc` and replace that range with `slice`
+/// (ProseMirror's `Node.replace` / `StepResult.fromReplace`).
+pub(crate) fn replace_doc(
+    doc: &Node,
+    from: usize,
+    to: usize,
+    slice: &Slice,
+) -> Result<Node, StepError> {
+    let r_from = doc
+        .resolve(Pos(from))
+        .map_err(|e| StepError::new(e.to_string()))?;
+    let r_to = doc
+        .resolve(Pos(to))
+        .map_err(|e| StepError::new(e.to_string()))?;
+    replace(&r_from, &r_to, slice)
+}
+
+/// Replace the range between two resolved positions with `slice`.
+fn replace(from: &ResolvedPos, to: &ResolvedPos, slice: &Slice) -> Result<Node, StepError> {
+    if slice.open_start > from.depth() {
+        return Err(StepError::new(
+            "inserted content deeper than insertion position",
+        ));
+    }
+    if from.depth() as isize - slice.open_start as isize
+        != to.depth() as isize - slice.open_end as isize
+    {
+        return Err(StepError::new("inconsistent open depths"));
+    }
+    replace_outer(from, to, slice, 0)
+}
+
+fn replace_outer(
+    from: &ResolvedPos,
+    to: &ResolvedPos,
+    slice: &Slice,
+    depth: usize,
+) -> Result<Node, StepError> {
+    let index = from.index(depth);
+    let node = from.node(depth).clone();
+    if index == to.index(depth) && depth < from.depth() - slice.open_start {
+        // The cut stays inside one child here — recurse, then splice the rebuilt
+        // child back in (sharing every sibling).
+        let inner = replace_outer(from, to, slice, depth + 1)?;
+        Ok(node.copy_with_content(node.content().replace_child(index, inner)))
+    } else if slice.is_empty() {
+        // Pure deletion: stitch the left and right remainders together.
+        let frag = replace_two_way(from, to, depth)?;
+        close(&node, frag)
+    } else if slice.open_start == 0
+        && slice.open_end == 0
+        && from.depth() == depth
+        && to.depth() == depth
+    {
+        // The flat, common case: insert closed content within a single textblock.
+        let parent = from.parent();
+        let content = parent.content();
+        let merged = content
+            .cut(0, from.parent_offset())
+            .append(&slice.content)
+            .append(&content.cut(to.parent_offset(), content.size()));
+        close(parent, merged)
+    } else {
+        // The general three-way case: left remainder + open slice + right remainder.
+        let (start, end) = prepare_slice_for_replace(slice, from)?;
+        let frag = replace_three_way(from, &start, &end, to, depth)?;
+        close(&node, frag)
+    }
+}
+
+/// Reconstruct `node`'s content as `content`, **enforcing the schema**: the child
+/// sequence must satisfy `node`'s content expression and each child's marks must
+/// be allowed. Returns `Err` otherwise — the schema gate for every replace.
+fn close(node: &Node, content: Fragment) -> Result<Node, StepError> {
+    let names: Vec<&str> = content.children().iter().map(Node::type_name).collect();
+    if !node.node_type().content_match().matches(&names) {
+        return Err(StepError::new(format!(
+            "invalid content for <{}>: {:?}",
+            node.type_name(),
+            names
+        )));
+    }
+    let mark_set = &node.node_type().spec().marks;
+    for child in content.children() {
+        for m in child.marks() {
+            if !mark_set.allows(m.type_name()) {
+                return Err(StepError::new(format!(
+                    "mark <{}> not allowed in <{}>",
+                    m.type_name(),
+                    node.type_name()
+                )));
+            }
+        }
+    }
+    Ok(node.copy_with_content(content))
+}
+
+/// Append a child to `target`, merging into the previous node if both are text
+/// with identical markup (so runs never fragment). Port of `addNode`.
+fn add_node(child: Node, target: &mut Vec<Node>) {
+    let merge = matches!(target.last(), Some(last)
+        if child.is_text() && last.is_text() && child.same_markup(last));
+    if merge {
+        let n = target.len() - 1;
+        let merged = format!("{}{}", target[n].text().unwrap(), child.text().unwrap());
+        target[n] = target[n].with_text(merged.into());
+    } else {
+        target.push(child);
+    }
+}
+
+/// Append the children of the node at `depth` that lie between `start` and `end`
+/// (either bound `None` means "this side's edge of the node"), slicing a text
+/// node at a mid-text bound. Port of `addRange`.
+fn add_range(
+    start: Option<&ResolvedPos>,
+    end: Option<&ResolvedPos>,
+    depth: usize,
+    target: &mut Vec<Node>,
+) {
+    let node = end
+        .or(start)
+        .expect("addRange needs a bound")
+        .node(depth)
+        .clone();
+    let end_index = match end {
+        Some(e) => e.index(depth),
+        None => node.child_count(),
+    };
+    let mut start_index = 0;
+    if let Some(s) = start {
+        start_index = s.index(depth);
+        if s.depth() > depth {
+            start_index += 1;
+        } else if s.text_offset() > 0 {
+            add_node(
+                s.node_after().expect("text offset implies a node after"),
+                target,
+            );
+            start_index += 1;
+        }
+    }
+    for i in start_index..end_index {
+        add_node(node.child(i).clone(), target);
+    }
+    if let Some(e) = end
+        && e.depth() == depth
+        && e.text_offset() > 0
+    {
+        add_node(
+            e.node_before().expect("text offset implies a node before"),
+            target,
+        );
+    }
+}
+
+/// Check two nodes can be joined (their content types are compatible). Port of
+/// `checkJoin`.
+fn check_join(main: &Node, sub: &Node) -> Result<(), StepError> {
+    if !sub.node_type().compatible_content(main.node_type()) {
+        return Err(StepError::new(format!(
+            "cannot join <{}> onto <{}>",
+            sub.type_name(),
+            main.type_name()
+        )));
+    }
+    Ok(())
+}
+
+/// The node at `depth` on the `before` path, validated as joinable with the node
+/// at `depth` on the `after` path. Port of `joinable`.
+fn joinable(before: &ResolvedPos, after: &ResolvedPos, depth: usize) -> Result<Node, StepError> {
+    let node = before.node(depth).clone();
+    check_join(&node, after.node(depth))?;
+    Ok(node)
+}
+
+/// Stitch the content to the left of `from` and to the right of `to` together,
+/// recursing through joined ancestors. Port of `replaceTwoWay`.
+fn replace_two_way(
+    from: &ResolvedPos,
+    to: &ResolvedPos,
+    depth: usize,
+) -> Result<Fragment, StepError> {
+    let mut content: Vec<Node> = Vec::new();
+    add_range(None, Some(from), depth, &mut content);
+    if from.depth() > depth {
+        let typ = joinable(from, to, depth + 1)?;
+        let inner = replace_two_way(from, to, depth + 1)?;
+        add_node(close(&typ, inner)?, &mut content);
+    }
+    add_range(Some(to), None, depth, &mut content);
+    Ok(Fragment::from_children(content))
+}
+
+/// The general case: left remainder, then the (open) slice content represented by
+/// `start..end`, then the right remainder, joining open boundaries where the
+/// depths line up. Port of `replaceThreeWay`.
+fn replace_three_way(
+    from: &ResolvedPos,
+    start: &ResolvedPos,
+    end: &ResolvedPos,
+    to: &ResolvedPos,
+    depth: usize,
+) -> Result<Fragment, StepError> {
+    let open_start = if from.depth() > depth {
+        Some(joinable(from, start, depth + 1)?)
+    } else {
+        None
+    };
+    let open_end = if to.depth() > depth {
+        Some(joinable(end, to, depth + 1)?)
+    } else {
+        None
+    };
+
+    let mut content: Vec<Node> = Vec::new();
+    add_range(None, Some(from), depth, &mut content);
+    match (&open_start, &open_end) {
+        (Some(os), Some(oe)) if start.index(depth) == end.index(depth) => {
+            check_join(os, oe)?;
+            let inner = replace_three_way(from, start, end, to, depth + 1)?;
+            add_node(close(os, inner)?, &mut content);
+        }
+        _ => {
+            if let Some(os) = &open_start {
+                let inner = replace_two_way(from, start, depth + 1)?;
+                add_node(close(os, inner)?, &mut content);
+            }
+            add_range(Some(start), Some(end), depth, &mut content);
+            if let Some(oe) = &open_end {
+                let inner = replace_two_way(end, to, depth + 1)?;
+                add_node(close(oe, inner)?, &mut content);
+            }
+        }
+    }
+    add_range(Some(to), None, depth, &mut content);
+    Ok(Fragment::from_children(content))
+}
+
+/// Wrap the slice's content in copies of `along`'s open ancestors, then resolve
+/// the slice's two open edges within that synthetic node — giving the `start`/`end`
+/// resolved positions `replace_three_way` consumes. Port of
+/// `prepareSliceForReplace`.
+fn prepare_slice_for_replace(
+    slice: &Slice,
+    along: &ResolvedPos,
+) -> Result<(ResolvedPos, ResolvedPos), StepError> {
+    let extra = along.depth() - slice.open_start;
+    let parent = along.node(extra);
+    let mut node = parent.copy_with_content(slice.content.clone());
+    let mut i = extra as isize - 1;
+    while i >= 0 {
+        node = along
+            .node(i as usize)
+            .copy_with_content(Fragment::from_node(node));
+        i -= 1;
+    }
+    let start_pos = slice.open_start + extra;
+    let end_pos = node.content_size() - slice.open_end - extra;
+    let start = node
+        .resolve(Pos(start_pos))
+        .map_err(|e| StepError::new(e.to_string()))?;
+    let end = node
+        .resolve(Pos(end_pos))
+        .map_err(|e| StepError::new(e.to_string()))?;
+    Ok((start, end))
+}

--- a/crates/rinch-editor-core/src/transform/step.rs
+++ b/crates/rinch-editor-core/src/transform/step.rs
@@ -1,0 +1,68 @@
+//! The [`Step`] trait — the unit of document change.
+//!
+//! Every edit in the system is a sequence of `Step`s. A step is **invertible**
+//! (so undo is "apply the inverse"), **mappable** (so a step can be rebased over
+//! other steps for collaboration and redo), and carries a [`StepMap`] describing
+//! how it shifts positions. This is the structural property that lets one engine
+//! serve typing, undo/redo, and collaborative editing without special cases.
+//!
+//! Faithful port of ProseMirror's `transform/src/step.ts`. The one Rust-specific
+//! addition is [`Step::clone_box`] (amendment A12): trait objects cannot derive
+//! `Clone`, yet `Transaction`'s step list, history's inverted steps, and collab
+//! rebase all need to clone boxed steps.
+
+use crate::model::Node;
+use crate::transform::step_map::{Mapping, StepMap};
+use std::any::Any;
+use thiserror::Error;
+
+/// Why a [`Step::apply`] failed: the position was invalid, or the result would
+/// violate the schema. A failed step rejects its entire transaction — invalid
+/// content is never written.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("{0}")]
+pub struct StepError(pub String);
+
+impl StepError {
+    /// Construct a step error with a diagnostic message.
+    pub fn new(msg: impl Into<String>) -> StepError {
+        StepError(msg.into())
+    }
+}
+
+/// A single, invertible, mappable change to a document.
+pub trait Step: std::fmt::Debug {
+    /// Apply this step to `doc`, returning the new document or a failure. **Schema
+    /// enforcement lives here**: a step whose result would violate a parent's
+    /// content expression returns `Err`, leaving the original document untouched.
+    fn apply(&self, doc: &Node) -> Result<Node, StepError>;
+
+    /// The position map this step induces (for mapping later steps and selections).
+    fn get_map(&self) -> StepMap;
+
+    /// The inverse of this step against the document it was applied to (for undo).
+    /// `doc` must be the document this step was applied to.
+    fn invert(&self, doc: &Node) -> Box<dyn Step>;
+
+    /// Rebase this step over a mapping (collab/redo). Returns `None` if the step no
+    /// longer has anywhere to apply (its range was entirely deleted).
+    fn map(&self, mapping: &Mapping) -> Option<Box<dyn Step>>;
+
+    /// Try to fold a following step into this one (typing coalescing). Returns the
+    /// merged step, or `None` if they cannot be combined.
+    fn merge(&self, _other: &dyn Step) -> Option<Box<dyn Step>> {
+        None
+    }
+
+    /// Clone into a fresh box (A12 — trait objects can't derive `Clone`).
+    fn clone_box(&self) -> Box<dyn Step>;
+
+    /// Downcast support, so `merge` can recognise a same-typed neighbour.
+    fn as_any(&self) -> &dyn Any;
+}
+
+impl Clone for Box<dyn Step> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
+}

--- a/crates/rinch-editor-core/src/transform/step_map.rs
+++ b/crates/rinch-editor-core/src/transform/step_map.rs
@@ -1,0 +1,356 @@
+//! Position remapping: [`StepMap`] and [`Mapping`].
+//!
+//! When a step changes the document it shifts every position after the edited
+//! range. A [`StepMap`] is the compact description of that shift — a flat list of
+//! `[start, old_size, new_size]` triples — and knows how to map any old position
+//! to its new home (and, inverted, back again). A [`Mapping`] is an ordered
+//! pipeline of step maps with *mirror* bookkeeping, so that mapping a position
+//! through a step **and its inverse** (collab rebase, undo) recovers the original
+//! position instead of collapsing it into a deleted range.
+//!
+//! This is a faithful port of ProseMirror's `transform/src/map.ts`; the
+//! association (`assoc`) and deletion-tracking semantics match exactly, because
+//! selection mapping, history, and collaborative rebase all depend on them.
+
+/// `pos` falls inside content that was deleted, on the side **before** it.
+const DEL_BEFORE: u8 = 1;
+/// `pos` falls inside content that was deleted, on the side **after** it.
+const DEL_AFTER: u8 = 2;
+/// `pos` was inside a deleted range (content removed on both sides).
+const DEL_ACROSS: u8 = 4;
+/// The position itself was inside deleted content.
+const DEL_SIDE: u8 = DEL_BEFORE | DEL_AFTER;
+
+/// An opaque token (produced by [`StepMap::map_result`], consumed by the *mirror*
+/// map's [`StepMap::recover`]) that records where, inside a step's replaced range,
+/// a position sat — so the inverse map can restore it precisely.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Recover {
+    /// Which range (triple index) of the step map the position fell in.
+    index: usize,
+    /// The offset of the position from that range's start.
+    offset: usize,
+}
+
+/// The result of mapping a position through a [`StepMap`]/[`Mapping`]: the new
+/// position plus information about whether it landed in deleted content.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MapResult {
+    /// The mapped position.
+    pub pos: usize,
+    del_info: u8,
+    recover: Option<Recover>,
+}
+
+impl MapResult {
+    /// True if the position was inside content that the step deleted.
+    pub fn deleted(&self) -> bool {
+        self.del_info & DEL_SIDE > 0
+    }
+    /// True if the content immediately before the position was deleted.
+    pub fn deleted_before(&self) -> bool {
+        self.del_info & (DEL_BEFORE | DEL_ACROSS) > 0
+    }
+    /// True if the content immediately after the position was deleted.
+    pub fn deleted_after(&self) -> bool {
+        self.del_info & (DEL_AFTER | DEL_ACROSS) > 0
+    }
+    /// True if a range *spanning* the position was deleted.
+    pub fn deleted_across(&self) -> bool {
+        self.del_info & DEL_ACROSS > 0
+    }
+}
+
+/// A map of the positions affected by a single step: a flat list of
+/// `[start, old_size, new_size]` triples (sorted by `start`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StepMap {
+    /// Flattened `[start, old_size, new_size]` triples.
+    ranges: Vec<usize>,
+    /// When true, the map is read in the inverse direction (new ↔ old).
+    inverted: bool,
+}
+
+impl StepMap {
+    /// Build a step map from a flat list of `[start, old_size, new_size]` triples.
+    pub fn new(ranges: Vec<usize>) -> StepMap {
+        debug_assert!(
+            ranges.len().is_multiple_of(3),
+            "step map ranges must be triples"
+        );
+        StepMap {
+            ranges,
+            inverted: false,
+        }
+    }
+
+    /// The identity map (no position changes) — for steps that don't move content
+    /// (mark/attr steps).
+    pub fn empty() -> StepMap {
+        StepMap {
+            ranges: Vec::new(),
+            inverted: false,
+        }
+    }
+
+    /// The inverse map (swaps the old/new direction). Cheap: shares the ranges.
+    pub fn invert(&self) -> StepMap {
+        StepMap {
+            ranges: self.ranges.clone(),
+            inverted: !self.inverted,
+        }
+    }
+
+    /// Map a position, returning just the new position. `assoc` (`-1` or `1`)
+    /// chooses which side a position on a boundary biases toward.
+    pub fn map(&self, pos: usize, assoc: i32) -> usize {
+        self.map_full(pos, assoc).pos
+    }
+
+    /// Map a position, returning the new position plus deletion information.
+    pub fn map_result(&self, pos: usize, assoc: i32) -> MapResult {
+        self.map_full(pos, assoc)
+    }
+
+    fn map_full(&self, pos: usize, assoc: i32) -> MapResult {
+        let pos = pos as isize;
+        let mut diff: isize = 0;
+        let (old_index, new_index) = if self.inverted { (2, 1) } else { (1, 2) };
+        let mut i = 0;
+        while i < self.ranges.len() {
+            let start = self.ranges[i] as isize - if self.inverted { diff } else { 0 };
+            if start > pos {
+                break;
+            }
+            let old_size = self.ranges[i + old_index] as isize;
+            let new_size = self.ranges[i + new_index] as isize;
+            let end = start + old_size;
+            if pos <= end {
+                let side = if old_size == 0 {
+                    assoc
+                } else if pos == start {
+                    -1
+                } else if pos == end {
+                    1
+                } else {
+                    assoc
+                };
+                let result = start + diff + if side < 0 { 0 } else { new_size };
+                let recover = if pos == (if assoc < 0 { start } else { end }) {
+                    None
+                } else {
+                    Some(Recover {
+                        index: i / 3,
+                        offset: (pos - start) as usize,
+                    })
+                };
+                let mut del_info = if pos == start {
+                    DEL_AFTER
+                } else if pos == end {
+                    DEL_BEFORE
+                } else {
+                    DEL_ACROSS
+                };
+                let on_side = if assoc < 0 { pos != start } else { pos != end };
+                if on_side {
+                    del_info |= DEL_SIDE;
+                }
+                return MapResult {
+                    pos: result as usize,
+                    del_info,
+                    recover,
+                };
+            }
+            diff += new_size - old_size;
+            i += 3;
+        }
+        MapResult {
+            pos: (pos + diff) as usize,
+            del_info: 0,
+            recover: None,
+        }
+    }
+
+    /// Recover the absolute position encoded by a [`Recover`] token (produced by
+    /// this map's mirror). Used by [`Mapping`] to skip a deletion/re-insertion pair.
+    fn recover(&self, rec: Recover) -> usize {
+        let mut diff: isize = 0;
+        if !self.inverted {
+            for i in 0..rec.index {
+                diff += self.ranges[i * 3 + 2] as isize - self.ranges[i * 3 + 1] as isize;
+            }
+        }
+        (self.ranges[rec.index * 3] as isize + diff + rec.offset as isize) as usize
+    }
+}
+
+/// An ordered pipeline of [`StepMap`]s with *mirror* bookkeeping.
+///
+/// A transaction accumulates one step map per step; mapping a position through
+/// the whole `Mapping` walks every map in order. The mirror table records that
+/// map *i* is the inverse of map *j* (e.g. a delete that a later step re-inserts,
+/// or undo), so a position that a map would drop into a deleted hole is *recovered*
+/// in the mirror map instead of being clamped.
+#[derive(Clone, Debug, Default)]
+pub struct Mapping {
+    maps: Vec<StepMap>,
+    /// Flat pairs `[a, b, a, b, …]` meaning map `a` mirrors map `b`.
+    mirror: Vec<usize>,
+    from: usize,
+    to: usize,
+}
+
+impl Mapping {
+    /// An empty mapping.
+    pub fn new() -> Mapping {
+        Mapping {
+            maps: Vec::new(),
+            mirror: Vec::new(),
+            from: 0,
+            to: 0,
+        }
+    }
+
+    /// The accumulated step maps.
+    pub fn maps(&self) -> &[StepMap] {
+        &self.maps
+    }
+
+    /// Number of step maps.
+    pub fn len(&self) -> usize {
+        self.maps.len()
+    }
+
+    /// True if no maps have been appended.
+    pub fn is_empty(&self) -> bool {
+        self.maps.is_empty()
+    }
+
+    /// A view over the maps `from..to`, sharing the underlying maps and mirror
+    /// table. The state-layer [`Transaction`](crate::state::Transaction) uses this
+    /// to map a selection forward through only the maps added since it was last
+    /// set (PM's `Mapping.slice`). The mirror indices remain absolute into the
+    /// shared `maps`, so recover/mirror behavior is preserved within the window.
+    pub fn slice(&self, from: usize, to: usize) -> Mapping {
+        Mapping {
+            maps: self.maps.clone(),
+            mirror: self.mirror.clone(),
+            from,
+            to,
+        }
+    }
+
+    /// Append a step map to the pipeline.
+    pub fn append_map(&mut self, map: StepMap) {
+        self.maps.push(map);
+        self.to = self.maps.len();
+    }
+
+    /// Append a step map that mirrors (is the inverse of) the map at index
+    /// `mirror`.
+    pub fn append_map_mirrored(&mut self, map: StepMap, mirror: usize) {
+        self.maps.push(map);
+        self.to = self.maps.len();
+        let n = self.maps.len() - 1;
+        self.mirror.push(n);
+        self.mirror.push(mirror);
+    }
+
+    /// Append all of `mapping`'s maps (preserving mirror relations).
+    pub fn append_mapping(&mut self, mapping: &Mapping) {
+        let start_size = self.maps.len();
+        for i in 0..mapping.maps.len() {
+            let mirr = mapping.get_mirror(i);
+            match mirr {
+                Some(m) if m < i => {
+                    self.append_map_mirrored(mapping.maps[i].clone(), start_size + m)
+                }
+                _ => self.append_map(mapping.maps[i].clone()),
+            }
+        }
+    }
+
+    /// Append the *inverse* of every map in `mapping`, in reverse order — the
+    /// basis for inverting an accumulated mapping (undo, collab rebase).
+    pub fn append_mapping_inverted(&mut self, mapping: &Mapping) {
+        if mapping.maps.is_empty() {
+            return;
+        }
+        let total_size = self.maps.len() + mapping.maps.len();
+        let mut i = mapping.maps.len() as isize - 1;
+        while i >= 0 {
+            let idx = i as usize;
+            let mirror_arg = match mapping.get_mirror(idx) {
+                Some(m) if m > idx => Some(total_size - m - 1),
+                _ => None,
+            };
+            match mirror_arg {
+                Some(mv) => self.append_map_mirrored(mapping.maps[idx].invert(), mv),
+                None => self.append_map(mapping.maps[idx].invert()),
+            }
+            i -= 1;
+        }
+    }
+
+    /// A new mapping that inverts this one.
+    pub fn invert(&self) -> Mapping {
+        let mut inverse = Mapping::new();
+        inverse.append_mapping_inverted(self);
+        inverse
+    }
+
+    fn get_mirror(&self, n: usize) -> Option<usize> {
+        let mut i = 0;
+        while i < self.mirror.len() {
+            if self.mirror[i] == n {
+                let partner = if i % 2 == 1 { i - 1 } else { i + 1 };
+                return Some(self.mirror[partner]);
+            }
+            i += 1;
+        }
+        None
+    }
+
+    /// Map a position through the whole pipeline, returning the new position.
+    pub fn map(&self, pos: usize, assoc: i32) -> usize {
+        if !self.mirror.is_empty() {
+            return self.map_inner(pos, assoc).pos;
+        }
+        let mut pos = pos;
+        for i in self.from..self.to {
+            pos = self.maps[i].map(pos, assoc);
+        }
+        pos
+    }
+
+    /// Map a position through the whole pipeline, returning deletion info too.
+    pub fn map_result(&self, pos: usize, assoc: i32) -> MapResult {
+        self.map_inner(pos, assoc)
+    }
+
+    fn map_inner(&self, pos: usize, assoc: i32) -> MapResult {
+        let mut del_info = 0u8;
+        let mut pos = pos;
+        let mut i = self.from;
+        while i < self.to {
+            let result = self.maps[i].map_result(pos, assoc);
+            if let Some(rec) = result.recover
+                && let Some(corr) = self.get_mirror(i)
+                && corr > i
+                && corr < self.to
+            {
+                pos = self.maps[corr].recover(rec);
+                i = corr + 1;
+                continue;
+            }
+            del_info |= result.del_info;
+            pos = result.pos;
+            i += 1;
+        }
+        MapResult {
+            pos,
+            del_info,
+            recover: None,
+        }
+    }
+}

--- a/crates/rinch-editor-core/src/transform/steps/attr_step.rs
+++ b/crates/rinch-editor-core/src/transform/steps/attr_step.rs
@@ -1,0 +1,165 @@
+//! [`SetNodeAttrStep`] / [`SetDocAttrStep`] — change a single attribute.
+//!
+//! Setting `heading.level`, `image.alt`, `ordered_list.start`, or a doc-level
+//! attribute. These induce no position change (their step map is empty). Unlike
+//! ProseMirror's slice-based `AttrStep`, the node-attr step rebuilds the target
+//! node in place and splices it back up the ancestor path — the result is
+//! identical (an equal-sized node with new attrs) but avoids the empty-content
+//! slice dance.
+//!
+//! `value` is `Option<AttrValue>`: `Some` sets the attribute, `None` removes it.
+//! This lets `invert` capture "the attribute was absent" precisely, so
+//! `apply∘invert` is an exact identity even for attrs that had no prior value.
+
+use crate::model::{AttrValue, Node};
+use crate::pos::{Pos, ResolvedPos};
+use crate::transform::step::{Step, StepError};
+use crate::transform::step_map::{Mapping, StepMap};
+use std::any::Any;
+
+/// Rebuild the document with the node at `r.node(depth)`'s child index
+/// `r.index(depth)` replaced by `new_child`, splicing every ancestor up to the
+/// root (sharing all untouched subtrees).
+fn rebuild_up(r: &ResolvedPos, depth: usize, new_child: Node) -> Node {
+    let parent = r.node(depth);
+    let idx = r.index(depth);
+    let rebuilt = parent.copy_with_content(parent.content().replace_child(idx, new_child));
+    if depth == 0 {
+        rebuilt
+    } else {
+        rebuild_up(r, depth - 1, rebuilt)
+    }
+}
+
+/// Set (or remove) one attribute on the node that starts at `pos`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SetNodeAttrStep {
+    /// Position before the target node (its open token).
+    pub pos: usize,
+    /// The attribute name.
+    pub attr: String,
+    /// The new value, or `None` to remove the attribute.
+    pub value: Option<AttrValue>,
+}
+
+impl SetNodeAttrStep {
+    /// Set the attribute `attr` of the node at `pos` to `value`.
+    pub fn new(pos: usize, attr: impl Into<String>, value: AttrValue) -> SetNodeAttrStep {
+        SetNodeAttrStep {
+            pos,
+            attr: attr.into(),
+            value: Some(value),
+        }
+    }
+}
+
+impl Step for SetNodeAttrStep {
+    fn apply(&self, doc: &Node) -> Result<Node, StepError> {
+        let r = doc
+            .resolve(Pos(self.pos))
+            .map_err(|e| StepError::new(e.to_string()))?;
+        let depth = r.depth();
+        let index = r.index(depth);
+        let target = r
+            .parent()
+            .content()
+            .maybe_child(index)
+            .ok_or_else(|| StepError::new("no node at attr step position"))?;
+        if target.is_text() {
+            return Err(StepError::new("cannot set attributes on a text node"));
+        }
+        let new_attrs = match &self.value {
+            Some(v) => target.attrs().with(self.attr.clone(), v.clone()),
+            None => target.attrs().without(&self.attr),
+        };
+        let updated = target.with_attrs(new_attrs);
+        Ok(rebuild_up(&r, depth, updated))
+    }
+
+    fn get_map(&self) -> StepMap {
+        StepMap::empty()
+    }
+
+    fn invert(&self, doc: &Node) -> Box<dyn Step> {
+        let prior = doc
+            .node_at(self.pos)
+            .and_then(|n| n.attrs().get(&self.attr).cloned());
+        Box::new(SetNodeAttrStep {
+            pos: self.pos,
+            attr: self.attr.clone(),
+            value: prior,
+        })
+    }
+
+    fn map(&self, mapping: &Mapping) -> Option<Box<dyn Step>> {
+        let pos = mapping.map_result(self.pos, 1);
+        if pos.deleted_after() {
+            return None;
+        }
+        Some(Box::new(SetNodeAttrStep {
+            pos: pos.pos,
+            attr: self.attr.clone(),
+            value: self.value.clone(),
+        }))
+    }
+
+    fn clone_box(&self) -> Box<dyn Step> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// Set (or remove) one document-level attribute.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SetDocAttrStep {
+    /// The attribute name.
+    pub attr: String,
+    /// The new value, or `None` to remove the attribute.
+    pub value: Option<AttrValue>,
+}
+
+impl SetDocAttrStep {
+    /// Set the document attribute `attr` to `value`.
+    pub fn new(attr: impl Into<String>, value: AttrValue) -> SetDocAttrStep {
+        SetDocAttrStep {
+            attr: attr.into(),
+            value: Some(value),
+        }
+    }
+}
+
+impl Step for SetDocAttrStep {
+    fn apply(&self, doc: &Node) -> Result<Node, StepError> {
+        let new_attrs = match &self.value {
+            Some(v) => doc.attrs().with(self.attr.clone(), v.clone()),
+            None => doc.attrs().without(&self.attr),
+        };
+        Ok(doc.with_attrs(new_attrs))
+    }
+
+    fn get_map(&self) -> StepMap {
+        StepMap::empty()
+    }
+
+    fn invert(&self, doc: &Node) -> Box<dyn Step> {
+        Box::new(SetDocAttrStep {
+            attr: self.attr.clone(),
+            value: doc.attrs().get(&self.attr).cloned(),
+        })
+    }
+
+    fn map(&self, _mapping: &Mapping) -> Option<Box<dyn Step>> {
+        Some(self.clone_box())
+    }
+
+    fn clone_box(&self) -> Box<dyn Step> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/crates/rinch-editor-core/src/transform/steps/mark_step.rs
+++ b/crates/rinch-editor-core/src/transform/steps/mark_step.rs
@@ -1,0 +1,202 @@
+//! [`AddMarkStep`] / [`RemoveMarkStep`] — add or remove a mark across an inline
+//! range.
+//!
+//! Both rebuild the inline content of the range with the mark added to / removed
+//! from each text or inline-leaf node's mark set, then replace the range with the
+//! re-marked copy. They induce no position change (their step map is empty) and
+//! invert into each other. Port of ProseMirror's mark steps.
+
+use crate::Slice;
+use crate::model::{Fragment, Mark, Node};
+use crate::pos::Pos;
+use crate::transform::replace::replace_doc;
+use crate::transform::step::{Step, StepError};
+use crate::transform::step_map::{Mapping, StepMap};
+use std::any::Any;
+
+/// Map every inline node in `fragment` through `f`, recursing into block content.
+/// Port of `mapFragment` (the `i` index argument is unused here and dropped).
+fn map_inline<F: Fn(&Node, &Node) -> Node>(fragment: &Fragment, parent: &Node, f: &F) -> Fragment {
+    let mut mapped = Vec::with_capacity(fragment.child_count());
+    for child in fragment.children() {
+        let mut child = child.clone();
+        if child.content_size() > 0 {
+            let new_content = map_inline(child.content(), &child, f);
+            child = child.copy_with_content(new_content);
+        }
+        if child.is_inline() {
+            child = f(&child, parent);
+        }
+        mapped.push(child);
+    }
+    Fragment::from_children(mapped)
+}
+
+/// True for inline nodes that can carry marks (text and inline leaves/atoms) —
+/// ProseMirror's `Node.isAtom` (`isLeaf || atom`).
+fn markable(node: &Node) -> bool {
+    node.is_leaf() || node.is_atom()
+}
+
+/// Add `mark` to every markable inline node in `from..to` (where the parent
+/// permits it).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AddMarkStep {
+    /// Start of the inline range.
+    pub from: usize,
+    /// End of the inline range.
+    pub to: usize,
+    /// The mark to add.
+    pub mark: Mark,
+}
+
+impl AddMarkStep {
+    /// Construct an add-mark step.
+    pub fn new(from: usize, to: usize, mark: Mark) -> AddMarkStep {
+        AddMarkStep { from, to, mark }
+    }
+}
+
+impl Step for AddMarkStep {
+    fn apply(&self, doc: &Node) -> Result<Node, StepError> {
+        let old_slice = doc
+            .slice(self.from, self.to)
+            .map_err(|e| StepError::new(e.to_string()))?;
+        let r_from = doc
+            .resolve(Pos(self.from))
+            .map_err(|e| StepError::new(e.to_string()))?;
+        let parent = r_from.node(r_from.shared_depth(Pos(self.to))).clone();
+        let mark = self.mark.clone();
+        let f = move |node: &Node, parent: &Node| -> Node {
+            if !markable(node) || !parent.node_type().spec().marks.allows(mark.type_name()) {
+                node.clone()
+            } else {
+                node.mark(mark.add_to_set(node.marks()))
+            }
+        };
+        let content = map_inline(&old_slice.content, &parent, &f);
+        let slice = Slice::new(content, old_slice.open_start, old_slice.open_end);
+        replace_doc(doc, self.from, self.to, &slice)
+    }
+
+    fn get_map(&self) -> StepMap {
+        StepMap::empty()
+    }
+
+    fn invert(&self, _doc: &Node) -> Box<dyn Step> {
+        Box::new(RemoveMarkStep::new(self.from, self.to, self.mark.clone()))
+    }
+
+    fn map(&self, mapping: &Mapping) -> Option<Box<dyn Step>> {
+        let from = mapping.map_result(self.from, 1);
+        let to = mapping.map_result(self.to, -1);
+        if (from.deleted() && to.deleted()) || from.pos >= to.pos {
+            return None;
+        }
+        Some(Box::new(AddMarkStep::new(
+            from.pos,
+            to.pos,
+            self.mark.clone(),
+        )))
+    }
+
+    fn merge(&self, other: &dyn Step) -> Option<Box<dyn Step>> {
+        let other = other.as_any().downcast_ref::<AddMarkStep>()?;
+        if other.mark == self.mark && self.from <= other.to && self.to >= other.from {
+            Some(Box::new(AddMarkStep::new(
+                self.from.min(other.from),
+                self.to.max(other.to),
+                self.mark.clone(),
+            )))
+        } else {
+            None
+        }
+    }
+
+    fn clone_box(&self) -> Box<dyn Step> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// Remove `mark` from every inline node in `from..to`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RemoveMarkStep {
+    /// Start of the inline range.
+    pub from: usize,
+    /// End of the inline range.
+    pub to: usize,
+    /// The mark to remove.
+    pub mark: Mark,
+}
+
+impl RemoveMarkStep {
+    /// Construct a remove-mark step.
+    pub fn new(from: usize, to: usize, mark: Mark) -> RemoveMarkStep {
+        RemoveMarkStep { from, to, mark }
+    }
+}
+
+impl Step for RemoveMarkStep {
+    fn apply(&self, doc: &Node) -> Result<Node, StepError> {
+        let old_slice = doc
+            .slice(self.from, self.to)
+            .map_err(|e| StepError::new(e.to_string()))?;
+        let r_from = doc
+            .resolve(Pos(self.from))
+            .map_err(|e| StepError::new(e.to_string()))?;
+        let parent = r_from.node(r_from.shared_depth(Pos(self.to))).clone();
+        let mark = self.mark.clone();
+        let f = move |node: &Node, _parent: &Node| -> Node {
+            node.mark(mark.remove_from_set(node.marks()))
+        };
+        let content = map_inline(&old_slice.content, &parent, &f);
+        let slice = Slice::new(content, old_slice.open_start, old_slice.open_end);
+        replace_doc(doc, self.from, self.to, &slice)
+    }
+
+    fn get_map(&self) -> StepMap {
+        StepMap::empty()
+    }
+
+    fn invert(&self, _doc: &Node) -> Box<dyn Step> {
+        Box::new(AddMarkStep::new(self.from, self.to, self.mark.clone()))
+    }
+
+    fn map(&self, mapping: &Mapping) -> Option<Box<dyn Step>> {
+        let from = mapping.map_result(self.from, 1);
+        let to = mapping.map_result(self.to, -1);
+        if (from.deleted() && to.deleted()) || from.pos >= to.pos {
+            return None;
+        }
+        Some(Box::new(RemoveMarkStep::new(
+            from.pos,
+            to.pos,
+            self.mark.clone(),
+        )))
+    }
+
+    fn merge(&self, other: &dyn Step) -> Option<Box<dyn Step>> {
+        let other = other.as_any().downcast_ref::<RemoveMarkStep>()?;
+        if other.mark == self.mark && self.from <= other.to && self.to >= other.from {
+            Some(Box::new(RemoveMarkStep::new(
+                self.from.min(other.from),
+                self.to.max(other.to),
+                self.mark.clone(),
+            )))
+        } else {
+            None
+        }
+    }
+
+    fn clone_box(&self) -> Box<dyn Step> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/crates/rinch-editor-core/src/transform/steps/mod.rs
+++ b/crates/rinch-editor-core/src/transform/steps/mod.rs
@@ -1,0 +1,11 @@
+//! The concrete step types.
+
+mod attr_step;
+mod mark_step;
+mod replace_around_step;
+mod replace_step;
+
+pub use attr_step::{SetDocAttrStep, SetNodeAttrStep};
+pub use mark_step::{AddMarkStep, RemoveMarkStep};
+pub use replace_around_step::ReplaceAroundStep;
+pub use replace_step::ReplaceStep;

--- a/crates/rinch-editor-core/src/transform/steps/replace_around_step.rs
+++ b/crates/rinch-editor-core/src/transform/steps/replace_around_step.rs
@@ -1,0 +1,139 @@
+//! [`ReplaceAroundStep`] — replace around a preserved gap.
+//!
+//! Wrapping (blockquote, list), lifting, and node-type changes that re-parent
+//! content all keep an inner range of content while changing the structure around
+//! it. `ReplaceAroundStep` replaces `from..to` with `slice`, but first drops the
+//! content currently in the *gap* `gap_from..gap_to` into the slice at offset
+//! `insert`. Port of ProseMirror's `ReplaceAroundStep`.
+
+use crate::Slice;
+use crate::model::Node;
+use crate::transform::replace::replace_doc;
+use crate::transform::step::{Step, StepError};
+use crate::transform::step_map::{Mapping, StepMap};
+use std::any::Any;
+
+/// Replace `from..to` with `slice`, preserving the gap `gap_from..gap_to` by
+/// inserting it into `slice` at content offset `insert`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReplaceAroundStep {
+    /// Start of the outer replaced range.
+    pub from: usize,
+    /// End of the outer replaced range.
+    pub to: usize,
+    /// Start of the preserved gap.
+    pub gap_from: usize,
+    /// End of the preserved gap.
+    pub gap_to: usize,
+    /// The wrapping content.
+    pub slice: Slice,
+    /// Content offset inside `slice` at which the gap content is inserted.
+    pub insert: usize,
+    /// Structural marker (these steps are always structural).
+    pub structure: bool,
+}
+
+impl ReplaceAroundStep {
+    /// Construct a replace-around step.
+    pub fn new(
+        from: usize,
+        to: usize,
+        gap_from: usize,
+        gap_to: usize,
+        slice: Slice,
+        insert: usize,
+        structure: bool,
+    ) -> ReplaceAroundStep {
+        ReplaceAroundStep {
+            from,
+            to,
+            gap_from,
+            gap_to,
+            slice,
+            insert,
+            structure,
+        }
+    }
+}
+
+impl Step for ReplaceAroundStep {
+    fn apply(&self, doc: &Node) -> Result<Node, StepError> {
+        let gap = doc
+            .slice(self.gap_from, self.gap_to)
+            .map_err(|e| StepError::new(e.to_string()))?;
+        if gap.open_start != 0 || gap.open_end != 0 {
+            return Err(StepError::new(
+                "structure gap-replace would overwrite content",
+            ));
+        }
+        let inserted = self
+            .slice
+            .insert_at(self.insert, &gap.content)
+            .ok_or_else(|| StepError::new("content does not fit in gap"))?;
+        replace_doc(doc, self.from, self.to, &inserted)
+    }
+
+    fn get_map(&self) -> StepMap {
+        StepMap::new(vec![
+            self.from,
+            self.gap_from - self.from,
+            self.insert,
+            self.gap_to,
+            self.to - self.gap_to,
+            self.slice.size() - self.insert,
+        ])
+    }
+
+    fn invert(&self, doc: &Node) -> Box<dyn Step> {
+        let gap = self.gap_to - self.gap_from;
+        let recovered = doc
+            .slice(self.from, self.to)
+            .expect("invert: outer range must be valid in the pre-step document")
+            .remove_between(self.gap_from - self.from, self.gap_to - self.from);
+        Box::new(ReplaceAroundStep {
+            from: self.from,
+            to: self.from + self.slice.size() + gap,
+            gap_from: self.from + self.insert,
+            gap_to: self.from + self.insert + gap,
+            slice: recovered,
+            insert: self.gap_from - self.from,
+            structure: self.structure,
+        })
+    }
+
+    fn map(&self, mapping: &Mapping) -> Option<Box<dyn Step>> {
+        let from = mapping.map_result(self.from, 1);
+        let to = mapping.map_result(self.to, -1);
+        let gap_from = if self.from == self.gap_from {
+            from.pos
+        } else {
+            mapping.map(self.gap_from, -1)
+        };
+        let gap_to = if self.to == self.gap_to {
+            to.pos
+        } else {
+            mapping.map(self.gap_to, 1)
+        };
+        if (from.deleted_across() && to.deleted_across()) || gap_from < from.pos || gap_to > to.pos
+        {
+            return None;
+        }
+        Some(Box::new(ReplaceAroundStep {
+            from: from.pos,
+            to: to.pos,
+            gap_from,
+            gap_to,
+            slice: self.slice.clone(),
+            insert: self.insert,
+            structure: self.structure,
+        }))
+    }
+
+    fn clone_box(&self) -> Box<dyn Step> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/crates/rinch-editor-core/src/transform/steps/replace_step.rs
+++ b/crates/rinch-editor-core/src/transform/steps/replace_step.rs
@@ -1,0 +1,180 @@
+//! [`ReplaceStep`] — replace a range with a slice. The workhorse step.
+//!
+//! Text insertion, deletion, splitting, joining, and paste all reduce to a
+//! `ReplaceStep`. It is its own inverse family (a replace inverts to another
+//! replace) and merges with adjacent replaces so that typing groups into one
+//! undo step.
+
+use crate::Slice;
+use crate::model::Node;
+use crate::pos::Pos;
+use crate::transform::replace::replace_doc;
+use crate::transform::step::{Step, StepError};
+use crate::transform::step_map::{Mapping, StepMap};
+use std::any::Any;
+
+/// Replace the document range `from..to` with `slice`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReplaceStep {
+    /// Start of the replaced range.
+    pub from: usize,
+    /// End of the replaced range.
+    pub to: usize,
+    /// The content to insert in its place.
+    pub slice: Slice,
+    /// When true this is a *structural* replace (e.g. a split): it refuses to run
+    /// if it would overwrite real content, and never merges with a neighbour.
+    pub structure: bool,
+}
+
+impl ReplaceStep {
+    /// A content replace (`structure = false`) — text insert/delete/paste.
+    pub fn new(from: usize, to: usize, slice: Slice) -> ReplaceStep {
+        ReplaceStep {
+            from,
+            to,
+            slice,
+            structure: false,
+        }
+    }
+
+    /// A structural replace (`structure = true`) — split/join/boundary edits.
+    pub fn structural(from: usize, to: usize, slice: Slice) -> ReplaceStep {
+        ReplaceStep {
+            from,
+            to,
+            slice,
+            structure: true,
+        }
+    }
+}
+
+impl Step for ReplaceStep {
+    fn apply(&self, doc: &Node) -> Result<Node, StepError> {
+        if self.structure && content_between(doc, self.from, self.to) {
+            return Err(StepError::new("structure replace would overwrite content"));
+        }
+        replace_doc(doc, self.from, self.to, &self.slice)
+    }
+
+    fn get_map(&self) -> StepMap {
+        StepMap::new(vec![self.from, self.to - self.from, self.slice.size()])
+    }
+
+    fn invert(&self, doc: &Node) -> Box<dyn Step> {
+        // The forward step's slice now occupies `from .. from + slice.size`; the
+        // inverse puts back what was originally in `from .. to`. The positions are
+        // valid in `doc` by contract (this is the doc the step was applied to).
+        let recovered = doc
+            .slice(self.from, self.to)
+            .expect("invert: original range must be valid in the pre-step document");
+        Box::new(ReplaceStep::new(
+            self.from,
+            self.from + self.slice.size(),
+            recovered,
+        ))
+    }
+
+    fn map(&self, mapping: &Mapping) -> Option<Box<dyn Step>> {
+        let from = mapping.map_result(self.from, 1);
+        let to = mapping.map_result(self.to, -1);
+        if from.deleted_across() && to.deleted_across() {
+            return None;
+        }
+        Some(Box::new(ReplaceStep {
+            from: from.pos,
+            to: from.pos.max(to.pos),
+            slice: self.slice.clone(),
+            structure: self.structure,
+        }))
+    }
+
+    fn merge(&self, other: &dyn Step) -> Option<Box<dyn Step>> {
+        let other = other.as_any().downcast_ref::<ReplaceStep>()?;
+        if other.structure || self.structure {
+            return None;
+        }
+        if self.from + self.slice.size() == other.from
+            && self.slice.open_end == 0
+            && other.slice.open_start == 0
+        {
+            // adjacent inserts (typing) — append the two slices
+            let slice = if self.slice.size() + other.slice.size() == 0 {
+                Slice::empty()
+            } else {
+                Slice::new(
+                    self.slice.content.append(&other.slice.content),
+                    self.slice.open_start,
+                    other.slice.open_end,
+                )
+            };
+            Some(Box::new(ReplaceStep {
+                from: self.from,
+                to: self.to + (other.to - other.from),
+                slice,
+                structure: self.structure,
+            }))
+        } else if other.to == self.from && self.slice.open_start == 0 && other.slice.open_end == 0 {
+            // adjacent deletes
+            let slice = if self.slice.size() + other.slice.size() == 0 {
+                Slice::empty()
+            } else {
+                Slice::new(
+                    other.slice.content.append(&self.slice.content),
+                    other.slice.open_start,
+                    self.slice.open_end,
+                )
+            };
+            Some(Box::new(ReplaceStep {
+                from: other.from,
+                to: self.to,
+                slice,
+                structure: self.structure,
+            }))
+        } else {
+            None
+        }
+    }
+
+    fn clone_box(&self) -> Box<dyn Step> {
+        Box::new(self.clone())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// True if `from..to` spans any real (non-boundary) content — used by structural
+/// replaces to refuse overwriting content. Port of `contentBetween`.
+fn content_between(doc: &Node, from: usize, to: usize) -> bool {
+    let r_from = match doc.resolve(Pos(from)) {
+        Ok(r) => r,
+        Err(_) => return false,
+    };
+    let mut dist = to as isize - from as isize;
+    let mut depth = r_from.depth();
+    while dist > 0 && depth > 0 && r_from.index_after(depth) == r_from.node(depth).child_count() {
+        depth -= 1;
+        dist -= 1;
+    }
+    if dist > 0 {
+        let mut next = r_from
+            .node(depth)
+            .content()
+            .maybe_child(r_from.index_after(depth))
+            .cloned();
+        while dist > 0 {
+            let n = match &next {
+                None => return true,
+                Some(n) => n,
+            };
+            if n.is_leaf() {
+                return true;
+            }
+            next = n.content().maybe_child(0).cloned();
+            dist -= 1;
+        }
+    }
+    false
+}

--- a/crates/rinch-editor-core/src/view.rs
+++ b/crates/rinch-editor-core/src/view.rs
@@ -1,0 +1,128 @@
+//! The view seam — the renderer-agnostic boundary between the pure editor state
+//! and a platform's host tree (design §6).
+//!
+//! "The view is a pure function of state" (non-negotiable principle #3): an
+//! [`EditorView`] projects `EditorState` onto a host (desktop rinch-dom now, web
+//! `contentEditable` later) and is **never read back** for content. The caret is
+//! rendered from `state.selection`; the host is derived from `state.doc`. There is
+//! no DOM-direct mutation path.
+//!
+//! ## Two-phase update (design A3)
+//!
+//! Projection is split to straddle the host's *mutate → layout → measure*
+//! pipeline, the same seam the desktop block-virtualizer already lives on:
+//!
+//! 1. [`update_dom`](EditorView::update_dom) runs **before** layout. It diffs
+//!    `prev.doc` vs `next.doc` and patches the host, and diffs
+//!    `prev.decorations()` vs `next.decorations()` and patches overlay nodes
+//!    **independently of the document diff** (design A4) — so an IME-preedit
+//!    transaction that changes only decorations still produces a visible update.
+//! 2. [`update_caret`](EditorView::update_caret) runs **after** layout, once the
+//!    host has fresh geometry. Caret/selection rectangles and the IME candidate
+//!    box are computed here from `next.selection`. **Caret geometry must never be
+//!    computed in the call that mutates the host**, because the layout it would
+//!    read is stale.
+//!
+//! Each phase returns the [`ViewRequest`]s the runtime must fulfil on the
+//! platform window (scrolling the caret into view now; enabling IME and
+//! positioning the candidate box from M6). The view itself owns no window — only
+//! the runtime does — so these cross back as data.
+//!
+//! Input translation (key/pointer/IME events → commands/transactions) is **not**
+//! on this trait: it is inherently platform-specific (desktop reads Parley
+//! geometry for pointer→`Pos`; web delegates to the browser), so each platform's
+//! runtime glue owns it. The trait covers only the state→host projection.
+
+use crate::state::EditorState;
+
+/// A platform request a view emits for the runtime to fulfil on the window. The
+/// runtime owns the window; the view does not, so these cross back as data from
+/// the two-phase update (design §6). Grows with later milestones: IME
+/// enable/candidate-box positioning (M6) and accessibility refresh (M7b).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ViewRequest {
+    /// Scroll the host so the current selection's caret is visible. Emitted after
+    /// a selection-changing transaction.
+    ScrollSelectionIntoView,
+}
+
+/// Projects [`EditorState`] onto a platform host tree (design §6). Implemented by
+/// the desktop view in the `rinch` crate and the web view in `rinch-web`; nothing
+/// else knows the renderer.
+///
+/// See the [module docs](self) for the two-phase contract. The initial render is
+/// the implementor's responsibility (its constructor builds the host from the
+/// starting state); [`update_dom`](Self::update_dom) handles every subsequent
+/// transaction.
+pub trait EditorView {
+    /// Phase 1 — **before** layout. Diff `prev` vs `next` (document and
+    /// decorations) and patch the host accordingly. Returns the platform requests
+    /// to fulfil before measuring (e.g. IME enable, from M6).
+    fn update_dom(&mut self, prev: &EditorState, next: &EditorState) -> Vec<ViewRequest>;
+
+    /// Phase 2 — **after** layout. Render caret/selection geometry from
+    /// `next.selection` using the host's now-fresh layout, and return the
+    /// geometry-dependent platform requests (scroll into view; the IME candidate
+    /// box, from M6).
+    fn update_caret(&mut self, next: &EditorState) -> Vec<ViewRequest>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Schema, default_plugins};
+    use std::rc::Rc;
+
+    /// A no-op view that records how many times each phase ran and echoes a
+    /// request — enough to exercise the seam in the pure core (the real
+    /// projection lives in the platform crates).
+    #[derive(Default)]
+    struct RecordingView {
+        dom_updates: usize,
+        caret_updates: usize,
+    }
+
+    impl EditorView for RecordingView {
+        fn update_dom(&mut self, _prev: &EditorState, _next: &EditorState) -> Vec<ViewRequest> {
+            self.dom_updates += 1;
+            Vec::new()
+        }
+
+        fn update_caret(&mut self, _next: &EditorState) -> Vec<ViewRequest> {
+            self.caret_updates += 1;
+            vec![ViewRequest::ScrollSelectionIntoView]
+        }
+    }
+
+    fn empty_state() -> EditorState {
+        let schema = Rc::new(Schema::starter_kit());
+        let doc = schema
+            .branch(
+                "doc",
+                crate::model::Fragment::from_node(
+                    schema
+                        .branch("paragraph", crate::model::Fragment::empty())
+                        .unwrap(),
+                ),
+            )
+            .unwrap();
+        EditorState::create(schema, doc, default_plugins())
+    }
+
+    #[test]
+    fn two_phase_update_runs_both_phases() {
+        let mut view = RecordingView::default();
+        let prev = empty_state();
+        let mut tr = prev.tr();
+        tr.insert_text("hi").unwrap();
+        let next = prev.apply(tr);
+
+        let dom_reqs = view.update_dom(&prev, &next);
+        let caret_reqs = view.update_caret(&next);
+
+        assert_eq!(view.dom_updates, 1);
+        assert_eq!(view.caret_updates, 1);
+        assert!(dom_reqs.is_empty());
+        assert_eq!(caret_reqs, vec![ViewRequest::ScrollSelectionIntoView]);
+    }
+}

--- a/crates/rinch-editor-core/tests/gestures.rs
+++ b/crates/rinch-editor-core/tests/gestures.rs
@@ -1,0 +1,393 @@
+//! One test per row of the design's "editing gesture → steps" table, driven
+//! through the [`Transform`] builder (the public gesture API M4 commands compose).
+
+use rinch_editor_core::*;
+
+fn sk() -> Schema {
+    Schema::starter_kit()
+}
+
+fn para(s: &Schema, text: &str) -> Node {
+    s.branch("paragraph", Fragment::from_node(s.text(text).unwrap()))
+        .unwrap()
+}
+
+fn doc(s: &Schema, blocks: Vec<Node>) -> Node {
+    s.branch("doc", Fragment::from_children(blocks)).unwrap()
+}
+
+fn all_text(node: &Node) -> String {
+    if let Some(t) = node.text() {
+        return t.to_string();
+    }
+    node.content().iter().map(all_text).collect()
+}
+
+fn bold(s: &Schema) -> Mark {
+    Mark::simple(s.mark_type("bold").unwrap().clone())
+}
+
+/// Invert every step of `tr` (in reverse, against its pre-step snapshots) and
+/// confirm we land back on `original` — the whole-transform undo invariant.
+fn assert_undo(tr: &Transform, original: &Node) {
+    let mut d = tr.doc.clone();
+    for i in (0..tr.steps().len()).rev() {
+        let pre = &tr.docs()[i];
+        let inv = tr.steps()[i].invert(pre);
+        d = inv.apply(&d).unwrap();
+    }
+    assert_eq!(
+        &d, original,
+        "inverting the whole transform must restore the doc"
+    );
+}
+
+// --- type a character ------------------------------------------------------
+
+#[test]
+fn type_a_character() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "ab")]);
+    let mut tr = Transform::new(&s, d.clone());
+    tr.insert_text(2, 2, "X").unwrap();
+    assert_eq!(all_text(&tr.doc), "aXb");
+    assert!(tr.doc_changed());
+    assert_undo(&tr, &d);
+}
+
+// --- backspace mid-text ----------------------------------------------------
+
+#[test]
+fn backspace_mid_text() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "abc")]);
+    let mut tr = Transform::new(&s, d.clone());
+    tr.delete(2, 3).unwrap(); // remove 'b'
+    assert_eq!(all_text(&tr.doc), "ac");
+    assert_undo(&tr, &d);
+}
+
+// --- backspace at block start (join) ---------------------------------------
+
+#[test]
+fn backspace_at_block_start_joins() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "ab"), para(&s, "cd")]);
+    let mut tr = Transform::new(&s, d.clone());
+    tr.delete(3, 5).unwrap(); // join the two paragraphs
+    assert_eq!(tr.doc.child_count(), 1);
+    assert_eq!(all_text(&tr.doc), "abcd");
+    assert_undo(&tr, &d);
+}
+
+// --- delete forward --------------------------------------------------------
+
+#[test]
+fn delete_forward() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "abc")]);
+    let mut tr = Transform::new(&s, d.clone());
+    tr.delete(1, 2).unwrap(); // delete 'a'
+    assert_eq!(all_text(&tr.doc), "bc");
+}
+
+// --- enter / split block ---------------------------------------------------
+
+#[test]
+fn enter_splits_block() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "ab")]);
+    let mut tr = Transform::new(&s, d.clone());
+    tr.split(2, 1, None).unwrap(); // split between a and b
+    assert_eq!(tr.doc.child_count(), 2);
+    assert_eq!(all_text(tr.doc.child(0)), "a");
+    assert_eq!(all_text(tr.doc.child(1)), "b");
+    assert_undo(&tr, &d);
+}
+
+#[test]
+fn enter_at_end_of_heading_makes_paragraph() {
+    let s = sk();
+    let h = s
+        .branch("heading", Fragment::from_node(s.text("Title").unwrap()))
+        .unwrap();
+    let d = doc(&s, vec![h]);
+    let mut tr = Transform::new(&s, d.clone());
+    // split at end of heading content (pos 6 = after "Title"), new block = paragraph
+    let para_ty = s.node_type("paragraph").unwrap().clone();
+    tr.split(6, 1, Some(vec![Some((para_ty, Attrs::new()))]))
+        .unwrap();
+    assert_eq!(tr.doc.child(0).type_name(), "heading");
+    assert_eq!(tr.doc.child(1).type_name(), "paragraph");
+    assert_undo(&tr, &d);
+}
+
+// --- shift+enter / hard break ----------------------------------------------
+
+#[test]
+fn shift_enter_inserts_hard_break() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "ab")]);
+    let hb = s.branch("hard_break", Fragment::empty()).unwrap();
+    let mut tr = Transform::new(&s, d.clone());
+    tr.replace_with(2, 2, Fragment::from_node(hb)).unwrap();
+    // paragraph now: text "a", hard_break, text "b"
+    assert_eq!(tr.doc.child(0).child_count(), 3);
+    assert_eq!(tr.doc.child(0).child(1).type_name(), "hard_break");
+    assert_undo(&tr, &d);
+}
+
+// --- toggle bold over a range ----------------------------------------------
+
+#[test]
+fn toggle_bold_over_range() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "abcd")]);
+    let mut tr = Transform::new(&s, d.clone());
+    tr.add_mark(2, 4, bold(&s)).unwrap(); // bold "bc"
+    let has_bold = tr
+        .doc
+        .child(0)
+        .content()
+        .iter()
+        .any(|n| n.text() == Some("bc") && !n.marks().is_empty());
+    assert!(has_bold);
+    assert_undo(&tr, &d);
+}
+
+#[test]
+fn remove_bold_over_range() {
+    let s = sk();
+    let bolded = s
+        .branch(
+            "paragraph",
+            Fragment::from_node(s.text_with_marks("abcd", vec![bold(&s)]).unwrap()),
+        )
+        .unwrap();
+    let d = doc(&s, vec![bolded]);
+    let mut tr = Transform::new(&s, d.clone());
+    tr.remove_mark(2, 4, bold(&s)).unwrap();
+    // the middle run "bc" loses bold
+    assert_eq!(all_text(&tr.doc), "abcd");
+    assert_undo(&tr, &d);
+}
+
+// --- set heading level (attr) ----------------------------------------------
+
+#[test]
+fn set_heading_level() {
+    let s = sk();
+    let h = s
+        .branch("heading", Fragment::from_node(s.text("T").unwrap()))
+        .unwrap();
+    let d = doc(&s, vec![h]);
+    let mut tr = Transform::new(&s, d.clone());
+    tr.set_node_attr(0, "level", AttrValue::Int(3)).unwrap();
+    assert_eq!(tr.doc.child(0).attrs().get_int("level"), Some(3));
+    assert_undo(&tr, &d);
+}
+
+// --- paragraph -> heading (set block type) ---------------------------------
+
+#[test]
+fn paragraph_to_heading() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "ab")]);
+    let heading_ty = s.node_type("heading").unwrap().clone();
+    let attrs = Attrs::from_iter([("level", AttrValue::Int(2))]);
+    let mut tr = Transform::new(&s, d.clone());
+    tr.set_block_type(0, 4, heading_ty, attrs).unwrap();
+    assert_eq!(tr.doc.child(0).type_name(), "heading");
+    assert_eq!(tr.doc.child(0).attrs().get_int("level"), Some(2));
+    assert_eq!(all_text(&tr.doc), "ab");
+    assert_undo(&tr, &d);
+}
+
+// --- wrap in blockquote ----------------------------------------------------
+
+#[test]
+fn wrap_in_blockquote() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "ab")]);
+    let r_from = d.resolve(Pos(1)).unwrap();
+    let r_to = d.resolve(Pos(3)).unwrap();
+    let range = block_range_simple(&r_from, &r_to).unwrap();
+    let bq = s.node_type("blockquote").unwrap().clone();
+    let mut tr = Transform::new(&s, d.clone());
+    tr.wrap(&range, &[(bq, Attrs::new())]).unwrap();
+    assert_eq!(tr.doc.child(0).type_name(), "blockquote");
+    assert_eq!(tr.doc.child(0).child(0).type_name(), "paragraph");
+    assert_undo(&tr, &d);
+}
+
+// --- toggle bullet list (wrap into list_item + list) -----------------------
+
+#[test]
+fn wrap_in_bullet_list() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "ab")]);
+    let r_from = d.resolve(Pos(1)).unwrap();
+    let r_to = d.resolve(Pos(3)).unwrap();
+    let range = block_range_simple(&r_from, &r_to).unwrap();
+    let list = s.node_type("bullet_list").unwrap().clone();
+    let item = s.node_type("list_item").unwrap().clone();
+    let mut tr = Transform::new(&s, d.clone());
+    tr.wrap(&range, &[(list, Attrs::new()), (item, Attrs::new())])
+        .unwrap();
+    assert_eq!(tr.doc.child(0).type_name(), "bullet_list");
+    assert_eq!(tr.doc.child(0).child(0).type_name(), "list_item");
+    assert_eq!(tr.doc.child(0).child(0).child(0).type_name(), "paragraph");
+    assert_undo(&tr, &d);
+}
+
+// --- outdent (lift out of blockquote) --------------------------------------
+
+#[test]
+fn lift_paragraph_out_of_blockquote() {
+    let s = sk();
+    let inner = para(&s, "x");
+    let bq = s.branch("blockquote", Fragment::from_node(inner)).unwrap();
+    let d = doc(&s, vec![bq]);
+    // resolve inside the paragraph (pos 2), range over it within the blockquote
+    let r = d.resolve(Pos(2)).unwrap();
+    let range = block_range_simple(&r, &r).unwrap();
+    assert_eq!(range.depth, 1); // parent = blockquote
+    let mut tr = Transform::new(&s, d.clone());
+    tr.lift(&range, 0).unwrap(); // lift to doc level
+    assert_eq!(tr.doc.child(0).type_name(), "paragraph");
+    assert_eq!(all_text(&tr.doc), "x");
+    assert_undo(&tr, &d);
+}
+
+// --- insert hr -------------------------------------------------------------
+
+#[test]
+fn insert_horizontal_rule() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "ab")]);
+    let hr = s.branch("horizontal_rule", Fragment::empty()).unwrap();
+    let mut tr = Transform::new(&s, d.clone());
+    // insert between the two paragraphs-to-be: at the doc-level gap after the paragraph (pos 4)
+    tr.replace_with(4, 4, Fragment::from_node(hr)).unwrap();
+    assert_eq!(tr.doc.child_count(), 2);
+    assert_eq!(tr.doc.child(1).type_name(), "horizontal_rule");
+    assert_undo(&tr, &d);
+}
+
+// --- insert link (add link mark) -------------------------------------------
+
+#[test]
+fn insert_link_mark() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "abcd")]);
+    let link = Mark::new(
+        s.mark_type("link").unwrap().clone(),
+        Attrs::from_iter([("href", AttrValue::from("https://x.test"))]),
+    );
+    let mut tr = Transform::new(&s, d.clone());
+    tr.add_mark(2, 4, link).unwrap();
+    let linked = tr.doc.child(0).content().iter().any(|n| {
+        n.text() == Some("bc")
+            && n.marks().iter().any(|m| {
+                m.type_name() == "link" && m.attrs.get_str("href") == Some("https://x.test")
+            })
+    });
+    assert!(
+        linked,
+        "expected a linked 'bc' run, got {:?}",
+        tr.doc.child(0)
+    );
+    assert_undo(&tr, &d);
+}
+
+// --- insert image (inline atom) --------------------------------------------
+
+#[test]
+fn insert_image() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "ab")]);
+    let img = s
+        .create_node(
+            "image",
+            Attrs::from_iter([("src", AttrValue::from("a.png"))]),
+            Fragment::empty(),
+        )
+        .unwrap();
+    let mut tr = Transform::new(&s, d.clone());
+    tr.replace_with(2, 2, Fragment::from_node(img)).unwrap();
+    assert_eq!(tr.doc.child(0).child_count(), 3);
+    assert_eq!(tr.doc.child(0).child(1).type_name(), "image");
+    assert_undo(&tr, &d);
+}
+
+// --- paste (open slice) ----------------------------------------------------
+
+#[test]
+fn paste_open_slice() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "ab")]);
+    let slice = Slice::new(
+        Fragment::from_children(vec![para(&s, "X"), para(&s, "Y")]),
+        1,
+        1,
+    );
+    let mut tr = Transform::new(&s, d.clone());
+    tr.replace(2, 2, slice).unwrap();
+    assert_eq!(tr.doc.child_count(), 2);
+    assert_eq!(all_text(tr.doc.child(0)), "aX");
+    assert_eq!(all_text(tr.doc.child(1)), "Yb");
+    assert_undo(&tr, &d);
+}
+
+// --- regression: split depth must not underflow (verification must-fix 1) ---
+
+#[test]
+fn split_depth_beyond_position_errors_not_panics() {
+    let s = sk();
+    // pos 4 is the top-level gap between the two paragraphs (resolves to depth 0).
+    let d = doc(&s, vec![para(&s, "ab"), para(&s, "cd")]);
+    let mut tr = Transform::new(&s, d.clone());
+    assert!(tr.split(4, 1, None).is_err());
+    // depth 2 at a depth-1 position.
+    let d2 = doc(&s, vec![para(&s, "ab")]);
+    let mut tr2 = Transform::new(&s, d2);
+    assert!(tr2.split(2, 2, None).is_err());
+}
+
+// --- regression: degenerate block range must not panic (must-fix 2) ---------
+
+#[test]
+fn degenerate_cross_boundary_range_does_not_panic() {
+    let s = sk();
+    // doc(blockquote(paragraph "ab"), paragraph "cd")
+    let bq = s
+        .branch("blockquote", Fragment::from_node(para(&s, "ab")))
+        .unwrap();
+    let d = doc(&s, vec![bq, para(&s, "cd")]);
+    let r_from = d.resolve(Pos(2)).unwrap(); // inside blockquote>paragraph (depth 2)
+    let r_to = d.resolve(Pos(6)).unwrap(); // the doc-level gap after the blockquote (depth 0)
+    let range = block_range_simple(&r_from, &r_to).unwrap();
+    // start()/end() must be total (no out-of-bounds path index)
+    let _ = range.start();
+    let _ = range.end();
+    // wrap/lift over the degenerate range must return a Result, not panic
+    let bqty = s.node_type("blockquote").unwrap().clone();
+    let mut tr = Transform::new(&s, d.clone());
+    let _ = tr.wrap(&range, &[(bqty, Attrs::new())]);
+}
+
+// --- mapping accumulates across steps --------------------------------------
+
+#[test]
+fn mapping_tracks_position_through_multiple_inserts() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "ab")]);
+    let mut tr = Transform::new(&s, d.clone());
+    // a position at the end of "ab" (pos 3) tracked through two leading inserts
+    tr.insert_text(1, 1, "XX").unwrap(); // "XXab"
+    tr.insert_text(1, 1, "Y").unwrap(); // "YXXab"
+    let mapped = tr.mapping().map(3, 1);
+    // original pos 3 ("ab|") shifted by +2 then +1 = +3 -> 6
+    assert_eq!(mapped, 6);
+    assert_eq!(all_text(&tr.doc), "YXXab");
+}

--- a/crates/rinch-editor-core/tests/serialize.rs
+++ b/crates/rinch-editor-core/tests/serialize.rs
@@ -1,0 +1,424 @@
+//! End-to-end serialization round-trip tests (M3) — the acceptance fixtures for
+//! the structural #59 fix.
+//!
+//! These port the spirit of the old `rinch-editor` `from_block_data` round-trip
+//! suite (`serialization.rs`, `roundtrip_tests.rs`) to the new total, schema-driven
+//! pipeline, exercising the durable `DocNode`/JSON wire shape, HTML, and markdown
+//! through the **public** API only. The recurring assertion is that content
+//! survives the full persistence cycle with no mark, node, or attribute dropped.
+//!
+//! Gated on `serde` + `markdown` so `cargo test` with no features still builds an
+//! empty (passing) test binary.
+#![cfg(all(feature = "serde", feature = "markdown"))]
+
+use rinch_editor_core::serialize::{
+    DocMark, DocNode, JsonAttr, doc_from_markdown, doc_to_markdown, node_to_html, slice_from_html,
+};
+use rinch_editor_core::{Node, Schema};
+use std::collections::BTreeMap;
+
+// ─── DocNode fixture builders (the wire shape's fields are public) ────────────
+
+fn attr_map(pairs: &[(&str, JsonAttr)]) -> BTreeMap<String, JsonAttr> {
+    pairs
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.clone()))
+        .collect()
+}
+
+fn node(ty: &str, attrs: BTreeMap<String, JsonAttr>, content: Vec<DocNode>) -> DocNode {
+    DocNode {
+        node_type: ty.to_string(),
+        attrs,
+        content,
+        text: None,
+        marks: Vec::new(),
+    }
+}
+
+fn text(s: &str, marks: Vec<DocMark>) -> DocNode {
+    DocNode {
+        node_type: "text".to_string(),
+        attrs: BTreeMap::new(),
+        content: Vec::new(),
+        text: Some(s.to_string()),
+        marks,
+    }
+}
+
+fn mark(ty: &str) -> DocMark {
+    DocMark {
+        mark_type: ty.to_string(),
+        attrs: BTreeMap::new(),
+    }
+}
+
+fn mark_attr(ty: &str, pairs: &[(&str, JsonAttr)]) -> DocMark {
+    DocMark {
+        mark_type: ty.to_string(),
+        attrs: attr_map(pairs),
+    }
+}
+
+fn para(content: Vec<DocNode>) -> DocNode {
+    node("paragraph", BTreeMap::new(), content)
+}
+
+fn doc(blocks: Vec<DocNode>) -> DocNode {
+    node("doc", BTreeMap::new(), blocks)
+}
+
+/// Round-trip a fixture through the model and through a JSON string, asserting the
+/// model value and the wire value are both stable (lossless). Returns the model.
+fn assert_stable(schema: &Schema, fixture: &DocNode) -> Node {
+    let model = schema.node_from_doc(fixture).expect("deserialize fixture");
+    let wire1 = model.to_doc().expect("serialize model");
+    let json = serde_json::to_string(&wire1).expect("to json");
+    let wire2: DocNode = serde_json::from_str(&json).expect("from json");
+    assert_eq!(
+        wire1, wire2,
+        "wire shape not stable across a JSON round-trip"
+    );
+    let model2 = schema.node_from_doc(&wire2).expect("re-deserialize");
+    assert_eq!(model, model2, "model not stable across a JSON round-trip");
+    model
+}
+
+fn mark_names(text_node: &Node) -> Vec<String> {
+    text_node
+        .marks()
+        .iter()
+        .map(|m| m.type_name().to_string())
+        .collect()
+}
+
+// ─── Mark preservation (the #59 class) ───────────────────────────────────────
+
+#[test]
+fn single_bold_run_survives() {
+    let s = Schema::starter_kit();
+    let fixture = doc(vec![para(vec![text("bold text", vec![mark("bold")])])]);
+    let model = assert_stable(&s, &fixture);
+    let run = model.child(0).child(0);
+    assert_eq!(run.text(), Some("bold text"));
+    assert_eq!(mark_names(run), vec!["bold"]);
+}
+
+#[test]
+fn plain_bold_italic_plain_sequence_survives() {
+    let s = Schema::starter_kit();
+    let fixture = doc(vec![para(vec![
+        text("start ", vec![]),
+        text("bold", vec![mark("bold")]),
+        text(" middle ", vec![]),
+        text("italic", vec![mark("italic")]),
+        text(" end", vec![]),
+    ])]);
+    let model = assert_stable(&s, &fixture);
+    let para = model.child(0);
+    assert_eq!(para.child_count(), 5);
+    assert_eq!(mark_names(para.child(1)), vec!["bold"]);
+    assert_eq!(mark_names(para.child(3)), vec!["italic"]);
+}
+
+#[test]
+fn nested_marks_survive() {
+    let s = Schema::starter_kit();
+    let fixture = doc(vec![para(vec![text(
+        "bold+italic",
+        vec![mark("bold"), mark("italic")],
+    )])]);
+    let model = assert_stable(&s, &fixture);
+    let names = mark_names(model.child(0).child(0));
+    assert!(names.contains(&"bold".to_string()), "{names:?}");
+    assert!(names.contains(&"italic".to_string()), "{names:?}");
+}
+
+#[test]
+fn all_simple_mark_types_survive() {
+    let s = Schema::starter_kit();
+    let fixture = doc(vec![para(vec![
+        text("b", vec![mark("bold")]),
+        text("i", vec![mark("italic")]),
+        text("u", vec![mark("underline")]),
+        text("s", vec![mark("strike")]),
+        text("c", vec![mark("code")]),
+        text("sub", vec![mark("subscript")]),
+        text("sup", vec![mark("superscript")]),
+    ])]);
+    let model = assert_stable(&s, &fixture);
+    let para = model.child(0);
+    for (i, expected) in [
+        "bold",
+        "italic",
+        "underline",
+        "strike",
+        "code",
+        "subscript",
+        "superscript",
+    ]
+    .iter()
+    .enumerate()
+    {
+        assert_eq!(mark_names(para.child(i)), vec![expected.to_string()]);
+    }
+}
+
+#[test]
+fn marks_with_attrs_survive() {
+    let s = Schema::starter_kit();
+    let fixture = doc(vec![para(vec![
+        text(
+            "link",
+            vec![mark_attr(
+                "link",
+                &[("href", JsonAttr::Str("https://example.com".into()))],
+            )],
+        ),
+        text(
+            "hi",
+            vec![mark_attr(
+                "highlight",
+                &[("color", JsonAttr::Str("yellow".into()))],
+            )],
+        ),
+        text(
+            "red",
+            vec![mark_attr(
+                "text_color",
+                &[("color", JsonAttr::Str("#f00".into()))],
+            )],
+        ),
+    ])]);
+    let model = assert_stable(&s, &fixture);
+    let para = model.child(0);
+    assert_eq!(
+        para.child(0).marks()[0].attrs.get_str("href"),
+        Some("https://example.com")
+    );
+    assert_eq!(
+        para.child(1).marks()[0].attrs.get_str("color"),
+        Some("yellow")
+    );
+    assert_eq!(
+        para.child(2).marks()[0].attrs.get_str("color"),
+        Some("#f00")
+    );
+}
+
+// ─── Block types & nesting ───────────────────────────────────────────────────
+
+#[test]
+fn mixed_and_nested_block_types_survive() {
+    let s = Schema::starter_kit();
+    let fixture = doc(vec![
+        node(
+            "heading",
+            attr_map(&[("level", JsonAttr::Int(1))]),
+            vec![text("Title", vec![])],
+        ),
+        para(vec![text("Intro.", vec![])]),
+        node(
+            "blockquote",
+            BTreeMap::new(),
+            vec![para(vec![text("Quote.", vec![])])],
+        ),
+        node(
+            "bullet_list",
+            BTreeMap::new(),
+            vec![
+                node(
+                    "list_item",
+                    BTreeMap::new(),
+                    vec![para(vec![text("Item A", vec![])])],
+                ),
+                node(
+                    "list_item",
+                    BTreeMap::new(),
+                    vec![para(vec![text("Item B", vec![])])],
+                ),
+            ],
+        ),
+        node(
+            "ordered_list",
+            attr_map(&[("start", JsonAttr::Int(1))]),
+            vec![node(
+                "list_item",
+                BTreeMap::new(),
+                vec![para(vec![text("First", vec![])])],
+            )],
+        ),
+        node(
+            "code_block",
+            attr_map(&[("language", JsonAttr::Str("rust".into()))]),
+            vec![text("fn main() {}", vec![])],
+        ),
+        node("horizontal_rule", BTreeMap::new(), vec![]),
+    ]);
+    let model = assert_stable(&s, &fixture);
+    let kinds: Vec<&str> = model
+        .content()
+        .children()
+        .iter()
+        .map(Node::type_name)
+        .collect();
+    assert_eq!(
+        kinds,
+        [
+            "heading",
+            "paragraph",
+            "blockquote",
+            "bullet_list",
+            "ordered_list",
+            "code_block",
+            "horizontal_rule",
+        ]
+    );
+    // nested list_item > paragraph survives
+    let list = model.child(3);
+    assert_eq!(list.child(0).type_name(), "list_item");
+    assert_eq!(list.child(0).child(0).type_name(), "paragraph");
+}
+
+#[test]
+fn atoms_image_and_hard_break_survive() {
+    let s = Schema::starter_kit();
+    let mut img_attrs = attr_map(&[
+        ("src", JsonAttr::Str("a.png".into())),
+        ("alt", JsonAttr::Str("logo".into())),
+    ]);
+    img_attrs.insert("title".into(), JsonAttr::Str(String::new()));
+    let fixture = doc(vec![para(vec![
+        text("before", vec![]),
+        node("image", img_attrs, vec![]),
+        node("hard_break", BTreeMap::new(), vec![]),
+        text("after", vec![]),
+    ])]);
+    let model = assert_stable(&s, &fixture);
+    let para = model.child(0);
+    assert_eq!(para.child(1).type_name(), "image");
+    assert_eq!(para.child(1).attrs().get_str("src"), Some("a.png"));
+    assert_eq!(para.child(2).type_name(), "hard_break");
+}
+
+// ─── Unicode ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn unicode_survives_round_trip() {
+    let s = Schema::starter_kit();
+    let fixture = doc(vec![
+        para(vec![text("Hello 🌍 world 🎉!", vec![])]),
+        para(vec![text("café résumé naïve", vec![])]),
+        para(vec![text("你好世界", vec![])]),
+        para(vec![
+            text("café ", vec![]),
+            text("résumé", vec![mark("bold")]),
+            text(" 🎉", vec![]),
+        ]),
+    ]);
+    let model = assert_stable(&s, &fixture);
+    assert_eq!(model.child(0).child(0).text(), Some("Hello 🌍 world 🎉!"));
+    assert_eq!(model.child(2).child(0).text(), Some("你好世界"));
+}
+
+// ─── Totality: unknown types / missing required are hard errors ───────────────
+
+#[test]
+fn unknown_node_type_rejected() {
+    let s = Schema::starter_kit();
+    let fixture = doc(vec![node("blink", BTreeMap::new(), vec![])]);
+    assert!(s.node_from_doc(&fixture).is_err());
+}
+
+#[test]
+fn missing_required_image_src_rejected() {
+    let s = Schema::starter_kit();
+    let fixture = doc(vec![para(vec![node("image", BTreeMap::new(), vec![])])]);
+    assert!(s.node_from_doc(&fixture).is_err());
+}
+
+#[test]
+fn special_html_characters_in_text_are_escaped_then_recovered() {
+    let s = Schema::starter_kit();
+    let raw = r#"Angle <brackets>, "quotes", & ampersands"#;
+    let fixture = doc(vec![para(vec![text(raw, vec![])])]);
+    let model = schema_doc(&s, &fixture);
+    // Through HTML the special characters must survive (escaped, then decoded).
+    let html = node_to_html(&model);
+    assert!(html.contains("&lt;brackets&gt;"), "{html}");
+    assert!(html.contains("&amp; ampersands"), "{html}");
+    let slice = slice_from_html(&s, &html).unwrap();
+    assert_eq!(slice.content.child(0).child(0).text(), Some(raw));
+}
+
+fn schema_doc(s: &Schema, fixture: &DocNode) -> Node {
+    s.node_from_doc(fixture).unwrap()
+}
+
+// ─── Cross-format: HTML and markdown on a realistic doc ───────────────────────
+
+#[test]
+fn html_round_trip_for_representable_doc() {
+    let s = Schema::starter_kit();
+    let fixture = doc(vec![
+        node(
+            "heading",
+            attr_map(&[("level", JsonAttr::Int(2))]),
+            vec![text("Title", vec![])],
+        ),
+        para(vec![
+            text("a ", vec![]),
+            text("bold", vec![mark("bold")]),
+            text(" and ", vec![]),
+            text("italic", vec![mark("italic")]),
+        ]),
+        node(
+            "bullet_list",
+            BTreeMap::new(),
+            vec![
+                node(
+                    "list_item",
+                    BTreeMap::new(),
+                    vec![para(vec![text("one", vec![])])],
+                ),
+                node(
+                    "list_item",
+                    BTreeMap::new(),
+                    vec![para(vec![text("two", vec![])])],
+                ),
+            ],
+        ),
+    ]);
+    let model = schema_doc(&s, &fixture);
+    let html = node_to_html(&model);
+    let slice = slice_from_html(&s, &html).unwrap();
+    // Structural survival: same block kinds, marks preserved.
+    let blocks = &slice.content;
+    let kinds: Vec<&str> = blocks.children().iter().map(Node::type_name).collect();
+    assert_eq!(kinds, ["heading", "paragraph", "bullet_list"]);
+    let names: Vec<Vec<String>> = blocks
+        .child(1)
+        .content()
+        .children()
+        .iter()
+        .map(mark_names)
+        .collect();
+    assert!(names.iter().any(|m| m == &vec!["bold".to_string()]));
+    assert!(names.iter().any(|m| m == &vec!["italic".to_string()]));
+}
+
+#[test]
+fn markdown_round_trip_for_representable_doc() {
+    let s = Schema::starter_kit();
+    let md = "# Heading\n\nThis is **bold** and *italic* and a [link](https://x.io).\n\n- one\n- two\n\n> a quote";
+    let model = doc_from_markdown(&s, md).unwrap();
+    let out = doc_to_markdown(&model);
+    assert!(out.contains("# Heading"), "{out}");
+    assert!(out.contains("**bold**"), "{out}");
+    assert!(out.contains("*italic*"), "{out}");
+    assert!(out.contains("[link](https://x.io)"), "{out}");
+    assert!(out.contains("- one"), "{out}");
+    assert!(out.contains("> a quote"), "{out}");
+    // and the model is a valid DocNode (lossless to JSON)
+    assert_stable(&s, &model.to_doc().unwrap());
+}

--- a/crates/rinch-editor-core/tests/state.rs
+++ b/crates/rinch-editor-core/tests/state.rs
@@ -1,0 +1,194 @@
+//! M4 acceptance tests, driven through the **public** state API (no view) — the
+//! design's M4 test list: type → bold a range → undo → redo; stored-marks "cursor
+//! bold then type"; typing coalesces into one undo group; markdown input rules;
+//! toolbar queries read state.
+
+use rinch_editor_core::commands::{current_block_type, in_node_type, is_mark_active};
+use rinch_editor_core::*;
+use std::rc::Rc;
+
+fn editor(text: &str) -> EditorState {
+    let schema = Rc::new(Schema::starter_kit());
+    let para = schema
+        .branch("paragraph", Fragment::from_node(schema.text(text).unwrap()))
+        .unwrap();
+    let doc = schema.branch("doc", Fragment::from_node(para)).unwrap();
+    EditorState::create(schema, doc, default_plugins())
+}
+
+fn empty_editor() -> EditorState {
+    let schema = Rc::new(Schema::starter_kit());
+    let para = schema.branch("paragraph", Fragment::empty()).unwrap();
+    let doc = schema.branch("doc", Fragment::from_node(para)).unwrap();
+    EditorState::create(schema, doc, default_plugins())
+}
+
+fn all_text(node: &Node) -> String {
+    if let Some(t) = node.text() {
+        return t.to_string();
+    }
+    node.content().iter().map(all_text).collect()
+}
+
+/// Type text at the current selection (the view's printable-key path).
+fn type_text(state: &EditorState, text: &str) -> EditorState {
+    let mut tr = state.tr();
+    tr.insert_text(text).unwrap();
+    state.apply(tr)
+}
+
+#[test]
+fn type_bold_undo_redo_end_to_end() {
+    // type "hi", bold it, undo (removes bold), undo (removes typing), redo, redo
+    let mut state = empty_editor();
+    state.selection = Selection::cursor(Pos(1));
+    state = type_text(&state, "h");
+    state = type_text(&state, "i");
+    assert_eq!(all_text(&state.doc), "hi");
+
+    // select the whole word and bold it
+    state.selection = Selection::text(Pos(1), Pos(3));
+    state = state.run("toggleBold").expect("bold applies");
+    let bold = state.schema().mark_type("bold").unwrap().clone();
+    assert!(is_mark_active(&state, &bold));
+
+    // undo bold (its own group) → text remains, no bold
+    state = state.run("undo").expect("undo bold");
+    assert_eq!(all_text(&state.doc), "hi");
+    assert!(!is_mark_active(&state, &bold));
+
+    // undo typing (coalesced into one group) → empty
+    state = state.run("undo").expect("undo typing");
+    assert_eq!(all_text(&state.doc), "");
+
+    // redo typing, redo bold
+    state = state.run("redo").expect("redo typing");
+    assert_eq!(all_text(&state.doc), "hi");
+    state = state.run("redo").expect("redo bold");
+    assert!(is_mark_active(&state, &bold));
+}
+
+#[test]
+fn stored_marks_cursor_bold_then_type() {
+    // audit S2: bold with a collapsed cursor, then type → the typed text is bold
+    let mut state = editor("ab");
+    state.selection = Selection::cursor(Pos(3)); // end of "ab"
+    state = state.run("toggleBold").expect("toggleBold (cursor)");
+    let bold = state.schema().mark_type("bold").unwrap().clone();
+    assert!(
+        is_mark_active(&state, &bold),
+        "stored bold is active at the cursor"
+    );
+
+    state = type_text(&state, "C");
+    let c_is_bold = state
+        .doc
+        .child(0)
+        .content()
+        .iter()
+        .any(|n| n.text() == Some("C") && n.marks().iter().any(|m| m.type_name() == "bold"));
+    assert!(c_is_bold, "typed text after cursor-bold is bold");
+    // ...and continuing to type stays bold (inherited from the bold run)
+    state = type_text(&state, "D");
+    let d_is_bold = state
+        .doc
+        .child(0)
+        .content()
+        .iter()
+        .any(|n| n.text() == Some("CD") && n.marks().iter().any(|m| m.type_name() == "bold"));
+    assert!(d_is_bold);
+}
+
+#[test]
+fn typing_is_one_undo_group_via_keymap() {
+    // resolve the keymap binding for Mod-z to confirm the keymap aggregates plugins
+    let state = empty_editor();
+    let undo_binding = KeyBinding::parse("Mod-z").unwrap();
+    assert_eq!(state.keymap().command_for(&undo_binding), Some("undo"));
+    let bold_binding = KeyBinding::parse("Mod-b").unwrap();
+    assert_eq!(
+        state.keymap().command_for(&bold_binding),
+        Some("toggleBold")
+    );
+}
+
+#[test]
+fn markdown_heading_input_rule_via_public_api() {
+    // type "##" then a space → the input rule turns the block into an <h2>
+    let mut state = empty_editor();
+    state.selection = Selection::cursor(Pos(1));
+    state = type_text(&state, "#");
+    state = type_text(&state, "#");
+    assert_eq!(all_text(&state.doc), "##");
+
+    // the view runs input rules before the plain insert of " "
+    let pos = state.selection.from().0;
+    let tr =
+        apply_input_rules(&state, state.input_rules(), pos, " ").expect("heading input rule fires");
+    state = state.apply(tr);
+    assert_eq!(state.doc.child(0).type_name(), "heading");
+    assert_eq!(state.doc.child(0).attrs().get_int("level"), Some(2));
+
+    // undo the rule → back to a paragraph with "##"
+    state = state.run("undo").expect("undo the input rule");
+    assert_eq!(state.doc.child(0).type_name(), "paragraph");
+    assert_eq!(all_text(&state.doc), "##");
+}
+
+#[test]
+fn bullet_list_input_rule_and_block_queries() {
+    let mut state = empty_editor();
+    state.selection = Selection::cursor(Pos(1));
+    state = type_text(&state, "-");
+    let pos = state.selection.from().0;
+    let tr = apply_input_rules(&state, state.input_rules(), pos, " ").expect("bullet rule fires");
+    state = state.apply(tr);
+    assert!(in_node_type(&state, "bullet_list"));
+    // the inner textblock is still a paragraph (A6: List button needs in_node_type)
+    assert_eq!(
+        current_block_type(&state).map(|t| t.name().to_string()),
+        Some("paragraph".to_string())
+    );
+}
+
+#[test]
+fn toolbar_queries_drive_button_states() {
+    let mut state = editor("hello world");
+    // no selection mark active initially
+    let bold = state.schema().mark_type("bold").unwrap().clone();
+    state.selection = Selection::text(Pos(1), Pos(6)); // "hello"
+    assert!(!is_mark_active(&state, &bold));
+    let state = state.run("toggleBold").unwrap();
+    assert!(is_mark_active(&state, &bold));
+    // commands report applicability without performing an edit
+    assert!(state.can_run("toggleItalic"));
+    assert!(state.can_run("wrapInBlockquote"));
+}
+
+#[test]
+fn apply_is_pure_old_state_unchanged() {
+    // applying a transaction returns a NEW state; the old one is untouched
+    let state = editor("ab");
+    let before_text = all_text(&state.doc);
+    let next = type_text(&state, "X");
+    assert_eq!(all_text(&state.doc), before_text, "old state is immutable");
+    assert_ne!(all_text(&next.doc), before_text);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn doc_json_round_trips_an_edited_document() {
+    // M3 serialization still round-trips a document the state layer produced
+    let mut state = empty_editor();
+    state.selection = Selection::cursor(Pos(1));
+    state = type_text(&state, "x");
+    state.selection = Selection::text(Pos(1), Pos(2));
+    state = state.run("toggleBold").unwrap();
+
+    let doc_node = state.doc.to_doc().expect("serialize to DocNode");
+    let restored = state
+        .schema()
+        .node_from_doc(&doc_node)
+        .expect("deserialize");
+    assert_eq!(restored, state.doc, "DocNode round-trip is lossless");
+}

--- a/crates/rinch-editor-core/tests/transform.rs
+++ b/crates/rinch-editor-core/tests/transform.rs
@@ -1,0 +1,454 @@
+//! Integration tests for the M2 transform engine, exercised through the public
+//! API only (the surface M4+ and the views will build on).
+
+use rinch_editor_core::*;
+
+fn sk() -> Schema {
+    Schema::starter_kit()
+}
+
+/// A paragraph with a single text run.
+fn para(s: &Schema, text: &str) -> Node {
+    s.branch("paragraph", Fragment::from_node(s.text(text).unwrap()))
+        .unwrap()
+}
+
+/// A doc wrapping the given block children.
+fn doc(s: &Schema, blocks: Vec<Node>) -> Node {
+    s.branch("doc", Fragment::from_children(blocks)).unwrap()
+}
+
+/// All text in a subtree, concatenated (block boundaries ignored).
+fn all_text(node: &Node) -> String {
+    if let Some(t) = node.text() {
+        return t.to_string();
+    }
+    node.content().iter().map(all_text).collect()
+}
+
+fn bold(s: &Schema) -> Mark {
+    Mark::simple(s.mark_type("bold").unwrap().clone())
+}
+
+fn inline_slice(s: &Schema, text: &str) -> Slice {
+    Slice::from_fragment(Fragment::from_node(s.text(text).unwrap()))
+}
+
+// ---------------------------------------------------------------------------
+// ReplaceStep — insert / delete
+// ---------------------------------------------------------------------------
+
+#[test]
+fn insert_text_mid_run() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "ab")]);
+    let step = ReplaceStep::new(2, 2, inline_slice(&s, "X")); // between a and b
+    let after = step.apply(&d).unwrap();
+    assert_eq!(all_text(&after), "aXb");
+    // one merged text run, not fragmented
+    assert_eq!(after.child(0).child_count(), 1);
+}
+
+#[test]
+fn insert_text_at_block_start_and_end() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "ab")]);
+    assert_eq!(
+        all_text(
+            &ReplaceStep::new(1, 1, inline_slice(&s, "X"))
+                .apply(&d)
+                .unwrap()
+        ),
+        "Xab"
+    );
+    assert_eq!(
+        all_text(
+            &ReplaceStep::new(3, 3, inline_slice(&s, "X"))
+                .apply(&d)
+                .unwrap()
+        ),
+        "abX"
+    );
+}
+
+#[test]
+fn delete_text_mid_run() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "abcd")]);
+    let step = ReplaceStep::new(2, 3, Slice::empty()); // delete "b"
+    let after = step.apply(&d).unwrap();
+    assert_eq!(all_text(&after), "acd");
+}
+
+#[test]
+fn delete_across_blocks_joins_them() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "ab"), para(&s, "cd")]);
+    // delete from end of p1 content (3) to start of p2 content (5)
+    let after = ReplaceStep::new(3, 5, Slice::empty()).apply(&d).unwrap();
+    assert_eq!(after.child_count(), 1);
+    assert_eq!(all_text(&after), "abcd");
+}
+
+#[test]
+fn paste_open_slice_splits_block() {
+    // Insert "X<split>Y" into "a|b" -> p("aX"), p("Yb")
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "ab")]);
+    let slice = Slice::new(
+        Fragment::from_children(vec![para(&s, "X"), para(&s, "Y")]),
+        1,
+        1,
+    );
+    let after = ReplaceStep::new(2, 2, slice).apply(&d).unwrap();
+    assert_eq!(after.child_count(), 2);
+    assert_eq!(all_text(after.child(0)), "aX");
+    assert_eq!(all_text(after.child(1)), "Yb");
+}
+
+// ---------------------------------------------------------------------------
+// ReplaceStep — schema enforcement (decision G): invalid steps are rejected
+// ---------------------------------------------------------------------------
+
+#[test]
+fn block_into_inline_position_is_rejected() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "ab")]);
+    // Try to insert a whole paragraph inside the paragraph's inline content.
+    let step = ReplaceStep::new(
+        2,
+        2,
+        Slice::from_fragment(Fragment::from_node(para(&s, "x"))),
+    );
+    assert!(step.apply(&d).is_err());
+    // The original document value is untouched (apply is pure).
+    assert_eq!(all_text(&d), "ab");
+}
+
+#[test]
+fn text_into_doc_top_level_is_rejected() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "ab")]);
+    // doc content is block+, so bare text at the top is invalid.
+    let step = ReplaceStep::new(4, 4, inline_slice(&s, "loose"));
+    assert!(step.apply(&d).is_err());
+}
+
+// ---------------------------------------------------------------------------
+// ReplaceStep — invert round-trips
+// ---------------------------------------------------------------------------
+
+fn assert_roundtrip(d: &Node, step: &dyn Step) {
+    let after = step.apply(d).unwrap();
+    let inverse = step.invert(d);
+    let restored = inverse.apply(&after).unwrap();
+    assert_eq!(&restored, d, "apply∘invert must be identity");
+}
+
+#[test]
+fn invert_insert() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "ab")]);
+    assert_roundtrip(&d, &ReplaceStep::new(2, 2, inline_slice(&s, "XYZ")));
+}
+
+#[test]
+fn invert_delete() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "abcd")]);
+    assert_roundtrip(&d, &ReplaceStep::new(2, 4, Slice::empty()));
+}
+
+#[test]
+fn invert_join_blocks() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "ab"), para(&s, "cd")]);
+    assert_roundtrip(&d, &ReplaceStep::new(3, 5, Slice::empty()));
+}
+
+#[test]
+fn invert_paste_split() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "ab")]);
+    let slice = Slice::new(
+        Fragment::from_children(vec![para(&s, "X"), para(&s, "Y")]),
+        1,
+        1,
+    );
+    assert_roundtrip(&d, &ReplaceStep::new(2, 2, slice));
+}
+
+// ---------------------------------------------------------------------------
+// ReplaceStep — merge (typing coalescing)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn consecutive_single_char_inserts_merge() {
+    let s = sk();
+    // type "X" at 2 then "Y" at 3 — the second is adjacent to the first
+    let a = ReplaceStep::new(2, 2, inline_slice(&s, "X"));
+    let b = ReplaceStep::new(3, 3, inline_slice(&s, "Y"));
+    let merged = a.merge(&b).expect("adjacent inserts should merge");
+    // Apply the merged step and confirm it equals applying both in sequence.
+    let d = doc(&s, vec![para(&s, "ab")]);
+    let seq = b.apply(&a.apply(&d).unwrap()).unwrap();
+    let one = merged.apply(&d).unwrap();
+    assert_eq!(one, seq);
+    assert_eq!(all_text(&one), "aXYb");
+}
+
+#[test]
+fn non_adjacent_inserts_do_not_merge() {
+    let s = sk();
+    let a = ReplaceStep::new(2, 2, inline_slice(&s, "X"));
+    let c = ReplaceStep::new(1, 1, inline_slice(&s, "Z"));
+    assert!(a.merge(&c).is_none());
+}
+
+// ---------------------------------------------------------------------------
+// ReplaceAroundStep — wrap / lift
+// ---------------------------------------------------------------------------
+
+#[test]
+fn wrap_paragraph_in_blockquote() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "ab")]); // paragraph spans 0..4
+    let bq = s.branch("blockquote", Fragment::empty()).unwrap();
+    let slice = Slice::new(Fragment::from_node(bq), 0, 0);
+    let step = ReplaceAroundStep::new(0, 4, 0, 4, slice, 1, true);
+    let after = step.apply(&d).unwrap();
+    assert_eq!(after.child(0).type_name(), "blockquote");
+    assert_eq!(after.child(0).child(0).type_name(), "paragraph");
+    assert_eq!(all_text(&after), "ab");
+}
+
+#[test]
+fn wrap_then_invert_restores() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "ab")]);
+    let bq = s.branch("blockquote", Fragment::empty()).unwrap();
+    let slice = Slice::new(Fragment::from_node(bq), 0, 0);
+    assert_roundtrip(&d, &ReplaceAroundStep::new(0, 4, 0, 4, slice, 1, true));
+}
+
+// ---------------------------------------------------------------------------
+// Mark steps
+// ---------------------------------------------------------------------------
+
+#[test]
+fn add_mark_over_range() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "abcd")]);
+    // bold "bc" -> positions 2..4
+    let after = AddMarkStep::new(2, 4, bold(&s)).apply(&d).unwrap();
+    // paragraph should now be [text "a", text "bc"(bold), text "d"]
+    let p = after.child(0);
+    assert_eq!(all_text(&after), "abcd");
+    // find the bold run
+    let has_bold = p
+        .content()
+        .iter()
+        .any(|n| n.text() == Some("bc") && n.marks().iter().any(|m| m.type_name() == "bold"));
+    assert!(has_bold, "expected a bold 'bc' run, got {p:?}");
+}
+
+#[test]
+fn add_mark_invert_removes_it() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "abcd")]);
+    assert_roundtrip(&d, &AddMarkStep::new(2, 4, bold(&s)));
+}
+
+#[test]
+fn remove_mark_invert_adds_it() {
+    let s = sk();
+    // start with a fully-bold paragraph
+    let bolded = s
+        .branch(
+            "paragraph",
+            Fragment::from_node(s.text_with_marks("abcd", vec![bold(&s)]).unwrap()),
+        )
+        .unwrap();
+    let d = doc(&s, vec![bolded]);
+    assert_roundtrip(&d, &RemoveMarkStep::new(1, 5, bold(&s)));
+}
+
+#[test]
+fn add_mark_disallowed_in_code_block_is_a_noop_not_error() {
+    let s = sk();
+    // code_block has MarkSet::None; adding bold should leave content unmarked
+    let cb = s
+        .branch("code_block", Fragment::from_node(s.text("x").unwrap()))
+        .unwrap();
+    let d = doc(&s, vec![cb]);
+    let after = AddMarkStep::new(1, 2, bold(&s)).apply(&d).unwrap();
+    let marked = after.child(0).child(0).marks().is_empty();
+    assert!(marked, "bold must not be applied inside a code_block");
+}
+
+// ---------------------------------------------------------------------------
+// Attr steps
+// ---------------------------------------------------------------------------
+
+#[test]
+fn set_heading_level() {
+    let s = sk();
+    let h = s
+        .branch("heading", Fragment::from_node(s.text("Title").unwrap()))
+        .unwrap();
+    let d = doc(&s, vec![h]);
+    let step = SetNodeAttrStep::new(0, "level", AttrValue::Int(2));
+    let after = step.apply(&d).unwrap();
+    assert_eq!(after.child(0).attrs().get_int("level"), Some(2));
+    assert_eq!(all_text(&after), "Title");
+}
+
+#[test]
+fn set_node_attr_invert_restores_absent_attr() {
+    let s = sk();
+    // heading built via branch() has NO level attr set; setting then inverting
+    // must restore "no level attr", not level=Null.
+    let h = s
+        .branch("heading", Fragment::from_node(s.text("T").unwrap()))
+        .unwrap();
+    let d = doc(&s, vec![h]);
+    assert!(d.child(0).attrs().get("level").is_none());
+    assert_roundtrip(&d, &SetNodeAttrStep::new(0, "level", AttrValue::Int(3)));
+}
+
+#[test]
+fn set_doc_attr_and_invert() {
+    let s = sk();
+    let d = doc(&s, vec![para(&s, "x")]);
+    assert_roundtrip(&d, &SetDocAttrStep::new("dir", AttrValue::from("rtl")));
+    let after = SetDocAttrStep::new("dir", AttrValue::from("rtl"))
+        .apply(&d)
+        .unwrap();
+    assert_eq!(after.attrs().get_str("dir"), Some("rtl"));
+}
+
+// ---------------------------------------------------------------------------
+// StepMap / Mapping
+// ---------------------------------------------------------------------------
+
+#[test]
+fn step_map_shifts_positions_after_an_insert() {
+    // Insert of size 3 at position 2: positions >= 2 shift by +3.
+    let map = StepMap::new(vec![2, 0, 3]);
+    assert_eq!(map.map(1, 1), 1); // before the insert
+    assert_eq!(map.map(5, 1), 8); // after the insert
+    // a position exactly at the insertion point biases by assoc
+    assert_eq!(map.map(2, 1), 5);
+    assert_eq!(map.map(2, -1), 2);
+}
+
+#[test]
+fn step_map_invert_round_trips_undeleted_positions() {
+    // A replace of old size 2 with new size 4 at pos 3.
+    let map = StepMap::new(vec![3, 2, 4]);
+    let inv = map.invert();
+    for pos in [0usize, 1, 2, 3, 7, 9, 12] {
+        let fwd = map.map(pos, 1);
+        // positions outside the replaced range round-trip exactly
+        if pos <= 3 || pos >= 5 {
+            assert_eq!(inv.map(fwd, 1), pos, "round-trip failed for {pos}");
+        }
+    }
+}
+
+#[test]
+fn mapping_through_step_and_its_mirror_recovers_position() {
+    // map then its inverse, registered as mirrors, must recover the original.
+    let map = StepMap::new(vec![3, 2, 4]);
+    let mut mapping = Mapping::new();
+    mapping.append_map(map.clone());
+    mapping.append_map_mirrored(map.invert(), 0);
+    for pos in [0usize, 3, 4, 5, 9] {
+        assert_eq!(mapping.map(pos, 1), pos, "mirror recovery failed for {pos}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Property tests — exhaustive over small spaces (stronger than random sampling)
+// ---------------------------------------------------------------------------
+
+/// `apply∘invert == identity` for an insert at every textblock position and a
+/// delete over every valid range, across several document shapes.
+#[test]
+fn invert_is_identity_exhaustively() {
+    let s = sk();
+    let nested = s
+        .branch("blockquote", Fragment::from_node(para(&s, "xy")))
+        .unwrap();
+    let docs = vec![
+        doc(&s, vec![para(&s, "hello")]),
+        doc(&s, vec![para(&s, "ab"), para(&s, "cd")]),
+        doc(&s, vec![nested]),
+    ];
+    for d in &docs {
+        let size = d.content_size();
+        // Insert text at every position that resolves inside a textblock.
+        for pos in 0..=size {
+            if let Ok(r) = d.resolve(Pos(pos))
+                && r.parent().is_textblock()
+            {
+                let step = ReplaceStep::new(pos, pos, inline_slice(&s, "Z"));
+                let after = step.apply(d).unwrap();
+                assert_eq!(&step.invert(d).apply(&after).unwrap(), d, "insert@{pos}");
+            }
+        }
+        // Delete every valid range that applies cleanly.
+        for from in 0..=size {
+            for to in from..=size {
+                let step = ReplaceStep::new(from, to, Slice::empty());
+                if let Ok(after) = step.apply(d) {
+                    assert_eq!(
+                        &step.invert(d).apply(&after).unwrap(),
+                        d,
+                        "delete {from}..{to}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+/// A position not inside the replaced range maps forward then back to itself
+/// through a replace map and its inverse, for every range/size pair in a window.
+#[test]
+fn step_map_round_trips_outside_replaced_range_exhaustively() {
+    for start in 0..6usize {
+        for old_size in 0..6usize {
+            for new_size in 0..6usize {
+                let map = StepMap::new(vec![start, old_size, new_size]);
+                let inv = map.invert();
+                for pos in 0..12usize {
+                    // Only positions STRICTLY outside the replaced range round-trip
+                    // through a bare map+inverse; the boundary positions are
+                    // intentionally ambiguous (recovered only via Mapping mirrors).
+                    if pos < start || pos > start + old_size {
+                        let fwd = map.map(pos, 1);
+                        assert_eq!(
+                            inv.map(fwd, 1),
+                            pos,
+                            "round-trip {pos} via [{start},{old_size},{new_size}]"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn replace_step_map_rebases_over_an_earlier_insert() {
+    let s = sk();
+    // An AddMark over 2..4, rebased over an insert of size 2 at position 0,
+    // should shift to 4..6.
+    let add = AddMarkStep::new(2, 4, bold(&s));
+    let mut mapping = Mapping::new();
+    mapping.append_map(StepMap::new(vec![0, 0, 2]));
+    let mapped = add.map(&mapping).expect("step should survive mapping");
+    let mapped = mapped.as_any().downcast_ref::<AddMarkStep>().unwrap();
+    assert_eq!((mapped.from, mapped.to), (4, 6));
+}

--- a/crates/rinch/Cargo.toml
+++ b/crates/rinch/Cargo.toml
@@ -46,10 +46,17 @@ rinch-theme = { workspace = true, optional = true }
 rinch-components = { workspace = true, optional = true }
 rinch-debug = { path = "../rinch-debug", optional = true }
 rinch-editor = { workspace = true }
+# New ProseMirror-style editor core (M5+). Optional, behind `new-editor`, so `main`
+# stays green while the old CE engine is still live; the rip/flip lands in M8.
+rinch-editor-core = { workspace = true, optional = true }
 rinch-video = { workspace = true, optional = true }
 ureq = { version = "3", optional = true }
 memory-stats = { version = "1.2", optional = true }
 softbuffer = { git = "https://github.com/rust-windowing/softbuffer", rev = "672d180", optional = true }
+
+[dev-dependencies]
+# Test-only: the headless DomDocument double, used by the new editor view's tests.
+rinch-core = { workspace = true, features = ["test-util"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = { version = "0.18", optional = true }
@@ -116,6 +123,10 @@ debug = ["dep:rinch-debug"]
 video = ["dep:rinch-video"]
 image-network = ["dep:ureq"]
 collaboration = ["rinch-editor/collaboration"]
+# The new desktop rich-text editor view (M5). Behind a feature so `main` stays
+# green; needs the desktop renderer. Flipped to default and the old engine ripped
+# in M8.
+new-editor = ["desktop", "dep:rinch-editor-core"]
 # Derive serde on the CE interchange types (BlockData / InlineRunData /
 # InlineMarkData) for persisting contenteditable content.
 serde = ["rinch-core/serde"]

--- a/crates/rinch/src/app/click_handling.rs
+++ b/crates/rinch/src/app/click_handling.rs
@@ -52,7 +52,8 @@ impl RinchApp {
             };
 
             if let Some((surface_id, local_x, local_y)) = surface_hit {
-                // Dispatch MouseDown to the surface
+                // Dispatch MouseDown to the surface (every click, regardless of
+                // whether focus changes).
                 crate::render_surface::dispatch_surface_event(
                     surface_id,
                     crate::render_surface::SurfaceEvent::MouseDown {
@@ -62,67 +63,24 @@ impl RinchApp {
                     },
                 );
 
-                // Focus the surface
-                let prev_focused = crate::render_surface::focused_surface_id();
-                if prev_focused != Some(surface_id) {
-                    // Dispatch FocusLost to the previous surface
-                    if let Some(prev_id) = prev_focused {
-                        crate::render_surface::dispatch_surface_event(
-                            prev_id,
-                            crate::render_surface::SurfaceEvent::FocusLost,
-                        );
-                    }
+                // Take keyboard focus through the arbiter: it tears down whatever
+                // was focused before (input / CE / editor / a prior surface), then
+                // we register this surface. `set_focused_surface` dispatches
+                // `FocusGained` (and `FocusLost` to any prior surface) — surfaces
+                // are routed by `FocusTarget::Surface` now, not the old keyboard
+                // interceptor hijack.
+                if self.set_focus_target(FocusTarget::Surface(surface_id)) {
                     crate::render_surface::set_focused_surface(Some(surface_id));
-                    crate::render_surface::dispatch_surface_event(
-                        surface_id,
-                        crate::render_surface::SurfaceEvent::FocusGained,
-                    );
-
-                    // Install keyboard interceptor that forwards all keys to the surface
-                    let sid = surface_id;
-                    events::set_keyboard_interceptor(move |key_data| {
-                        crate::render_surface::dispatch_surface_event(
-                            sid,
-                            crate::render_surface::SurfaceEvent::KeyDown(
-                                crate::render_surface::SurfaceKeyData {
-                                    key: key_data.key.clone(),
-                                    code: key_data.code.clone(),
-                                    ctrl: key_data.ctrl,
-                                    shift: key_data.shift,
-                                    alt: key_data.alt,
-                                    meta: key_data.meta,
-                                },
-                            ),
-                        );
-                        true // consume all keys
-                    });
-                }
-
-                // Clear any existing input/CE focus
-                self.clear_input_focus_attrs();
-                self.focused_input_handler_id = None;
-                self.focused_input_value.clear();
-                self.focused_input_state = None;
-                self.focused_input_node_id = None;
-                if let Some(prev_ce) = self.focused_contenteditable.take() {
-                    ce::clear_active_ce_api();
-                    self.ce_ops = None;
-                    self.set_contenteditable_attributes(prev_ce.ce_node_id, false, 0, 0);
                 }
 
                 actions.push(AppAction::RequestRedraw);
                 return actions;
             }
 
-            // If clicking outside a focused render surface, unfocus it
-            if crate::render_surface::focused_surface_id().is_some() {
-                let prev_id = crate::render_surface::focused_surface_id().unwrap();
-                crate::render_surface::dispatch_surface_event(
-                    prev_id,
-                    crate::render_surface::SurfaceEvent::FocusLost,
-                );
-                crate::render_surface::set_focused_surface(None);
-                events::clear_keyboard_interceptor();
+            // Clicking outside any surface drops surface focus (the arbiter's
+            // teardown dispatches FocusLost). Other targets are taken below.
+            if matches!(self.focus_target, FocusTarget::Surface(_)) {
+                self.set_focus_target(FocusTarget::None);
             }
         }
 
@@ -134,7 +92,6 @@ impl RinchApp {
             Focus {
                 ce_node_id: usize,
                 dom_cursor: DomCursor,
-                prev_node_id: Option<usize>,
             },
             /// We did NOT hit contenteditable — clear previous if any.
             Clear { prev_node_id: Option<usize> },
@@ -173,7 +130,6 @@ impl RinchApp {
                     CeAction::Focus {
                         ce_node_id,
                         dom_cursor,
-                        prev_node_id,
                     }
                 } else {
                     // Check if the click target has a data-rid handler — if so,
@@ -210,7 +166,6 @@ impl RinchApp {
             CeAction::Focus {
                 ce_node_id,
                 mut dom_cursor,
-                prev_node_id,
             } => {
                 let input_handler = InputHandler::new()
                     .with_multiline(true)
@@ -254,6 +209,11 @@ impl RinchApp {
                     _ => {} // Single click: cursor already set
                 }
 
+                // Take focus through the arbiter: tears down a prior input /
+                // surface / editor / different CE (re-clicking the same CE is a
+                // no-op teardown, so its state survives — we just move the cursor).
+                self.set_focus_target(FocusTarget::ContentEditable(ce_node_id));
+
                 self.focused_contenteditable = Some(ContentEditableFocus {
                     ce_node_id,
                     cursor: dom_cursor,
@@ -265,32 +225,29 @@ impl RinchApp {
                 // Start mouse-drag selection tracking
                 self.ce_selecting = true;
 
-                // Clear regular input focus
-                self.clear_input_focus_attrs();
-                self.focused_input_handler_id = None;
-                self.focused_input_value.clear();
-                self.focused_input_state = None;
-                self.focused_input_node_id = None;
-
-                // Clear previous contenteditable focus attributes
-                if let Some(prev_id) = prev_node_id
-                    && prev_id != ce_node_id
-                {
-                    self.set_contenteditable_attributes(prev_id, false, 0, 0);
-                }
-                // Set cursor/selection attributes on the new focused node
+                // Set cursor/selection attributes on the focused node.
                 self.set_contenteditable_attributes_dom(ce_node_id, true, dom_cursor, anchor);
                 self.scene_dirty = true;
                 actions.push(AppAction::RequestRedraw);
                 return actions;
             }
             CeAction::Clear { prev_node_id } => {
-                if let Some(prev_id) = prev_node_id {
-                    self.focused_contenteditable = None;
-                    ce::clear_active_ce_api();
-                    self.ce_ops = None;
-                    self.set_contenteditable_attributes(prev_id, false, 0, 0);
-                    self.scene_dirty = true;
+                // Clicked a non-editable, non-toolbar (no `data-rid`) target: blur
+                // any focused rich-text editor. Toolbar clicks take the
+                // `PreserveCe` path and keep focus (the "click Bold, keep typing"
+                // case — audit S2).
+                if prev_node_id.is_some() {
+                    self.set_focus_target(FocusTarget::None);
+                }
+                // A click on the focused editor's OWN chrome (padding / empty area)
+                // is not a blur — only blur when the click landed outside its
+                // container. (Left clicks inside the editor never reach here: they
+                // short-circuit in `try_new_editor_click`. This covers right-click.)
+                #[cfg(feature = "new-editor")]
+                if let FocusTarget::Editor(focused) = self.focus_target
+                    && self.editor_container_at(x, y) != Some(focused)
+                {
+                    self.set_focus_target(FocusTarget::None);
                 }
             }
             CeAction::PreserveCe => {
@@ -387,10 +344,10 @@ impl RinchApp {
         drop(d);
 
         if let Some((nid, handler_id, value)) = found_input_focus {
-            // Clear previous input focus attrs if switching to a different input
-            if self.focused_input_node_id.is_some() && self.focused_input_node_id != Some(nid) {
-                self.clear_input_focus_attrs();
-            }
+            // Take input focus through the arbiter: tears down a prior surface /
+            // CE / editor / different input (re-clicking the same input is a no-op
+            // teardown, so we just move its cursor below).
+            self.set_focus_target(FocusTarget::Input(nid));
             self.focused_input_handler_id = Some(handler_id);
             self.focused_input_value = value.clone();
             self.focused_input_node_id = Some(nid);
@@ -402,16 +359,15 @@ impl RinchApp {
             self.focused_input_state = Some(state);
             self.sync_input_cursor_to_dom();
             self.scene_dirty = true;
-        } else {
-            // Clicked outside any input — clear focus
-            if self.focused_input_node_id.is_some() {
-                self.clear_input_focus_attrs();
-                self.scene_dirty = true;
-            }
-            self.focused_input_handler_id = None;
-            self.focused_input_value.clear();
-            self.focused_input_state = None;
-            self.focused_input_node_id = None;
+        } else if matches!(
+            self.focus_target,
+            FocusTarget::Input(_) | FocusTarget::Surface(_)
+        ) {
+            // Clicked a non-input target: drop input/surface focus. CE/editor focus
+            // is preserved here so their toolbar buttons (data-rid, dispatched
+            // below) keep working; an empty/non-toolbar click already blurred them
+            // via `CeAction::Clear`.
+            self.set_focus_target(FocusTarget::None);
         }
 
         // Re-borrow for the data-rid walk

--- a/crates/rinch/src/app/contenteditable/ce_virtualization.rs
+++ b/crates/rinch/src/app/contenteditable/ce_virtualization.rs
@@ -48,12 +48,26 @@ pub(crate) struct CeVirtualWindow {
     /// and must not be collapsed by the next `pre_layout_update`.
     /// Cleared after each `pre_layout_update`.
     pub pending_nav_blocks: Vec<usize>,
+
+    /// When true, the window models only the container's `data-pm-type` children
+    /// (the new-editor's block elements), excluding overlay siblings (caret /
+    /// selection / node-outline / placeholder). The old contenteditable keeps
+    /// the original behavior (every direct child is a block) with `false`.
+    filter_blocks: bool,
 }
 
 impl CeVirtualWindow {
     /// Create a new VirtualWindow and collapse blocks outside the initial range.
+    /// Every direct child of `ce_node_id` is treated as a block (contenteditable).
     pub fn new(ce_node_id: usize, doc: &mut RinchDocument) -> Self {
-        let children: Vec<usize> = doc.tree.nodes[ce_node_id].children.clone();
+        Self::new_filtered(ce_node_id, doc, false)
+    }
+
+    /// As [`Self::new`], but when `filter_blocks` is true the window models only
+    /// the container's `data-pm-type` children (new-editor blocks), so overlay
+    /// siblings are never collapsed or counted.
+    pub fn new_filtered(ce_node_id: usize, doc: &mut RinchDocument, filter_blocks: bool) -> Self {
+        let children: Vec<usize> = block_children_of(doc, ce_node_id, filter_blocks);
         let block_count = children.len();
 
         let active = block_count >= MIN_BLOCKS_FOR_VIRTUALIZATION;
@@ -72,6 +86,7 @@ impl CeVirtualWindow {
             active,
             initialized: false,
             pending_nav_blocks: Vec::new(),
+            filter_blocks,
         };
 
         if active {
@@ -102,7 +117,7 @@ impl CeVirtualWindow {
             return false;
         }
 
-        let children: Vec<usize> = doc.tree.nodes[self.ce_node_id].children.clone();
+        let children: Vec<usize> = self.block_children(doc);
         let block_count = children.len();
         if block_count == 0 {
             return false;
@@ -178,7 +193,7 @@ impl CeVirtualWindow {
             return;
         }
 
-        let children: Vec<usize> = doc.tree.nodes[self.ce_node_id].children.clone();
+        let children: Vec<usize> = self.block_children(doc);
         if self.measured_heights.len() != children.len() {
             self.measured_heights.resize(children.len(), None);
         }
@@ -257,7 +272,7 @@ impl CeVirtualWindow {
         if !self.active {
             return false;
         }
-        let children = &doc.tree.nodes[self.ce_node_id].children;
+        let children = self.block_children(doc);
         let Some(idx) = children.iter().position(|&id| id == block_node_id) else {
             return false;
         };
@@ -283,7 +298,7 @@ impl CeVirtualWindow {
 
     /// Called when blocks are inserted/removed.
     pub fn on_blocks_changed(&mut self, doc: &mut RinchDocument) {
-        let children: Vec<usize> = doc.tree.nodes[self.ce_node_id].children.clone();
+        let children: Vec<usize> = self.block_children(doc);
         let block_count = children.len();
 
         if block_count < MIN_BLOCKS_FOR_VIRTUALIZATION {
@@ -328,5 +343,134 @@ impl CeVirtualWindow {
 
     pub fn is_active(&self) -> bool {
         self.active
+    }
+
+    /// The number of blocks this window currently models (used by the new-editor
+    /// driver to detect insert/delete and re-sync via `on_blocks_changed`).
+    #[cfg(feature = "new-editor")]
+    pub fn block_count(&self) -> usize {
+        self.measured_heights.len()
+    }
+
+    /// The container's block children, honoring `filter_blocks` (excludes overlay
+    /// siblings for the new editor).
+    fn block_children(&self, doc: &RinchDocument) -> Vec<usize> {
+        block_children_of(doc, self.ce_node_id, self.filter_blocks)
+    }
+}
+
+/// The block children of `ce_node_id`: every direct child when `filter_blocks` is
+/// false (contenteditable), or only the `data-pm-type` children when true (the
+/// new editor, where caret / selection / outline / placeholder overlays are
+/// container siblings with no `data-pm-type`).
+fn block_children_of(doc: &RinchDocument, ce_node_id: usize, filter_blocks: bool) -> Vec<usize> {
+    let children = &doc.tree.nodes[ce_node_id].children;
+    if !filter_blocks {
+        return children.clone();
+    }
+    children
+        .iter()
+        .copied()
+        .filter(|&id| {
+            doc.tree
+                .nodes
+                .get(id)
+                .is_some_and(|n| n.attributes.contains_key("data-pm-type"))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rinch_core::dom::DomDocument;
+
+    /// Build a new-editor-like host: a `data-pm-editor` scroll container with `n`
+    /// `<p data-pm-type="paragraph">` blocks (each wrapping to ~2 lines in a narrow
+    /// column) plus a `data-pm-caret` overlay sibling that has **no** `data-pm-type`
+    /// (so the block filter must exclude it). Returns `(container, block_ids, caret)`.
+    fn build_editor_host(doc: &mut RinchDocument, n: usize) -> (usize, Vec<usize>, usize) {
+        let body = doc.body();
+        let container = doc.create_element("div");
+        doc.set_attribute(container, "data-pm-editor", "true");
+        doc.set_attribute(container, "data-pm-type", "doc");
+        doc.set_attribute(
+            container,
+            "style",
+            "width: 150px; height: 300px; overflow-y: auto; position: relative",
+        );
+        doc.append_child(body, container);
+
+        let mut blocks = Vec::new();
+        for i in 0..n {
+            let p = doc.create_element("p");
+            doc.set_attribute(p, "data-pm-type", "paragraph");
+            doc.append_child(container, p);
+            let text = doc.create_text(&format!(
+                "Block {i} with plenty of words here so it wraps across at least two lines in a narrow column"
+            ));
+            doc.append_child(p, text);
+            blocks.push(p.0);
+        }
+
+        // A caret overlay (container child, no data-pm-type) — like the live tree
+        // after focus. The block filter must never collapse it.
+        let caret = doc.create_element("div");
+        doc.set_attribute(caret, "data-pm-caret", "true");
+        doc.set_attribute(
+            caret,
+            "style",
+            "position: absolute; left: 0; top: 0; width: 2px; height: 18px",
+        );
+        doc.append_child(container, caret);
+
+        (container.0, blocks, caret.0)
+    }
+
+    #[test]
+    fn block_filter_excludes_overlay_siblings() {
+        let mut doc = RinchDocument::new();
+        let (container, blocks, caret) = build_editor_host(&mut doc, 5);
+        let filtered = block_children_of(&doc, container, true);
+        assert_eq!(filtered, blocks, "only data-pm-type blocks are modeled");
+        assert!(!filtered.contains(&caret), "the caret overlay is excluded");
+        // Without filtering (contenteditable), every child is a block.
+        assert_eq!(
+            block_children_of(&doc, container, false).len(),
+            blocks.len() + 1
+        );
+    }
+
+    #[test]
+    fn new_filtered_collapses_far_offscreen_block_and_spares_overlay() {
+        let mut doc = RinchDocument::new();
+        let (container, blocks, caret) = build_editor_host(&mut doc, 80);
+        doc.resolve_layout(400.0, 600.0);
+
+        let probe = blocks[50];
+        let full_h = doc.tree.nodes[probe].layout.height;
+        assert!(
+            full_h > 30.0,
+            "expected a multi-line block (>30px), got {full_h}"
+        );
+        let caret_h = doc.tree.nodes[caret].layout.height;
+
+        // This is exactly what the driver does on first run for a scroll editor.
+        let vw = CeVirtualWindow::new_filtered(container, &mut doc, true);
+        assert!(vw.is_active(), "80 blocks must activate virtualization");
+        doc.resolve_layout(400.0, 600.0);
+
+        let collapsed_h = doc.tree.nodes[probe].layout.height;
+        assert!(
+            (collapsed_h - DEFAULT_ESTIMATED_HEIGHT).abs() < 1.0,
+            "off-screen block 50 should collapse to ~{DEFAULT_ESTIMATED_HEIGHT}px, \
+             got {collapsed_h} (full height was {full_h})"
+        );
+        // The overlay must be untouched by virtualization.
+        assert_eq!(
+            doc.tree.nodes[caret].estimated_height, None,
+            "the caret overlay must not get an estimated height"
+        );
+        assert!((doc.tree.nodes[caret].layout.height - caret_h).abs() < 0.5);
     }
 }

--- a/crates/rinch/src/app/debug_commands.rs
+++ b/crates/rinch/src/app/debug_commands.rs
@@ -8,6 +8,73 @@ fn parse_button(s: &Option<String>) -> MouseButton {
     }
 }
 
+/// Map a printable character to a physical `KeyCode` for synthesizing keystrokes
+/// (the `text` field carries the actual character; the keycode only matters for
+/// shortcut/interceptor matching). Unknown characters fall back to `Space`.
+fn char_to_keycode(c: char) -> KeyCode {
+    match c.to_ascii_lowercase() {
+        'a' => KeyCode::KeyA,
+        'b' => KeyCode::KeyB,
+        'c' => KeyCode::KeyC,
+        'd' => KeyCode::KeyD,
+        'e' => KeyCode::KeyE,
+        'f' => KeyCode::KeyF,
+        'g' => KeyCode::KeyG,
+        'h' => KeyCode::KeyH,
+        'i' => KeyCode::KeyI,
+        'j' => KeyCode::KeyJ,
+        'k' => KeyCode::KeyK,
+        'l' => KeyCode::KeyL,
+        'm' => KeyCode::KeyM,
+        'n' => KeyCode::KeyN,
+        'o' => KeyCode::KeyO,
+        'p' => KeyCode::KeyP,
+        'q' => KeyCode::KeyQ,
+        'r' => KeyCode::KeyR,
+        's' => KeyCode::KeyS,
+        't' => KeyCode::KeyT,
+        'u' => KeyCode::KeyU,
+        'v' => KeyCode::KeyV,
+        'w' => KeyCode::KeyW,
+        'x' => KeyCode::KeyX,
+        'y' => KeyCode::KeyY,
+        'z' => KeyCode::KeyZ,
+        '0' => KeyCode::Digit0,
+        '1' => KeyCode::Digit1,
+        '2' => KeyCode::Digit2,
+        '3' => KeyCode::Digit3,
+        '4' => KeyCode::Digit4,
+        '5' => KeyCode::Digit5,
+        '6' => KeyCode::Digit6,
+        '7' => KeyCode::Digit7,
+        '8' => KeyCode::Digit8,
+        '9' => KeyCode::Digit9,
+        _ => KeyCode::Space,
+    }
+}
+
+/// Map a debug `key_press` key-name string to a `KeyCode`.
+fn keyname_to_keycode(key: &str) -> KeyCode {
+    match key {
+        "ArrowLeft" => KeyCode::ArrowLeft,
+        "ArrowRight" => KeyCode::ArrowRight,
+        "ArrowUp" => KeyCode::ArrowUp,
+        "ArrowDown" => KeyCode::ArrowDown,
+        "Home" => KeyCode::Home,
+        "End" => KeyCode::End,
+        "PageUp" => KeyCode::PageUp,
+        "PageDown" => KeyCode::PageDown,
+        "Enter" => KeyCode::Enter,
+        "Backspace" => KeyCode::Backspace,
+        "Delete" => KeyCode::Delete,
+        "Tab" => KeyCode::Tab,
+        "Escape" => KeyCode::Escape,
+        "F12" => KeyCode::F12,
+        k if k.chars().count() == 1 => char_to_keycode(k.chars().next().unwrap()),
+        _ => KeyCode::Space,
+    }
+}
+
 #[cfg(feature = "debug")]
 impl RinchApp {
     // ── Debug commands ───────────────────────────────────────────────────
@@ -101,405 +168,75 @@ impl RinchApp {
                 }
             }
             DebugCommandKind::Click { x, y, ref button } => {
+                // Route through the REAL input path (press + release) so MCP
+                // exercises exactly what a real mouse does — `handle_event` owns all
+                // the click logic (contextmenu, focus, editor, drag). Injecting via a
+                // parallel path here is what hid the dual-arm MouseDown bug.
                 let mouse_button = parse_button(button);
-                if mouse_button == MouseButton::Right {
-                    // Right-click: try oncontextmenu dispatch first, then fallback
-                    let mods = self.modifier_state();
-                    let mut handled = false;
-                    if let Some(doc) = &self.doc {
-                        let hit_id = {
-                            let d = doc.borrow();
-                            hit_test(&d.tree, x, y)
-                        };
-                        if let Some(hit_id) = hit_id {
-                            let vw = window_size.0 as f32 / scale_factor as f32;
-                            let vh = window_size.1 as f32 / scale_factor as f32;
-                            if Self::dispatch_oncontextmenu(doc, hit_id, x, y, vw, vh, mods) {
-                                actions.push(AppAction::RequestRedraw);
-                                handled = true;
-                            }
-                        }
-                    }
-                    if !handled {
-                        let click_actions = self.handle_click_with_button(
-                            x,
-                            y,
-                            scale_factor,
-                            mouse_button,
-                            window_size.0 as f32 / scale_factor as f32,
-                            window_size.1 as f32 / scale_factor as f32,
-                        );
-                        actions.extend(click_actions);
-                    }
-                } else {
-                    let click_actions = self.handle_click_with_button(
+                self.cursor_pos = Some((x, y));
+                actions.extend(self.handle_event(
+                    PlatformEvent::MouseDown {
                         x,
                         y,
-                        scale_factor,
-                        mouse_button,
-                        window_size.0 as f32 / scale_factor as f32,
-                        window_size.1 as f32 / scale_factor as f32,
-                    );
-                    actions.extend(click_actions);
-                }
-                self.ce_selecting = false;
+                        button: mouse_button,
+                    },
+                    window_size,
+                    scale_factor,
+                ));
+                actions.extend(self.handle_event(
+                    PlatformEvent::MouseUp {
+                        x,
+                        y,
+                        button: mouse_button,
+                    },
+                    window_size,
+                    scale_factor,
+                ));
                 actions.push(AppAction::RequestRedraw);
                 DebugResult::Json { data: json!(null) }
             }
             DebugCommandKind::MouseDown { x, y, ref button } => {
+                // Route through the real input path so MCP matches a real press.
                 let mouse_button = parse_button(button);
                 self.cursor_pos = Some((x, y));
-                self.dispatch_mouse_attr(
-                    "data-onmousedown",
-                    x,
-                    y,
-                    Self::core_button(mouse_button),
-                    window_size.0 as f32 / scale_factor as f32,
-                    window_size.1 as f32 / scale_factor as f32,
-                );
-
-                if mouse_button == MouseButton::Right {
-                    // Right-click: try oncontextmenu dispatch first
-                    let mods = self.modifier_state();
-                    let mut handled = false;
-                    if let Some(doc) = &self.doc {
-                        let hit_id = {
-                            let d = doc.borrow();
-                            hit_test(&d.tree, x, y)
-                        };
-                        if let Some(hit_id) = hit_id {
-                            let vw = window_size.0 as f32 / scale_factor as f32;
-                            let vh = window_size.1 as f32 / scale_factor as f32;
-                            if Self::dispatch_oncontextmenu(doc, hit_id, x, y, vw, vh, mods) {
-                                actions.push(AppAction::RequestRedraw);
-                                handled = true;
-                            }
-                        }
-                    }
-                    if !handled {
-                        let click_actions = self.handle_click_with_button(
-                            x,
-                            y,
-                            scale_factor,
-                            mouse_button,
-                            window_size.0 as f32 / scale_factor as f32,
-                            window_size.1 as f32 / scale_factor as f32,
-                        );
-                        actions.extend(click_actions);
-                    }
-                } else {
-                    // Update :active and :focus
-                    if let Some(doc) = &self.doc {
-                        let hit = {
-                            let d = doc.borrow();
-                            hit_test(&d.tree, x, y)
-                        };
-                        let active_changed = doc.borrow_mut().update_active(hit);
-                        let focus_changed = doc.borrow_mut().update_focus(hit);
-                        if active_changed || focus_changed {
-                            actions.push(AppAction::RequestRedraw);
-                        }
-                    }
-
-                    // Check for draggable element — enter pending drag
-                    let draggable_node = if let Some(doc) = &self.doc {
-                        let d = doc.borrow();
-                        if let Some(hit_id) = hit_test(&d.tree, x, y) {
-                            Self::find_draggable(&d.tree, hit_id)
-                        } else {
-                            None
-                        }
-                    } else {
-                        None
-                    };
-
-                    if let Some(drag_node_id) = draggable_node {
-                        self.pending_drag = Some(PendingDrag {
-                            node_id: drag_node_id,
-                            mousedown_pos: (x, y),
-                        });
-                    } else {
-                        let click_actions = self.handle_click_with_button(
-                            x,
-                            y,
-                            scale_factor,
-                            mouse_button,
-                            window_size.0 as f32 / scale_factor as f32,
-                            window_size.1 as f32 / scale_factor as f32,
-                        );
-                        actions.extend(click_actions);
-                    }
-                }
+                actions.extend(self.handle_event(
+                    PlatformEvent::MouseDown {
+                        x,
+                        y,
+                        button: mouse_button,
+                    },
+                    window_size,
+                    scale_factor,
+                ));
                 actions.push(AppAction::RequestRedraw);
                 DebugResult::Json { data: json!(null) }
             }
             DebugCommandKind::MouseUp { x, y, ref button } => {
+                // Route through the real input path so MCP matches a real release.
                 let mouse_button = parse_button(button);
-                self.dispatch_mouse_attr(
-                    "data-onmouseup",
-                    x,
-                    y,
-                    Self::core_button(mouse_button),
-                    window_size.0 as f32 / scale_factor as f32,
-                    window_size.1 as f32 / scale_factor as f32,
-                );
-
-                // Dispatch MouseUp to focused render surface
-                if let Some(surface_id) = crate::render_surface::focused_surface_id() {
-                    if let Some(doc) = &self.doc {
-                        let surface_hit = {
-                            let d = doc.borrow();
-                            if let Some(hit_id) = hit_test(&d.tree, x, y) {
-                                Self::find_render_surface_at(&d.tree, hit_id, x, y)
-                            } else {
-                                None
-                            }
-                        };
-                        let (local_x, local_y) = surface_hit
-                            .filter(|(sid, _, _)| *sid == surface_id)
-                            .map(|(_, lx, ly)| (lx, ly))
-                            .unwrap_or((x, y));
-                        crate::render_surface::dispatch_surface_event(
-                            surface_id,
-                            crate::render_surface::SurfaceEvent::MouseUp {
-                                x: local_x,
-                                y: local_y,
-                                button: crate::render_surface::SurfaceMouseButton::from_platform(
-                                    mouse_button,
-                                ),
-                            },
-                        );
-                    }
-                }
-
-                // Drag-and-drop: complete or cancel
-                if let Some(pending) = self.pending_drag.take() {
-                    // Threshold never crossed — fire normal click
-                    let (px, py) = pending.mousedown_pos;
-                    let click_actions = self.handle_click(
-                        px,
-                        py,
-                        scale_factor,
-                        window_size.0 as f32 / scale_factor as f32,
-                        window_size.1 as f32 / scale_factor as f32,
-                    );
-                    actions.extend(click_actions);
-                } else if let Some(drag) = self.active_dnd.take() {
-                    // Fire ondrop on target if present
-                    if let Some(target_id) = drag.over_target {
-                        if let Some(doc) = &self.doc {
-                            Self::dispatch_drag_attr(doc, target_id, "data-ondrop");
-                        }
-                    }
-                    // Fire ondragend on dragged element
-                    if let Some(doc) = &self.doc {
-                        Self::dispatch_drag_attr(doc, drag.node_id, "data-ondragend");
-                    }
-                    let (w, h) = (window_size.0 as f32, window_size.1 as f32);
-                    self.resolve_and_repaint(w, h);
-                }
-
-                rinch_core::finish_drag(x, y);
-                self.scrollbar_drag = None;
-
-                // Finalize CE selection at the mouse_up position.
-                // Without this, mouse_down → mouse_up (no intermediate mouse_move)
-                // would leave the cursor at the mouse_down position with no selection.
-                if self.ce_selecting {
-                    if let Some(ref mut ce) = self.focused_contenteditable {
-                        let ce_node_id = ce.ce_node_id;
-                        if let Some(doc) = &self.doc {
-                            let new_cursor = {
-                                let d = doc.borrow();
-                                Self::compute_dom_cursor_from_click(&d.tree, ce_node_id, x, y)
-                            };
-                            ce.cursor = new_cursor;
-                            let anchor = ce.anchor;
-                            self.set_contenteditable_attributes_dom(
-                                ce_node_id, true, new_cursor, anchor,
-                            );
-                            self.sync_ce_ops_cursor();
-                            self.scene_dirty = true;
-                        }
-                    }
-                }
-
-                self.ce_selecting = false;
-                self.text_selecting = false;
+                self.cursor_pos = Some((x, y));
+                actions.extend(self.handle_event(
+                    PlatformEvent::MouseUp {
+                        x,
+                        y,
+                        button: mouse_button,
+                    },
+                    window_size,
+                    scale_factor,
+                ));
                 actions.push(AppAction::RequestRedraw);
                 DebugResult::Json { data: json!(null) }
             }
             DebugCommandKind::MouseMove { x, y } => {
+                // Route through the real input path so MCP matches a real move
+                // (drag-select, hover, surface dispatch all live in `handle_event`).
                 self.cursor_pos = Some((x, y));
-                self.dispatch_mouse_attr(
-                    "data-onmousemove",
-                    x,
-                    y,
-                    events::MouseButton::Left,
-                    window_size.0 as f32 / scale_factor as f32,
-                    window_size.1 as f32 / scale_factor as f32,
-                );
-
-                // Drag-and-drop: pending → active transition
-                if let Some(ref pending) = self.pending_drag {
-                    let dx = x - pending.mousedown_pos.0;
-                    let dy = y - pending.mousedown_pos.1;
-                    let dist = (dx * dx + dy * dy).sqrt();
-                    if dist >= DRAG_THRESHOLD {
-                        let node_id = pending.node_id;
-                        let mousedown_pos = pending.mousedown_pos;
-                        self.pending_drag = None;
-
-                        self.activate_drag(node_id, mousedown_pos, (x, y), scale_factor);
-
-                        if let Some(doc) = &self.doc {
-                            Self::dispatch_drag_attr(doc, node_id, "data-ondragstart");
-                        }
-                        let (w, h) = (window_size.0 as f32, window_size.1 as f32);
-                        self.resolve_and_repaint(w, h);
-                        actions.push(AppAction::RequestRedraw);
-                        return DebugResult::Json { data: json!(null) };
-                    }
-                    return DebugResult::Json { data: json!(null) };
-                }
-
-                // Drag-and-drop: active drag tracking
-                if let Some(ref mut drag) = self.active_dnd {
-                    drag.cursor = (x, y);
-
-                    let new_target = if let Some(doc) = &self.doc {
-                        let d = doc.borrow();
-                        hit_test(&d.tree, x, y)
-                            .and_then(|hit_id| Self::find_drop_target(&d.tree, hit_id))
-                    } else {
-                        None
-                    };
-
-                    let old_target = drag.over_target;
-                    if new_target != old_target {
-                        drag.over_target = new_target;
-                        if let Some(doc) = &self.doc {
-                            if let Some(old_id) = old_target {
-                                Self::dispatch_drag_attr(doc, old_id, "data-ondragleave");
-                            }
-                            if let Some(new_id) = new_target {
-                                Self::dispatch_drag_attr(doc, new_id, "data-ondragenter");
-                            }
-                        }
-                    }
-
-                    // Fire ondragover on current drop target
-                    let current_target = drag.over_target;
-                    if let Some(target_id) = current_target {
-                        if let Some(doc) = &self.doc {
-                            Self::dispatch_drag_attr_with_context(
-                                doc,
-                                target_id,
-                                "data-ondragover",
-                                x,
-                                y,
-                            );
-                        }
-                    }
-
-                    self.scene_dirty = true;
-                    let (w, h) = (window_size.0 as f32, window_size.1 as f32);
-                    self.resolve_and_repaint(w, h);
-                    actions.push(AppAction::RequestRedraw);
-                    return DebugResult::Json { data: json!(null) };
-                }
-
-                // Handle component drag (sliders, floating panels, etc.)
-                let (drag_active, _drag_forward_surface) = rinch_core::update_drag(x, y);
-                if drag_active {
-                    let (w, h) = (window_size.0 as f32, window_size.1 as f32);
-                    self.resolve_and_repaint(w, h);
-                    actions.push(AppAction::RequestRedraw);
-                    return DebugResult::Json { data: json!(null) };
-                }
-
-                // Handle contenteditable text selection drag
-                if self.ce_selecting
-                    && let Some(ref mut ce) = self.focused_contenteditable
-                {
-                    let ce_node_id = ce.ce_node_id;
-                    if let Some(doc) = &self.doc {
-                        let new_cursor = {
-                            let d = doc.borrow();
-                            Self::compute_dom_cursor_from_click(&d.tree, ce_node_id, x, y)
-                        };
-                        ce.cursor = new_cursor;
-                        let anchor = ce.anchor;
-                        self.set_contenteditable_attributes_dom(
-                            ce_node_id, true, new_cursor, anchor,
-                        );
-                        self.scene_dirty = true;
-                        actions.push(AppAction::RequestRedraw);
-                        return DebugResult::Json { data: json!(null) };
-                    }
-                }
-
-                // Handle read-only text selection drag
-                if self.text_selecting {
-                    if let Some(sel) = &self.text_selection {
-                        let ifc_node_id = sel.ifc_node_id;
-                        let anchor = sel.anchor_offset;
-                        let new_offset = if let Some(doc) = &self.doc {
-                            let d = doc.borrow();
-                            Self::compute_ifc_offset_from_click(&d.tree, ifc_node_id, x, y)
-                        } else {
-                            anchor
-                        };
-                        if let Some(sel) = &mut self.text_selection {
-                            sel.focus_offset = new_offset;
-                        }
-                        self.set_text_selection_attributes(ifc_node_id, anchor, new_offset);
-                        self.scene_dirty = true;
-                        let (w, h) = (window_size.0 as f32, window_size.1 as f32);
-                        self.resolve_and_repaint(w, h);
-                        actions.push(AppAction::RequestRedraw);
-                        return DebugResult::Json { data: json!(null) };
-                    }
-                }
-
-                // Update hover state
-                if let Some(doc) = &self.doc {
-                    let (hovered, old_hovered) = {
-                        let d = doc.borrow();
-                        (hit_test(&d.tree, x, y), d.tree.hovered_node)
-                    };
-                    let mut hovered_changed = false;
-                    let needs_repaint =
-                        doc.borrow_mut().update_hover(hovered, &mut hovered_changed);
-                    if hovered_changed {
-                        if let Some(old_id) = old_hovered {
-                            Self::dispatch_onleave(doc, old_id);
-                        }
-                        if let Some(hit_id) = hovered {
-                            Self::dispatch_onenter(doc, hit_id);
-                        }
-                    }
-                    if needs_repaint {
-                        actions.push(AppAction::RequestRedraw);
-                    }
-
-                    // Dispatch MouseMove to render surface under cursor
-                    if let Some(hit_id) = hovered {
-                        let surface_hit = {
-                            let d = doc.borrow();
-                            Self::find_render_surface_at(&d.tree, hit_id, x, y)
-                        };
-                        if let Some((surface_id, local_x, local_y)) = surface_hit {
-                            crate::render_surface::dispatch_surface_event(
-                                surface_id,
-                                crate::render_surface::SurfaceEvent::MouseMove {
-                                    x: local_x,
-                                    y: local_y,
-                                },
-                            );
-                        }
-                    }
-                }
+                actions.extend(self.handle_event(
+                    PlatformEvent::MouseMove { x, y },
+                    window_size,
+                    scale_factor,
+                ));
+                actions.push(AppAction::RequestRedraw);
                 DebugResult::Json { data: json!(null) }
             }
             DebugCommandKind::Scroll {
@@ -586,47 +323,25 @@ impl RinchApp {
                 DebugResult::Json { data: json!(null) }
             }
             DebugCommandKind::TypeText { text } => {
+                // Synthesize a real KeyDown per character and route through
+                // `handle_event`, so MCP `type_text` drives the exact same path as
+                // physical keystrokes.
                 for ch in text.chars() {
-                    let key = match ch {
-                        ' ' => "Space".to_string(),
-                        '\n' => "Enter".to_string(),
-                        '\t' => "Tab".to_string(),
-                        c => c.to_string(),
+                    let (key, txt) = match ch {
+                        '\n' => (KeyCode::Enter, None),
+                        '\t' => (KeyCode::Tab, None),
+                        '\x08' => (KeyCode::Backspace, None),
+                        c => (char_to_keycode(c), Some(c.to_string())),
                     };
-                    let key_data = events::KeyEventData {
-                        key: key.clone(),
-                        code: key,
-                        ctrl: false,
-                        shift: false,
-                        alt: false,
-                        meta: false,
-                    };
-                    let handled = events::dispatch_keyboard_event(&key_data);
-                    if !handled {
-                        if self.focused_contenteditable.is_some() {
-                            // Route to contenteditable handler
-                            let key_code = match ch {
-                                '\n' => KeyCode::Enter,
-                                '\t' => KeyCode::Tab,
-                                '\x08' => KeyCode::Backspace,
-                                _ => KeyCode::Space, // Use Space as a safe unmapped key
-                            };
-                            let text_str = ch.to_string();
-                            if self.handle_contenteditable_key(
-                                key_code,
-                                Some(&text_str),
-                                false,
-                                false,
-                                false,
-                            ) {
-                                let (w, h) = (window_size.0 as f32, window_size.1 as f32);
-                                self.resolve_and_repaint(w, h);
-                            }
-                        } else {
-                            // Fallback to handle_text_input for non-intercepted chars
-                            self.handle_text_input(&ch.to_string());
-                        }
-                    }
+                    actions.extend(self.handle_event(
+                        PlatformEvent::KeyDown {
+                            key,
+                            text: txt,
+                            modifiers: rinch_platform::Modifiers::default(),
+                        },
+                        window_size,
+                        scale_factor,
+                    ));
                 }
                 actions.push(AppAction::RequestRedraw);
                 DebugResult::Json { data: json!(null) }
@@ -664,130 +379,29 @@ impl RinchApp {
                 ctrl,
                 alt,
             } => {
-                // Escape cancels active drag-and-drop
-                if key == "Escape" {
-                    if let Some(drag) = self.active_dnd.take() {
-                        if let Some(doc) = &self.doc {
-                            if let Some(target_id) = drag.over_target {
-                                Self::dispatch_drag_attr(doc, target_id, "data-ondragleave");
-                            }
-                            Self::dispatch_drag_attr(doc, drag.node_id, "data-ondragend");
-                        }
-                        rinch_core::Drag::cancel();
-                        self.scene_dirty = true;
-                        let (w, h) = (window_size.0 as f32, window_size.1 as f32);
-                        self.resolve_and_repaint(w, h);
-                        actions.push(AppAction::RequestRedraw);
-                        return DebugResult::Json { data: json!(null) };
-                    }
-                    if self.pending_drag.take().is_some() {
-                        actions.push(AppAction::RequestRedraw);
-                        return DebugResult::Json { data: json!(null) };
-                    }
-                }
-
-                // F12: toggle devtools
-                if key == "F12" {
-                    actions.push(AppAction::ToggleDevTools);
-                    actions.push(AppAction::RequestRedraw);
-                    return DebugResult::Json { data: json!(null) };
-                }
-
-                // Alt+I: toggle inspect mode
-                if (key == "i" || key == "I") && alt && !ctrl && !shift {
-                    actions.push(AppAction::ToggleInspectMode);
-                    actions.push(AppAction::RequestRedraw);
-                    return DebugResult::Json { data: json!(null) };
-                }
-
-                let key_data = events::KeyEventData {
-                    key: key.clone(),
-                    code: key.clone(),
-                    ctrl,
-                    shift,
-                    alt,
-                    meta: false,
+                // Synthesize a real KeyDown and route through `handle_event` (which
+                // owns Escape/F12/inspect/editor/CE handling) so MCP `key_press`
+                // matches a physical keystroke.
+                let key_code = keyname_to_keycode(&key);
+                let text = match key.as_str() {
+                    "Enter" => Some("\n".to_string()),
+                    k if k.chars().count() == 1 => Some(k.to_string()),
+                    _ => None,
                 };
-                let handled = events::dispatch_keyboard_event(&key_data);
-
-                if handled {
-                    actions.push(AppAction::RequestRedraw);
-                }
-
-                if !handled {
-                    if self.focused_contenteditable.is_some() {
-                        // Route to contenteditable handler
-                        let key_code = match key.as_str() {
-                            "ArrowUp" => KeyCode::ArrowUp,
-                            "ArrowDown" => KeyCode::ArrowDown,
-                            "ArrowLeft" => KeyCode::ArrowLeft,
-                            "ArrowRight" => KeyCode::ArrowRight,
-                            "Home" => KeyCode::Home,
-                            "End" => KeyCode::End,
-                            "Enter" => KeyCode::Enter,
-                            "Backspace" => KeyCode::Backspace,
-                            "Delete" => KeyCode::Delete,
-                            "Tab" => KeyCode::Tab,
-                            "Escape" => KeyCode::Escape,
-                            // Map single letter keys to their KeyCode variants
-                            "a" | "A" => KeyCode::KeyA,
-                            "b" | "B" => KeyCode::KeyB,
-                            "c" | "C" => KeyCode::KeyC,
-                            "d" | "D" => KeyCode::KeyD,
-                            "e" | "E" => KeyCode::KeyE,
-                            "f" | "F" => KeyCode::KeyF,
-                            "g" | "G" => KeyCode::KeyG,
-                            "h" | "H" => KeyCode::KeyH,
-                            "i" | "I" => KeyCode::KeyI,
-                            "j" | "J" => KeyCode::KeyJ,
-                            "k" | "K" => KeyCode::KeyK,
-                            "l" | "L" => KeyCode::KeyL,
-                            "m" | "M" => KeyCode::KeyM,
-                            "n" | "N" => KeyCode::KeyN,
-                            "o" | "O" => KeyCode::KeyO,
-                            "p" | "P" => KeyCode::KeyP,
-                            "q" | "Q" => KeyCode::KeyQ,
-                            "r" | "R" => KeyCode::KeyR,
-                            "s" | "S" => KeyCode::KeyS,
-                            "t" | "T" => KeyCode::KeyT,
-                            "u" | "U" => KeyCode::KeyU,
-                            "v" | "V" => KeyCode::KeyV,
-                            "w" | "W" => KeyCode::KeyW,
-                            "x" | "X" => KeyCode::KeyX,
-                            "y" | "Y" => KeyCode::KeyY,
-                            "z" | "Z" => KeyCode::KeyZ,
-                            _ => KeyCode::Space, // Safe fallback for other keys
-                        };
-                        let text = match key.as_str() {
-                            "Enter" => Some("\n".to_string()),
-                            k if k.len() == 1 => Some(k.to_string()),
-                            _ => None,
-                        };
-                        if self.handle_contenteditable_key(
-                            key_code,
-                            text.as_deref(),
+                actions.extend(self.handle_event(
+                    PlatformEvent::KeyDown {
+                        key: key_code,
+                        text,
+                        modifiers: rinch_platform::Modifiers {
                             shift,
                             ctrl,
                             alt,
-                        ) {
-                            let (w, h) = (window_size.0 as f32, window_size.1 as f32);
-                            self.resolve_and_repaint(w, h);
-                        }
-                    } else {
-                        match key.as_str() {
-                            "ArrowUp" => self.handle_arrow_up(shift),
-                            "ArrowDown" => self.handle_arrow_down(shift),
-                            "ArrowLeft" => self.handle_arrow_left(shift, ctrl),
-                            "ArrowRight" => self.handle_arrow_right(shift, ctrl),
-                            "Home" => self.handle_home(shift),
-                            "End" => self.handle_end(shift),
-                            "Enter" => self.handle_enter(),
-                            "Backspace" => self.handle_backspace(),
-                            "Delete" => self.handle_delete(),
-                            _ => {}
-                        }
-                    }
-                }
+                            meta: false,
+                        },
+                    },
+                    window_size,
+                    scale_factor,
+                ));
                 actions.push(AppAction::RequestRedraw);
                 DebugResult::Json { data: json!(null) }
             }

--- a/crates/rinch/src/app/event_dispatch.rs
+++ b/crates/rinch/src/app/event_dispatch.rs
@@ -40,6 +40,15 @@ impl RinchApp {
             PlatformEvent::MouseMove { x, y } => {
                 self.cursor_pos = Some((x, y));
 
+                // New editor (M5): extend an in-progress drag-select.
+                #[cfg(feature = "new-editor")]
+                if crate::editor::drag_anchor().is_some()
+                    && self.extend_editor_drag(x, y, scale_factor, window_size)
+                {
+                    actions.push(AppAction::RequestRedraw);
+                    return actions;
+                }
+
                 // Additive: fire data-onmousemove before any drag/scroll/hover
                 // logic below (which can early-return).
                 self.dispatch_mouse_attr(
@@ -447,6 +456,23 @@ impl RinchApp {
                 self.last_click_time = now;
                 self.last_click_pos = (x, y);
 
+                // New editor (M5): a left click inside an editor places the cursor
+                // (and arms a drag-select). This MUST run in the Left-specific arm —
+                // the general MouseDown arm below never sees left buttons (the cause
+                // of the original "click does nothing" bug).
+                #[cfg(feature = "new-editor")]
+                if self.try_new_editor_click(
+                    x,
+                    y,
+                    scale_factor,
+                    window_size,
+                    self.click_count,
+                    self.modifiers.shift,
+                ) {
+                    actions.push(AppAction::RequestRedraw);
+                    return actions;
+                }
+
                 // Update :active and :focus pseudo-class state.
                 // Don't request redraw here — AboutToWait will pick up the
                 // dirty styles and batch them into a single repaint.
@@ -583,6 +609,10 @@ impl RinchApp {
                     vp_w,
                     vp_h,
                 );
+
+                // New editor (M5): end any drag-select.
+                #[cfg(feature = "new-editor")]
+                crate::editor::end_drag();
 
                 // ── Drag-and-drop: complete or cancel ─────────────────────
                 if let Some(pending) = self.pending_drag.take() {
@@ -822,7 +852,7 @@ impl RinchApp {
                 let ctrl = modifiers.primary();
                 let alt = modifiers.alt;
 
-                // Build key string for keyboard interceptor - handle ALL key types
+                // Build key string for the user keyboard hook + global fallback.
                 let key_str: Option<String> = match key {
                     // Named keys
                     KeyCode::ArrowLeft => Some("ArrowLeft".into()),
@@ -871,8 +901,11 @@ impl RinchApp {
 
                 tracing::trace!(?key, ?text, ?key_str, shift, ctrl, alt, "KeyDown event");
 
-                // Try keyboard interceptor first for ALL keys
-                let handled_by_interceptor = if let Some(ref ks) = key_str {
+                // 1. User keyboard hooks (document-level interceptor). A user
+                //    handler that consumes the key wins and stops here, like a
+                //    capturing DOM listener. Render surfaces no longer hijack this
+                //    slot — they are routed by `FocusTarget::Surface` below.
+                if let Some(ref ks) = key_str {
                     let key_data = events::KeyEventData {
                         key: ks.clone(),
                         code: format!("{:?}", key),
@@ -881,14 +914,43 @@ impl RinchApp {
                         alt,
                         meta: false,
                     };
-                    events::dispatch_keyboard_event(&key_data)
-                } else {
-                    false
-                };
+                    if events::dispatch_keyboard_event(&key_data) {
+                        actions.push(AppAction::RequestRedraw);
+                        return actions;
+                    }
+                }
 
-                if handled_by_interceptor {
-                    // If a render surface is focused, forward KeyDown + text input
-                    if let Some(surface_id) = crate::render_surface::focused_surface_id() {
+                // 2. Route by the focus arbiter (design A10): exactly one target
+                //    owns keyboard input, so there is no order-dependent fallthrough.
+                match self.focus_target {
+                    #[cfg(feature = "new-editor")]
+                    FocusTarget::Editor(container) => {
+                        if let Some(handle) = crate::editor::editor_for(container) {
+                            self.dispatch_new_editor_key(
+                                &handle,
+                                key,
+                                text.as_deref(),
+                                shift,
+                                ctrl,
+                                alt,
+                            );
+                            // Position the caret against the current layout (dirtying
+                            // its block if it reparented), re-layout, then the
+                            // post-layout caret pass finalizes it with fresh geometry.
+                            crate::editor::update_all_carets(self.focused_editor_id());
+                            let (w, h) = (window_size.0 as f32, window_size.1 as f32);
+                            self.resolve_and_repaint(w, h);
+                            actions.push(AppAction::RequestRedraw);
+                        } else {
+                            // The focused editor was unmounted out from under us:
+                            // drop the stale focus so this key (and future ones)
+                            // fall through to the global handlers instead of being
+                            // silently swallowed.
+                            self.focus_target = FocusTarget::None;
+                        }
+                    }
+                    FocusTarget::Surface(surface_id) => {
+                        // Forward KeyDown + text input to the focused surface.
                         crate::render_surface::dispatch_surface_event(
                             surface_id,
                             crate::render_surface::SurfaceEvent::KeyDown(
@@ -910,53 +972,59 @@ impl RinchApp {
                                 );
                             }
                         }
-                    }
-                    actions.push(AppAction::RequestRedraw);
-                } else if self.focused_contenteditable.is_some() {
-                    // Route keyboard events to the contenteditable editing state
-                    if self.handle_contenteditable_key(key, text.as_deref(), shift, ctrl, alt) {
-                        // Resolve layout immediately so the IFC text layout is
-                        // rebuilt before the next paint.  Without this, the
-                        // invalidated text_layout (set to None by set_text_content)
-                        // causes a one-frame flicker where text is invisible.
-                        let (w, h) = (window_size.0 as f32, window_size.1 as f32);
-                        self.resolve_and_repaint(w, h);
                         actions.push(AppAction::RequestRedraw);
                     }
-                } else {
-                    #[cfg(feature = "desktop")]
-                    if key == KeyCode::F12 {
-                        actions.push(AppAction::ToggleDevTools);
-                        return actions;
+                    FocusTarget::ContentEditable(_) => {
+                        // Route keyboard events to the legacy contenteditable engine.
+                        if self.handle_contenteditable_key(key, text.as_deref(), shift, ctrl, alt) {
+                            // Resolve layout immediately so the IFC text layout is
+                            // rebuilt before the next paint. Without this, the
+                            // invalidated text_layout (set to None by set_text_content)
+                            // causes a one-frame flicker where text is invisible.
+                            let (w, h) = (window_size.0 as f32, window_size.1 as f32);
+                            self.resolve_and_repaint(w, h);
+                            actions.push(AppAction::RequestRedraw);
+                        }
                     }
+                    // No widget owns the key, or a plain `<input>` does (its editing
+                    // commands live in the global handlers, gated internally on
+                    // `focused_input_state`). Falls through to DevTools / inspect /
+                    // Tab navigation / read-only text-selection caret motion.
+                    FocusTarget::Input(_) | FocusTarget::None => {
+                        #[cfg(feature = "desktop")]
+                        if key == KeyCode::F12 {
+                            actions.push(AppAction::ToggleDevTools);
+                            return actions;
+                        }
 
-                    // Alt+I: toggle inspect mode
-                    if key == KeyCode::KeyI && alt && !ctrl && !shift {
-                        actions.push(AppAction::ToggleInspectMode);
-                        return actions;
-                    }
+                        // Alt+I: toggle inspect mode
+                        if key == KeyCode::KeyI && alt && !ctrl && !shift {
+                            actions.push(AppAction::ToggleInspectMode);
+                            return actions;
+                        }
 
-                    match key {
-                        KeyCode::Tab => self.handle_tab(shift),
-                        KeyCode::Backspace => self.handle_backspace(),
-                        KeyCode::Delete => self.handle_delete(),
-                        KeyCode::ArrowLeft => self.handle_arrow_left(shift, ctrl),
-                        KeyCode::ArrowRight => self.handle_arrow_right(shift, ctrl),
-                        KeyCode::Home => self.handle_home(shift),
-                        KeyCode::End => self.handle_end(shift),
-                        KeyCode::KeyA if ctrl => self.handle_select_all(),
-                        KeyCode::KeyC if ctrl => self.handle_copy(),
-                        KeyCode::KeyV if ctrl => self.handle_paste(),
-                        KeyCode::KeyX if ctrl => self.handle_cut(),
-                        KeyCode::Enter if !ctrl => self.handle_enter(),
-                        KeyCode::ArrowUp => self.handle_arrow_up(shift),
-                        KeyCode::ArrowDown => self.handle_arrow_down(shift),
-                        _ => {
-                            if !ctrl
-                                && let Some(t) = &text
-                                && !t.is_empty()
-                            {
-                                self.handle_text_input(t);
+                        match key {
+                            KeyCode::Tab => self.handle_tab(shift),
+                            KeyCode::Backspace => self.handle_backspace(),
+                            KeyCode::Delete => self.handle_delete(),
+                            KeyCode::ArrowLeft => self.handle_arrow_left(shift, ctrl),
+                            KeyCode::ArrowRight => self.handle_arrow_right(shift, ctrl),
+                            KeyCode::Home => self.handle_home(shift),
+                            KeyCode::End => self.handle_end(shift),
+                            KeyCode::KeyA if ctrl => self.handle_select_all(),
+                            KeyCode::KeyC if ctrl => self.handle_copy(),
+                            KeyCode::KeyV if ctrl => self.handle_paste(),
+                            KeyCode::KeyX if ctrl => self.handle_cut(),
+                            KeyCode::Enter if !ctrl => self.handle_enter(),
+                            KeyCode::ArrowUp => self.handle_arrow_up(shift),
+                            KeyCode::ArrowDown => self.handle_arrow_down(shift),
+                            _ => {
+                                if !ctrl
+                                    && let Some(t) = &text
+                                    && !t.is_empty()
+                                {
+                                    self.handle_text_input(t);
+                                }
                             }
                         }
                     }
@@ -1681,5 +1749,754 @@ impl RinchApp {
             cursor,
             over_target: None,
         });
+    }
+}
+
+/// A cursor motion produced by an arrow/Home/End key (design §7 keyboard).
+#[cfg(feature = "new-editor")]
+#[derive(Clone, Copy)]
+pub(crate) enum Motion {
+    CharLeft,
+    CharRight,
+    WordLeft,
+    WordRight,
+    LineUp,
+    LineDown,
+    LineStart,
+    LineEnd,
+    DocStart,
+    DocEnd,
+}
+
+/// New-editor (M5) keyboard handling, behind the `new-editor` feature.
+#[cfg(feature = "new-editor")]
+impl RinchApp {
+    /// Translate a key press into an action on the focused editor's
+    /// [`EditorHandle`](crate::editor::EditorHandle). Returns whether the document
+    /// or selection changed (and a repaint/caret refresh is needed).
+    pub(crate) fn dispatch_new_editor_key(
+        &mut self,
+        handle: &crate::editor::EditorHandle,
+        key: KeyCode,
+        text: Option<&str>,
+        shift: bool,
+        ctrl: bool,
+        _alt: bool,
+    ) -> bool {
+        match key {
+            KeyCode::Backspace => handle.command("deleteCharBackward"),
+            KeyCode::Delete => handle.command("deleteCharForward"),
+            KeyCode::Enter if !ctrl => handle.command("enter"),
+            // Cursor movement / selection extension (Shift extends, Ctrl = word/doc).
+            KeyCode::ArrowLeft => self.move_editor(
+                handle,
+                if ctrl {
+                    Motion::WordLeft
+                } else {
+                    Motion::CharLeft
+                },
+                shift,
+            ),
+            KeyCode::ArrowRight => self.move_editor(
+                handle,
+                if ctrl {
+                    Motion::WordRight
+                } else {
+                    Motion::CharRight
+                },
+                shift,
+            ),
+            KeyCode::ArrowUp => self.move_editor(handle, Motion::LineUp, shift),
+            KeyCode::ArrowDown => self.move_editor(handle, Motion::LineDown, shift),
+            KeyCode::Home => self.move_editor(
+                handle,
+                if ctrl {
+                    Motion::DocStart
+                } else {
+                    Motion::LineStart
+                },
+                shift,
+            ),
+            KeyCode::End => self.move_editor(
+                handle,
+                if ctrl {
+                    Motion::DocEnd
+                } else {
+                    Motion::LineEnd
+                },
+                shift,
+            ),
+            KeyCode::KeyA if ctrl => {
+                let state = handle.state();
+                let sel = rinch_editor_core::Selection::text(
+                    rinch_editor_core::Selection::at_start(&state.doc).head(),
+                    rinch_editor_core::Selection::at_end(&state.doc).head(),
+                );
+                handle.set_selection(sel);
+                true
+            }
+            KeyCode::KeyB if ctrl => handle.command("toggleBold"),
+            KeyCode::KeyI if ctrl => handle.command("toggleItalic"),
+            KeyCode::KeyU if ctrl => handle.command("toggleUnderline"),
+            #[cfg(feature = "clipboard")]
+            KeyCode::KeyC if ctrl => {
+                self.editor_copy(handle);
+                false // copy doesn't change the document or selection
+            }
+            #[cfg(feature = "clipboard")]
+            KeyCode::KeyX if ctrl => self.editor_cut(handle),
+            #[cfg(feature = "clipboard")]
+            KeyCode::KeyV if ctrl => self.editor_paste(handle),
+            KeyCode::KeyZ if ctrl && shift => handle.command("redo"),
+            KeyCode::KeyZ if ctrl => handle.command("undo"),
+            KeyCode::KeyY if ctrl => handle.command("redo"),
+            _ => {
+                if ctrl {
+                    return false;
+                }
+                match text {
+                    Some(t) if !t.is_empty() && t.chars().all(|c| !c.is_control()) => handle
+                        .update(|state| {
+                            let mut tr = state.tr();
+                            tr.insert_text(t).ok()?;
+                            Some(tr)
+                        }),
+                    _ => false,
+                }
+            }
+        }
+    }
+
+    /// Apply a cursor [`Motion`] to the focused editor: compute the new head and
+    /// either collapse the cursor there or, when `extend` (Shift), keep the anchor
+    /// and move only the head (extending the selection).
+    pub(crate) fn move_editor(
+        &mut self,
+        handle: &crate::editor::EditorHandle,
+        motion: Motion,
+        extend: bool,
+    ) -> bool {
+        use rinch_editor_core::{Pos, Selection};
+        let state = handle.state();
+        let doc = state.doc.clone();
+        let head = state.selection.head();
+        let new_head: Option<Pos> = match motion {
+            Motion::CharLeft => {
+                Some(Selection::near(&doc, Pos(head.0.saturating_sub(1)), -1).head())
+            }
+            Motion::CharRight => {
+                Some(Selection::near(&doc, Pos((head.0 + 1).min(doc.content_size())), 1).head())
+            }
+            Motion::WordLeft => word_boundary(&doc, head, false),
+            Motion::WordRight => word_boundary(&doc, head, true),
+            Motion::LineStart => line_bound(&doc, head, false),
+            Motion::LineEnd => line_bound(&doc, head, true),
+            Motion::DocStart => Some(Selection::at_start(&doc).head()),
+            Motion::DocEnd => Some(Selection::at_end(&doc).head()),
+            Motion::LineUp | Motion::LineDown => match self.editor_caret_point(handle, head) {
+                Some((cx, cy, ch)) => {
+                    let ty = if matches!(motion, Motion::LineUp) {
+                        cy - ch * 0.5
+                    } else {
+                        cy + ch * 1.5
+                    };
+                    self.editor_point_address(cx, ty)
+                        .and_then(|(_c, tb, ifc)| handle.pos_at(tb, ifc))
+                }
+                None => None,
+            },
+        };
+        match new_head {
+            Some(nh) => {
+                let sel = if extend {
+                    Selection::text(state.selection.anchor(), nh)
+                } else {
+                    Selection::cursor(nh)
+                };
+                handle.set_selection(sel);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Copy the focused editor's selection to the clipboard as both `text/html`
+    /// (rich) and `text/plain` (the fall-back alternative). A no-op for an empty
+    /// selection.
+    #[cfg(feature = "clipboard")]
+    fn editor_copy(&self, handle: &crate::editor::EditorHandle) {
+        if let Some((html, text)) = handle.selection_clipboard() {
+            let _ = crate::clipboard::copy_html(&html, Some(&text));
+        }
+    }
+
+    /// Cut: copy the selection to the clipboard, then delete it. Returns whether the
+    /// document changed.
+    #[cfg(feature = "clipboard")]
+    fn editor_cut(&self, handle: &crate::editor::EditorHandle) -> bool {
+        match handle.selection_clipboard() {
+            Some((html, text)) => {
+                let _ = crate::clipboard::copy_html(&html, Some(&text));
+                handle.command("deleteSelection")
+            }
+            None => false,
+        }
+    }
+
+    /// Paste the clipboard over the selection, preferring rich `text/html` and
+    /// falling back to `text/plain`. Returns whether the document changed.
+    #[cfg(feature = "clipboard")]
+    fn editor_paste(&self, handle: &crate::editor::EditorHandle) -> bool {
+        if let Ok(html) = crate::clipboard::paste_html()
+            && !html.trim().is_empty()
+            && handle.replace_selection_with_html(&html)
+        {
+            return true;
+        }
+        if let Ok(text) = crate::clipboard::paste_text()
+            && !text.is_empty()
+        {
+            return handle.replace_selection_with_text(&text);
+        }
+        false
+    }
+
+    /// Like [`Self::editor_point_address`] but for a **physical** pointer position:
+    /// the layout is in logical pixels while pointer events arrive in physical
+    /// pixels, so we don't know up front whether the layout is logical or physical.
+    ///
+    /// Resolve in two passes so the scale hedge is sound (a wrong-space coordinate
+    /// must fail rather than silently snap): first try an **exact** textblock hit
+    /// at the raw point, then at the scale-divided point — a click on actual text
+    /// lands here in the correct space. Only if neither lands directly on a
+    /// textblock (a genuine click on chrome / padding / beside a short line) do we
+    /// **snap** to the nearest block, preferring the raw point. Snapping last (not
+    /// per-attempt) is what stops a HiDPI text-click from resolving to garbage in
+    /// the physical space before the logical retry runs.
+    pub(crate) fn editor_point_address_physical(
+        &self,
+        x: f32,
+        y: f32,
+        scale: f64,
+    ) -> Option<(usize, usize, usize)> {
+        let s = scale as f32;
+        let scaled = (s - 1.0).abs() > f32::EPSILON;
+        // Pass 1: exact textblock resolution (no snap) at raw, then scaled.
+        if let Some(r) = self.editor_point_address_in(x, y, false) {
+            return Some(r);
+        }
+        if scaled && let Some(r) = self.editor_point_address_in(x / s, y / s, false) {
+            return Some(r);
+        }
+        // Pass 2: genuine chrome click — snap to the nearest block, raw first.
+        if let Some(r) = self.editor_point_address_in(x, y, true) {
+            return Some(r);
+        }
+        if scaled {
+            return self.editor_point_address_in(x / s, y / s, true);
+        }
+        None
+    }
+
+    /// Resolve a window/logical point to `(container id, textblock id, flat IFC
+    /// byte offset)` inside whatever editor it lands on — the shared primitive for
+    /// click, drag-select, and vertical/Home-End movement. Snaps to the nearest
+    /// block when the point misses every textblock (see [`Self::editor_point_address_in`]).
+    pub(crate) fn editor_point_address(&self, x: f32, y: f32) -> Option<(usize, usize, usize)> {
+        self.editor_point_address_in(x, y, true)
+    }
+
+    /// The shared resolver. When `allow_nearest` is false it requires the point to
+    /// land directly on (or inside) a textblock; when true it falls back to the
+    /// geometrically nearest block in the editor (snap-to-line).
+    fn editor_point_address_in(
+        &self,
+        x: f32,
+        y: f32,
+        allow_nearest: bool,
+    ) -> Option<(usize, usize, usize)> {
+        let doc = self.doc.clone()?;
+        let d = doc.borrow();
+        let hit = hit_test(&d.tree, x, y)?;
+        // Walk up for the nearest editor textblock (including empty ones, which
+        // have no Parley layout) and the `data-pm-editor` container.
+        let mut textblock = None;
+        let mut container = None;
+        let mut cur = Some(hit);
+        while let Some(id) = cur {
+            let node = d.tree.get(id)?;
+            if textblock.is_none() && Self::is_editor_textblock(&d.tree, id) {
+                textblock = Some(id);
+            }
+            if node.attributes.get("data-pm-editor").map(String::as_str) == Some("true") {
+                container = Some(id);
+                break;
+            }
+            cur = node.parent;
+        }
+        let cont = container?;
+        // The point missed every textblock — a click on padding, a vertical gap, or
+        // the whitespace beside a short line (e.g. right of a narrow list item).
+        // Snap to the nearest block when allowed.
+        let tb = match textblock {
+            Some(tb) => tb,
+            None if allow_nearest => Self::nearest_textblock_in(&d.tree, cont, x, y)?,
+            None => return None,
+        };
+        let node = d.tree.get(tb)?;
+        // An empty textblock has no inline content and so no Parley layout — the
+        // only cursor position in it is offset 0.
+        let Some(layout) = node.text_layout.as_ref() else {
+            return Some((cont, tb, 0));
+        };
+        let (abs_x, abs_y) = Self::compute_absolute_position(&d.tree, tb);
+        let pad_l = node.computed_style.padding_left.to_px();
+        let pad_t = node.computed_style.padding_top.to_px();
+        let rel_x = x - abs_x - pad_l + node.scroll_offset.0 as f32;
+        let rel_y = y - abs_y - pad_t + node.scroll_offset.1 as f32;
+        let ifc_byte =
+            rinch_dom::text_query::byte_offset_from_position(&layout.layout, rel_x, rel_y);
+        Some((cont, tb, ifc_byte))
+    }
+
+    /// Whether `id` is an editor textblock element — one that holds inline content
+    /// (a `<p>`/`<h*>`/`<pre>`), as opposed to a block container (list / list item /
+    /// blockquote / the editor root, which carry schema-node element children) or a
+    /// void leaf (image / hr / hard break). Recognizes **empty** textblocks too,
+    /// which have no Parley `text_layout`, by structure rather than layout.
+    fn is_editor_textblock(tree: &rinch_dom::NodeTree, id: usize) -> bool {
+        let Some(node) = tree.get(id) else {
+            return false;
+        };
+        let Some(pm_type) = node.attributes.get("data-pm-type") else {
+            return false; // text node or mark wrapper (`data-pm-mark`)
+        };
+        // The editor root and void leaves are never text-cursor targets.
+        if matches!(
+            pm_type.as_str(),
+            "doc" | "image" | "horizontal_rule" | "hard_break"
+        ) {
+            return false;
+        }
+        // Containers hold schema-node element children; a textblock's children are
+        // inline (text / mark wrappers) or it is empty.
+        !node.children.iter().any(|&c| {
+            tree.get(c)
+                .is_some_and(|n| n.attributes.contains_key("data-pm-type"))
+        })
+    }
+
+    /// The editor textblock inside `container` geometrically nearest to window
+    /// point `(x, y)`. Distance prioritizes vertical proximity — the line/block
+    /// whose vertical band contains `y` wins — then horizontal, so a click in the
+    /// whitespace beside a line resolves to that line's textblock rather than an
+    /// unrelated one above/below. Considers empty textblocks (no `text_layout`) too.
+    fn nearest_textblock_in(
+        tree: &rinch_dom::NodeTree,
+        container: usize,
+        x: f32,
+        y: f32,
+    ) -> Option<usize> {
+        let mut best: Option<(usize, f32)> = None;
+        let mut stack = vec![container];
+        while let Some(id) = stack.pop() {
+            let Some(node) = tree.get(id) else { continue };
+            if Self::is_editor_textblock(tree, id) {
+                let (ax, ay) = Self::compute_absolute_position(tree, id);
+                let (w, h) = (node.layout.width, node.layout.height);
+                let dy = (ay - y).max(0.0).max(y - (ay + h));
+                let dx = (ax - x).max(0.0).max(x - (ax + w));
+                // Vertical distance dominates so same-line beats nearer-but-other-line.
+                let dist = dy * 1.0e4 + dx;
+                if best.is_none_or(|(_, bd)| dist < bd) {
+                    best = Some((id, dist));
+                }
+            }
+            stack.extend(node.children.iter().copied());
+        }
+        best.map(|(id, _)| id)
+    }
+
+    /// The caret's `(x, y, height)` in window coordinates for a model `pos` — the
+    /// forward geometry used to anchor vertical movement.
+    fn editor_caret_point(
+        &self,
+        handle: &crate::editor::EditorHandle,
+        pos: rinch_editor_core::Pos,
+    ) -> Option<(f32, f32, f32)> {
+        let (tb, flat) = handle.caret_address(pos)?;
+        let doc = self.doc.clone()?;
+        let d = doc.borrow();
+        let (local_x, local_y) = d.query_caret_position(tb as u64, flat)?;
+        let height = d
+            .query_glyph_bounds(tb as u64, flat)
+            .map(|g| g.height)
+            .unwrap_or(18.0);
+        let node = d.tree.get(tb)?;
+        let (abs_x, abs_y) = Self::compute_absolute_position(&d.tree, tb);
+        let pad_l = node.computed_style.padding_left.to_px();
+        let pad_t = node.computed_style.padding_top.to_px();
+        Some((abs_x + pad_l + local_x, abs_y + pad_t + local_y, height))
+    }
+
+    /// The id of the `data-pm-editor` container under window/logical point
+    /// `(x, y)`, if the click landed inside any editor — independent of whether it
+    /// hit a textblock. Used so a click on the editor's padding / empty area still
+    /// takes (or keeps) focus rather than blurring it.
+    pub(crate) fn editor_container_at(&self, x: f32, y: f32) -> Option<usize> {
+        let doc = self.doc.clone()?;
+        let d = doc.borrow();
+        let hit = hit_test(&d.tree, x, y)?;
+        let mut cur = Some(hit);
+        while let Some(id) = cur {
+            let node = d.tree.get(id)?;
+            if node.attributes.get("data-pm-editor").map(String::as_str) == Some("true") {
+                return Some(id);
+            }
+            cur = node.parent;
+        }
+        None
+    }
+
+    /// Physical-coordinate variant of [`Self::editor_container_at`] (the raw-or-
+    /// scaled HiDPI hedge, mirroring [`Self::editor_point_address_physical`]).
+    pub(crate) fn editor_container_at_physical(&self, x: f32, y: f32, scale: f64) -> Option<usize> {
+        self.editor_container_at(x, y).or_else(|| {
+            let s = scale as f32;
+            if (s - 1.0).abs() > f32::EPSILON {
+                self.editor_container_at(x / s, y / s)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Focus the new editor under a pointer click at physical `(x, y)` and set the
+    /// selection per the click gesture. Returns whether the click landed in an
+    /// editor.
+    ///
+    /// A click **anywhere inside** the editor container takes/keeps focus — even on
+    /// the container's padding or empty `min-height` area (otherwise it would fall
+    /// through to `handle_click` and blur the editor, silently killing input). The
+    /// click resolves to a model position via the nearest textblock (the clicked
+    /// line, or the nearest line for a click on padding / in a gap); from there the
+    /// gesture chooses the selection:
+    /// - `click_count == 2` → select the **word** under the pointer;
+    /// - `click_count == 3` → select the whole **textblock**;
+    /// - `shift` → **extend** the existing selection from its anchor to the click;
+    /// - otherwise → place a collapsed **cursor** and arm a drag-select.
+    ///
+    /// Only the single-click cases arm a drag (a plain click drags from the click;
+    /// Shift+click drags from the existing anchor). The only click that keeps the
+    /// prior selection is one that resolves to no textblock at all (an empty editor
+    /// with no addressable block).
+    pub(crate) fn try_new_editor_click(
+        &mut self,
+        x: f32,
+        y: f32,
+        scale: f64,
+        window_size: (u32, u32),
+        click_count: u8,
+        shift: bool,
+    ) -> bool {
+        let Some(container) = self.editor_container_at_physical(x, y, scale) else {
+            return false;
+        };
+        let Some(handle) = crate::editor::editor_for(container) else {
+            return false;
+        };
+        // Take keyboard focus through the arbiter (tears down a prior surface /
+        // input / CE / different editor).
+        self.set_focus_target(FocusTarget::Editor(container));
+        if let Some((c, textblock, ifc_byte)) = self.editor_point_address_physical(x, y, scale)
+            && c == container
+            && let Some(clicked) = handle.pos_at(textblock, ifc_byte)
+        {
+            use rinch_editor_core::Selection;
+            let doc = handle.doc();
+            let prior_anchor = handle.selection().anchor();
+            let (selection, drag_anchor) = match click_count {
+                2 => {
+                    let (from, to) = word_range_at(&doc, clicked);
+                    (Selection::text(from, to), None)
+                }
+                3 => {
+                    let (from, to) = block_range_at(&doc, clicked);
+                    (Selection::text(from, to), None)
+                }
+                _ if shift => (Selection::text(prior_anchor, clicked), Some(prior_anchor)),
+                _ => (Selection::cursor(clicked), Some(clicked)),
+            };
+            handle.set_selection(selection);
+            if let Some(anchor) = drag_anchor {
+                crate::editor::begin_drag(container, anchor.0);
+            }
+        }
+        // Position the caret first, then re-layout so the post-layout caret pass
+        // finalizes it against fresh geometry.
+        crate::editor::update_all_carets(self.focused_editor_id());
+        let (w, h) = (window_size.0 as f32, window_size.1 as f32);
+        self.resolve_and_repaint(w, h);
+        true
+    }
+
+    /// Extend an in-progress drag-select to physical pointer `(x, y)`: the
+    /// selection runs from the mousedown anchor to the position under the pointer.
+    /// Returns whether a drag was active and updated.
+    pub(crate) fn extend_editor_drag(
+        &mut self,
+        x: f32,
+        y: f32,
+        scale: f64,
+        window_size: (u32, u32),
+    ) -> bool {
+        let Some((container, anchor)) = crate::editor::drag_anchor() else {
+            return false;
+        };
+        let Some((c, tb, ifc)) = self.editor_point_address_physical(x, y, scale) else {
+            return true; // dragged off the text; keep the drag, don't change selection
+        };
+        if c != container {
+            return true;
+        }
+        let Some(handle) = crate::editor::editor_for(container) else {
+            return false;
+        };
+        if let Some(head) = handle.pos_at(tb, ifc) {
+            handle.set_selection(rinch_editor_core::Selection::text(
+                rinch_editor_core::Pos(anchor),
+                head,
+            ));
+            crate::editor::update_all_carets(self.focused_editor_id());
+            let (w, h) = (window_size.0 as f32, window_size.1 as f32);
+            self.resolve_and_repaint(w, h);
+        }
+        true
+    }
+}
+
+/// The model position at the start (`end=false`) or end (`end=true`) of the
+/// textblock `head` is in. (Visual-line Home/End for wrapped lines is a later
+/// refinement; this is block start/end.)
+#[cfg(feature = "new-editor")]
+fn line_bound(
+    doc: &rinch_editor_core::Node,
+    head: rinch_editor_core::Pos,
+    end: bool,
+) -> Option<rinch_editor_core::Pos> {
+    let r = doc.resolve(head).ok()?;
+    if !r.parent().is_textblock() {
+        return None;
+    }
+    let content_start = head.0 - r.parent_offset();
+    Some(rinch_editor_core::Pos(if end {
+        content_start + r.parent().content().size()
+    } else {
+        content_start
+    }))
+}
+
+/// The model position at the previous/next word boundary within `head`'s
+/// textblock (a simple whitespace/word-character scan; cross-block word motion is
+/// a later refinement).
+#[cfg(feature = "new-editor")]
+fn word_boundary(
+    doc: &rinch_editor_core::Node,
+    head: rinch_editor_core::Pos,
+    forward: bool,
+) -> Option<rinch_editor_core::Pos> {
+    let r = doc.resolve(head).ok()?;
+    if !r.parent().is_textblock() {
+        return None;
+    }
+    let chars: Vec<char> = block_text(r.parent()).chars().collect();
+    let content_start = head.0 - r.parent_offset();
+    let mut i = r.parent_offset();
+    if forward {
+        while i < chars.len() && chars[i].is_whitespace() {
+            i += 1;
+        }
+        while i < chars.len() && !chars[i].is_whitespace() {
+            i += 1;
+        }
+    } else {
+        i = i.saturating_sub(1);
+        while i > 0 && chars[i].is_whitespace() {
+            i -= 1;
+        }
+        while i > 0 && !chars[i - 1].is_whitespace() {
+            i -= 1;
+        }
+    }
+    Some(rinch_editor_core::Pos(content_start + i))
+}
+
+/// The concatenated inline text of a textblock, with each non-text leaf counted as
+/// one placeholder char (so word/line offsets line up with the position space).
+#[cfg(feature = "new-editor")]
+fn block_text(block: &rinch_editor_core::Node) -> String {
+    let mut s = String::new();
+    for i in 0..block.child_count() {
+        let child = block.child(i);
+        match child.text() {
+            Some(t) => s.push_str(t),
+            None => s.push(' '),
+        }
+    }
+    s
+}
+
+/// The model word range `(start, end)` around `pos` — the contiguous run of
+/// like-classed characters (word vs. whitespace) under a double-click, classified
+/// by the character to the right of the gap (or the last character at block end).
+/// Falls back to a collapsed range at `pos` when it is not inside a textblock or
+/// the block is empty.
+#[cfg(feature = "new-editor")]
+fn word_range_at(
+    doc: &rinch_editor_core::Node,
+    pos: rinch_editor_core::Pos,
+) -> (rinch_editor_core::Pos, rinch_editor_core::Pos) {
+    use rinch_editor_core::Pos;
+    let Ok(r) = doc.resolve(pos) else {
+        return (pos, pos);
+    };
+    if !r.parent().is_textblock() {
+        return (pos, pos);
+    }
+    let chars: Vec<char> = block_text(r.parent()).chars().collect();
+    if chars.is_empty() {
+        return (pos, pos);
+    }
+    let content_start = pos.0 - r.parent_offset();
+    let off = r.parent_offset().min(chars.len());
+    let is_word_char = |c: char| !c.is_whitespace();
+    // Classify the run to select. Normally use the char to the right of the gap, but
+    // at a word's *trailing* edge (the right char is whitespace, or we're at block
+    // end, while the left char is a word char) prefer the word — a double-click just
+    // after a word selects the word, not the following space. A click genuinely
+    // inside a whitespace run (whitespace on both sides) still selects the whitespace.
+    let classify_right = off < chars.len()
+        && (is_word_char(chars[off]) || off == 0 || !is_word_char(chars[off - 1]));
+    let class_idx = if classify_right { off } else { off - 1 };
+    let target = is_word_char(chars[class_idx]);
+    let mut start = off;
+    while start > 0 && is_word_char(chars[start - 1]) == target {
+        start -= 1;
+    }
+    let mut end = off;
+    while end < chars.len() && is_word_char(chars[end]) == target {
+        end += 1;
+    }
+    (Pos(content_start + start), Pos(content_start + end))
+}
+
+/// The model content range `(start, end)` of the textblock containing `pos` — the
+/// whole-block selection a triple-click makes. Falls back to a collapsed range at
+/// `pos` when it is not inside a textblock.
+#[cfg(feature = "new-editor")]
+fn block_range_at(
+    doc: &rinch_editor_core::Node,
+    pos: rinch_editor_core::Pos,
+) -> (rinch_editor_core::Pos, rinch_editor_core::Pos) {
+    use rinch_editor_core::Pos;
+    let Ok(r) = doc.resolve(pos) else {
+        return (pos, pos);
+    };
+    if !r.parent().is_textblock() {
+        return (pos, pos);
+    }
+    let content_start = pos.0 - r.parent_offset();
+    let content_end = content_start + r.parent().content().size();
+    (Pos(content_start), Pos(content_end))
+}
+
+#[cfg(all(test, feature = "new-editor"))]
+mod editor_selection_tests {
+    use super::{block_range_at, word_range_at};
+    use rinch_editor_core::model::Fragment;
+    use rinch_editor_core::{Node, Pos, Schema};
+
+    fn paragraph_doc(text: &str) -> Node {
+        let s = Schema::starter_kit();
+        let p = s
+            .branch("paragraph", Fragment::from_node(s.text(text).unwrap()))
+            .unwrap();
+        s.branch("doc", Fragment::from_node(p)).unwrap()
+    }
+
+    #[test]
+    fn word_range_selects_word_under_pos() {
+        let doc = paragraph_doc("hello world");
+        // Positions: 0[p 1 'hello world'(11) 12]13.
+        assert_eq!(
+            word_range_at(&doc, Pos(3)),
+            (Pos(1), Pos(6)),
+            "inside 'hello'"
+        );
+        assert_eq!(
+            word_range_at(&doc, Pos(9)),
+            (Pos(7), Pos(12)),
+            "inside 'world'"
+        );
+    }
+
+    #[test]
+    fn word_range_at_block_end_selects_last_word() {
+        let doc = paragraph_doc("hello world");
+        // The gap at block end classifies by the last char ('d').
+        assert_eq!(word_range_at(&doc, Pos(12)), (Pos(7), Pos(12)));
+    }
+
+    #[test]
+    fn word_range_on_whitespace_selects_whitespace_run() {
+        let doc = paragraph_doc("a  b");
+        // chars a,_,_,b — a click *between* the two spaces (both neighbours
+        // whitespace) selects the run of spaces.
+        assert_eq!(word_range_at(&doc, Pos(3)), (Pos(2), Pos(4)));
+    }
+
+    #[test]
+    fn word_range_at_word_trailing_edge_selects_the_word() {
+        let doc = paragraph_doc("a  b");
+        // A click in the gap just *after* 'a' (right char is whitespace, left char is
+        // a word char) selects the word 'a', not the following space.
+        assert_eq!(word_range_at(&doc, Pos(2)), (Pos(1), Pos(2)));
+        // And the gap just before 'b' selects 'b'.
+        assert_eq!(word_range_at(&doc, Pos(4)), (Pos(4), Pos(5)));
+    }
+
+    #[test]
+    fn word_range_empty_block_is_collapsed() {
+        let s = Schema::starter_kit();
+        let doc = s
+            .branch(
+                "doc",
+                Fragment::from_node(s.branch("paragraph", Fragment::empty()).unwrap()),
+            )
+            .unwrap();
+        assert_eq!(word_range_at(&doc, Pos(1)), (Pos(1), Pos(1)));
+    }
+
+    #[test]
+    fn block_range_selects_whole_textblock() {
+        let doc = paragraph_doc("hello world");
+        assert_eq!(block_range_at(&doc, Pos(3)), (Pos(1), Pos(12)));
+        assert_eq!(block_range_at(&doc, Pos(8)), (Pos(1), Pos(12)));
+    }
+
+    #[test]
+    fn block_range_targets_the_clicked_block() {
+        let s = Schema::starter_kit();
+        let p1 = s
+            .branch("paragraph", Fragment::from_node(s.text("ab").unwrap()))
+            .unwrap();
+        let p2 = s
+            .branch("paragraph", Fragment::from_node(s.text("cdef").unwrap()))
+            .unwrap();
+        let doc = s
+            .branch("doc", Fragment::from_children(vec![p1, p2]))
+            .unwrap();
+        // Positions: 0[p 1 ab 3]4[p 5 cdef 9]10 — second block content is [5, 9).
+        assert_eq!(block_range_at(&doc, Pos(7)), (Pos(5), Pos(9)));
     }
 }

--- a/crates/rinch/src/app/event_dispatch.rs
+++ b/crates/rinch/src/app/event_dispatch.rs
@@ -937,7 +937,7 @@ impl RinchApp {
                             // Position the caret against the current layout (dirtying
                             // its block if it reparented), re-layout, then the
                             // post-layout caret pass finalizes it with fresh geometry.
-                            crate::editor::update_all_carets(self.focused_editor_id());
+                            self.refresh_editor_overlays();
                             let (w, h) = (window_size.0 as f32, window_size.1 as f32);
                             self.resolve_and_repaint(w, h);
                             actions.push(AppAction::RequestRedraw);
@@ -1855,12 +1855,9 @@ impl RinchApp {
                     return false;
                 }
                 match text {
-                    Some(t) if !t.is_empty() && t.chars().all(|c| !c.is_control()) => handle
-                        .update(|state| {
-                            let mut tr = state.tr();
-                            tr.insert_text(t).ok()?;
-                            Some(tr)
-                        }),
+                    Some(t) if !t.is_empty() && t.chars().all(|c| !c.is_control()) => {
+                        handle.insert_text(t)
+                    }
                     _ => false,
                 }
             }
@@ -1882,10 +1879,23 @@ impl RinchApp {
         let head = state.selection.head();
         let new_head: Option<Pos> = match motion {
             Motion::CharLeft => {
-                Some(Selection::near(&doc, Pos(head.0.saturating_sub(1)), -1).head())
+                let near = Selection::near(&doc, Pos(head.0.saturating_sub(1)), -1);
+                // A char move that lands on a selectable block atom (a horizontal
+                // rule) is a node selection, not a cursor. Honor it when collapsing
+                // (not extending) so the leaf is keyboard-reachable and deletable.
+                if !extend && matches!(near, Selection::Node(_)) {
+                    handle.set_selection(near);
+                    return true;
+                }
+                Some(near.head())
             }
             Motion::CharRight => {
-                Some(Selection::near(&doc, Pos((head.0 + 1).min(doc.content_size())), 1).head())
+                let near = Selection::near(&doc, Pos((head.0 + 1).min(doc.content_size())), 1);
+                if !extend && matches!(near, Selection::Node(_)) {
+                    handle.set_selection(near);
+                    return true;
+                }
+                Some(near.head())
             }
             Motion::WordLeft => word_boundary(&doc, head, false),
             Motion::WordRight => word_boundary(&doc, head, true),
@@ -1893,18 +1903,9 @@ impl RinchApp {
             Motion::LineEnd => line_bound(&doc, head, true),
             Motion::DocStart => Some(Selection::at_start(&doc).head()),
             Motion::DocEnd => Some(Selection::at_end(&doc).head()),
-            Motion::LineUp | Motion::LineDown => match self.editor_caret_point(handle, head) {
-                Some((cx, cy, ch)) => {
-                    let ty = if matches!(motion, Motion::LineUp) {
-                        cy - ch * 0.5
-                    } else {
-                        cy + ch * 1.5
-                    };
-                    self.editor_point_address(cx, ty)
-                        .and_then(|(_c, tb, ifc)| handle.pos_at(tb, ifc))
-                }
-                None => None,
-            },
+            Motion::LineUp | Motion::LineDown => self
+                .vertical_step(handle, head, matches!(motion, Motion::LineDown))
+                .map(|sel| sel.head()),
         };
         match new_head {
             Some(nh) => {
@@ -2139,6 +2140,70 @@ impl RinchApp {
         Some((abs_x + pad_l + local_x, abs_y + pad_t + local_y, height))
     }
 
+    /// One vertical cursor step (Up / Down), as a text cursor. First tries the
+    /// visual line above or below via Parley geometry; when that is **stuck** — the
+    /// caret would stay on the same visual line because a block atom (a horizontal
+    /// rule) or a large gap blocks the way — it steps **over** the atom to the
+    /// next/previous textblock (`Selection::near_text`, which skips atoms). `None`
+    /// when there is nowhere to go. Vertical movement never node-selects an atom;
+    /// the horizontal arrows and clicks do that.
+    fn vertical_step(
+        &self,
+        handle: &crate::editor::EditorHandle,
+        head: rinch_editor_core::Pos,
+        down: bool,
+    ) -> Option<rinch_editor_core::Selection> {
+        use rinch_editor_core::{Pos, Selection};
+        let doc = handle.doc();
+        if let Some((cx, cy, ch)) = self.editor_caret_point(handle, head)
+            && let Some((_c, tb, ifc)) = {
+                let ty = if down { cy + ch * 1.5 } else { cy - ch * 0.5 };
+                self.editor_point_address(cx, ty)
+            }
+            && let Some(p) = handle.pos_at(tb, ifc)
+        {
+            // A move into a *different* textblock is always a real line change.
+            let head_tb = handle.caret_address(head).map(|(t, _)| t);
+            let p_tb = handle.caret_address(p).map(|(t, _)| t);
+            if p_tb != head_tb {
+                return Some(Selection::cursor(p));
+            }
+            // Same textblock: accept only if the caret actually advanced to a
+            // different visual line (a wrapped paragraph) — otherwise the target
+            // point snapped back to the current line (a block atom is in the way).
+            if let Some((_, py, _)) = self.editor_caret_point(handle, p) {
+                let advanced = if down {
+                    py > cy + ch * 0.5
+                } else {
+                    py < cy - ch * 0.5
+                };
+                if advanced {
+                    return Some(Selection::cursor(p));
+                }
+            }
+        }
+        // Stuck (or an empty target with no Parley geometry) — step over any block
+        // atom(s) to the next/previous textblock. Probe from just outside the
+        // current block (for a cursor in a textblock) or from `head` itself (a
+        // doc-level boundary, e.g. coming from a node selection).
+        let r = doc.resolve(head).ok()?;
+        let probe = if r.parent().is_textblock() {
+            let content_start = head.0 - r.parent_offset();
+            if down {
+                content_start + r.parent().content().size() + 1
+            } else {
+                content_start.checked_sub(1)?
+            }
+        } else {
+            head.0
+        };
+        Selection::near_text(
+            &doc,
+            Pos(probe.min(doc.content_size())),
+            if down { 1 } else { -1 },
+        )
+    }
+
     /// The id of the `data-pm-editor` container under window/logical point
     /// `(x, y)`, if the click landed inside any editor — independent of whether it
     /// hit a textblock. Used so a click on the editor's padding / empty area still
@@ -2165,6 +2230,47 @@ impl RinchApp {
             let s = scale as f32;
             if (s - 1.0).abs() > f32::EPSILON {
                 self.editor_container_at(x / s, y / s)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// The host id of an editor **leaf** node element — an `<img>`/`<hr>` whose
+    /// `data-pm-type` is `image` or `horizontal_rule` — under logical point
+    /// `(x, y)`, if the click landed on one inside an editor container. Walks up
+    /// from the hit node, recording the first leaf seen, and returns it only once
+    /// the walk reaches the `data-pm-editor` container (so a leaf outside any editor,
+    /// or a click on a non-leaf block, yields `None`). The click→node-select path.
+    fn editor_leaf_at(&self, x: f32, y: f32) -> Option<usize> {
+        let doc = self.doc.clone()?;
+        let d = doc.borrow();
+        let hit = hit_test(&d.tree, x, y)?;
+        let mut leaf: Option<usize> = None;
+        let mut cur = Some(hit);
+        while let Some(id) = cur {
+            let node = d.tree.get(id)?;
+            if leaf.is_none()
+                && let Some(t) = node.attributes.get("data-pm-type")
+                && matches!(t.as_str(), "image" | "horizontal_rule")
+            {
+                leaf = Some(id);
+            }
+            if node.attributes.get("data-pm-editor").map(String::as_str) == Some("true") {
+                return leaf; // inside an editor — return the leaf if we passed one
+            }
+            cur = node.parent;
+        }
+        None
+    }
+
+    /// Physical-coordinate variant of [`Self::editor_leaf_at`] (the raw-or-scaled
+    /// HiDPI hedge, mirroring [`Self::editor_container_at_physical`]).
+    fn editor_leaf_at_physical(&self, x: f32, y: f32, scale: f64) -> Option<usize> {
+        self.editor_leaf_at(x, y).or_else(|| {
+            let s = scale as f32;
+            if (s - 1.0).abs() > f32::EPSILON {
+                self.editor_leaf_at(x / s, y / s)
             } else {
                 None
             }
@@ -2208,7 +2314,16 @@ impl RinchApp {
         // Take keyboard focus through the arbiter (tears down a prior surface /
         // input / CE / different editor).
         self.set_focus_target(FocusTarget::Editor(container));
-        if let Some((c, textblock, ifc_byte)) = self.editor_point_address_physical(x, y, scale)
+        // A click on a leaf node (an image or horizontal rule) selects the node
+        // itself — a `Selection::Node`, outlined by the view — rather than placing a
+        // text cursor (design §6 node-views). A node-select never arms a drag.
+        if let Some(leaf) = self.editor_leaf_at_physical(x, y, scale)
+            && let Some(selection) = handle.node_selection_at_host(leaf)
+        {
+            handle.set_selection(selection);
+            crate::editor::end_drag();
+        } else if let Some((c, textblock, ifc_byte)) =
+            self.editor_point_address_physical(x, y, scale)
             && c == container
             && let Some(clicked) = handle.pos_at(textblock, ifc_byte)
         {
@@ -2234,7 +2349,7 @@ impl RinchApp {
         }
         // Position the caret first, then re-layout so the post-layout caret pass
         // finalizes it against fresh geometry.
-        crate::editor::update_all_carets(self.focused_editor_id());
+        self.refresh_editor_overlays();
         let (w, h) = (window_size.0 as f32, window_size.1 as f32);
         self.resolve_and_repaint(w, h);
         true
@@ -2267,7 +2382,7 @@ impl RinchApp {
                 rinch_editor_core::Pos(anchor),
                 head,
             ));
-            crate::editor::update_all_carets(self.focused_editor_id());
+            self.refresh_editor_overlays();
             let (w, h) = (window_size.0 as f32, window_size.1 as f32);
             self.resolve_and_repaint(w, h);
         }

--- a/crates/rinch/src/app/event_dispatch.rs
+++ b/crates/rinch/src/app/event_dispatch.rs
@@ -1783,6 +1783,11 @@ impl RinchApp {
         ctrl: bool,
         _alt: bool,
     ) -> bool {
+        // The vertical "goal column" survives only a run of Up/Down — any other key
+        // (typing, horizontal arrows, Home/End, edits) abandons it.
+        if !matches!(key, KeyCode::ArrowUp | KeyCode::ArrowDown) {
+            self.editor_goal_x = None;
+        }
         match key {
             KeyCode::Backspace => handle.command("deleteCharBackward"),
             KeyCode::Delete => handle.command("deleteCharForward"),
@@ -1903,9 +1908,17 @@ impl RinchApp {
             Motion::LineEnd => line_bound(&doc, head, true),
             Motion::DocStart => Some(Selection::at_start(&doc).head()),
             Motion::DocEnd => Some(Selection::at_end(&doc).head()),
-            Motion::LineUp | Motion::LineDown => self
-                .vertical_step(handle, head, matches!(motion, Motion::LineDown))
-                .map(|sel| sel.head()),
+            Motion::LineUp | Motion::LineDown => {
+                // Establish the goal column from the current caret on the first
+                // vertical step, then reuse it so the cursor keeps its horizontal
+                // position through short lines instead of drifting to line ends.
+                let goal_x = self
+                    .editor_goal_x
+                    .or_else(|| self.editor_caret_point(handle, head).map(|(x, _, _)| x));
+                self.editor_goal_x = goal_x;
+                self.vertical_step(handle, head, matches!(motion, Motion::LineDown), goal_x)
+                    .map(|sel| sel.head())
+            }
         };
         match new_head {
             Some(nh) => {
@@ -2152,13 +2165,17 @@ impl RinchApp {
         handle: &crate::editor::EditorHandle,
         head: rinch_editor_core::Pos,
         down: bool,
+        goal_x: Option<f32>,
     ) -> Option<rinch_editor_core::Selection> {
         use rinch_editor_core::{Pos, Selection};
         let doc = handle.doc();
         if let Some((cx, cy, ch)) = self.editor_caret_point(handle, head)
             && let Some((_c, tb, ifc)) = {
+                // Hit-test at the goal column (preserved across consecutive
+                // Up/Down), falling back to the live caret x for the first step.
+                let tx = goal_x.unwrap_or(cx);
                 let ty = if down { cy + ch * 1.5 } else { cy - ch * 0.5 };
-                self.editor_point_address(cx, ty)
+                self.editor_point_address(tx, ty)
             }
             && let Some(p) = handle.pos_at(tb, ifc)
         {
@@ -2314,6 +2331,9 @@ impl RinchApp {
         // Take keyboard focus through the arbiter (tears down a prior surface /
         // input / CE / different editor).
         self.set_focus_target(FocusTarget::Editor(container));
+        // A click places the cursor at a new column, so abandon any vertical goal
+        // column from a prior Up/Down run.
+        self.editor_goal_x = None;
         // A click on a leaf node (an image or horizontal rule) selects the node
         // itself — a `Selection::Node`, outlined by the view — rather than placing a
         // text cursor (design §6 node-views). A node-select never arms a drag.

--- a/crates/rinch/src/app/event_dispatch.rs
+++ b/crates/rinch/src/app/event_dispatch.rs
@@ -1904,8 +1904,14 @@ impl RinchApp {
             }
             Motion::WordLeft => word_boundary(&doc, head, false),
             Motion::WordRight => word_boundary(&doc, head, true),
-            Motion::LineStart => line_bound(&doc, head, false),
-            Motion::LineEnd => line_bound(&doc, head, true),
+            // Visual-line edge for wrapped paragraphs (geometry), falling back to
+            // the block edge when the caret has no Parley layout (an empty block).
+            Motion::LineStart => self
+                .visual_line_bound(handle, head, false)
+                .or_else(|| line_bound(&doc, head, false)),
+            Motion::LineEnd => self
+                .visual_line_bound(handle, head, true)
+                .or_else(|| line_bound(&doc, head, true)),
             Motion::DocStart => Some(Selection::at_start(&doc).head()),
             Motion::DocEnd => Some(Selection::at_end(&doc).head()),
             Motion::LineUp | Motion::LineDown => {
@@ -2219,6 +2225,53 @@ impl RinchApp {
             Pos(probe.min(doc.content_size())),
             if down { 1 } else { -1 },
         )
+    }
+
+    /// The model position at the start (`end = false`) or end (`end = true`) of the
+    /// caret's current **visual** line — so Home/End land at the wrapped line's edge,
+    /// not the whole block's. Hit-tests the far-left / far-right of the caret's line
+    /// box via the same geometry as [`Self::vertical_step`]. `None` when the caret
+    /// has no Parley geometry (an empty block); the caller falls back to the
+    /// block-level [`line_bound`].
+    fn visual_line_bound(
+        &self,
+        handle: &crate::editor::EditorHandle,
+        head: rinch_editor_core::Pos,
+        end: bool,
+    ) -> Option<rinch_editor_core::Pos> {
+        let (_cx, cy, ch) = self.editor_caret_point(handle, head)?;
+        let (tb, _flat) = handle.caret_address(head)?;
+        // Content-box left/right of the textblock, in window coords.
+        let (content_left, content_right) = {
+            let doc = self.doc.clone()?;
+            let d = doc.borrow();
+            let node = d.tree.get(tb)?;
+            let (abs_x, _abs_y) = Self::compute_absolute_position(&d.tree, tb);
+            let pad_l = node.computed_style.padding_left.to_px();
+            let pad_r = node.computed_style.padding_right.to_px();
+            (abs_x + pad_l, abs_x + node.layout.width - pad_r)
+        };
+        // Probe the middle of the caret's line box, just inside the far edge.
+        let ty = cy + ch * 0.5;
+        let tx = if end {
+            content_right - 1.0
+        } else {
+            content_left + 1.0
+        };
+        let (_c, tb2, ifc) = self.editor_point_address(tx, ty)?;
+        let p = handle.pos_at(tb2, ifc)?;
+        // At a soft-wrap boundary the end-of-line byte is the same model position as
+        // the start of the next visual line, and rinch-dom renders its caret with
+        // *downstream* affinity (at the next line's start). For End, step back one
+        // position when the target spilled onto the next line so the caret stays at
+        // the visual end of the current line.
+        if end
+            && let Some((_, py, _)) = self.editor_caret_point(handle, p)
+            && py > cy + ch * 0.5
+        {
+            return Some(rinch_editor_core::Pos(p.0.saturating_sub(1)));
+        }
+        Some(p)
     }
 
     /// The id of the `data-pm-editor` container under window/logical point

--- a/crates/rinch/src/app/focus.rs
+++ b/crates/rinch/src/app/focus.rs
@@ -1,0 +1,96 @@
+//! The focus arbiter (design A10).
+//!
+//! [`FocusTarget`](super::FocusTarget) is the single source of truth for which
+//! widget owns keyboard/IME input. All focus changes go through
+//! [`RinchApp::set_focus_target`], which tears the previous owner down before the
+//! caller installs the next — so the four engines (render surfaces, `<input>`,
+//! the legacy contenteditable, and the new editor) can never be focused at once,
+//! and the `KeyDown`/`KeyUp` routing is a single exhaustive match instead of the
+//! old interceptor-then-fallback chain.
+
+use super::*;
+
+impl RinchApp {
+    /// Switch keyboard/IME focus to `target`, tearing down whatever was focused
+    /// before. Returns `true` if the focus target actually changed.
+    ///
+    /// This only handles **teardown** of the previous owner; the caller installs
+    /// the new owner's state (the rich per-engine state — `EditableState`, the CE
+    /// cursor, the editor selection — lives outside the enum). Re-focusing the
+    /// same target is a no-op (returns `false`) so a re-click inside the focused
+    /// widget keeps its state rather than tearing itself down.
+    ///
+    /// Must be called with no outstanding borrow of `self.doc` (it writes DOM
+    /// attributes while clearing input/CE focus).
+    pub(crate) fn set_focus_target(&mut self, target: FocusTarget) -> bool {
+        if self.focus_target == target {
+            return false;
+        }
+        match self.focus_target {
+            FocusTarget::None => {}
+            FocusTarget::Surface(_) => {
+                // `set_focused_surface` dispatches `FocusLost` to the old surface.
+                crate::render_surface::set_focused_surface(None);
+            }
+            FocusTarget::Input(_) => {
+                self.clear_input_focus_attrs();
+                self.focused_input_handler_id = None;
+                self.focused_input_value.clear();
+                self.focused_input_state = None;
+                self.focused_input_node_id = None;
+            }
+            FocusTarget::ContentEditable(prev) => {
+                ce::clear_active_ce_api();
+                self.ce_ops = None;
+                self.set_contenteditable_attributes(prev, false, 0, 0);
+                self.focused_contenteditable = None;
+            }
+            #[cfg(feature = "new-editor")]
+            FocusTarget::Editor(prev) => {
+                // Hide the blurred editor's caret and selection highlight so an
+                // unfocused editor shows neither. (Its model state lives in the
+                // `EditorHandle` — this only clears the overlays.) A pure focus
+                // change doesn't dirty layout, so the post-layout caret pass may
+                // short-circuit; hide explicitly here at the focus choke-point.
+                if let Some(handle) = crate::editor::editor_for(prev) {
+                    handle.hide_overlays();
+                }
+            }
+        }
+        self.focus_target = target;
+        self.scene_dirty = true;
+        true
+    }
+
+    /// Whether a text input element is currently focused.
+    pub fn has_focused_input(&self) -> bool {
+        matches!(self.focus_target, FocusTarget::Input(_))
+    }
+
+    /// The container id of the focused new-editor, if one holds focus. Drives the
+    /// runtime's caret-blink tick.
+    #[cfg(feature = "new-editor")]
+    pub(crate) fn focused_editor_id(&self) -> Option<usize> {
+        match self.focus_target {
+            FocusTarget::Editor(id) => Some(id),
+            _ => None,
+        }
+    }
+
+    /// Whether a rich-text editor (legacy contenteditable or the new editor) is
+    /// currently focused. Kept (and repointed at `FocusTarget`) for the embed and
+    /// Android soft-keyboard callers (design A9).
+    pub fn has_focused_contenteditable(&self) -> bool {
+        #[cfg(feature = "new-editor")]
+        {
+            matches!(
+                self.focus_target,
+                FocusTarget::ContentEditable(_) | FocusTarget::Editor(_)
+            )
+        }
+        #[cfg(not(feature = "new-editor"))]
+        {
+            matches!(self.focus_target, FocusTarget::ContentEditable(_))
+        }
+    }
+}

--- a/crates/rinch/src/app/mod.rs
+++ b/crates/rinch/src/app/mod.rs
@@ -561,6 +561,18 @@ impl RinchApp {
             }
         }
 
+        // New-editor block virtualization (design A3, phase 1) — run BEFORE the
+        // short-circuit. Creating a window (or moving the materialized range) sets
+        // the document's style/layout dirty flags, so this frame won't short-circuit
+        // and the resolve below applies the collapse. A selection-only first
+        // interaction otherwise never triggers the initial collapse.
+        #[cfg(feature = "new-editor")]
+        {
+            let focused = self.focused_editor_id();
+            let mut d = doc.borrow_mut();
+            crate::editor::virtualization_pre_layout(&mut d, focused);
+        }
+
         // Short-circuit when nothing needs resolving — avoids redundant tree walks
         // when a ReRender event arrives after the drag handler already resolved.
         {
@@ -619,6 +631,22 @@ impl RinchApp {
         // Apply deferred scroll-into-view now that layout is fresh
         self.apply_ce_scroll_into_view();
         self.apply_scroll_into_view();
+
+        // New-editor block virtualization (design A3, phase 2): cache measured
+        // heights and re-verify the materialized range with fresh positions, re
+        // laying out once if a big scroll jump changed it. Before the caret pass so
+        // the caret reads post-virtualization geometry.
+        #[cfg(feature = "new-editor")]
+        {
+            let focused = self.focused_editor_id();
+            let mut d = doc.borrow_mut();
+            crate::editor::virtualization_post_layout(
+                &mut d,
+                focused,
+                viewport_width,
+                viewport_height,
+            );
+        }
 
         // New-editor phase 2 (design A3): render each mounted editor's caret from
         // its selection now that layout geometry is fresh. If an overlay (caret /

--- a/crates/rinch/src/app/mod.rs
+++ b/crates/rinch/src/app/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod contenteditable;
 #[cfg(feature = "debug")]
 mod debug_commands;
 mod event_dispatch;
+mod focus;
 pub(crate) mod hit_testing;
 mod html_parser;
 mod text_selection;
@@ -130,6 +131,30 @@ pub(crate) struct ScrollbarDrag {
 /// platform event. The returned [`AppAction`]s tell the shell what to do
 /// (request redraw, exit, etc.).
 #[allow(dead_code)] // Some fields are only used behind feature gates (debug, theme)
+/// What currently owns keyboard / IME input. Exactly one target is focused at a
+/// time — the [`RinchApp::set_focus_target`] choke-point tears the previous one
+/// down before installing the next, so focus is **mutually exclusive by
+/// construction** (design A10). The runtime routes `KeyDown`/`KeyUp` (and, in M6,
+/// `Ime`) by matching on this single field instead of the old order-dependent
+/// interceptor-then-fallback chain that caused the dual-arm routing bugs.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub(crate) enum FocusTarget {
+    /// Nothing focused — keys fall through to the global handlers (DevTools,
+    /// inspect mode, Tab navigation, read-only text-selection caret motion).
+    #[default]
+    None,
+    /// A render surface (game viewport / custom renderer), by surface id.
+    Surface(usize),
+    /// An `<input>`/`<textarea>` (the rinch-editable engine), by DOM node id.
+    Input(usize),
+    /// The legacy contenteditable engine, by DOM node id. Transitional — the M8
+    /// rip deletes this variant along with the engine.
+    ContentEditable(usize),
+    /// A new-editor (`rinch-editor-core`) instance, by container node id.
+    #[cfg(feature = "new-editor")]
+    Editor(usize),
+}
+
 pub struct RinchApp {
     /// Component function to render (consumed on mount).
     #[allow(clippy::type_complexity)]
@@ -147,7 +172,8 @@ pub struct RinchApp {
     /// Software painter (reused across frames). Uses tiny-skia for CPU rendering.
     #[cfg(not(feature = "gpu"))]
     pub(crate) skia_painter: Option<TinySkiaPainter>,
-    /// Parley layout context for paint-time text layout.
+    /// Parley layout context for paint-time text layout (debug screenshots).
+    #[cfg(feature = "debug")]
     pub(crate) paint_layout_cx: parley::LayoutContext<peniko::Brush>,
     /// Current cursor position.
     pub(crate) cursor_pos: Option<(f32, f32)>,
@@ -189,6 +215,11 @@ pub struct RinchApp {
     pub(crate) focused_input_state: Option<EditableState<StringDocument>>,
     /// DOM node ID of the currently focused text input.
     pub(crate) focused_input_node_id: Option<usize>,
+    /// The single authority for which widget owns keyboard/IME input (design
+    /// A10). Kept in lockstep with the per-engine focus state below
+    /// (`focused_input_*`, `focused_contenteditable`, the surface/editor
+    /// registries) via [`Self::set_focus_target`].
+    pub(crate) focus_target: FocusTarget,
     /// State for a focused contenteditable element.
     pub(crate) focused_contenteditable: Option<ContentEditableFocus>,
     /// Active CE API instance for the focused contentEditable element.
@@ -232,6 +263,7 @@ impl RinchApp {
             painter: VelloPainter::new(),
             #[cfg(not(feature = "gpu"))]
             skia_painter: None,
+            #[cfg(feature = "debug")]
             paint_layout_cx: parley::LayoutContext::new(),
             cursor_pos: None,
             scrollbar_drag: None,
@@ -253,6 +285,7 @@ impl RinchApp {
             focused_input_value: String::new(),
             focused_input_state: None,
             focused_input_node_id: None,
+            focus_target: FocusTarget::None,
             focused_contenteditable: None,
             ce_ops: None,
             ce_selecting: false,
@@ -431,6 +464,12 @@ impl RinchApp {
             let _ = d.take_dirty_nodes();
         }
 
+        // New-editor phase 2 (design A3): render mounted editors' carets against
+        // the fresh initial layout (the steady-state pass in resolve_and_repaint
+        // short-circuits when nothing is dirty, so the first caret renders here).
+        #[cfg(feature = "new-editor")]
+        crate::editor::update_all_carets(self.focused_editor_id());
+
         self.scene_dirty = true;
         self.doc = Some(doc.clone());
         self._render_scope = Some(scope);
@@ -564,6 +603,11 @@ impl RinchApp {
         // Apply deferred scroll-into-view now that layout is fresh
         self.apply_ce_scroll_into_view();
         self.apply_scroll_into_view();
+
+        // New-editor phase 2 (design A3): render each mounted editor's caret from
+        // its selection now that layout geometry is fresh.
+        #[cfg(feature = "new-editor")]
+        crate::editor::update_all_carets(self.focused_editor_id());
 
         // Post-layout: cache heights, then verify materialized range with
         // fresh positions. If the range changed (big scroll jump), re-layout.
@@ -1442,12 +1486,8 @@ impl RinchApp {
         };
 
         if has_oninput {
-            // Clear any CE focus first
-            if let Some(prev_ce) = self.focused_contenteditable.take() {
-                ce::clear_active_ce_api();
-                self.ce_ops = None;
-                self.set_contenteditable_attributes(prev_ce.ce_node_id, false, 0, 0);
-            }
+            // `try_focus_input` takes focus through the arbiter (tears down any
+            // prior CE / surface / editor / input).
             self.try_focus_input(node_id);
             // Update DOM focus state
             if let Some(doc) = &self.doc {
@@ -1455,12 +1495,9 @@ impl RinchApp {
                 d.update_focus(Some(node_id));
             }
         } else if is_contenteditable {
-            // Clear any input focus first
-            self.clear_input_focus_attrs();
-            self.focused_input_handler_id = None;
-            self.focused_input_value.clear();
-            self.focused_input_state = None;
-            self.focused_input_node_id = None;
+            // Take CE focus through the arbiter (tears down any prior input /
+            // surface / editor / different CE).
+            self.set_focus_target(FocusTarget::ContentEditable(node_id));
 
             // Set up CE focus with cursor at position 0
             let input_handler = InputHandler::new()
@@ -1514,10 +1551,9 @@ impl RinchApp {
         let value = node.attributes.get("value").cloned().unwrap_or_default();
         drop(d);
 
-        // Clear previous input focus if switching to a different node
-        if self.focused_input_node_id.is_some() && self.focused_input_node_id != Some(node_id) {
-            self.clear_input_focus_attrs();
-        }
+        // Take input focus through the arbiter (tears down a prior surface / CE /
+        // editor / different input; re-focusing the same input is a no-op).
+        self.set_focus_target(FocusTarget::Input(node_id));
 
         self.focused_input_handler_id = Some(handler_id);
         self.focused_input_value = value.clone();
@@ -1562,16 +1598,8 @@ impl RinchApp {
     }
 
     // ── Embed API helpers ─────────────────────────────────────────────
-
-    /// Whether a text input element is currently focused.
-    pub fn has_focused_input(&self) -> bool {
-        self.focused_input_handler_id.is_some()
-    }
-
-    /// Whether a contenteditable element is currently focused.
-    pub fn has_focused_contenteditable(&self) -> bool {
-        self.focused_contenteditable.is_some()
-    }
+    // `has_focused_input` / `has_focused_contenteditable` now live in `focus.rs`
+    // (repointed at `FocusTarget`, design A9/A10).
 
     /// Query the computed layout rect of a `GameViewport` component by name.
     ///

--- a/crates/rinch/src/app/mod.rs
+++ b/crates/rinch/src/app/mod.rs
@@ -512,6 +512,22 @@ impl RinchApp {
 
     // ── Layout / repaint ─────────────────────────────────────────────────
 
+    /// Run the post-layout overlay pass for mounted editors (from an input handler,
+    /// where a selection-only change doesn't dirty the document) and, if any overlay
+    /// moved, force a full repaint. The caret / selection / node-outline overlays are
+    /// absolutely positioned, and the software renderer's dirty-region cache can't
+    /// clear a moved absolute element's old rect — so without this they ghost.
+    #[cfg(feature = "new-editor")]
+    pub(crate) fn refresh_editor_overlays(&mut self) {
+        if crate::editor::update_all_carets(self.focused_editor_id()) {
+            self.scene_dirty = true;
+            #[cfg(not(feature = "gpu"))]
+            {
+                self.has_previous_frame = false;
+            }
+        }
+    }
+
     /// Re-resolve layout after signal changes. Returns `true` if a redraw
     /// is needed.
     pub fn resolve_and_repaint(&mut self, viewport_width: f32, viewport_height: f32) -> bool {
@@ -605,9 +621,24 @@ impl RinchApp {
         self.apply_scroll_into_view();
 
         // New-editor phase 2 (design A3): render each mounted editor's caret from
-        // its selection now that layout geometry is fresh.
+        // its selection now that layout geometry is fresh. If an overlay (caret /
+        // selection / node-outline) actually moved, re-resolve so its new absolute
+        // position is current, then force a full repaint — the software renderer's
+        // dirty-region cache can't clear a moved absolute element's *old* rect, so
+        // the overlay would otherwise ghost.
         #[cfg(feature = "new-editor")]
-        crate::editor::update_all_carets(self.focused_editor_id());
+        if crate::editor::update_all_carets(self.focused_editor_id()) {
+            {
+                let mut d = doc.borrow_mut();
+                let _ = d.take_dirty_nodes();
+                d.resolve_layout(viewport_width, viewport_height);
+            }
+            self.scene_dirty = true;
+            #[cfg(not(feature = "gpu"))]
+            {
+                self.has_previous_frame = false;
+            }
+        }
 
         // Post-layout: cache heights, then verify materialized range with
         // fresh positions. If the range changed (big scroll jump), re-layout.

--- a/crates/rinch/src/app/mod.rs
+++ b/crates/rinch/src/app/mod.rs
@@ -220,6 +220,12 @@ pub struct RinchApp {
     /// (`focused_input_*`, `focused_contenteditable`, the surface/editor
     /// registries) via [`Self::set_focus_target`].
     pub(crate) focus_target: FocusTarget,
+    /// The "goal column" (a window-space x) preserved across consecutive vertical
+    /// cursor moves (Up/Down) in the focused new editor, so the caret keeps its
+    /// horizontal position through short lines instead of drifting to line ends.
+    /// Set on the first Up/Down, reset by any other key, click, or drag.
+    #[cfg(feature = "new-editor")]
+    pub(crate) editor_goal_x: Option<f32>,
     /// State for a focused contenteditable element.
     pub(crate) focused_contenteditable: Option<ContentEditableFocus>,
     /// Active CE API instance for the focused contentEditable element.
@@ -286,6 +292,8 @@ impl RinchApp {
             focused_input_state: None,
             focused_input_node_id: None,
             focus_target: FocusTarget::None,
+            #[cfg(feature = "new-editor")]
+            editor_goal_x: None,
             focused_contenteditable: None,
             ce_ops: None,
             ce_selecting: false,

--- a/crates/rinch/src/app/mod.rs
+++ b/crates/rinch/src/app/mod.rs
@@ -467,8 +467,28 @@ impl RinchApp {
 
         // Initial layout
         {
+            #[cfg(feature = "new-editor")]
+            let focused = self.focused_editor_id();
             let mut d = doc.borrow_mut();
+            // New-editor: virtualize each large scroll editor BEFORE the first
+            // layout so its off-screen blocks are never Parley-measured at mount.
+            // The scroll-container gate reads computed `overflow-y`, so resolve
+            // styles first (the `resolve_layout` below re-resolves them); the
+            // post-layout pass then settles the off-screen height estimates so they
+            // don't jump on the first interaction.
+            #[cfg(feature = "new-editor")]
+            {
+                d.resolve_styles();
+                crate::editor::virtualization_pre_layout(&mut d, focused);
+            }
             d.resolve_layout(viewport_width, viewport_height);
+            #[cfg(feature = "new-editor")]
+            crate::editor::virtualization_post_layout(
+                &mut d,
+                focused,
+                viewport_width,
+                viewport_height,
+            );
             let _ = d.take_dirty_nodes();
         }
 

--- a/crates/rinch/src/editor/blink.rs
+++ b/crates/rinch/src/editor/blink.rs
@@ -1,0 +1,117 @@
+//! The caret blink clock.
+//!
+//! The runtime is event-driven ([`ControlFlow::Wait`](winit::event_loop::ControlFlow)):
+//! it only wakes for input, so there is no free-running animation tick. To blink
+//! the focused editor's caret, [`RinchRuntime::about_to_wait`](crate::shell) calls
+//! [`caret_blink_tick`](super::caret_blink_tick) every iteration, which consults
+//! this clock to decide the current phase and how long until the next toggle —
+//! the runtime then arms `ControlFlow::WaitUntil` for exactly that long. When no
+//! caret is blinking the clock reports nothing and the loop returns to `Wait`
+//! (zero idle CPU).
+//!
+//! The phase is anchored at the last [`reset`] (a caret move or edit), so the
+//! caret is always solid immediately after an interaction — standard text-editor
+//! behaviour — then alternates every [`BLINK_INTERVAL`].
+
+use std::cell::Cell;
+use std::time::{Duration, Instant};
+
+/// Caret blink half-period (solid for this long, then hidden for this long).
+/// 530 ms is the long-standing platform default (Win32 `GetCaretBlinkTime`).
+pub(crate) const BLINK_INTERVAL: Duration = Duration::from_millis(530);
+
+thread_local! {
+    /// The instant the caret phase last reset to "solid". `None` until the first
+    /// [`tick`] anchors it.
+    static ANCHOR: Cell<Option<Instant>> = const { Cell::new(None) };
+    /// The container id of the editor currently being blinked, so a focus change
+    /// can restore the previously-blinked caret to solid (never leave a blurred
+    /// editor frozen mid-blink with a hidden caret).
+    static TARGET: Cell<Option<usize>> = const { Cell::new(None) };
+}
+
+/// Reset the blink phase to "solid". Called whenever the caret moves or the
+/// document is edited so the caret is solid right after the interaction.
+pub(crate) fn reset() {
+    ANCHOR.with(|a| a.set(Some(Instant::now())));
+}
+
+/// The editor container currently being blinked, if any.
+pub(crate) fn target() -> Option<usize> {
+    TARGET.with(|t| t.get())
+}
+
+/// Record which editor container is being blinked (`None` = none).
+pub(crate) fn set_target(id: Option<usize>) {
+    TARGET.with(|t| t.set(id));
+}
+
+/// The current blink phase and the time until the next toggle. Lazily anchors
+/// the phase to "now" on first call after a [`reset`]/cold start.
+pub(crate) fn tick() -> (bool, Duration) {
+    let now = Instant::now();
+    let anchor = ANCHOR.with(|a| {
+        let cur = a.get().unwrap_or(now);
+        a.set(Some(cur));
+        cur
+    });
+    phase_at(anchor, now)
+}
+
+/// Pure phase computation (factored out so it is unit-testable without a clock):
+/// given the phase `anchor` and the current instant `now`, return whether the
+/// caret should currently be visible and the [`Duration`] until the next toggle.
+fn phase_at(anchor: Instant, now: Instant) -> (bool, Duration) {
+    let elapsed = now.saturating_duration_since(anchor).as_millis();
+    let period = BLINK_INTERVAL.as_millis();
+    // Even half-periods are visible, odd are hidden.
+    let visible = (elapsed / period).is_multiple_of(2);
+    let into_phase = elapsed % period;
+    let remaining = (period - into_phase) as u64;
+    (visible, Duration::from_millis(remaining))
+}
+
+/// The current phase anchor — test-only, so view tests can assert which editor's
+/// caret move actually re-anchored the (global) blink clock.
+#[cfg(test)]
+pub(crate) fn anchor_for_test() -> Option<Instant> {
+    ANCHOR.with(|a| a.get())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn phase_is_solid_at_anchor_and_alternates_each_half_period() {
+        let a = Instant::now();
+        // At the anchor: visible, a full period until the next toggle.
+        let (v0, n0) = phase_at(a, a);
+        assert!(v0);
+        assert_eq!(n0, BLINK_INTERVAL);
+        // Just before the first boundary: still visible, a sliver remaining.
+        let (v1, n1) = phase_at(a, a + Duration::from_millis(529));
+        assert!(v1);
+        assert_eq!(n1, Duration::from_millis(1));
+        // At the first boundary: hidden, a fresh full period remaining.
+        let (v2, n2) = phase_at(a, a + Duration::from_millis(530));
+        assert!(!v2);
+        assert_eq!(n2, BLINK_INTERVAL);
+        // Mid second half-period: hidden.
+        let (v3, _) = phase_at(a, a + Duration::from_millis(800));
+        assert!(!v3);
+        // Second boundary: visible again.
+        let (v4, _) = phase_at(a, a + Duration::from_millis(1060));
+        assert!(v4);
+    }
+
+    #[test]
+    fn now_before_anchor_is_clamped_to_solid() {
+        // saturating_duration_since guards a non-monotonic / pre-anchor `now`.
+        let a = Instant::now();
+        let earlier = a;
+        let (v, n) = phase_at(a, earlier);
+        assert!(v);
+        assert_eq!(n, BLINK_INTERVAL);
+    }
+}

--- a/crates/rinch/src/editor/component.rs
+++ b/crates/rinch/src/editor/component.rs
@@ -1,0 +1,62 @@
+//! The [`Editor`] component — declarative placement of a rich-text editor in
+//! `rsx!`, mirroring the [`RenderSurface`](crate::render_surface::RenderSurface)
+//! "factory handle + component" pattern.
+
+use rinch_core::Component;
+use rinch_core::dom::{NodeHandle, RenderScope};
+
+use super::create_editor;
+use super::handle::EditorHandle;
+
+/// A rich-text editor placed declaratively in `rsx!`.
+///
+/// Create a handle with [`create_editor`](super::create_editor) when you need
+/// programmatic control (toolbar commands, load/save), then place it:
+///
+/// ```ignore
+/// let editor = create_editor();
+/// editor.load_html("<p>Hello</p>");
+/// rsx! {
+///     div {
+///         button { onclick: move || { editor.command("toggleBold"); }, "Bold" }
+///         Editor { editor: editor.clone() }
+///     }
+/// }
+/// ```
+///
+/// With no handle, `Editor {}` mounts a self-contained editor — editable via the
+/// keyboard once clicked into, but with no external control surface. Pass initial
+/// content as HTML with the `content` prop.
+#[derive(Debug, Default)]
+pub struct Editor {
+    /// A handle from [`create_editor`](super::create_editor) for programmatic
+    /// control. When `None`, the component creates and owns an internal handle.
+    ///
+    /// Place a given handle in **one** `Editor` at a time: a handle owns a single
+    /// projection, so mounting it in two live components would abandon the first's
+    /// view. (Re-mounting across a reactive re-render is fine — the old scope is
+    /// disposed before the new one mounts, and the view rebuilds from the handle's
+    /// preserved state.)
+    pub editor: Option<EditorHandle>,
+    /// Initial content as schema-whitelisted HTML, loaded once when the editor
+    /// mounts. Empty means "start with an empty paragraph".
+    pub content: String,
+}
+
+impl Component for Editor {
+    fn render(&self, scope: &mut RenderScope, _children: &[NodeHandle]) -> NodeHandle {
+        let handle = self.editor.clone().unwrap_or_else(create_editor);
+        // Load initial content *before* mounting so the view's first build renders
+        // it directly (no empty→content diff). A no-op for empty content; on an
+        // already-loaded external handle, the `content` prop wins.
+        if !self.content.is_empty() {
+            handle.load_html(&self.content);
+        }
+        let container = handle.mount(scope);
+        // Stop the runtime from driving this mount once the scope is disposed
+        // (conditional hide, tab switch) — the handle itself may live on.
+        let container_id = container.node_id().0;
+        scope.on_cleanup(move || super::registry::unregister_editor(container_id));
+        container
+    }
+}

--- a/crates/rinch/src/editor/handle.rs
+++ b/crates/rinch/src/editor/handle.rs
@@ -232,6 +232,24 @@ impl EditorHandle {
             .pos_at(textblock_dom_id, ifc_byte)
     }
 
+    /// A [`Selection::Node`] for the leaf node (image / horizontal rule) whose host
+    /// element is `host_id` — the pointer hit-test path for node-selecting a leaf the
+    /// user clicks. `None` if `host_id` isn't a placed node, or its node isn't
+    /// selectable (design §6 node-views).
+    ///
+    /// [`Selection::Node`]: rinch_editor_core::Selection::Node
+    pub fn node_selection_at_host(&self, host_id: usize) -> Option<Selection> {
+        let core = self.inner.borrow();
+        let (pos, node) = core.view.as_ref()?.node_pos_for_host(host_id)?;
+        // Node-views are *leaf* atoms (image / horizontal rule). A block container
+        // (paragraph, list, blockquote) is `selectable` in the schema but is never
+        // node-selected by a click, so restrict to leaves here.
+        if !node.node_type().is_leaf() {
+            return None;
+        }
+        Selection::node_at(&core.state.doc, Pos(pos))
+    }
+
     /// Place the cursor at a host caret address `(textblock element id, flat UTF-8
     /// byte offset)` produced by a pointer hit-test (the click→`Pos` path). Returns
     /// whether the address resolved to a model position.
@@ -243,6 +261,28 @@ impl EditorHandle {
             }
             None => false,
         }
+    }
+
+    /// Insert `text`, replacing the current selection — the keyboard text-input
+    /// path. A flat insert handles a text range or an *inline* node selection
+    /// directly (text is valid inline content); for a *block* node selection (a
+    /// selected horizontal rule, where a bare text node isn't valid `doc` content)
+    /// it deletes the node first, then inserts the text at the resulting cursor
+    /// (ProseMirror `replaceSelection` for text input). Returns whether the
+    /// document changed.
+    pub fn insert_text(&self, text: &str) -> bool {
+        self.update(|state| {
+            let mut tr = state.tr();
+            if tr.insert_text(text).is_ok() {
+                return Some(tr);
+            }
+            // The flat insert couldn't replace the selection in place (a block node
+            // selection). Delete it, then insert the text at the collapsed cursor.
+            let mut tr = state.tr();
+            tr.delete_selection().ok()?;
+            tr.insert_text(text).ok()?;
+            Some(tr)
+        })
     }
 
     /// Move the selection (and re-project, so the caret follows once geometry lands).
@@ -346,20 +386,32 @@ impl EditorHandle {
 
     /// Phase-2 projection: render caret/selection geometry from the current state.
     /// The runtime calls this **after** layout (design A3); headless it is a no-op.
-    pub fn update_caret(&self) {
+    /// Returns whether an overlay actually moved (so the runtime can force a full
+    /// repaint — the overlays are absolutely positioned and the software renderer's
+    /// dirty-region cache can't clear their old rect).
+    pub fn update_caret(&self) -> bool {
         let mut core = self.inner.borrow_mut();
         let state = core.state.clone();
-        if let Some(view) = core.view.as_mut() {
-            view.update_caret(&state);
+        match core.view.as_mut() {
+            Some(view) => {
+                view.update_caret(&state);
+                view.take_overlay_dirty()
+            }
+            None => false,
         }
     }
 
     /// Hide this editor's overlays (caret + selection highlight) because it isn't
     /// focused. The runtime's focus-aware caret pass calls this for every editor
-    /// that isn't the focused one. A no-op before mount.
-    pub(crate) fn hide_overlays(&self) {
-        if let Some(view) = self.inner.borrow_mut().view.as_mut() {
-            view.hide_overlays();
+    /// that isn't the focused one. A no-op before mount. Returns whether an overlay
+    /// was actually cleared (so the runtime can force a full repaint).
+    pub(crate) fn hide_overlays(&self) -> bool {
+        match self.inner.borrow_mut().view.as_mut() {
+            Some(view) => {
+                view.hide_overlays();
+                view.take_overlay_dirty()
+            }
+            None => false,
         }
     }
 
@@ -615,6 +667,123 @@ mod tests {
         assert_eq!(
             text(&h, children(&h, h.container_id)[0]).as_deref(),
             Some("abcd")
+        );
+    }
+
+    // ── Node-views (NodeSelection of an image / horizontal rule) ─────────────
+
+    fn hr(s: &Schema) -> Node {
+        s.branch("horizontal_rule", Fragment::empty()).unwrap()
+    }
+
+    fn img(s: &Schema) -> Node {
+        s.create_node(
+            "image",
+            rinch_editor_core::Attrs::from_iter([(
+                "src",
+                rinch_editor_core::AttrValue::from("a.png"),
+            )]),
+            Fragment::empty(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn node_selection_at_host_resolves_a_leaf_and_rejects_a_textblock() {
+        let s = schema();
+        let h = mount(doc_node(&s, vec![para(&s, "ab"), hr(&s)]));
+        let blocks = children(&h, h.container_id);
+        assert_eq!(tag(&h, blocks[1]).as_deref(), Some("hr"));
+
+        // The hr's host id → a NodeSelection of the hr (model pos 4..5).
+        let sel = h
+            .handle
+            .node_selection_at_host(blocks[1].0)
+            .expect("hr host resolves to a node selection");
+        assert_eq!(sel.from(), Pos(4));
+        assert_eq!(sel.to(), Pos(5));
+
+        // The paragraph host is a node but not a selectable leaf → None.
+        assert!(
+            h.handle.node_selection_at_host(blocks[0].0).is_none(),
+            "a textblock is not node-selectable"
+        );
+    }
+
+    #[test]
+    fn backspace_deletes_a_node_selection() {
+        let s = schema();
+        let h = mount(doc_node(&s, vec![para(&s, "ab"), hr(&s)]));
+        let sel = h
+            .handle
+            .node_selection_at_host(children(&h, h.container_id)[1].0)
+            .unwrap();
+        h.handle.set_selection(sel);
+
+        // Backspace over a (never-empty) node selection deletes the node.
+        assert!(h.handle.command("deleteCharBackward"));
+        let blocks = children(&h, h.container_id);
+        assert_eq!(blocks.len(), 1, "the hr was removed");
+        assert_eq!(tag(&h, blocks[0]).as_deref(), Some("p"));
+    }
+
+    #[test]
+    fn typing_replaces_an_inline_image_node_selection() {
+        let s = schema();
+        // doc(paragraph(text "a", image)) — positions 0[p 1 a 2 (img) 3]4.
+        let p = s
+            .branch(
+                "paragraph",
+                Fragment::from_children(vec![s.text("a").unwrap(), img(&s)]),
+            )
+            .unwrap();
+        let h = mount(doc_node(&s, vec![p]));
+        // The image is the paragraph's 2nd inline host child; node-select it.
+        let para_host = children(&h, h.container_id)[0];
+        let img_host = children(&h, para_host)[1];
+        let sel = h
+            .handle
+            .node_selection_at_host(img_host.0)
+            .expect("inline image node-selects");
+        h.handle.set_selection(sel);
+
+        // A flat text insert *can* replace an inline image (text is valid inline
+        // content) — the image becomes the typed text within the paragraph.
+        assert!(h.handle.update(|state| {
+            let mut tr = state.tr();
+            tr.insert_text("X").ok()?;
+            Some(tr)
+        }));
+        assert_eq!(
+            text(&h, children(&h, h.container_id)[0]).as_deref(),
+            Some("aX")
+        );
+        assert!(
+            h.handle.selection().is_empty(),
+            "cursor collapses after insert"
+        );
+    }
+
+    #[test]
+    fn insert_text_over_a_block_node_selection_deletes_then_inserts() {
+        let s = schema();
+        let h = mount(doc_node(&s, vec![para(&s, "ab"), hr(&s)]));
+        let sel = h
+            .handle
+            .node_selection_at_host(children(&h, h.container_id)[1].0)
+            .unwrap();
+        h.handle.set_selection(sel);
+
+        // Typing over a *block* node selection (a selected hr, where a bare text
+        // node isn't valid `doc` content) deletes the node, then inserts the text
+        // at the resulting cursor — landing at the end of the previous paragraph.
+        assert!(h.handle.insert_text("X"));
+        let blocks = children(&h, h.container_id);
+        assert_eq!(blocks.len(), 1, "the hr was removed");
+        assert_eq!(text(&h, blocks[0]).as_deref(), Some("abX"));
+        assert!(
+            h.handle.selection().is_empty(),
+            "cursor collapses after insert"
         );
     }
 

--- a/crates/rinch/src/editor/handle.rs
+++ b/crates/rinch/src/editor/handle.rs
@@ -1,0 +1,669 @@
+//! [`EditorHandle`] — the imperative editor API for app/component code (design
+//! A7), the successor to the deleted `with_active_ce_api`/`NodeHandle::with_ce_api`
+//! surface.
+//!
+//! A handle owns the authoritative [`EditorState`] **and** its desktop projection
+//! ([`RinchDomEditorView`]). Every mutation runs through `EditorState::apply` and
+//! then re-projects the host via the view's phase-1 `update_dom` — there is one
+//! mutation path and the host is always derived from the model (design §6). The
+//! handle is cheap to [`Clone`] (an `Rc`), so a component can hand it to toolbar
+//! buttons and the runtime alike. It works **before focus** — `load_doc`/`command`
+//! operate on the owned state whether or not the editor is focused.
+//!
+//! Caret geometry (phase-2 `update_caret`) is driven by the runtime *after* layout
+//! via [`EditorHandle::update_caret`]; in a headless context it is a no-op.
+
+use std::cell::RefCell;
+use std::fmt;
+use std::rc::{Rc, Weak};
+
+use rinch_core::dom::{DomDocument, NodeHandle, RenderScope};
+use rinch_editor_core::commands::{current_block_type, in_node_type, is_mark_active};
+use rinch_editor_core::model::Slice;
+use rinch_editor_core::serialize::{
+    slice_from_html, slice_from_text, slice_to_html, slice_to_text,
+};
+use rinch_editor_core::{
+    EditorState, EditorView, Node, Plugin, Pos, Schema, Selection, Transaction,
+};
+
+use super::view::RinchDomEditorView;
+
+/// The owned editor: its state, its desktop projection, and the schema/plugins
+/// needed to rebuild a fresh state on `load_doc`.
+///
+/// `view` is `None` until the editor is mounted into a host element (design A7:
+/// a handle is created with [`create_editor`](super::create_editor) *before* its
+/// container exists, then projected when the [`Editor`](super::Editor) component
+/// renders). State edits (`load_doc`/`command`/`set_selection`) work before mount
+/// — they mutate the owned state, and the view renders the current state when it
+/// attaches.
+struct EditorCore {
+    state: EditorState,
+    view: Option<RinchDomEditorView>,
+    schema: Rc<Schema>,
+    plugins: Vec<Rc<dyn Plugin>>,
+}
+
+/// A cloneable handle to an editor (design A7). Cheap to [`Clone`] (an `Rc`), so a
+/// component can hand it to toolbar buttons and the runtime alike.
+#[derive(Clone)]
+pub struct EditorHandle {
+    inner: Rc<RefCell<EditorCore>>,
+}
+
+impl fmt::Debug for EditorHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // The state/view aren't `Debug`; the host id is the useful identity.
+        let mounted = self.inner.borrow().view.is_some();
+        f.debug_struct("EditorHandle")
+            .field("mounted", &mounted)
+            .finish_non_exhaustive()
+    }
+}
+
+impl EditorHandle {
+    /// Build a handle over a fresh [`EditorState`] **without** a host projection —
+    /// the deferred-mount path. The view is attached later by [`Self::mount`] (or
+    /// [`Self::attach`]) when the host container exists. Used by
+    /// [`create_editor`](super::create_editor).
+    pub(crate) fn unmounted(
+        schema: Rc<Schema>,
+        doc: Node,
+        plugins: Vec<Rc<dyn Plugin>>,
+    ) -> EditorHandle {
+        let state = EditorState::create(schema.clone(), doc, plugins.clone());
+        EditorHandle {
+            inner: Rc::new(RefCell::new(EditorCore {
+                state,
+                view: None,
+                schema,
+                plugins,
+            })),
+        }
+    }
+
+    /// Build a handle and project it into `container` in one step (the eager path,
+    /// used by tests and by [`Self::mount`]). `doc_ref` is a weak handle to the
+    /// host document the view patches. Does **not** register the editor with the
+    /// runtime — that is [`Self::mount`]'s job.
+    pub fn new(
+        container: NodeHandle,
+        doc_ref: Weak<RefCell<dyn DomDocument>>,
+        schema: Rc<Schema>,
+        doc: Node,
+        plugins: Vec<Rc<dyn Plugin>>,
+    ) -> EditorHandle {
+        let state = EditorState::create(schema.clone(), doc, plugins.clone());
+        let view = RinchDomEditorView::new(container, doc_ref, &state);
+        EditorHandle {
+            inner: Rc::new(RefCell::new(EditorCore {
+                state,
+                view: Some(view),
+                schema,
+                plugins,
+            })),
+        }
+    }
+
+    /// Project this (unmounted) handle into `container`, building the view from the
+    /// current state — so any content loaded before mount renders immediately. The
+    /// caller owns `container` (an empty host element); `doc_ref` is a weak handle
+    /// to the host document. Re-attaching a handle that is already mounted replaces
+    /// its view (the old projection is abandoned).
+    pub(crate) fn attach(&self, container: NodeHandle, doc_ref: Weak<RefCell<dyn DomDocument>>) {
+        let mut core = self.inner.borrow_mut();
+        let view = RinchDomEditorView::new(container, doc_ref, &core.state);
+        core.view = Some(view);
+    }
+
+    /// Mount this handle into `scope`: create its host container (`data-pm-editor`,
+    /// deliberately **not** `contenteditable` so the legacy CE engine doesn't also
+    /// activate), project the current state into it, and register the editor so the
+    /// runtime drives its caret and routes input. Returns the container to place in
+    /// the tree. The [`Editor`](super::Editor) component calls this on render.
+    pub fn mount(&self, scope: &mut RenderScope) -> NodeHandle {
+        let container = scope.create_element("div");
+        container.set_attribute("data-pm-editor", "true");
+        self.attach(container.clone(), scope.doc_weak());
+        super::registry::register_editor(container.node_id().0, self.clone());
+        container
+    }
+
+    /// Apply the transaction built by `build` (given the current state), then
+    /// re-project the host. `build` returns `None` to dispatch nothing. Returns
+    /// whether a transaction was applied. The single dispatch path — `command`,
+    /// keyboard insert, paste, and IME commit all funnel through here.
+    pub fn update(&self, build: impl FnOnce(&EditorState) -> Option<Transaction>) -> bool {
+        let mut core = self.inner.borrow_mut();
+        let Some(tr) = build(&core.state) else {
+            return false;
+        };
+        let prev = core.state.clone();
+        let next = core.state.apply(tr);
+        core.state = next.clone();
+        if let Some(view) = core.view.as_mut() {
+            view.update_dom(&prev, &next);
+        }
+        true
+    }
+
+    /// Run the named command (applying + re-projecting if it applies). Returns
+    /// whether it applied. The toolbar/keymap entry point.
+    pub fn command(&self, name: &str) -> bool {
+        let mut core = self.inner.borrow_mut();
+        let Some(next) = core.state.run(name) else {
+            return false;
+        };
+        let prev = core.state.clone();
+        core.state = next.clone();
+        if let Some(view) = core.view.as_mut() {
+            view.update_dom(&prev, &next);
+        }
+        true
+    }
+
+    /// Whether the named command currently applies (toolbar enablement).
+    pub fn can_run(&self, name: &str) -> bool {
+        self.inner.borrow().state.can_run(name)
+    }
+
+    /// Whether the mark named `mark` is active for the current selection (toolbar
+    /// "on" state) — reads **state**, never the host.
+    pub fn is_mark_active(&self, mark: &str) -> bool {
+        let core = self.inner.borrow();
+        match core.state.schema().mark_type(mark) {
+            Some(mt) => is_mark_active(&core.state, mt),
+            None => false,
+        }
+    }
+
+    /// The schema type name of the block the cursor is in (e.g. `"heading"`), or
+    /// `None` across a multi-block selection.
+    pub fn current_block_type(&self) -> Option<String> {
+        current_block_type(&self.inner.borrow().state).map(|nt| nt.name().to_string())
+    }
+
+    /// Whether the selection is inside a node of the given type (e.g. `"blockquote"`,
+    /// `"bullet_list"`) — drives the List/Blockquote toolbar active states (A6).
+    pub fn in_node_type(&self, type_name: &str) -> bool {
+        in_node_type(&self.inner.borrow().state, type_name)
+    }
+
+    /// The current document (the save shape; serialize with `to_doc()` under the
+    /// `serde` feature).
+    pub fn doc(&self) -> Node {
+        self.inner.borrow().state.doc.clone()
+    }
+
+    /// A snapshot of the whole editor state.
+    pub fn state(&self) -> EditorState {
+        self.inner.borrow().state.clone()
+    }
+
+    /// The current selection.
+    pub fn selection(&self) -> Selection {
+        self.inner.borrow().state.selection.clone()
+    }
+
+    /// The host id of the editor container element, or `0` if not yet mounted.
+    pub fn container_id(&self) -> usize {
+        self.inner
+            .borrow()
+            .view
+            .as_ref()
+            .map_or(0, |v| v.container_id())
+    }
+
+    /// The host caret address `(textblock element id, flat UTF-8 byte offset)` for a
+    /// model `pos` (used by app-side geometry: caret point, vertical movement).
+    pub fn caret_address(&self, pos: Pos) -> Option<(usize, usize)> {
+        let core = self.inner.borrow();
+        core.view.as_ref()?.caret_address(&core.state.doc, pos)
+    }
+
+    /// Map a host caret address `(textblock element id, flat UTF-8 byte offset)` —
+    /// e.g. from a pointer hit-test — to a model [`Pos`] (without moving the cursor).
+    pub fn pos_at(&self, textblock_dom_id: usize, ifc_byte: usize) -> Option<Pos> {
+        self.inner
+            .borrow()
+            .view
+            .as_ref()?
+            .pos_at(textblock_dom_id, ifc_byte)
+    }
+
+    /// Place the cursor at a host caret address `(textblock element id, flat UTF-8
+    /// byte offset)` produced by a pointer hit-test (the click→`Pos` path). Returns
+    /// whether the address resolved to a model position.
+    pub fn set_cursor_from_ifc(&self, textblock_dom_id: usize, ifc_byte: usize) -> bool {
+        match self.pos_at(textblock_dom_id, ifc_byte) {
+            Some(pos) => {
+                self.set_selection(Selection::cursor(pos));
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Move the selection (and re-project, so the caret follows once geometry lands).
+    pub fn set_selection(&self, selection: Selection) {
+        self.update(|state| {
+            let mut tr = state.tr();
+            tr.set_selection(selection.clone());
+            Some(tr)
+        });
+    }
+
+    /// Replace the document with `doc`, resetting selection and history (a fresh
+    /// load, not an undoable edit). The host diffs from the old content to the new,
+    /// so unchanged leading blocks are reused. Works before focus.
+    pub fn load_doc(&self, doc: Node) {
+        let mut core = self.inner.borrow_mut();
+        let prev = core.state.clone();
+        let next = EditorState::create(core.schema.clone(), doc, core.plugins.clone());
+        core.state = next.clone();
+        if let Some(view) = core.view.as_mut() {
+            view.update_dom(&prev, &next);
+        }
+    }
+
+    /// Parse `html` (schema-whitelisted) and load it as the document. Returns
+    /// `false` if it does not parse into valid top-level document content.
+    pub fn load_html(&self, html: &str) -> bool {
+        let schema = self.inner.borrow().schema.clone();
+        let Ok(slice) = slice_from_html(&schema, html) else {
+            return false;
+        };
+        let Ok(doc) = schema.branch("doc", slice.content.clone()) else {
+            return false;
+        };
+        self.load_doc(doc);
+        true
+    }
+
+    // ── Clipboard (copy / cut / paste) ──────────────────────────────────────
+    //
+    // The model side of the clipboard: serialize the current selection to the
+    // `(text/html, text/plain)` pair to put on the clipboard, and replace the
+    // selection with a parsed HTML or plain-text payload on paste. The actual
+    // clipboard I/O (`copy_html`/`paste_html`) lives app-side behind the
+    // `clipboard` feature; these methods keep all model/serialize knowledge here.
+
+    /// The current selection serialized as `(html, plain_text)` for the clipboard,
+    /// or `None` when the selection is empty (nothing to copy). The HTML is the
+    /// rich payload (round-trips back via [`Self::replace_selection_with_html`]);
+    /// the plain text is the `text/plain` alternative.
+    pub fn selection_clipboard(&self) -> Option<(String, String)> {
+        let core = self.inner.borrow();
+        let sel = &core.state.selection;
+        if sel.is_empty() {
+            return None;
+        }
+        let slice = core.state.doc.slice(sel.from().0, sel.to().0).ok()?;
+        Some((slice_to_html(&slice), slice_to_text(&slice)))
+    }
+
+    /// Replace the current selection with a parsed (schema-whitelisted) HTML
+    /// payload — the rich paste path. Returns whether anything was inserted.
+    pub fn replace_selection_with_html(&self, html: &str) -> bool {
+        let schema = self.inner.borrow().schema.clone();
+        match slice_from_html(&schema, html) {
+            Ok(slice) if slice.content.child_count() > 0 => self.replace_selection_slice(slice),
+            _ => false,
+        }
+    }
+
+    /// Replace the current selection with plain text (one paragraph per line) —
+    /// the plain-text paste path. Returns whether anything was inserted.
+    pub fn replace_selection_with_text(&self, text: &str) -> bool {
+        let schema = self.inner.borrow().schema.clone();
+        match slice_from_text(&schema, text) {
+            Ok(slice) if slice.content.child_count() > 0 => self.replace_selection_slice(slice),
+            _ => false,
+        }
+    }
+
+    /// Replace the selection range with `slice` (the shared paste mechanism). The
+    /// open slice merges into the surrounding block via the transform's `replace`;
+    /// the cursor lands after the inserted content via the transaction's selection
+    /// mapping.
+    fn replace_selection_slice(&self, slice: Slice) -> bool {
+        self.update(move |state| {
+            let (from, to) = (state.selection.from().0, state.selection.to().0);
+            let mut tr = state.tr();
+            tr.replace(from, to, slice).ok()?;
+            // Collapse the cursor just after the inserted content (PM
+            // `replaceSelection` semantics). Without this, the default per-endpoint
+            // selection mapping leaves a range selection spanning the paste. Map the
+            // range's right edge with assoc +1 so a pure-insert cursor lands *after*
+            // the inserted content (assoc -1 would keep it before).
+            let end = tr.mapping().map(to, 1);
+            let cursor = Selection::near(tr.doc(), Pos(end), -1);
+            tr.set_selection(cursor);
+            Some(tr)
+        })
+    }
+
+    /// Phase-2 projection: render caret/selection geometry from the current state.
+    /// The runtime calls this **after** layout (design A3); headless it is a no-op.
+    pub fn update_caret(&self) {
+        let mut core = self.inner.borrow_mut();
+        let state = core.state.clone();
+        if let Some(view) = core.view.as_mut() {
+            view.update_caret(&state);
+        }
+    }
+
+    /// Hide this editor's overlays (caret + selection highlight) because it isn't
+    /// focused. The runtime's focus-aware caret pass calls this for every editor
+    /// that isn't the focused one. A no-op before mount.
+    pub(crate) fn hide_overlays(&self) {
+        if let Some(view) = self.inner.borrow_mut().view.as_mut() {
+            view.hide_overlays();
+        }
+    }
+
+    /// Apply a caret blink phase (the runtime's blink driver calls this each
+    /// half-period). Returns `None` if there is no caret to blink (no collapsed
+    /// cursor), `Some(true)` if the caret's visibility actually toggled (repaint
+    /// needed), or `Some(false)` if the phase was already applied.
+    pub(crate) fn set_caret_blink(&self, visible: bool) -> Option<bool> {
+        self.inner
+            .borrow_mut()
+            .view
+            .as_mut()?
+            .set_caret_blink_visible(visible)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rinch_core::dom::NodeId;
+    use rinch_core::dom::mock::MockDomDocument;
+    use rinch_editor_core::model::Fragment;
+    use rinch_editor_core::{Pos, default_plugins};
+
+    struct Harness {
+        doc: Rc<RefCell<dyn DomDocument>>,
+        container_id: NodeId,
+        handle: EditorHandle,
+    }
+
+    fn mount(html_blocks: Node) -> Harness {
+        let doc: Rc<RefCell<dyn DomDocument>> = Rc::new(RefCell::new(MockDomDocument::new()));
+        let container_id = doc.borrow_mut().create_element("div");
+        let container = NodeHandle::new(container_id, Rc::downgrade(&doc));
+        let schema = Rc::new(Schema::starter_kit());
+        let handle = EditorHandle::new(
+            container,
+            Rc::downgrade(&doc),
+            schema,
+            html_blocks,
+            default_plugins(),
+        );
+        Harness {
+            doc,
+            container_id,
+            handle,
+        }
+    }
+
+    fn schema() -> Schema {
+        Schema::starter_kit()
+    }
+    fn para(s: &Schema, t: &str) -> Node {
+        s.branch("paragraph", Fragment::from_node(s.text(t).unwrap()))
+            .unwrap()
+    }
+    fn doc_node(s: &Schema, blocks: Vec<Node>) -> Node {
+        s.branch("doc", Fragment::from_children(blocks)).unwrap()
+    }
+    fn children(h: &Harness, id: NodeId) -> Vec<NodeId> {
+        h.doc.borrow().get_children(id)
+    }
+    fn tag(h: &Harness, id: NodeId) -> Option<String> {
+        h.doc.borrow().tag_name(id)
+    }
+    fn text(h: &Harness, id: NodeId) -> Option<String> {
+        h.doc.borrow().text_content(id)
+    }
+
+    #[test]
+    fn command_toggles_mark_and_reprojects() {
+        let s = schema();
+        let h = mount(doc_node(&s, vec![para(&s, "abcd")]));
+        // Select the whole word, then bold it via the command.
+        h.handle.set_selection(Selection::text(Pos(1), Pos(5)));
+        assert!(!h.handle.is_mark_active("bold"));
+        assert!(h.handle.command("toggleBold"), "toggleBold applies");
+        assert!(h.handle.is_mark_active("bold"), "state reports bold active");
+
+        // The host re-projected: the run is now wrapped in <strong>.
+        let p = children(&h, h.container_id)[0];
+        let strong = children(&h, p)[0];
+        assert_eq!(tag(&h, strong).as_deref(), Some("strong"));
+        assert_eq!(text(&h, strong).as_deref(), Some("abcd"));
+    }
+
+    #[test]
+    fn block_type_command_and_query() {
+        let s = schema();
+        let h = mount(doc_node(&s, vec![para(&s, "title")]));
+        h.handle.set_selection(Selection::cursor(Pos(2)));
+        assert_eq!(h.handle.current_block_type().as_deref(), Some("paragraph"));
+        assert!(h.handle.command("setHeading2"));
+        assert_eq!(h.handle.current_block_type().as_deref(), Some("heading"));
+        let block = children(&h, h.container_id)[0];
+        assert_eq!(tag(&h, block).as_deref(), Some("h2"));
+    }
+
+    #[test]
+    fn update_inserts_text_through_one_path() {
+        let s = schema();
+        let h = mount(doc_node(&s, vec![para(&s, "ab")]));
+        h.handle.set_selection(Selection::cursor(Pos(3))); // end of "ab"
+        let applied = h.handle.update(|state| {
+            let mut tr = state.tr();
+            tr.insert_text("c").ok()?;
+            Some(tr)
+        });
+        assert!(applied);
+        let p = children(&h, h.container_id)[0];
+        assert_eq!(text(&h, p).as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn load_doc_replaces_content() {
+        let s = schema();
+        let h = mount(doc_node(&s, vec![para(&s, "old")]));
+        assert_eq!(
+            text(&h, children(&h, h.container_id)[0]).as_deref(),
+            Some("old")
+        );
+
+        h.handle
+            .load_doc(doc_node(&s, vec![para(&s, "fresh"), para(&s, "lines")]));
+        let blocks = children(&h, h.container_id);
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(text(&h, blocks[0]).as_deref(), Some("fresh"));
+        assert_eq!(text(&h, blocks[1]).as_deref(), Some("lines"));
+    }
+
+    #[test]
+    fn load_html_parses_and_loads() {
+        let s = schema();
+        let h = mount(doc_node(&s, vec![para(&s, "x")]));
+        assert!(
+            h.handle
+                .load_html("<h1>Title</h1><p>Body <strong>bold</strong></p>")
+        );
+        let blocks = children(&h, h.container_id);
+        assert_eq!(tag(&h, blocks[0]).as_deref(), Some("h1"));
+        assert_eq!(text(&h, blocks[0]).as_deref(), Some("Title"));
+        assert_eq!(tag(&h, blocks[1]).as_deref(), Some("p"));
+        // The bold run is wrapped.
+        let p_children = children(&h, blocks[1]);
+        let has_strong = p_children
+            .iter()
+            .any(|&c| tag(&h, c).as_deref() == Some("strong"));
+        assert!(has_strong, "bold inline survived the load");
+    }
+
+    #[test]
+    fn handle_clones_share_one_editor() {
+        let s = schema();
+        let h = mount(doc_node(&s, vec![para(&s, "ab")]));
+        let clone = h.handle.clone();
+        clone.set_selection(Selection::cursor(Pos(3)));
+        clone.update(|state| {
+            let mut tr = state.tr();
+            tr.insert_text("Z").ok()?;
+            Some(tr)
+        });
+        // The original handle sees the mutation (shared Rc).
+        assert_eq!(
+            text(&h, children(&h, h.container_id)[0]).as_deref(),
+            Some("abZ")
+        );
+    }
+
+    // ── Clipboard (copy / cut / paste) ───────────────────────────────────────
+
+    #[test]
+    fn selection_clipboard_serializes_marked_run() {
+        let s = schema();
+        let h = mount(doc_node(&s, vec![para(&s, "abcd")]));
+        // Empty selection → nothing to copy.
+        h.handle.set_selection(Selection::cursor(Pos(2)));
+        assert!(h.handle.selection_clipboard().is_none());
+
+        // Bold the whole word, select it, copy.
+        h.handle.set_selection(Selection::text(Pos(1), Pos(5)));
+        assert!(h.handle.command("toggleBold"));
+        let (html, plain) = h
+            .handle
+            .selection_clipboard()
+            .expect("non-empty selection copies");
+        assert_eq!(html, "<strong>abcd</strong>", "rich HTML carries the mark");
+        assert_eq!(plain, "abcd", "plain text drops the mark");
+    }
+
+    #[test]
+    fn paste_html_inserts_rich_content_at_cursor() {
+        let s = schema();
+        let h = mount(doc_node(&s, vec![para(&s, "ab")]));
+        h.handle.set_selection(Selection::cursor(Pos(2))); // between a and b
+        assert!(h.handle.replace_selection_with_html("<strong>X</strong>"));
+
+        // "a" + bold "X" + "b" inside the one paragraph.
+        let p = children(&h, h.container_id)[0];
+        assert_eq!(text(&h, p).as_deref(), Some("aXb"));
+        let strong = children(&h, p)
+            .into_iter()
+            .find(|&c| tag(&h, c).as_deref() == Some("strong"));
+        assert!(strong.is_some(), "pasted bold run wrapped in <strong>");
+        // Cursor lands after the inserted run (model pos 3: 0[p 1 a X b]).
+        assert!(
+            h.handle.selection().is_empty(),
+            "paste collapses the cursor"
+        );
+        assert_eq!(h.handle.selection().head(), Pos(3));
+    }
+
+    #[test]
+    fn paste_text_over_selection_replaces_it() {
+        let s = schema();
+        let h = mount(doc_node(&s, vec![para(&s, "hello")]));
+        h.handle.set_selection(Selection::text(Pos(1), Pos(6))); // whole word
+        assert!(h.handle.replace_selection_with_text("bye"));
+        assert_eq!(
+            text(&h, children(&h, h.container_id)[0]).as_deref(),
+            Some("bye")
+        );
+        assert!(h.handle.selection().is_empty());
+    }
+
+    #[test]
+    fn paste_multiline_text_splits_blocks() {
+        let s = schema();
+        let h = mount(doc_node(&s, vec![para(&s, "")]));
+        h.handle.set_selection(Selection::cursor(Pos(1)));
+        assert!(h.handle.replace_selection_with_text("one\ntwo"));
+        let blocks = children(&h, h.container_id);
+        assert_eq!(blocks.len(), 2, "two lines → two paragraphs");
+        assert_eq!(text(&h, blocks[0]).as_deref(), Some("one"));
+        assert_eq!(text(&h, blocks[1]).as_deref(), Some("two"));
+    }
+
+    #[test]
+    fn cut_then_paste_round_trips() {
+        let s = schema();
+        let h = mount(doc_node(&s, vec![para(&s, "abcd")]));
+        // "Cut" cd: copy then delete the selection.
+        h.handle.set_selection(Selection::text(Pos(3), Pos(5)));
+        let (html, _plain) = h.handle.selection_clipboard().expect("copies");
+        assert!(h.handle.command("deleteSelection"));
+        assert_eq!(
+            text(&h, children(&h, h.container_id)[0]).as_deref(),
+            Some("ab")
+        );
+
+        // Paste it back at the end.
+        h.handle.set_selection(Selection::cursor(Pos(3)));
+        assert!(h.handle.replace_selection_with_html(&html));
+        assert_eq!(
+            text(&h, children(&h, h.container_id)[0]).as_deref(),
+            Some("abcd")
+        );
+    }
+
+    // ── Deferred mount (create_editor → load → attach) ───────────────────────
+
+    fn empty_doc(s: &Schema) -> Node {
+        s.branch(
+            "doc",
+            Fragment::from_node(s.branch("paragraph", Fragment::empty()).unwrap()),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn unmounted_handle_is_safe_and_edits_state() {
+        let s = Rc::new(schema());
+        let h = EditorHandle::unmounted(s.clone(), empty_doc(&s), default_plugins());
+
+        // No host projection yet → view ops are safe no-ops, not panics.
+        assert_eq!(h.container_id(), 0);
+        assert_eq!(h.caret_address(Pos(0)), None);
+        assert_eq!(h.pos_at(1, 0), None);
+        assert_eq!(h.set_caret_blink(true), None);
+        h.update_caret();
+
+        // State edits still apply before mount (they render when the view attaches).
+        assert!(h.load_html("<p>hi there</p>"));
+        assert_eq!(h.doc().child_count(), 1);
+    }
+
+    #[test]
+    fn attach_projects_state_loaded_before_mount() {
+        let doc: Rc<RefCell<dyn DomDocument>> = Rc::new(RefCell::new(MockDomDocument::new()));
+        let container_id = doc.borrow_mut().create_element("div");
+        let container = NodeHandle::new(container_id, Rc::downgrade(&doc));
+        let s = Rc::new(schema());
+        let h = EditorHandle::unmounted(s.clone(), empty_doc(&s), default_plugins());
+
+        // Load while unmounted (state only), then attach: the first view build
+        // renders the loaded content directly.
+        assert!(h.load_html("<p>before mount</p>"));
+        h.attach(container, Rc::downgrade(&doc));
+
+        assert_eq!(h.container_id(), container_id.0);
+        let blocks = doc.borrow().get_children(container_id);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(
+            doc.borrow().text_content(blocks[0]).as_deref(),
+            Some("before mount")
+        );
+    }
+}

--- a/crates/rinch/src/editor/mod.rs
+++ b/crates/rinch/src/editor/mod.rs
@@ -1,0 +1,109 @@
+//! The new desktop rich-text editor view (M5+), behind the `new-editor` feature.
+//!
+//! [`RinchDomEditorView`] implements the renderer-agnostic
+//! [`EditorView`](rinch_editor_core::EditorView) seam from `rinch-editor-core`,
+//! projecting an immutable `EditorState { doc, selection }` onto the rinch-dom
+//! host tree. The model is the single source of truth; the host is *derived* from
+//! it on every transaction and never read back for content (design §6). This is
+//! the desktop replacement for the old contenteditable engine, which the M8 rip
+//! deletes.
+//!
+//! [`EditorHandle`] is the imperative API for app/component code (design A7);
+//! [`mount_editor`] wires one into a [`RenderScope`] and registers it so the
+//! runtime can drive its caret pass and route input.
+
+mod blink;
+mod component;
+mod handle;
+mod registry;
+mod view;
+
+pub use component::Editor;
+pub use handle::EditorHandle;
+pub use registry::{
+    begin_drag, drag_anchor, editor_for, end_drag, unregister_editor, update_all_carets,
+};
+pub use view::RinchDomEditorView;
+
+use std::rc::Rc;
+use std::time::Duration;
+
+use rinch_core::dom::{NodeHandle, RenderScope};
+use rinch_editor_core::model::Fragment;
+use rinch_editor_core::{Node, Schema, default_plugins};
+
+/// Create an unmounted [`EditorHandle`] over a fresh (single empty paragraph)
+/// document — the factory for the declarative API (mirrors
+/// [`create_render_surface`](crate::render_surface::create_render_surface)).
+///
+/// The handle works **before** it is placed in the tree: `load_html`/`load_doc`/
+/// `set_selection`/`command` operate on its owned state, which the view renders
+/// when the [`Editor`] component mounts it. Hand the same handle to toolbar
+/// buttons and to `Editor { editor: handle }`.
+pub fn create_editor() -> EditorHandle {
+    let schema = Rc::new(Schema::starter_kit());
+    let empty = empty_doc(&schema);
+    EditorHandle::unmounted(schema, empty, default_plugins())
+}
+
+/// Mount a new editor into `scope` imperatively: create the host container, build
+/// a handle over a fresh document, register it with the runtime, and return both.
+/// Equivalent to [`create_editor`] + [`EditorHandle::mount`]; prefer the
+/// declarative [`Editor`] component in `rsx!` for new code.
+///
+/// The container is marked `data-pm-editor` (deliberately **not**
+/// `contenteditable`, so the old CE engine does not also activate on it). Focus is
+/// click-driven through the runtime's `FocusTarget` arbiter (A10) — no auto-focus
+/// on mount (with multiple editors that would race the single focus authority).
+pub fn mount_editor(scope: &mut RenderScope) -> (NodeHandle, EditorHandle) {
+    let handle = create_editor();
+    let container = handle.mount(scope);
+    (container, handle)
+}
+
+/// The outcome of a [`caret_blink_tick`]: the runtime should repaint if `redraw`
+/// is set, then arm `ControlFlow::WaitUntil(now + next)` for the next toggle.
+pub struct CaretBlink {
+    /// The caret's visibility toggled this tick — request a redraw.
+    pub redraw: bool,
+    /// Time until the next phase toggle (the runtime's next wake).
+    pub next: Duration,
+}
+
+/// Advance the caret blink for the focused editor (`focused` = its container id,
+/// `None` if no editor is focused). Toggles the caret's `display` for the current
+/// half-period and reports when the next toggle is due.
+///
+/// Returns `None` when nothing is blinking — no editor focused, the editor has no
+/// caret (a non-collapsed selection), or it unmounted — in which case the runtime
+/// should return the event loop to `ControlFlow::Wait` (zero idle CPU). The
+/// runtime calls this from `about_to_wait` every iteration (design A3 phase 2 is
+/// for *geometry*; this is the standalone animation tick).
+pub fn caret_blink_tick(focused: Option<usize>) -> Option<CaretBlink> {
+    // On a focus change, restore the previously-blinked caret to solid so a
+    // blurred editor never freezes mid-blink with a hidden caret.
+    let prev = blink::target();
+    if prev != focused {
+        if let Some(prev_id) = prev
+            && let Some(h) = registry::editor_for(prev_id)
+        {
+            h.set_caret_blink(true);
+        }
+        blink::set_target(focused);
+        blink::reset();
+    }
+    let handle = registry::editor_for(focused?)?;
+    let (visible, next) = blink::tick();
+    let redraw = handle.set_caret_blink(visible)?;
+    Some(CaretBlink { redraw, next })
+}
+
+/// A fresh document: one empty paragraph.
+fn empty_doc(schema: &Schema) -> Node {
+    schema
+        .branch(
+            "doc",
+            Fragment::from_node(schema.branch("paragraph", Fragment::empty()).unwrap()),
+        )
+        .unwrap()
+}

--- a/crates/rinch/src/editor/mod.rs
+++ b/crates/rinch/src/editor/mod.rs
@@ -17,6 +17,7 @@ mod component;
 mod handle;
 mod registry;
 mod view;
+mod virtualization;
 
 pub use component::Editor;
 pub use handle::EditorHandle;
@@ -24,6 +25,9 @@ pub use registry::{
     begin_drag, drag_anchor, editor_for, end_drag, unregister_editor, update_all_carets,
 };
 pub use view::RinchDomEditorView;
+pub(crate) use virtualization::{
+    post_layout as virtualization_post_layout, pre_layout as virtualization_pre_layout,
+};
 
 use std::rc::Rc;
 use std::time::Duration;

--- a/crates/rinch/src/editor/registry.rs
+++ b/crates/rinch/src/editor/registry.rs
@@ -1,0 +1,85 @@
+//! A thread-local registry of mounted editors, so the runtime can drive each
+//! editor's post-layout caret pass and look one up by container id.
+//!
+//! This is the cleaner successor to the old CE thread-local API registry
+//! (`set_ce_api_factory`/`with_active_ce_api`): an [`Editor`](super::Editor)
+//! registers its [`EditorHandle`] keyed by its container node id when it mounts,
+//! and the runtime looks editors up by container id (for input) or sweeps them
+//! all (for the caret pass).
+//!
+//! Keyboard focus is **not** tracked here — that is the runtime's single
+//! [`FocusTarget`](crate::app) authority (design A10). The runtime holds
+//! `FocusTarget::Editor(container_id)` and resolves it to a handle via
+//! [`editor_for`].
+
+use std::cell::RefCell;
+
+use super::handle::EditorHandle;
+
+thread_local! {
+    /// `(container node id, handle)` for every mounted editor.
+    static EDITORS: RefCell<Vec<(usize, EditorHandle)>> = const { RefCell::new(Vec::new()) };
+    /// An in-progress pointer drag-select: `(container id, anchor position)`.
+    static DRAG: RefCell<Option<(usize, usize)>> = const { RefCell::new(None) };
+}
+
+/// Begin a pointer drag-select at `anchor` (a `Pos.0`) in editor `container`.
+pub fn begin_drag(container: usize, anchor: usize) {
+    DRAG.with(|d| *d.borrow_mut() = Some((container, anchor)));
+}
+
+/// The active drag-select `(container id, anchor position)`, if a drag is in
+/// progress.
+pub fn drag_anchor() -> Option<(usize, usize)> {
+    DRAG.with(|d| *d.borrow())
+}
+
+/// End any in-progress pointer drag-select.
+pub fn end_drag() {
+    DRAG.with(|d| *d.borrow_mut() = None);
+}
+
+/// Register `handle` under its `container_id` (replacing any prior registration).
+pub fn register_editor(container_id: usize, handle: EditorHandle) {
+    EDITORS.with(|e| {
+        let mut e = e.borrow_mut();
+        e.retain(|(id, _)| *id != container_id);
+        e.push((container_id, handle));
+    });
+}
+
+/// Forget the editor mounted at `container_id`.
+pub fn unregister_editor(container_id: usize) {
+    EDITORS.with(|e| e.borrow_mut().retain(|(id, _)| *id != container_id));
+}
+
+/// The handle registered for `container_id`, if any. The runtime resolves its
+/// `FocusTarget::Editor(container_id)` to a handle through this.
+pub fn editor_for(container_id: usize) -> Option<EditorHandle> {
+    EDITORS.with(|e| {
+        e.borrow()
+            .iter()
+            .find(|(id, _)| *id == container_id)
+            .map(|(_, h)| h.clone())
+    })
+}
+
+/// Re-render mounted editors' overlays. The runtime calls this **after** layout
+/// (design A3, phase 2), when the host has fresh geometry, passing the focused
+/// editor's container id (from the `FocusTarget` arbiter).
+///
+/// Only the **focused** editor renders its caret and selection highlight; every
+/// other mounted editor hides its overlays — so a blurred editor shows neither a
+/// caret nor a selection (and the caret blink, which only runs for the focused
+/// editor, idles for the rest).
+pub fn update_all_carets(focused: Option<usize>) {
+    let editors: Vec<(usize, EditorHandle)> =
+        EDITORS.with(|e| e.borrow().iter().map(|(id, h)| (*id, h.clone())).collect());
+    for (id, handle) in editors {
+        if Some(id) == focused {
+            handle.update_caret();
+        } else {
+            handle.hide_overlays();
+        }
+    }
+}

--- a/crates/rinch/src/editor/registry.rs
+++ b/crates/rinch/src/editor/registry.rs
@@ -51,6 +51,13 @@ pub fn register_editor(container_id: usize, handle: EditorHandle) {
 /// Forget the editor mounted at `container_id`.
 pub fn unregister_editor(container_id: usize) {
     EDITORS.with(|e| e.borrow_mut().retain(|(id, _)| *id != container_id));
+    super::virtualization::forget(container_id);
+}
+
+/// Every mounted editor as `(container id, handle)`. The virtualization driver
+/// sweeps these each layout to maintain a per-editor block window.
+pub(crate) fn all_editors() -> Vec<(usize, EditorHandle)> {
+    EDITORS.with(|e| e.borrow().iter().map(|(id, h)| (*id, h.clone())).collect())
 }
 
 /// The handle registered for `container_id`, if any. The runtime resolves its

--- a/crates/rinch/src/editor/registry.rs
+++ b/crates/rinch/src/editor/registry.rs
@@ -72,14 +72,16 @@ pub fn editor_for(container_id: usize) -> Option<EditorHandle> {
 /// other mounted editor hides its overlays — so a blurred editor shows neither a
 /// caret nor a selection (and the caret blink, which only runs for the focused
 /// editor, idles for the rest).
-pub fn update_all_carets(focused: Option<usize>) {
+pub fn update_all_carets(focused: Option<usize>) -> bool {
     let editors: Vec<(usize, EditorHandle)> =
         EDITORS.with(|e| e.borrow().iter().map(|(id, h)| (*id, h.clone())).collect());
+    let mut moved = false;
     for (id, handle) in editors {
         if Some(id) == focused {
-            handle.update_caret();
+            moved |= handle.update_caret();
         } else {
-            handle.hide_overlays();
+            moved |= handle.hide_overlays();
         }
     }
+    moved
 }

--- a/crates/rinch/src/editor/view.rs
+++ b/crates/rinch/src/editor/view.rs
@@ -1,0 +1,1263 @@
+//! [`RinchDomEditorView`] and its [`ViewDesc`] tree — the desktop projection of
+//! `EditorState` onto rinch-dom (design §6).
+
+use std::cell::RefCell;
+use std::rc::Weak;
+
+use rinch_core::dom::{DomDocument, NodeHandle};
+use rinch_editor_core::decoration::DecorationSet;
+use rinch_editor_core::serialize::{mark_dom_tag, node_dom_tag};
+use rinch_editor_core::{EditorState, EditorView, Mark, Node, Pos, ViewRequest};
+
+/// A weak handle to the host document. The view upgrades + borrows it briefly to
+/// create/patch nodes; holding only a `Weak` lets the document drop normally.
+type DocRef = Weak<RefCell<dyn DomDocument>>;
+
+/// Create a host element and wrap it in a [`NodeHandle`]. `None` if the document
+/// has been dropped.
+fn create_element(doc: &DocRef, tag: &str) -> Option<NodeHandle> {
+    let d = doc.upgrade()?;
+    let id = d.borrow_mut().create_element(tag);
+    Some(NodeHandle::new(id, doc.clone()))
+}
+
+/// Create a host text node and wrap it in a [`NodeHandle`].
+fn create_text(doc: &DocRef, text: &str) -> Option<NodeHandle> {
+    let d = doc.upgrade()?;
+    let id = d.borrow_mut().create_text(text);
+    Some(NodeHandle::new(id, doc.clone()))
+}
+
+/// Set the host element's attributes from `node`: a `data-pm-type` marker (its
+/// schema type, a debugging/MCP/a11y aid) plus the node-specific attributes the
+/// tag itself does not encode. Idempotent — clears attributes that no longer
+/// apply, so an in-place update can't leave a stale `start`/`src`.
+fn apply_element_attrs(dom: &NodeHandle, node: &Node) {
+    dom.set_attribute("data-pm-type", node.type_name());
+    match node.type_name() {
+        "image" => {
+            dom.set_attribute("src", node.attrs().get_str("src").unwrap_or(""));
+            match node.attrs().get_str("alt") {
+                Some(alt) if !alt.is_empty() => dom.set_attribute("alt", alt),
+                _ => dom.remove_attribute("alt"),
+            }
+        }
+        "ordered_list" => match node.attrs().get_int("start") {
+            Some(start) if start != 1 => dom.set_attribute("start", &start.to_string()),
+            _ => dom.remove_attribute("start"),
+        },
+        _ => {}
+    }
+}
+
+/// Set a mark wrapper element's attributes: a `data-pm-mark` marker plus the
+/// attr-bearing specials (`link` → `href`/`title`/`target`+`rel`, `text_color` →
+/// inline `color`, `highlight` → inline `background-color`). Mirrors the
+/// schema-driven copy-out HTML in `serialize::html`.
+fn apply_mark_attrs(dom: &NodeHandle, mark: &Mark) {
+    dom.set_attribute("data-pm-mark", mark.type_name());
+    match mark.type_name() {
+        "link" => {
+            dom.set_attribute("href", mark.attrs.get_str("href").unwrap_or(""));
+            if let Some(title) = mark.attrs.get_str("title").filter(|t| !t.is_empty()) {
+                dom.set_attribute("title", title);
+            }
+            if let Some(target) = mark.attrs.get_str("target").filter(|t| !t.is_empty()) {
+                dom.set_attribute("target", target);
+                if target != "_self" {
+                    // Guard against reverse-tabnabbing, as copy-out HTML does.
+                    dom.set_attribute("rel", "noopener noreferrer");
+                }
+            }
+        }
+        "text_color" => {
+            if let Some(color) = mark.attrs.get_str("color").filter(|c| !c.is_empty()) {
+                dom.set_style("color", color);
+            }
+        }
+        "highlight" => {
+            if let Some(color) = mark.attrs.get_str("color").filter(|c| !c.is_empty()) {
+                dom.set_style("background-color", color);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Wrap `inner` in `marks`' host elements, innermost-first (`marks[0]` closest to
+/// the text, matching copy-out HTML), and return the outermost node (or `inner`
+/// itself when there are no marks / no mark renders to a tag).
+fn wrap_marks(inner: &NodeHandle, marks: &[Mark], doc: &DocRef) -> NodeHandle {
+    let mut current = inner.clone();
+    for mark in marks {
+        if let Some(tag) = mark_dom_tag(mark)
+            && let Some(wrapper) = create_element(doc, &tag)
+        {
+            apply_mark_attrs(&wrapper, mark);
+            wrapper.append_child(&current);
+            current = wrapper;
+        }
+    }
+    current
+}
+
+/// A descriptor mirroring one model [`Node`], owning the host node that projects
+/// it. The conceptual successor to the old `BlockMap`, but a proper persistent
+/// tree: because the model shares `Rc`s, [`Node::same_ref`] lets the diff skip an
+/// unchanged subtree wholesale (design A12).
+///
+/// **Inline marks (M5.5a):** a marked inline run (`text("ab", [bold, italic])`)
+/// projects to a *chain* of host nodes — `<strong><em>#text</em></strong>` — so
+/// [`Self::dom`] (the inner text/leaf node, used for caret geometry and the A15
+/// position map) is distinct from [`Self::outer`] (the outermost wrapper, the node
+/// actually placed in / removed from the parent). For an unmarked node the two are
+/// the same node. Wrappers are built **per run** (no cross-run sharing yet); a
+/// shared-wrapper pass is a later refinement.
+pub(crate) struct ViewDesc {
+    /// The model node this descriptor currently projects.
+    node: Node,
+    /// The inner host node projecting `node` itself — a host text node for a text
+    /// run, or the element for a block/leaf. Caret and the A15 map address this.
+    dom: NodeHandle,
+    /// The host node placed in the parent: the outermost inline mark wrapper, or
+    /// (when `node` is unmarked) the same node as [`Self::dom`].
+    outer: NodeHandle,
+    /// Child descriptors, positionally 1:1 with `node`'s children.
+    children: Vec<ViewDesc>,
+    /// Whether [`Self::dom`] is a host text node (vs an element).
+    is_text: bool,
+}
+
+impl ViewDesc {
+    /// Build a descriptor (and its host subtree, including inline mark wrappers)
+    /// for `node`.
+    fn build(node: &Node, doc: &DocRef) -> Option<ViewDesc> {
+        let (dom, children, is_text) = if let Some(text) = node.text() {
+            (create_text(doc, text)?, Vec::new(), true)
+        } else {
+            let el = create_element(doc, &node_dom_tag(node))?;
+            apply_element_attrs(&el, node);
+            let mut children = Vec::with_capacity(node.child_count());
+            for i in 0..node.child_count() {
+                if let Some(child) = ViewDesc::build(node.child(i), doc) {
+                    el.append_child(&child.outer);
+                    children.push(child);
+                }
+            }
+            (el, children, false)
+        };
+        // Inline marks (on a text run or inline leaf) wrap the node's own host
+        // node; blocks are unmarked, so `outer == dom` there.
+        let outer = wrap_marks(&dom, node.marks(), doc);
+        Some(ViewDesc {
+            node: node.clone(),
+            dom,
+            outer,
+            children,
+            is_text,
+        })
+    }
+
+    /// Patch this descriptor in place to project `new`. Returns `false` if the
+    /// kinds are incompatible (text vs element, a different element tag, or a
+    /// changed mark set whose wrapper chain differs) and the caller must replace
+    /// the whole subtree instead.
+    fn update(&mut self, new: &Node, doc: &DocRef) -> bool {
+        // Fast path: same persistent subtree — nothing changed (design A12).
+        if self.node.same_ref(new) {
+            return true;
+        }
+        // A changed mark set alters the wrapper chain (`outer`), which can't be
+        // patched in place — force a rebuild. (Blocks are always unmarked.)
+        if self.node.marks() != new.marks() {
+            return false;
+        }
+        if new.is_text() {
+            if !self.is_text {
+                return false;
+            }
+            if self.node.text() != new.text() {
+                self.dom.set_text(new.text().unwrap_or(""));
+            }
+            self.node = new.clone();
+            return true;
+        }
+        // Element: the tag must match to patch in place.
+        if self.is_text || node_dom_tag(&self.node) != node_dom_tag(new) {
+            return false;
+        }
+        if self.node.attrs() != new.attrs() {
+            apply_element_attrs(&self.dom, new);
+        }
+        self.diff_children(new, doc);
+        self.node = new.clone();
+        true
+    }
+
+    /// Reconcile this descriptor's children against `new`'s children: a positional
+    /// diff that recurses (with the `same_ref` fast skip), replaces a child whose
+    /// kind changed, appends new trailing children, and removes surplus ones.
+    ///
+    /// Positional (not keyed) is correct and minimal for text editing, where edits
+    /// are local; a keyed/LIS pass can replace this if reorder churn ever matters.
+    fn diff_children(&mut self, new: &Node, doc: &DocRef) {
+        let new_count = new.child_count();
+        for i in 0..new_count {
+            let new_child = new.child(i);
+            if i < self.children.len() {
+                if self.children[i].update(new_child, doc) {
+                    continue;
+                }
+                // Kind changed — build a replacement and swap it into the host
+                // (by the placed `outer` node, which differs from `dom` for a
+                // mark-wrapped run).
+                if let Some(replacement) = ViewDesc::build(new_child, doc) {
+                    self.children[i].outer.replace_with(&replacement.outer);
+                    self.children[i] = replacement;
+                }
+            } else if let Some(new_desc) = ViewDesc::build(new_child, doc) {
+                self.dom.append_child(&new_desc.outer);
+                self.children.push(new_desc);
+            }
+        }
+        while self.children.len() > new_count {
+            // `pop` keeps removal O(1) and order-independent (host removal is by id).
+            if let Some(extra) = self.children.pop() {
+                extra.outer.remove();
+            }
+        }
+    }
+
+    /// The placed host node of the first block child, if any (the placeholder is
+    /// inserted before it so it overlays the empty editor).
+    fn first_child_dom(&self) -> Option<&NodeHandle> {
+        self.children.first().map(|c| &c.outer)
+    }
+}
+
+/// The desktop editor view: projects [`EditorState`] onto rinch-dom and keeps the
+/// host in sync as transactions are applied (design §6). Implements the
+/// renderer-agnostic [`EditorView`] seam.
+pub struct RinchDomEditorView {
+    doc: DocRef,
+    /// The descriptor for the document root. Its [`ViewDesc::dom`] is the host
+    /// container (created by the caller, e.g. the `Editor {}` component) and is
+    /// **never replaced** — only its children diff.
+    root: ViewDesc,
+    /// The placeholder overlay node while shown — decoration-diff state (A4/A8).
+    placeholder: Option<NodeHandle>,
+    /// The caret overlay node — an absolutely-positioned bar the view owns and
+    /// repositions from `state.selection` (design §6: caret is rendered *from*
+    /// the selection, never via a `data-ce-cursor` attribute). It lives as a child
+    /// of the **container** (never a textblock — a child node would disrupt the
+    /// block's inline-formatting context), positioned in container space.
+    caret: Option<NodeHandle>,
+    /// The last rendered caret `(x, y, height)` (pixels rounded), so a re-run that
+    /// lands on the same spot writes nothing — otherwise the caret's own style
+    /// writes would re-dirty the tree and spin the repaint loop.
+    last_caret: Option<(i32, i32, i32)>,
+    /// The blink phase last applied to the caret (`Some(true)` = shown,
+    /// `Some(false)` = hidden, `None` = no caret present). Guards
+    /// [`Self::set_caret_blink_visible`] against redundant writes so a blink tick
+    /// that doesn't change the phase doesn't re-dirty the tree.
+    blink_shown: Option<bool>,
+    /// Highlight rectangles for the current text selection (container children,
+    /// reused across updates).
+    selection_rects: Vec<NodeHandle>,
+    /// The last rendered selection `(from, to)`, for change-detection.
+    last_selection: Option<(usize, usize)>,
+    /// The decoration set currently projected, for the next diff.
+    decorations: DecorationSet,
+}
+
+impl RinchDomEditorView {
+    /// Build a view over `state`, rendering its document into `container` (the host
+    /// element standing in for the `doc` node). `container` is owned by the caller
+    /// and never replaced.
+    pub fn new(container: NodeHandle, doc: DocRef, state: &EditorState) -> RinchDomEditorView {
+        container.set_attribute("data-pm-type", state.doc.type_name());
+        // The caret and selection overlays are positioned absolutely relative to the
+        // container. A non-`auto` `z-index` makes the container a CSS stacking
+        // context, so the selection rects (`z-index: -1`) paint *behind* the in-flow
+        // text and the caret (`z-index: 1`) paints in front of it.
+        container.set_styles(&[("position", "relative"), ("z-index", "0")]);
+        let mut children = Vec::with_capacity(state.doc.child_count());
+        for i in 0..state.doc.child_count() {
+            if let Some(child) = ViewDesc::build(state.doc.child(i), &doc) {
+                container.append_child(&child.outer);
+                children.push(child);
+            }
+        }
+        let root = ViewDesc {
+            node: state.doc.clone(),
+            outer: container.clone(),
+            dom: container,
+            children,
+            is_text: false,
+        };
+        let mut view = RinchDomEditorView {
+            doc,
+            root,
+            placeholder: None,
+            caret: None,
+            last_caret: None,
+            blink_shown: None,
+            selection_rects: Vec::new(),
+            last_selection: None,
+            decorations: DecorationSet::empty(),
+        };
+        view.sync_decorations(state);
+        view
+    }
+
+    /// Diff `state`'s decorations against the projected set and patch the overlay
+    /// nodes — independent of the document diff (design A4). M5.4 handles the
+    /// placeholder widget only; M6 adds the IME preedit and richer kinds.
+    fn sync_decorations(&mut self, state: &EditorState) {
+        let next = state.decorations();
+        if next == self.decorations {
+            return;
+        }
+        let placeholder_text = next.iter().find_map(|d| d.as_placeholder());
+        match (placeholder_text, self.placeholder.is_some()) {
+            (Some(text), false) => {
+                if let Some(node) = create_element(&self.doc, "div") {
+                    node.set_attribute("data-pm-placeholder", "true");
+                    node.set_attribute("class", "rinch-editor-placeholder");
+                    if let Some(t) = create_text(&self.doc, text) {
+                        node.append_child(&t);
+                    }
+                    // Overlay the (empty) first block; if none, append to the root.
+                    match self.root.first_child_dom() {
+                        Some(first) => self.root.dom.insert_before(&node, first),
+                        None => self.root.dom.append_child(&node),
+                    }
+                    self.placeholder = Some(node);
+                }
+            }
+            (None, true) => {
+                if let Some(node) = self.placeholder.take() {
+                    node.remove();
+                }
+            }
+            // (Some, true): placeholder stays (its text is fixed per editor).
+            // (None, false): nothing to do.
+            _ => {}
+        }
+        self.decorations = next;
+    }
+}
+
+impl EditorView for RinchDomEditorView {
+    fn update_dom(&mut self, _prev: &EditorState, next: &EditorState) -> Vec<ViewRequest> {
+        // Phase 1 (before layout): diff the document and patch the host. The root's
+        // host element is fixed, so only its children reconcile.
+        self.root.diff_children(&next.doc, &self.doc);
+        self.root.node = next.doc.clone();
+        // Decoration diff, independent of the document diff (A4).
+        self.sync_decorations(next);
+        Vec::new()
+    }
+
+    fn update_caret(&mut self, next: &EditorState) -> Vec<ViewRequest> {
+        // Phase 2 (after layout): render the selection highlight (for a range) and
+        // the caret (at a collapsed cursor), both from `next.selection`.
+        self.render_selection(next);
+        // No caret while a range is selected — the highlight conveys the head, a
+        // caret blinking over a highlight reads as noise, and with no caret the
+        // blink loop idles (`set_caret_blink` reports "nothing to blink").
+        if !next.selection.is_empty() {
+            self.hide_caret();
+            return Vec::new();
+        }
+        let Some((block, flat_byte)) = self.caret_target(&next.doc, next.selection.head()) else {
+            self.hide_caret();
+            return Vec::new();
+        };
+        let Some(doc) = self.doc.upgrade() else {
+            return Vec::new();
+        };
+        let block_id = block.node_id().0;
+        // Query Parley for the caret geometry (layout-local to the textblock), then
+        // translate into the container's coordinate space.
+        let geometry = {
+            let d = doc.borrow();
+            d.query_caret_position(block_id as u64, flat_byte)
+                .map(|(local_x, local_y)| {
+                    let height = d
+                        .query_glyph_bounds(block_id as u64, flat_byte)
+                        .map(|g| g.height)
+                        .unwrap_or(18.0);
+                    let (ox, oy) = self.block_offset_in_container(&*d, block_id);
+                    (ox + local_x, oy + local_y, height)
+                })
+        };
+        match geometry {
+            Some((x, y, height)) => self.position_caret(x, y, height),
+            None => self.hide_caret(),
+        }
+        vec![ViewRequest::ScrollSelectionIntoView]
+    }
+}
+
+impl RinchDomEditorView {
+    /// The host id of the editor container (the `doc` node's element).
+    pub(crate) fn container_id(&self) -> usize {
+        self.root.dom.node_id().0
+    }
+
+    /// Resolve a model [`Pos`] to its host caret address `(textblock element id,
+    /// flat UTF-8 byte offset)` — the address app-side geometry (caret point,
+    /// vertical movement) queries Parley with. `None` if `pos` isn't in a textblock.
+    pub(crate) fn caret_address(&self, doc: &Node, pos: Pos) -> Option<(usize, usize)> {
+        self.caret_target(doc, pos)
+            .map(|(dom, byte)| (dom.node_id().0, byte))
+    }
+
+    /// Resolve a model [`Pos`] to the host caret address `(textblock element, flat
+    /// UTF-8 byte offset)` for the Parley layout query (the A15 char→byte IFC map).
+    /// `None` when the position is not inside a textblock.
+    fn caret_target(&self, doc: &Node, pos: Pos) -> Option<(NodeHandle, usize)> {
+        let r = doc.resolve(pos).ok()?;
+        if !r.parent().is_textblock() {
+            return None;
+        }
+        // Walk the descriptor tree to the textblock that owns `pos`, mirroring the
+        // resolved path's child indices.
+        let mut desc = &self.root;
+        for d in 0..r.depth() {
+            desc = desc.children.get(r.index(d))?;
+        }
+        let flat_byte = textblock_flat_byte(&desc.node, r.parent_offset());
+        Some((desc.dom.clone(), flat_byte))
+    }
+
+    /// Map a host caret address — `(textblock element id, flat UTF-8 byte offset)`,
+    /// as produced by a pointer hit-test — back to a model [`Pos`] (the inverse of
+    /// [`Self::caret_target`]). `None` if `textblock_dom_id` isn't a known
+    /// textblock in this view.
+    pub(crate) fn pos_at(&self, textblock_dom_id: usize, ifc_byte: usize) -> Option<Pos> {
+        let (content_start, block) = find_block(&self.root, textblock_dom_id, 0)?;
+        Some(Pos(content_start + ifc_byte_to_char(block, ifc_byte)))
+    }
+
+    /// The textblock's offset in container coordinates — the sum of parent-relative
+    /// layouts from the block up to (excluding) the container.
+    fn block_offset_in_container(&self, d: &dyn DomDocument, block_id: usize) -> (f32, f32) {
+        let container_id = self.root.dom.node_id().0;
+        let (mut x, mut y) = (0.0f32, 0.0f32);
+        let mut cur = Some(block_id);
+        while let Some(id) = cur {
+            if id == container_id {
+                break;
+            }
+            if let Some((nx, ny, _, _)) = d.query_node_layout(id as u64) {
+                x += nx;
+                y += ny;
+            }
+            cur = d.parent_node(rinch_core::dom::NodeId(id)).map(|n| n.0);
+        }
+        (x, y)
+    }
+
+    /// Render (or clear) the text-selection highlight from `state.selection`.
+    fn render_selection(&mut self, state: &EditorState) {
+        let sel = &state.selection;
+        if sel.is_empty() {
+            self.clear_selection_rects();
+            return;
+        }
+        let key = (sel.from().0, sel.to().0);
+        if self.last_selection == Some(key) {
+            return;
+        }
+        self.last_selection = Some(key);
+        let Some(doc) = self.doc.upgrade() else {
+            return;
+        };
+        let targets = self.selection_targets(&state.doc, sel.from(), sel.to());
+        let rects: Vec<(f32, f32, f32, f32)> = {
+            let d = doc.borrow();
+            let mut out = Vec::new();
+            for (block_id, byte_a, byte_b) in targets {
+                let (ox, oy) = self.block_offset_in_container(&*d, block_id);
+                for (rx, ry, rw, rh) in d.query_selection_rects(block_id as u64, byte_a, byte_b) {
+                    out.push((ox + rx, oy + ry, rw, rh));
+                }
+            }
+            out
+        };
+        self.set_selection_rects(&rects);
+    }
+
+    /// For each textblock overlapping `[from, to)`, the host element id and the
+    /// flat UTF-8 byte range of the selection within that block.
+    fn selection_targets(&self, doc: &Node, from: Pos, to: Pos) -> Vec<(usize, usize, usize)> {
+        let mut targets = Vec::new();
+        doc.nodes_between(from.0, to.0, &mut |node, pos, _parent| {
+            if node.is_textblock() {
+                let content_start = pos + 1;
+                let content_end = content_start + node.content().size();
+                let a = from.0.max(content_start);
+                let b = to.0.min(content_end);
+                if a < b
+                    && let Some((block_id, _)) = self.caret_address(doc, Pos(content_start))
+                {
+                    targets.push((
+                        block_id,
+                        textblock_flat_byte(node, a - content_start),
+                        textblock_flat_byte(node, b - content_start),
+                    ));
+                }
+                false // don't descend into the textblock's inline content
+            } else {
+                true
+            }
+        });
+        targets
+    }
+
+    /// Reconcile the selection-highlight divs (container children) to `rects`
+    /// (container space).
+    fn set_selection_rects(&mut self, rects: &[(f32, f32, f32, f32)]) {
+        while self.selection_rects.len() < rects.len() {
+            let Some(div) = create_element(&self.doc, "div") else {
+                break;
+            };
+            div.set_attribute("data-pm-selection", "true");
+            div.set_styles(&[
+                ("position", "absolute"),
+                ("background-color", "rgba(26,115,232,0.3)"),
+                ("pointer-events", "none"),
+                // Behind the in-flow text (the container is a stacking context).
+                ("z-index", "-1"),
+            ]);
+            self.root.dom.append_child(&div);
+            self.selection_rects.push(div);
+        }
+        while self.selection_rects.len() > rects.len() {
+            if let Some(div) = self.selection_rects.pop() {
+                div.remove();
+            }
+        }
+        for (div, (x, y, w, h)) in self.selection_rects.iter().zip(rects) {
+            let left = format!("{x}px");
+            let top = format!("{y}px");
+            let width = format!("{w}px");
+            let height = format!("{h}px");
+            div.set_styles(&[
+                ("left", &left),
+                ("top", &top),
+                ("width", &width),
+                ("height", &height),
+                ("display", "block"),
+            ]);
+        }
+    }
+
+    /// Remove all selection-highlight divs.
+    fn clear_selection_rects(&mut self) {
+        if self.last_selection.is_none() && self.selection_rects.is_empty() {
+            return;
+        }
+        self.last_selection = None;
+        for div in self.selection_rects.drain(..) {
+            div.remove();
+        }
+    }
+
+    /// Position the caret overlay at `(x, y)` in **container space** with `height`.
+    /// The caret is a child of the container (created lazily), so it never disrupts
+    /// a textblock's inline layout.
+    fn position_caret(&mut self, x: f32, y: f32, height: f32) {
+        let key = (x.round() as i32, y.round() as i32, height.round() as i32);
+        // Nothing changed since last frame — skip the writes so the caret doesn't
+        // re-dirty itself and spin the repaint loop.
+        if self.last_caret == Some(key) {
+            return;
+        }
+        self.last_caret = Some(key);
+        // The caret moved (edit/cursor move) — restart the blink phase so the
+        // caret is solid immediately after the interaction. Scope the reset to
+        // the *focused* (blink-target) editor: with several editors mounted,
+        // `update_all_carets` sweeps every one, and a programmatic caret move in
+        // an unfocused editor must not stomp the focused editor's global phase.
+        // (A focus change resets the phase separately, in `caret_blink_tick`.)
+        if super::blink::target() == Some(self.container_id()) {
+            super::blink::reset();
+        }
+        // The `display: block` written below always puts this caret in the
+        // "shown" phase, so a moved caret is never left mid-blink (hidden).
+        self.blink_shown = Some(true);
+        if self.caret.is_none() {
+            let Some(caret) = create_element(&self.doc, "div") else {
+                return;
+            };
+            caret.set_attribute("data-pm-caret", "true");
+            caret.set_styles(&[
+                ("position", "absolute"),
+                ("width", "2px"),
+                ("background-color", "#1a73e8"),
+                ("pointer-events", "none"),
+                // In front of the in-flow text and the selection highlight.
+                ("z-index", "1"),
+            ]);
+            self.root.dom.append_child(&caret);
+            self.caret = Some(caret);
+        }
+        if let Some(caret) = &self.caret {
+            let left = format!("{x}px");
+            let top = format!("{y}px");
+            let h = format!("{height}px");
+            caret.set_styles(&[
+                ("left", &left),
+                ("top", &top),
+                ("height", &h),
+                ("display", "block"),
+            ]);
+        }
+    }
+
+    /// Hide all overlays — the caret and the selection highlight. Used when the
+    /// editor loses focus, so a blurred editor shows neither (the runtime's
+    /// focus-aware caret pass calls this for every non-focused editor).
+    pub(crate) fn hide_overlays(&mut self) {
+        self.hide_caret();
+        self.clear_selection_rects();
+    }
+
+    /// Hide the caret (no collapsed cursor in a textblock).
+    fn hide_caret(&mut self) {
+        if self.last_caret.is_none() {
+            return;
+        }
+        self.last_caret = None;
+        self.blink_shown = None;
+        if let Some(caret) = &self.caret {
+            caret.set_style("display", "none");
+        }
+    }
+
+    /// Apply a blink phase to the caret: show it (`visible == true`) or hide it.
+    /// Returns `None` when there is no active caret to blink (no collapsed cursor),
+    /// `Some(true)` when the caret's `display` actually toggled (the caller should
+    /// repaint), and `Some(false)` when the phase was already applied (no write —
+    /// so a blink tick that doesn't change the phase never re-dirties the tree).
+    ///
+    /// Toggles only `display`; the caret's *position* is owned by
+    /// [`Self::position_caret`], which always leaves it in the shown phase.
+    pub(crate) fn set_caret_blink_visible(&mut self, visible: bool) -> Option<bool> {
+        // No collapsed-cursor caret present → nothing to blink.
+        self.last_caret?;
+        if self.blink_shown == Some(visible) {
+            return Some(false);
+        }
+        self.blink_shown = Some(visible);
+        if let Some(caret) = &self.caret {
+            caret.set_style("display", if visible { "block" } else { "none" });
+        }
+        Some(true)
+    }
+}
+
+/// The flat UTF-8 byte offset, within a textblock's concatenated inline text,
+/// corresponding to the model **char** offset `char_off` — the A15 char→byte half
+/// of the caret map. Walks the inline runs accumulating char and byte counts.
+///
+/// Inline leaves (image / hard_break) are treated as one char of zero flat-byte
+/// width for now; exact leaf byte widths in the IFC text stream are tuned against
+/// the live renderer (caret-after-leaf is the open edge).
+/// Walk the descriptor tree for the block whose host node is `target`, returning
+/// its model **content-start** position and its model node. `content_start` is the
+/// position passed in for `desc`'s own content (0 for the root/doc).
+fn find_block(desc: &ViewDesc, target: usize, content_start: usize) -> Option<(usize, &Node)> {
+    let mut pos = content_start; // the position just before the current child
+    for child in &desc.children {
+        if child.dom.node_id().0 == target {
+            // The child's content begins just inside its opening boundary token.
+            return Some((pos + 1, &child.node));
+        }
+        if let Some(found) = find_block(child, target, pos + 1) {
+            return Some(found);
+        }
+        pos += child.node.node_size();
+    }
+    None
+}
+
+/// The model **char** offset within a textblock for a flat UTF-8 `ifc_byte` offset
+/// — the inverse of [`textblock_flat_byte`], used to turn a pointer hit into a
+/// cursor position. Leaves count as one char (matching `textblock_flat_byte`).
+fn ifc_byte_to_char(block: &Node, ifc_byte: usize) -> usize {
+    let mut bytes = 0usize;
+    let mut chars = 0usize;
+    for i in 0..block.child_count() {
+        let child = block.child(i);
+        if let Some(text) = child.text() {
+            if ifc_byte <= bytes + text.len() {
+                let into_byte = ifc_byte - bytes;
+                for (b, _) in text.char_indices() {
+                    if b >= into_byte {
+                        return chars;
+                    }
+                    chars += 1;
+                }
+                return chars;
+            }
+            bytes += text.len();
+            chars += text.chars().count();
+        } else {
+            chars += 1;
+        }
+    }
+    chars
+}
+
+fn textblock_flat_byte(block: &Node, char_off: usize) -> usize {
+    let mut chars_seen = 0usize;
+    let mut bytes = 0usize;
+    for i in 0..block.child_count() {
+        let child = block.child(i);
+        if let Some(text) = child.text() {
+            let run_chars = text.chars().count();
+            if chars_seen + run_chars >= char_off {
+                let into = char_off - chars_seen;
+                let byte_in_run = text
+                    .char_indices()
+                    .nth(into)
+                    .map(|(b, _)| b)
+                    .unwrap_or(text.len());
+                return bytes + byte_in_run;
+            }
+            chars_seen += run_chars;
+            bytes += text.len();
+        } else {
+            if chars_seen >= char_off {
+                return bytes;
+            }
+            chars_seen += 1; // leaf occupies one model char
+        }
+    }
+    bytes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rinch_core::dom::NodeId;
+    use rinch_core::dom::mock::MockDomDocument;
+    use rinch_editor_core::model::Fragment;
+    use rinch_editor_core::plugins::PlaceholderPlugin;
+    use rinch_editor_core::{EditorState, Schema, Selection, default_plugins};
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    /// A host document plus a container node to mount the editor into.
+    struct Harness {
+        doc: Rc<RefCell<dyn DomDocument>>,
+        container: NodeHandle,
+        container_id: NodeId,
+    }
+
+    fn harness() -> Harness {
+        let doc: Rc<RefCell<dyn DomDocument>> = Rc::new(RefCell::new(MockDomDocument::new()));
+        let container_id = doc.borrow_mut().create_element("div");
+        let container = NodeHandle::new(container_id, Rc::downgrade(&doc));
+        Harness {
+            doc,
+            container,
+            container_id,
+        }
+    }
+
+    fn doc_ref(h: &Harness) -> DocRef {
+        Rc::downgrade(&h.doc)
+    }
+
+    fn schema() -> Rc<Schema> {
+        Rc::new(Schema::starter_kit())
+    }
+
+    fn para(s: &Schema, t: &str) -> Node {
+        s.branch("paragraph", Fragment::from_node(s.text(t).unwrap()))
+            .unwrap()
+    }
+
+    fn mk(s: &Schema, name: &str, attrs: rinch_editor_core::Attrs) -> Mark {
+        Mark::new(s.mark_type(name).unwrap().clone(), attrs)
+    }
+
+    fn marked_para(s: &Schema, t: &str, marks: Vec<Mark>) -> Node {
+        s.branch(
+            "paragraph",
+            Fragment::from_node(s.text_with_marks(t, marks).unwrap()),
+        )
+        .unwrap()
+    }
+
+    fn doc_node(s: &Schema, blocks: Vec<Node>) -> Node {
+        s.branch("doc", Fragment::from_children(blocks)).unwrap()
+    }
+
+    fn state(s: Rc<Schema>, doc: Node) -> EditorState {
+        EditorState::create(s, doc, default_plugins())
+    }
+
+    // Read helpers over the host document.
+    fn children(h: &Harness, id: NodeId) -> Vec<NodeId> {
+        h.doc.borrow().get_children(id)
+    }
+    fn tag(h: &Harness, id: NodeId) -> Option<String> {
+        h.doc.borrow().tag_name(id)
+    }
+    fn pm_type(h: &Harness, id: NodeId) -> Option<String> {
+        h.doc.borrow().get_attribute(id, "data-pm-type")
+    }
+    fn text(h: &Harness, id: NodeId) -> Option<String> {
+        h.doc.borrow().text_content(id)
+    }
+
+    #[test]
+    fn builds_initial_dom_from_doc() {
+        let h = harness();
+        let s = schema();
+        let st = state(
+            s.clone(),
+            doc_node(&s, vec![para(&s, "hello"), para(&s, "world")]),
+        );
+        let _view = RinchDomEditorView::new(h.container.clone(), doc_ref(&h), &st);
+
+        let blocks = children(&h, h.container_id);
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(tag(&h, blocks[0]).as_deref(), Some("p"));
+        assert_eq!(pm_type(&h, blocks[0]).as_deref(), Some("paragraph"));
+        assert_eq!(text(&h, blocks[0]).as_deref(), Some("hello"));
+        assert_eq!(text(&h, blocks[1]).as_deref(), Some("world"));
+        assert_eq!(pm_type(&h, h.container_id).as_deref(), Some("doc"));
+    }
+
+    #[test]
+    fn blink_toggles_caret_display_and_guards_redundant_writes() {
+        let h = harness();
+        let s = schema();
+        let st = state(s.clone(), doc_node(&s, vec![para(&s, "hi")]));
+        let mut view = RinchDomEditorView::new(h.container.clone(), doc_ref(&h), &st);
+
+        // No caret present yet → nothing to blink.
+        assert_eq!(view.set_caret_blink_visible(false), None);
+        assert_eq!(view.set_caret_blink_visible(true), None);
+
+        // Placing the caret leaves it in the shown phase (and resets the clock).
+        view.position_caret(1.0, 2.0, 18.0);
+        assert_eq!(view.blink_shown, Some(true));
+
+        // Hiding it for the off-phase writes once...
+        assert_eq!(view.set_caret_blink_visible(false), Some(true));
+        // ...and a repeated off-phase is a no-op (so a tick never re-dirties).
+        assert_eq!(view.set_caret_blink_visible(false), Some(false));
+        // Back to the on-phase writes again, then is idempotent.
+        assert_eq!(view.set_caret_blink_visible(true), Some(true));
+        assert_eq!(view.set_caret_blink_visible(true), Some(false));
+
+        // A re-position always returns the caret to the shown phase, so a moved
+        // caret is never left mid-blink (hidden).
+        view.set_caret_blink_visible(false);
+        view.position_caret(5.0, 2.0, 18.0);
+        assert_eq!(view.blink_shown, Some(true));
+
+        // Removing the caret (selection/blur) clears the blink state.
+        view.hide_caret();
+        assert_eq!(view.blink_shown, None);
+        assert_eq!(view.set_caret_blink_visible(true), None);
+    }
+
+    #[test]
+    fn blink_reset_is_scoped_to_the_focused_editor() {
+        // Two editors share one host doc so they get distinct container ids.
+        let h = harness();
+        let s = schema();
+        let container_b_id = h.doc.borrow_mut().create_element("div");
+        let container_b = NodeHandle::new(container_b_id, Rc::downgrade(&h.doc));
+
+        let st_a = state(s.clone(), doc_node(&s, vec![para(&s, "aaa")]));
+        let st_b = state(s.clone(), doc_node(&s, vec![para(&s, "bbb")]));
+        let mut view_a = RinchDomEditorView::new(h.container.clone(), doc_ref(&h), &st_a);
+        let mut view_b = RinchDomEditorView::new(container_b, doc_ref(&h), &st_b);
+
+        // Editor A is the focused / blink-target editor.
+        crate::editor::blink::set_target(Some(view_a.container_id()));
+        crate::editor::blink::reset();
+        let anchor0 = crate::editor::blink::anchor_for_test();
+
+        // A caret move in the UNFOCUSED editor B must NOT re-anchor the clock.
+        view_b.position_caret(1.0, 2.0, 18.0);
+        assert_eq!(
+            crate::editor::blink::anchor_for_test(),
+            anchor0,
+            "an unfocused editor's caret move stomped the focused editor's blink phase",
+        );
+
+        // A caret move in the FOCUSED editor A re-anchors it (caret back to solid).
+        view_a.position_caret(1.0, 2.0, 18.0);
+        assert_ne!(
+            crate::editor::blink::anchor_for_test(),
+            anchor0,
+            "the focused editor's caret move failed to reset its own blink phase",
+        );
+
+        crate::editor::blink::set_target(None);
+    }
+
+    #[test]
+    fn heading_uses_level_tag() {
+        let h = harness();
+        let s = schema();
+        let heading = s
+            .create_node(
+                "heading",
+                rinch_editor_core::Attrs::from_iter([(
+                    "level",
+                    rinch_editor_core::AttrValue::from(3_i64),
+                )]),
+                Fragment::from_node(s.text("Title").unwrap()),
+            )
+            .unwrap();
+        let st = state(s.clone(), doc_node(&s, vec![heading]));
+        let _view = RinchDomEditorView::new(h.container.clone(), doc_ref(&h), &st);
+
+        let blocks = children(&h, h.container_id);
+        assert_eq!(tag(&h, blocks[0]).as_deref(), Some("h3"));
+    }
+
+    #[test]
+    fn insert_text_patches_text_node_in_place() {
+        let h = harness();
+        let s = schema();
+        let st = state(s.clone(), doc_node(&s, vec![para(&s, "ab")]));
+        let mut view = RinchDomEditorView::new(h.container.clone(), doc_ref(&h), &st);
+
+        let p_id = children(&h, h.container_id)[0];
+        let text_id_before = children(&h, p_id)[0];
+
+        // Type "X" at the end of "ab".
+        let mut tr = st.tr();
+        tr.set_selection(Selection::cursor(rinch_editor_core::Pos(3)));
+        tr.insert_text("X").unwrap();
+        let next = st.apply(tr);
+        view.update_dom(&st, &next);
+
+        let p_id_after = children(&h, h.container_id)[0];
+        let text_id_after = children(&h, p_id_after)[0];
+        assert_eq!(p_id, p_id_after, "the paragraph element is reused");
+        assert_eq!(
+            text_id_before, text_id_after,
+            "the text node is patched in place"
+        );
+        assert_eq!(text(&h, p_id_after).as_deref(), Some("abX"));
+    }
+
+    #[test]
+    fn split_block_adds_a_paragraph_and_keeps_the_first() {
+        let h = harness();
+        let s = schema();
+        let mut st = state(s.clone(), doc_node(&s, vec![para(&s, "ab")]));
+        let mut view = RinchDomEditorView::new(h.container.clone(), doc_ref(&h), &st);
+        let first_p_before = children(&h, h.container_id)[0];
+
+        // Split between "a" and "b".
+        st.selection = Selection::cursor(rinch_editor_core::Pos(2));
+        let next = st.run("splitBlock").expect("split applies");
+        view.update_dom(&st, &next);
+
+        let blocks = children(&h, h.container_id);
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(
+            blocks[0], first_p_before,
+            "the first paragraph is reused, not rebuilt"
+        );
+        assert_eq!(text(&h, blocks[0]).as_deref(), Some("a"));
+        assert_eq!(text(&h, blocks[1]).as_deref(), Some("b"));
+    }
+
+    #[test]
+    fn wrap_in_blockquote_restructures_host() {
+        let h = harness();
+        let s = schema();
+        let st = state(s.clone(), doc_node(&s, vec![para(&s, "quote me")]));
+        let mut view = RinchDomEditorView::new(h.container.clone(), doc_ref(&h), &st);
+
+        let next = st.run("wrapInBlockquote").expect("wrap applies");
+        view.update_dom(&st, &next);
+
+        let blocks = children(&h, h.container_id);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(tag(&h, blocks[0]).as_deref(), Some("blockquote"));
+        let inner = children(&h, blocks[0]);
+        assert_eq!(tag(&h, inner[0]).as_deref(), Some("p"));
+        assert_eq!(text(&h, blocks[0]).as_deref(), Some("quote me"));
+    }
+
+    #[test]
+    fn unchanged_sibling_is_not_rebuilt() {
+        // Editing the 2nd paragraph must not touch the 1st paragraph's host node
+        // (the `same_ref` fast skip, A12).
+        let h = harness();
+        let s = schema();
+        let st = state(
+            s.clone(),
+            doc_node(&s, vec![para(&s, "keep"), para(&s, "edit")]),
+        );
+        let mut view = RinchDomEditorView::new(h.container.clone(), doc_ref(&h), &st);
+        let first_before = children(&h, h.container_id)[0];
+        let first_text_before = children(&h, first_before)[0];
+
+        // Type into the second paragraph (positions: 0[p 1 keep 5]6[p 7 edit 11]12).
+        let mut tr = st.tr();
+        tr.set_selection(Selection::cursor(rinch_editor_core::Pos(11)));
+        tr.insert_text("!").unwrap();
+        let next = st.apply(tr);
+        view.update_dom(&st, &next);
+
+        let first_after = children(&h, h.container_id)[0];
+        let first_text_after = children(&h, first_after)[0];
+        assert_eq!(first_before, first_after, "1st paragraph element untouched");
+        assert_eq!(
+            first_text_before, first_text_after,
+            "1st paragraph text node untouched"
+        );
+        assert_eq!(
+            text(&h, children(&h, h.container_id)[1]).as_deref(),
+            Some("edit!")
+        );
+    }
+
+    #[test]
+    fn placeholder_shows_for_empty_doc_and_hides_after_typing() {
+        let h = harness();
+        let s = schema();
+        let empty = doc_node(&s, vec![s.branch("paragraph", Fragment::empty()).unwrap()]);
+        let st = EditorState::create(
+            s.clone(),
+            empty,
+            vec![Rc::new(PlaceholderPlugin::new("Write something…"))],
+        );
+        let mut view = RinchDomEditorView::new(h.container.clone(), doc_ref(&h), &st);
+
+        // The placeholder overlay exists.
+        let has_placeholder = |h: &Harness| {
+            children(h, h.container_id).iter().any(|&id| {
+                h.doc
+                    .borrow()
+                    .get_attribute(id, "data-pm-placeholder")
+                    .is_some()
+            })
+        };
+        assert!(has_placeholder(&h), "placeholder shown while empty");
+
+        // Type a character — the doc is no longer empty, placeholder disappears.
+        let mut tr = st.tr();
+        tr.set_selection(Selection::cursor(rinch_editor_core::Pos(1)));
+        tr.insert_text("x").unwrap();
+        let next = st.apply(tr);
+        view.update_dom(&st, &next);
+        assert!(
+            !has_placeholder(&h),
+            "placeholder removed once content exists"
+        );
+    }
+
+    // ── inline mark wrappers (M5.5a) ─────────────────────────────────────────
+
+    fn attr_of(h: &Harness, id: NodeId, name: &str) -> Option<String> {
+        h.doc.borrow().get_attribute(id, name)
+    }
+
+    #[test]
+    fn bold_run_wraps_text_in_strong() {
+        let h = harness();
+        let s = schema();
+        let doc = doc_node(
+            &s,
+            vec![marked_para(
+                &s,
+                "hi",
+                vec![mk(&s, "bold", Default::default())],
+            )],
+        );
+        let st = state(s.clone(), doc);
+        let _view = RinchDomEditorView::new(h.container.clone(), doc_ref(&h), &st);
+
+        let p = children(&h, h.container_id)[0];
+        let strong = children(&h, p)[0];
+        assert_eq!(tag(&h, strong).as_deref(), Some("strong"));
+        assert_eq!(attr_of(&h, strong, "data-pm-mark").as_deref(), Some("bold"));
+        assert_eq!(text(&h, strong).as_deref(), Some("hi"));
+    }
+
+    #[test]
+    fn nested_marks_nest_wrappers_innermost_first() {
+        // marks = [bold, italic] → bold innermost, italic outermost (matches
+        // copy-out HTML `<em><strong>x</strong></em>`).
+        let h = harness();
+        let s = schema();
+        let marks = vec![
+            mk(&s, "bold", Default::default()),
+            mk(&s, "italic", Default::default()),
+        ];
+        let st = state(s.clone(), doc_node(&s, vec![marked_para(&s, "x", marks)]));
+        let _view = RinchDomEditorView::new(h.container.clone(), doc_ref(&h), &st);
+
+        let p = children(&h, h.container_id)[0];
+        let outer = children(&h, p)[0];
+        assert_eq!(tag(&h, outer).as_deref(), Some("em"), "italic is outermost");
+        let inner = children(&h, outer)[0];
+        assert_eq!(
+            tag(&h, inner).as_deref(),
+            Some("strong"),
+            "bold is innermost"
+        );
+        assert_eq!(text(&h, inner).as_deref(), Some("x"));
+    }
+
+    #[test]
+    fn list_items_with_combined_marks_project_wrappers() {
+        // bullet_list(li(p[bold "a"]), li(p[italic "b"]), li(p[bold+italic "c"]))
+        // → <ul><li><p><strong>a</strong></p>…<li><p><em><strong>c</strong></em>…
+        let h = harness();
+        let s = schema();
+        let li = |t: &str, marks: Vec<Mark>| {
+            s.branch("list_item", Fragment::from_node(marked_para(&s, t, marks)))
+                .unwrap()
+        };
+        let list = s
+            .branch(
+                "bullet_list",
+                Fragment::from_children(vec![
+                    li("a", vec![mk(&s, "bold", Default::default())]),
+                    li("b", vec![mk(&s, "italic", Default::default())]),
+                    li(
+                        "c",
+                        vec![
+                            mk(&s, "bold", Default::default()),
+                            mk(&s, "italic", Default::default()),
+                        ],
+                    ),
+                ]),
+            )
+            .unwrap();
+        let st = state(s.clone(), doc_node(&s, vec![list]));
+        let _view = RinchDomEditorView::new(h.container.clone(), doc_ref(&h), &st);
+
+        let ul = children(&h, h.container_id)[0];
+        assert_eq!(tag(&h, ul).as_deref(), Some("ul"));
+        let items = children(&h, ul);
+        assert_eq!(items.len(), 3, "three list items");
+
+        // The first inline child of an item's <p> (its outermost mark wrapper).
+        let item_wrapper = |idx: usize| {
+            let p = children(&h, items[idx])[0];
+            assert_eq!(
+                tag(&h, p).as_deref(),
+                Some("p"),
+                "list item holds a paragraph"
+            );
+            children(&h, p)[0]
+        };
+
+        let bold = item_wrapper(0);
+        assert_eq!(tag(&h, bold).as_deref(), Some("strong"));
+        assert_eq!(text(&h, bold).as_deref(), Some("a"));
+
+        let ital = item_wrapper(1);
+        assert_eq!(tag(&h, ital).as_deref(), Some("em"));
+        assert_eq!(text(&h, ital).as_deref(), Some("b"));
+
+        let outer = item_wrapper(2);
+        assert_eq!(tag(&h, outer).as_deref(), Some("em"), "italic outermost");
+        let inner = children(&h, outer)[0];
+        assert_eq!(tag(&h, inner).as_deref(), Some("strong"), "bold innermost");
+        assert_eq!(text(&h, inner).as_deref(), Some("c"));
+    }
+
+    #[test]
+    fn link_mark_sets_href_on_anchor() {
+        let h = harness();
+        let s = schema();
+        let href = rinch_editor_core::Attrs::from_iter([(
+            "href",
+            rinch_editor_core::AttrValue::from("https://example.test"),
+        )]);
+        let st = state(
+            s.clone(),
+            doc_node(
+                &s,
+                vec![marked_para(&s, "click", vec![mk(&s, "link", href)])],
+            ),
+        );
+        let _view = RinchDomEditorView::new(h.container.clone(), doc_ref(&h), &st);
+
+        let p = children(&h, h.container_id)[0];
+        let a = children(&h, p)[0];
+        assert_eq!(tag(&h, a).as_deref(), Some("a"));
+        assert_eq!(
+            attr_of(&h, a, "href").as_deref(),
+            Some("https://example.test")
+        );
+        assert_eq!(text(&h, a).as_deref(), Some("click"));
+    }
+
+    #[test]
+    fn toggling_bold_over_a_range_rebuilds_the_run_with_a_wrapper() {
+        // A mark-set change can't be patched in place — the run rebuilds, wrapping
+        // the text in <strong>.
+        let h = harness();
+        let mut st = state(schema(), doc_node(&schema(), vec![para(&schema(), "abcd")]));
+        let mut view = RinchDomEditorView::new(h.container.clone(), doc_ref(&h), &st);
+
+        let p = children(&h, h.container_id)[0];
+        assert_eq!(
+            tag(&h, children(&h, p)[0]),
+            None,
+            "plain text node, no wrapper"
+        );
+
+        // Select the whole word and bold it.
+        st.selection = Selection::text(rinch_editor_core::Pos(1), rinch_editor_core::Pos(5));
+        let next = st.run("toggleBold").expect("toggleBold applies");
+        view.update_dom(&st, &next);
+
+        let p_after = children(&h, h.container_id)[0];
+        let child = children(&h, p_after)[0];
+        assert_eq!(
+            tag(&h, child).as_deref(),
+            Some("strong"),
+            "run now wrapped in <strong>"
+        );
+        assert_eq!(text(&h, child).as_deref(), Some("abcd"));
+    }
+
+    // ── A15: char→flat-byte caret map (the off-by-one-prone part) ─────────────
+
+    #[test]
+    fn textblock_flat_byte_spans_runs_and_multibyte() {
+        // paragraph(text("ab",[bold]), text("é"), text("cd")) — flat text "abécd",
+        // where 'é' is one char but two UTF-8 bytes.
+        let s = schema();
+        let p = s
+            .branch(
+                "paragraph",
+                Fragment::from_children(vec![
+                    s.text_with_marks("ab", vec![mk(&s, "bold", Default::default())])
+                        .unwrap(),
+                    s.text("é").unwrap(),
+                    s.text("cd").unwrap(),
+                ]),
+            )
+            .unwrap();
+        assert_eq!(textblock_flat_byte(&p, 0), 0); // start
+        assert_eq!(textblock_flat_byte(&p, 2), 2); // after "ab"
+        assert_eq!(textblock_flat_byte(&p, 3), 4); // after "é" — past its 2 bytes
+        assert_eq!(textblock_flat_byte(&p, 4), 5); // after "c"
+        assert_eq!(textblock_flat_byte(&p, 5), 6); // end
+    }
+}

--- a/crates/rinch/src/editor/view.rs
+++ b/crates/rinch/src/editor/view.rs
@@ -736,7 +736,11 @@ impl RinchDomEditorView {
             desc = desc.children.get(r.index(d))?;
         }
         let child = desc.children.get(r.index(r.depth()))?;
-        Some(child.outer.node_id().0)
+        // The *inner* leaf element (`dom`), not the mark wrapper (`outer`): a node
+        // selection outlines the image / hr box itself, even when the leaf carries
+        // marks (e.g. a linked image, where `outer` is the `<a>`). For an unmarked
+        // leaf `dom == outer`, so this is unchanged for the common case.
+        Some(child.dom.node_id().0)
     }
 
     /// The model position immediately **before** the node whose placed host element
@@ -1477,6 +1481,38 @@ mod tests {
         assert!(view.node_pos_for_host(blocks[0].0).is_some()); // the paragraph IS a node…
         // …but its position-before is 0 and it isn't a leaf — selectability is the
         // core's call (`Selection::node_at`), exercised in the handle tests.
+    }
+
+    #[test]
+    fn marked_inline_leaf_node_host_is_the_inner_element() {
+        // A node selection of a *marked* inline leaf (a linked image) must outline
+        // the inner <img>, not the <a> mark wrapper — so node_host_at returns the
+        // img host id (the inner `dom`), not the wrapper id (`outer`).
+        let h = harness();
+        let s = schema();
+        let slice = rinch_editor_core::serialize::slice_from_html(
+            &s,
+            "<p>a<a href=\"https://example.com\"><img src=\"y.png\"></a></p>",
+        )
+        .expect("parse linked image");
+        let st = state(s.clone(), s.branch("doc", slice.content).unwrap());
+        let view = RinchDomEditorView::new(h.container.clone(), doc_ref(&h), &st);
+
+        // Host tree: the paragraph's children are the text "a" and the <a> mark
+        // wrapper, whose only child is the <img>. (Also asserts the fixture really
+        // wraps the image — i.e. the parser applied the link mark to the leaf.)
+        let para = children(&h, h.container_id)[0];
+        let a_id = *children(&h, para)
+            .iter()
+            .find(|&&c| tag(&h, c).as_deref() == Some("a"))
+            .expect("the image is wrapped in an <a> mark wrapper");
+        let img_id = children(&h, a_id)[0];
+        assert_eq!(tag(&h, img_id).as_deref(), Some("img"));
+
+        // doc(p(text "a", image)) → positions 0[p 1 a 2 (img) 3]4 ; the image is at 2.
+        let host = view.node_host_at(&st.doc, rinch_editor_core::Pos(2));
+        assert_eq!(host, Some(img_id.0), "outline traces the inner <img>");
+        assert_ne!(host, Some(a_id.0), "not the <a> mark wrapper");
     }
 
     #[test]

--- a/crates/rinch/src/editor/view.rs
+++ b/crates/rinch/src/editor/view.rs
@@ -266,8 +266,23 @@ pub struct RinchDomEditorView {
     selection_rects: Vec<NodeHandle>,
     /// The last rendered selection `(from, to)`, for change-detection.
     last_selection: Option<(usize, usize)>,
+    /// The outline overlay for a [`Selection::Node`] — a translucent box tracing the
+    /// selected leaf node (image / horizontal rule), drawn from `state.selection`
+    /// (design §6 node-views). `None` when the current selection is not a node
+    /// selection.
+    node_outline: Option<NodeHandle>,
+    /// The last rendered node-selection box `(x, y, w, h)` (pixels rounded), so a
+    /// re-run on the same geometry writes nothing (mirrors [`Self::last_caret`]).
+    last_node_outline: Option<(i32, i32, i32, i32)>,
     /// The decoration set currently projected, for the next diff.
     decorations: DecorationSet,
+    /// Set whenever the post-layout pass writes an overlay's geometry (caret,
+    /// selection rect, or node outline). The runtime reads it via
+    /// [`Self::take_overlay_dirty`] to force a full repaint: these overlays are
+    /// absolutely positioned, and the software renderer's dirty-region cache can't
+    /// clear an absolute element's *old* rect when it moves, so a moved overlay
+    /// would otherwise ghost.
+    overlay_dirty: bool,
 }
 
 impl RinchDomEditorView {
@@ -304,7 +319,10 @@ impl RinchDomEditorView {
             blink_shown: None,
             selection_rects: Vec::new(),
             last_selection: None,
+            node_outline: None,
+            last_node_outline: None,
             decorations: DecorationSet::empty(),
+            overlay_dirty: false,
         };
         view.sync_decorations(state);
         view
@@ -360,8 +378,18 @@ impl EditorView for RinchDomEditorView {
     }
 
     fn update_caret(&mut self, next: &EditorState) -> Vec<ViewRequest> {
-        // Phase 2 (after layout): render the selection highlight (for a range) and
-        // the caret (at a collapsed cursor), both from `next.selection`.
+        // Phase 2 (after layout): render the selection from `next.selection`.
+        // A node selection (a selected image / horizontal rule) outlines the node
+        // and shows neither a text highlight nor a caret (design §6 node-views).
+        if let rinch_editor_core::Selection::Node(_) = &next.selection {
+            self.clear_selection_rects();
+            self.hide_caret();
+            self.render_node_selection(next);
+            return vec![ViewRequest::ScrollSelectionIntoView];
+        }
+        self.clear_node_selection();
+        // Otherwise: the text selection highlight (for a range) and the caret (at a
+        // collapsed cursor).
         self.render_selection(next);
         // No caret while a range is selected — the highlight conveys the head, a
         // caret blinking over a highlight reads as noise, and with no caret the
@@ -379,18 +407,24 @@ impl EditorView for RinchDomEditorView {
         };
         let block_id = block.node_id().0;
         // Query Parley for the caret geometry (layout-local to the textblock), then
-        // translate into the container's coordinate space.
+        // translate into the container's coordinate space. An *empty* textblock has
+        // no Parley layout, so `query_caret_position` returns `None` there — fall
+        // back to the block's content origin with a sensible line height, so the
+        // caret is still visible on a blank line.
         let geometry = {
             let d = doc.borrow();
-            d.query_caret_position(block_id as u64, flat_byte)
-                .map(|(local_x, local_y)| {
-                    let height = d
-                        .query_glyph_bounds(block_id as u64, flat_byte)
-                        .map(|g| g.height)
-                        .unwrap_or(18.0);
-                    let (ox, oy) = self.block_offset_in_container(&*d, block_id);
-                    (ox + local_x, oy + local_y, height)
-                })
+            let from_parley =
+                d.query_caret_position(block_id as u64, flat_byte)
+                    .map(|(local_x, local_y)| {
+                        let height = d
+                            .query_glyph_bounds(block_id as u64, flat_byte)
+                            .map(|g| g.height)
+                            .unwrap_or(18.0);
+                        let (ox, oy) = self.block_offset_in_container(&*d, block_id);
+                        (ox + local_x, oy + local_y, height)
+                    });
+            from_parley
+                .or_else(|| self.empty_block_caret(&*d, &next.doc, next.selection.head(), block_id))
         };
         match geometry {
             Some((x, y, height)) => self.position_caret(x, y, height),
@@ -460,6 +494,39 @@ impl RinchDomEditorView {
         (x, y)
     }
 
+    /// Caret geometry for an *empty* textblock (which has no Parley layout, so
+    /// [`DomDocument::query_caret_position`] returns `None`): the block's content
+    /// origin in container space with the block's own box height as the line
+    /// height. `None` if the block at `pos` is *not* actually empty (a non-empty
+    /// block that merely failed to measure — leave the caret hidden rather than
+    /// misplace it) or has no host box yet.
+    fn empty_block_caret(
+        &self,
+        d: &dyn DomDocument,
+        doc: &Node,
+        pos: Pos,
+        block_id: usize,
+    ) -> Option<(f32, f32, f32)> {
+        let r = doc.resolve(pos).ok()?;
+        if r.parent().content().size() != 0 {
+            return None;
+        }
+        let (_, _, _, bh) = d.query_node_layout(block_id as u64)?;
+        let (ox, oy) = self.block_offset_in_container(d, block_id);
+        // An empty block's box height is its single line box; clamp to a sane range
+        // and fall back to a default when it has collapsed to zero.
+        let h = if (4.0..=80.0).contains(&bh) { bh } else { 18.0 };
+        Some((ox, oy, h))
+    }
+
+    /// Take and clear the "an overlay moved" flag. The runtime forces a full repaint
+    /// when set, because the caret / selection / node-outline overlays are absolutely
+    /// positioned and the software renderer's dirty-region cache can't clear their
+    /// *old* rect when they move (otherwise they ghost — see [`Self::overlay_dirty`]).
+    pub(crate) fn take_overlay_dirty(&mut self) -> bool {
+        std::mem::take(&mut self.overlay_dirty)
+    }
+
     /// Render (or clear) the text-selection highlight from `state.selection`.
     fn render_selection(&mut self, state: &EditorState) {
         let sel = &state.selection;
@@ -520,6 +587,7 @@ impl RinchDomEditorView {
     /// Reconcile the selection-highlight divs (container children) to `rects`
     /// (container space).
     fn set_selection_rects(&mut self, rects: &[(f32, f32, f32, f32)]) {
+        self.overlay_dirty = true;
         while self.selection_rects.len() < rects.len() {
             let Some(div) = create_element(&self.doc, "div") else {
                 break;
@@ -560,10 +628,125 @@ impl RinchDomEditorView {
         if self.last_selection.is_none() && self.selection_rects.is_empty() {
             return;
         }
+        self.overlay_dirty = true;
         self.last_selection = None;
         for div in self.selection_rects.drain(..) {
             div.remove();
         }
+    }
+
+    /// Outline the node a [`Selection::Node`] selects — resolve the node's host
+    /// element, compute its box in container space, and position a translucent
+    /// overlay over it. Clears the outline if the node can't be located or has no
+    /// geometry yet (e.g. an off-screen / virtualized block).
+    ///
+    /// [`Selection::Node`]: rinch_editor_core::Selection::Node
+    fn render_node_selection(&mut self, state: &EditorState) {
+        let Some(node_id) = self.node_host_at(&state.doc, state.selection.from()) else {
+            self.clear_node_selection();
+            return;
+        };
+        let Some(doc) = self.doc.upgrade() else {
+            return;
+        };
+        let geometry = {
+            let d = doc.borrow();
+            d.query_node_layout(node_id as u64).map(|(_, _, w, h)| {
+                let (ox, oy) = self.block_offset_in_container(&*d, node_id);
+                (ox, oy, w, h)
+            })
+        };
+        match geometry {
+            Some((x, y, w, h)) => self.position_node_outline(x, y, w, h),
+            None => self.clear_node_selection(),
+        }
+    }
+
+    /// Position the node-selection outline at the container-space box `(x, y, w, h)`.
+    /// Reuses one overlay div (created lazily) and skips the writes when the box is
+    /// unchanged, so a re-run doesn't re-dirty the tree (mirrors
+    /// [`Self::position_caret`]).
+    fn position_node_outline(&mut self, x: f32, y: f32, w: f32, h: f32) {
+        let key = (
+            x.round() as i32,
+            y.round() as i32,
+            w.round() as i32,
+            h.round() as i32,
+        );
+        if self.last_node_outline == Some(key) {
+            return;
+        }
+        self.overlay_dirty = true;
+        self.last_node_outline = Some(key);
+        if self.node_outline.is_none() {
+            let Some(div) = create_element(&self.doc, "div") else {
+                return;
+            };
+            div.set_attribute("data-pm-selected", "true");
+            div.set_styles(&[
+                ("position", "absolute"),
+                // Trace the node's box exactly (border drawn inside the box).
+                ("box-sizing", "border-box"),
+                ("border", "2px solid #1a73e8"),
+                ("background-color", "rgba(26,115,232,0.15)"),
+                ("pointer-events", "none"),
+                // In front of the node content, like the caret.
+                ("z-index", "1"),
+            ]);
+            self.root.dom.append_child(&div);
+            self.node_outline = Some(div);
+        }
+        if let Some(div) = &self.node_outline {
+            let left = format!("{x}px");
+            let top = format!("{y}px");
+            let width = format!("{w}px");
+            let height = format!("{h}px");
+            div.set_styles(&[
+                ("left", &left),
+                ("top", &top),
+                ("width", &width),
+                ("height", &height),
+                ("display", "block"),
+            ]);
+        }
+    }
+
+    /// Hide the node-selection outline (the selection is no longer a node selection,
+    /// or its node went off-screen).
+    fn clear_node_selection(&mut self) {
+        if self.last_node_outline.is_none() {
+            return;
+        }
+        self.overlay_dirty = true;
+        self.last_node_outline = None;
+        if let Some(div) = &self.node_outline {
+            div.set_style("display", "none");
+        }
+    }
+
+    /// The host element id of the node *after* `pos` — the node a [`Selection::Node`]
+    /// anchored at `pos` selects — navigating the descriptor tree by the resolved
+    /// path. `None` if `pos` doesn't sit immediately before a child node.
+    ///
+    /// [`Selection::Node`]: rinch_editor_core::Selection::Node
+    fn node_host_at(&self, doc: &Node, pos: Pos) -> Option<usize> {
+        let r = doc.resolve(pos).ok()?;
+        let mut desc = &self.root;
+        for d in 0..r.depth() {
+            desc = desc.children.get(r.index(d))?;
+        }
+        let child = desc.children.get(r.index(r.depth()))?;
+        Some(child.outer.node_id().0)
+    }
+
+    /// The model position immediately **before** the node whose placed host element
+    /// is `target`, plus that node — the inverse of [`Self::node_host_at`], used to
+    /// node-select a leaf (image / horizontal rule) the user clicks. Matches either
+    /// the node's inner element (`dom`) or its outermost mark wrapper (`outer`), so a
+    /// hit on a marked inline image still resolves. `None` if `target` isn't a placed
+    /// node in this view.
+    pub(crate) fn node_pos_for_host(&self, target: usize) -> Option<(usize, Node)> {
+        find_node_by_host(&self.root, target, 0).map(|(pos, node)| (pos, node.clone()))
     }
 
     /// Position the caret overlay at `(x, y)` in **container space** with `height`.
@@ -576,6 +759,7 @@ impl RinchDomEditorView {
         if self.last_caret == Some(key) {
             return;
         }
+        self.overlay_dirty = true;
         self.last_caret = Some(key);
         // The caret moved (edit/cursor move) — restart the blink phase so the
         // caret is solid immediately after the interaction. Scope the reset to
@@ -624,6 +808,7 @@ impl RinchDomEditorView {
     pub(crate) fn hide_overlays(&mut self) {
         self.hide_caret();
         self.clear_selection_rects();
+        self.clear_node_selection();
     }
 
     /// Hide the caret (no collapsed cursor in a textblock).
@@ -631,6 +816,7 @@ impl RinchDomEditorView {
         if self.last_caret.is_none() {
             return;
         }
+        self.overlay_dirty = true;
         self.last_caret = None;
         self.blink_shown = None;
         if let Some(caret) = &self.caret {
@@ -678,6 +864,29 @@ fn find_block(desc: &ViewDesc, target: usize, content_start: usize) -> Option<(u
             return Some((pos + 1, &child.node));
         }
         if let Some(found) = find_block(child, target, pos + 1) {
+            return Some(found);
+        }
+        pos += child.node.node_size();
+    }
+    None
+}
+
+/// Walk the descriptor tree for the node whose placed host element is `target`
+/// (matching either its inner `dom` or its outermost mark wrapper `outer`),
+/// returning its model **position-before** and the node. `content_start` is the
+/// position just inside `desc`'s content (0 for the root/doc). The successor lookup
+/// to [`find_block`] for *node* (not text-cursor) addressing.
+fn find_node_by_host(
+    desc: &ViewDesc,
+    target: usize,
+    content_start: usize,
+) -> Option<(usize, &Node)> {
+    let mut pos = content_start; // the position just before the current child
+    for child in &desc.children {
+        if child.dom.node_id().0 == target || child.outer.node_id().0 == target {
+            return Some((pos, &child.node));
+        }
+        if let Some(found) = find_node_by_host(child, target, pos + 1) {
             return Some(found);
         }
         pos += child.node.node_size();
@@ -1237,6 +1446,68 @@ mod tests {
     }
 
     // ── A15: char→flat-byte caret map (the off-by-one-prone part) ─────────────
+
+    // ── node-views: NodeSelection of a leaf (image / horizontal rule) ─────────
+
+    #[test]
+    fn node_selection_host_round_trips_for_block_atom() {
+        let h = harness();
+        let s = schema();
+        let hr = s.branch("horizontal_rule", Fragment::empty()).unwrap();
+        let st = state(s.clone(), doc_node(&s, vec![para(&s, "ab"), hr]));
+        let view = RinchDomEditorView::new(h.container.clone(), doc_ref(&h), &st);
+
+        // The hr is the 2nd container child; it renders as <hr>.
+        let blocks = children(&h, h.container_id);
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(tag(&h, blocks[1]).as_deref(), Some("hr"));
+        let hr_id = blocks[1].0;
+
+        // Forward: the position just before the hr (model pos 4) → the hr host id.
+        assert_eq!(
+            view.node_host_at(&st.doc, rinch_editor_core::Pos(4)),
+            Some(hr_id)
+        );
+        // Inverse: the hr host id → (pos-before, node).
+        let (pos, node) = view.node_pos_for_host(hr_id).expect("hr is a placed node");
+        assert_eq!(pos, 4, "position immediately before the hr");
+        assert_eq!(node.type_name(), "horizontal_rule");
+
+        // A textblock host is not a node-selectable leaf.
+        assert!(view.node_pos_for_host(blocks[0].0).is_some()); // the paragraph IS a node…
+        // …but its position-before is 0 and it isn't a leaf — selectability is the
+        // core's call (`Selection::node_at`), exercised in the handle tests.
+    }
+
+    #[test]
+    fn node_selection_hides_caret_and_text_highlight() {
+        let h = harness();
+        let s = schema();
+        let hr = s.branch("horizontal_rule", Fragment::empty()).unwrap();
+        let mut st = state(s.clone(), doc_node(&s, vec![para(&s, "ab"), hr]));
+        let mut view = RinchDomEditorView::new(h.container.clone(), doc_ref(&h), &st);
+
+        // Seed a caret so there is something for the node-selection pass to clear.
+        view.position_caret(1.0, 2.0, 18.0);
+        assert!(view.last_caret.is_some());
+
+        // Select the hr and run the post-layout pass.
+        st.selection =
+            rinch_editor_core::Selection::node_at(&st.doc, rinch_editor_core::Pos(4)).unwrap();
+        view.update_caret(&st);
+
+        // A node selection shows neither a caret nor a text highlight (the mock has
+        // no geometry, so the outline itself can't be positioned here — but the
+        // branch runs without panicking and leaves no stale overlays).
+        assert!(
+            view.last_caret.is_none(),
+            "caret hidden for a node selection"
+        );
+        assert!(
+            view.selection_rects.is_empty(),
+            "no text highlight for a node selection"
+        );
+    }
 
     #[test]
     fn textblock_flat_byte_spans_runs_and_multibyte() {

--- a/crates/rinch/src/editor/virtualization.rs
+++ b/crates/rinch/src/editor/virtualization.rs
@@ -1,0 +1,159 @@
+//! Block virtualization for mounted (M5+) editors — the re-homed `CeVirtualWindow`
+//! driver. Off-screen blocks of a *scroll-container* editor get a fixed estimated
+//! height so Taffy skips their Parley measurement entirely.
+//!
+//! `pre_layout`/`post_layout` are called from `resolve_and_repaint` (design A3 two
+//! phase). `pre_layout` runs **before** the resolve short-circuit so creating a
+//! window (and its initial collapse) un-short-circuits the frame — otherwise a
+//! selection-only first interaction would never trigger the collapse (the bug that
+//! reverted the first attempt; see `project-editor-virtualization`).
+//!
+//! Only the container's `data-pm-type` children are modeled — caret / selection /
+//! node-outline / placeholder overlays are container siblings and must never be
+//! collapsed (`CeVirtualWindow::new_filtered(.., true)`).
+
+use std::cell::RefCell;
+
+use rinch_core::dom::DomDocument; // take_dirty_nodes / resolve_layout trait methods
+use rinch_dom::RinchDocument;
+use rinch_dom::computed_style::OverflowValue;
+
+use super::handle::EditorHandle;
+use super::registry;
+use crate::app::contenteditable::ce_virtualization::CeVirtualWindow;
+
+thread_local! {
+    /// `(container id, window)` for each scroll-container editor being virtualized.
+    static WINDOWS: RefCell<Vec<(usize, CeVirtualWindow)>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Phase 1 (before layout): for every mounted editor that is a scroll container,
+/// ensure a virtual window exists and update the materialized range from the
+/// previous frame's positions. Creating a window (or moving the range) sets the
+/// document's style/layout dirty flags, so the caller's short-circuit will not fire
+/// and the upcoming resolve applies the collapse.
+pub(crate) fn pre_layout(doc: &mut RinchDocument, focused: Option<usize>) {
+    let editors = registry::all_editors();
+    WINDOWS.with(|w| {
+        let mut windows = w.borrow_mut();
+        // Drop windows whose editor unmounted.
+        windows.retain(|(id, _)| editors.iter().any(|(eid, _)| eid == id));
+        for (container, handle) in &editors {
+            let container = *container;
+            if container == 0 {
+                continue;
+            }
+            let idx = match windows.iter().position(|(id, _)| *id == container) {
+                Some(i) => i,
+                None => {
+                    if !is_scroll_container(doc, container) {
+                        continue;
+                    }
+                    let vw = CeVirtualWindow::new_filtered(container, doc, true);
+                    windows.push((container, vw));
+                    windows.len() - 1
+                }
+            };
+            let vw = &mut windows[idx].1;
+            // Re-sync only on a block-count change (insert/delete) — doing it every
+            // frame would stomp measured heights with the default estimate.
+            if block_count(doc, container) != vw.block_count() {
+                vw.on_blocks_changed(doc);
+            }
+            if !vw.is_active() {
+                continue;
+            }
+            let protected = protected_block(doc, handle, container, focused);
+            vw.pre_layout_update(doc, &protected);
+        }
+    });
+}
+
+/// Phase 2 (after layout): cache measured heights, then re-verify the materialized
+/// range with fresh positions; if it changed (a big scroll jump), re-layout once.
+pub(crate) fn post_layout(doc: &mut RinchDocument, focused: Option<usize>, vw_w: f32, vw_h: f32) {
+    let editors = registry::all_editors();
+    WINDOWS.with(|w| {
+        let mut windows = w.borrow_mut();
+        for (container, handle) in &editors {
+            let container = *container;
+            let Some(idx) = windows.iter().position(|(id, _)| *id == container) else {
+                continue;
+            };
+            let vw = &mut windows[idx].1;
+            if !vw.is_active() {
+                continue;
+            }
+            vw.post_layout_cache(doc);
+            let protected = protected_block(doc, handle, container, focused);
+            if vw.pre_layout_update(doc, &protected) {
+                let _ = doc.take_dirty_nodes();
+                doc.resolve_layout(vw_w, vw_h);
+                vw.post_layout_cache(doc);
+            }
+        }
+    });
+}
+
+/// Forget the window for an unmounted editor (called from `unregister_editor`).
+pub(crate) fn forget(container: usize) {
+    WINDOWS.with(|w| w.borrow_mut().retain(|(id, _)| *id != container));
+}
+
+/// The cursor's top-level block (must never be collapsed) for the focused editor.
+fn protected_block(
+    doc: &RinchDocument,
+    handle: &EditorHandle,
+    container: usize,
+    focused: Option<usize>,
+) -> Vec<usize> {
+    if Some(container) != focused {
+        return Vec::new();
+    }
+    let Some((textblock, _)) = handle.caret_address(handle.selection().head()) else {
+        return Vec::new();
+    };
+    top_block(doc, textblock, container)
+        .map(|b| vec![b])
+        .unwrap_or_default()
+}
+
+/// Walk up from `id` to the direct child of `container`.
+fn top_block(doc: &RinchDocument, mut id: usize, container: usize) -> Option<usize> {
+    loop {
+        let parent = doc.tree.nodes.get(id)?.parent?;
+        if parent == container {
+            return Some(id);
+        }
+        id = parent;
+    }
+}
+
+/// The number of `data-pm-type` block children of `container`.
+fn block_count(doc: &RinchDocument, container: usize) -> usize {
+    doc.tree
+        .nodes
+        .get(container)
+        .map(|n| {
+            n.children
+                .iter()
+                .filter(|&&id| {
+                    doc.tree
+                        .nodes
+                        .get(id)
+                        .is_some_and(|c| c.attributes.contains_key("data-pm-type"))
+                })
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+/// Whether `container`'s computed `overflow-y` makes it a scrollable viewport.
+fn is_scroll_container(doc: &RinchDocument, id: usize) -> bool {
+    doc.tree.nodes.get(id).is_some_and(|n| {
+        matches!(
+            n.computed_style.overflow_y,
+            OverflowValue::Auto | OverflowValue::Scroll
+        )
+    })
+}

--- a/crates/rinch/src/lib.rs
+++ b/crates/rinch/src/lib.rs
@@ -48,6 +48,10 @@ pub mod app;
 pub mod ce_ops;
 #[cfg(any(feature = "desktop", feature = "android"))]
 pub(crate) mod ce_render;
+/// The new ProseMirror-style desktop editor view (M5+), behind the `new-editor`
+/// feature. Implements `rinch_editor_core::EditorView` over rinch-dom primitives.
+#[cfg(feature = "new-editor")]
+pub mod editor;
 #[cfg(feature = "gpu")]
 pub mod embed;
 #[cfg(feature = "desktop")]
@@ -167,6 +171,10 @@ pub mod prelude {
         RenderSurface, RenderSurfaceHandle, SurfaceEvent, SurfaceKeyData, SurfaceMouseButton,
         SurfaceWriter, create_render_surface, invoke_render_callbacks,
     };
+
+    // New ProseMirror-style rich-text editor (M5+)
+    #[cfg(feature = "new-editor")]
+    pub use crate::editor::{Editor, EditorHandle, create_editor};
 
     // Desktop-only GPU types for render surfaces
     #[cfg(feature = "gpu")]

--- a/crates/rinch/src/shell/rinch_runtime.rs
+++ b/crates/rinch/src/shell/rinch_runtime.rs
@@ -1737,10 +1737,36 @@ impl ApplicationHandler for RinchRuntime {
                 }
             }
         }
+
+        // Drive the focused editor's caret blink. This is the only thing that
+        // arms a timed wake (`WaitUntil`); when nothing is blinking it returns the
+        // loop to `Wait` so the app stays idle.
+        #[cfg(feature = "new-editor")]
+        self.tick_caret_blink(event_loop);
     }
 }
 
 impl RinchRuntime {
+    /// Blink the focused editor's caret by arming a `WaitUntil` wake for the next
+    /// phase toggle (see [`crate::editor::caret_blink_tick`]). Owns the event
+    /// loop's control flow: `WaitUntil` while a caret blinks, `Wait` otherwise.
+    #[cfg(feature = "new-editor")]
+    fn tick_caret_blink(&mut self, event_loop: &dyn ActiveEventLoop) {
+        let focused = self.app.focused_editor_id();
+        match crate::editor::caret_blink_tick(focused) {
+            Some(blink) => {
+                if blink.redraw
+                    && let Some(w) = &self.window
+                {
+                    w.request_redraw();
+                }
+                event_loop.set_control_flow(ControlFlow::WaitUntil(
+                    std::time::Instant::now() + blink.next,
+                ));
+            }
+            None => event_loop.set_control_flow(ControlFlow::Wait),
+        }
+    }
     /// Handle a single native event from the queue.
     fn handle_native_event(&mut self, event: RinchNativeEvent, event_loop: &dyn ActiveEventLoop) {
         let platform_event = match event {

--- a/examples/new-editor-demo/Cargo.toml
+++ b/examples/new-editor-demo/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "new-editor-demo"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+rinch = { workspace = true, features = ["desktop", "new-editor", "debug", "clipboard"] }
+rinch-editor-core = { workspace = true }

--- a/examples/new-editor-demo/src/main.rs
+++ b/examples/new-editor-demo/src/main.rs
@@ -22,6 +22,8 @@ fn app() -> NodeHandle {
             color: #555; margin: 0 0 8px; } \
         [data-pm-editor] ul { padding-left: 24px; margin: 0; } \
         [data-pm-editor] li { display: flex; align-items: baseline; gap: 6px; } \
+        [data-pm-editor] hr { border: none; border-top: 2px solid #ccc; margin: 14px 0; \
+            height: 0; } \
         [data-pm-placeholder] { color: #999; position: absolute; pointer-events: none; }";
 
     let tree = rsx! {
@@ -32,6 +34,7 @@ fn app() -> NodeHandle {
                 editor: editor.clone(),
                 content: "<h1>New editor</h1>\
                     <p>Hello <strong>bold</strong> and <em>italic</em> world.</p>\
+                    <hr>\
                     <blockquote><p>A quote block.</p></blockquote>\
                     <ul><li><p>first item</p></li><li><p>second item</p></li></ul>",
             }

--- a/examples/new-editor-demo/src/main.rs
+++ b/examples/new-editor-demo/src/main.rs
@@ -1,0 +1,48 @@
+//! Minimal harness for the new (M5) ProseMirror-style editor, used to drive the
+//! desktop view under MCP: it mounts an `EditorHandle`, loads some rich content,
+//! and places the editor container in the layout. The runtime renders the caret
+//! from the editor's selection after layout.
+
+use rinch::prelude::*;
+use rinch_editor_core::{Pos, Selection};
+
+#[component]
+fn app() -> NodeHandle {
+    // The declarative API: create a handle for programmatic control, then place it
+    // with the `Editor {}` component. The handle works before and after mount.
+    let editor = create_editor();
+
+    // Style the editor's blocks a little so structure is visible in screenshots.
+    let css = "\
+        [data-pm-editor] { border: 1px solid #ccc; padding: 16px; min-height: 200px; \
+            font-family: sans-serif; font-size: 16px; line-height: 1.5; } \
+        [data-pm-editor] h1 { font-size: 28px; margin: 0 0 12px; } \
+        [data-pm-editor] p { margin: 0 0 8px; } \
+        [data-pm-editor] blockquote { border-left: 3px solid #ccc; padding-left: 12px; \
+            color: #555; margin: 0 0 8px; } \
+        [data-pm-editor] ul { padding-left: 24px; margin: 0; } \
+        [data-pm-editor] li { display: flex; align-items: baseline; gap: 6px; } \
+        [data-pm-placeholder] { color: #999; position: absolute; pointer-events: none; }";
+
+    let tree = rsx! {
+        div { style: "padding: 24px; background: #fff;",
+            style { {css} }
+            h2 { style: "font-family: sans-serif;", "New Editor (M5) — caret demo" }
+            Editor {
+                editor: editor.clone(),
+                content: "<h1>New editor</h1>\
+                    <p>Hello <strong>bold</strong> and <em>italic</em> world.</p>\
+                    <blockquote><p>A quote block.</p></blockquote>\
+                    <ul><li><p>first item</p></li><li><p>second item</p></li></ul>",
+            }
+        }
+    };
+    // The `content` prop loaded the document when the component mounted above;
+    // now place a cursor inside the first paragraph (mid-"Hello") so the caret shows.
+    editor.set_selection(Selection::cursor(Pos(16)));
+    tree
+}
+
+fn main() {
+    run("New Editor Demo", 900, 700, app);
+}


### PR DESCRIPTION
A clean rip-and-replace of the rich-text editing system: a renderer-agnostic,
pure-Rust ProseMirror-style core (`rinch-editor-core`) plus a desktop view in
`rinch`, all behind the `new-editor` feature so default builds are unaffected. The
old contenteditable engine is untouched here (its removal + flip-to-default is M8).

## Core — `rinch-editor-core` (wasm-clean, no renderer deps)
- **M0–M1** value model (immutable Rc Node/Fragment/Mark, typed Attrs), positions
  (one char-based `Pos` space, `ResolvedPos`), schema + `ContentMatch`. 79 tests.
- **M2** transform/Step engine (Replace/ReplaceAround/mark/attr steps, PM-faithful
  replace + position mapping, invert/map). 141 tests.
- **M3** total serialization (DocNode/JSON lossless; HTML + Markdown lossy, sanitized).
  Closes #59. 203 tests.
- **M4** state/commands/history (immutable EditorState, Transaction, Command catalogue,
  keymap, input rules, single undo system). 256 tests.

## Desktop view — `rinch` (`new-editor` feature)
- **M5** `EditorView` seam + `RinchDomEditorView` projecting state→host via a
  `ViewDesc` diff over rinch-dom primitives; caret/selection rendered from `Selection`
  via Parley geometry; `EditorHandle` (A7) + `Editor {}` rsx component; `FocusTarget`
  arbiter (A10) centralizing input routing.
- Full interaction: click-to-position, char/word/line/visual-line/doc movement with a
  preserved **goal column**, shift/drag/double/triple-click select, typing, Enter/
  Backspace/Delete, undo/redo, Ctrl+B/I/U, clipboard, caret blink, node-views
  (image/hr `NodeSelection`), placeholder.
- Block **virtualization** re-homed from the CE engine (off-screen blocks skip Parley;
  lazy + eager-at-mount).

All milestones gated (workspace clippy -D, wasm, dep-gate) and MCP-validated through
the real input path; each major step adversarially reviewed. Audit + design in
`docs/`. The `examples/new-editor-demo` is the MCP harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)