### PR TITLE
feat(editor): M6 — IME + rich paste

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -835,7 +835,7 @@ The software renderer includes **dirty region caching**: when only a few nodes c
 
 ### Image Support
 
-Images render on the desktop (Vello) backend via `<img>` elements and `background-image: url(...)` CSS. Images load asynchronously on background threads.
+Images render on **both** desktop backends — GPU (Vello, `scene.draw_image`) and software (tiny-skia, `draw_pixmap`) — via `<img>` elements and `background-image: url(...)` CSS. Remote/file images load asynchronously on background threads; `data:` URIs (e.g. base64 PNG) are decoded synchronously and inserted straight into the cache (`request_image_load_for_node`).
 
 **Architecture:**
 ```

--- a/crates/rinch-debug/src/protocol.rs
+++ b/crates/rinch-debug/src/protocol.rs
@@ -72,6 +72,17 @@ pub enum DebugCommandKind {
         #[serde(default)]
         alt: bool,
     },
+    #[serde(rename = "ime")]
+    Ime {
+        /// One of `"enable"`, `"preedit"`, `"commit"`, `"disable"`.
+        action: String,
+        /// The preedit composition string, or the committed text.
+        #[serde(default)]
+        text: String,
+        /// Optional `(begin, end)` byte cursor within a preedit composition.
+        #[serde(default)]
+        cursor: Option<(usize, usize)>,
+    },
     #[serde(rename = "get_caret_position")]
     GetCaretPosition { node_id: usize, byte_offset: usize },
     #[serde(rename = "get_glyph_bounds")]

--- a/crates/rinch-dom/src/paint/contenteditable.rs
+++ b/crates/rinch-dom/src/paint/contenteditable.rs
@@ -481,14 +481,33 @@ pub(super) fn paint_input_value(
         .map(|s| s == "true")
         .unwrap_or(true);
 
-    let (text, is_placeholder) = if value.is_empty() && !placeholder.is_empty() {
-        (placeholder, true)
+    let is_password = node.attributes.get("type").map(|s| s.as_str()) == Some("password");
+
+    // IME composition (preedit): the in-progress composition string lives only in
+    // `data-preedit` (written by the runtime during composition) — never in the
+    // field's `value`. Splice it into the displayed text at the caret so it flows
+    // inline, underline that run, and put the caret at its end. Composition takes
+    // precedence over the placeholder (composing into an empty field shows the
+    // composition, not the placeholder).
+    let preedit = node
+        .attributes
+        .get("data-preedit")
+        .map(|s| s.as_str())
+        .unwrap_or("");
+    let composing = is_focused && !preedit.is_empty() && !is_password;
+    let composed_text;
+    let (text, is_placeholder, cursor_pos, selection_start, preedit_range) = if composing {
+        let c = cursor_pos.min(value.len());
+        composed_text = format!("{}{}{}", &value[..c], preedit, &value[c..]);
+        let end = c + preedit.len();
+        (composed_text.as_str(), false, end, end, Some((c, end)))
+    } else if value.is_empty() && !placeholder.is_empty() {
+        (placeholder, true, cursor_pos, selection_start, None)
     } else {
-        (value, false)
+        (value, false, cursor_pos, selection_start, None)
     };
 
     // Password masking: replace display text with bullets for type="password"
-    let is_password = node.attributes.get("type").map(|s| s.as_str()) == Some("password");
     let password_display;
     let (text, cursor_pos, selection_start) = if is_password && !is_placeholder && !text.is_empty()
     {
@@ -655,6 +674,24 @@ pub(super) fn paint_input_value(
             caret_y + caret_height,
         );
         painter.fill_color(Fill::NonZero, transform, caret_color, &caret_rect.into());
+    }
+
+    // Underline the IME composition run so it reads as an in-progress composition.
+    if let Some((a, b)) = preedit_range {
+        let a = a.min(text.len());
+        let b = b.min(text.len());
+        let (start_x, start_y) =
+            crate::text_query::caret_position_for_offset_layout(&text_layout, a);
+        let (end_x, _end_y) = crate::text_query::caret_position_for_offset_layout(&text_layout, b);
+        let line_height = scaled_font_size as f64 * 1.2;
+        let underline_y = text_y + start_y as f64 + line_height - scale;
+        let ul_rect = Rect::new(
+            text_x + start_x as f64,
+            underline_y,
+            text_x + end_x as f64,
+            underline_y + scale,
+        );
+        painter.fill_color(Fill::NonZero, transform, base_color, &ul_rect.into());
     }
 }
 

--- a/crates/rinch-platform/src/event.rs
+++ b/crates/rinch-platform/src/event.rs
@@ -57,6 +57,53 @@ pub enum PlatformEvent {
         paths: Vec<PathBuf>,
         position: (f64, f64),
     },
+    /// An IME (input method editor) composition event for the focused text
+    /// target. Desktop (winit `WindowEvent::Ime`) and Android (the
+    /// `InputConnection` drain loop) both translate their native composition
+    /// events into this single portable variant, so IME rides the same
+    /// focus-arbiter routing as [`PlatformEvent::KeyDown`] — it is not an
+    /// editor-specific path.
+    Ime(ImeEvent),
+}
+
+/// A platform-agnostic IME (input method editor) composition event.
+///
+/// This is the **portable IME contract**: every text target (the rich-text
+/// editor, a single-line `<input>`, …) consumes the same five variants through
+/// the runtime's [`FocusTarget`](https://docs.rs) routing, so IME behaves
+/// uniformly everywhere rather than being re-implemented per widget.
+///
+/// Backends translate into this:
+/// - **Desktop:** winit `WindowEvent::Ime(Ime)` → one of these variants.
+/// - **Android:** `drain_committed_text()` → [`ImeEvent::Commit`],
+///   `drain_deletions()` → [`ImeEvent::DeleteSurrounding`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum ImeEvent {
+    /// Composition became available for the focused target. The target may
+    /// start receiving [`Preedit`](ImeEvent::Preedit)/[`Commit`](ImeEvent::Commit)
+    /// events.
+    Enabled,
+    /// Set (or clear) the current composition string shown inline at the caret.
+    ///
+    /// `text` is the in-progress composition (an empty string clears it).
+    /// `cursor` is an optional `(begin, end)` **byte** range within `text` for
+    /// candidate-box placement; `None` hides the candidate cursor. The preedit
+    /// is **never** part of the document — it is rendered as a transient overlay
+    /// and discarded on the next [`Commit`](ImeEvent::Commit) or clear.
+    Preedit {
+        text: String,
+        cursor: Option<(usize, usize)>,
+    },
+    /// Commit composed text into the focused target. The target clears any
+    /// pending preedit and inserts `text` at the selection in one edit.
+    Commit(String),
+    /// Delete `before`/`after` units around the cursor (surrounding-text edit
+    /// some IMEs use to recompose). Units are characters in rinch's char-based
+    /// model; the platform boundary converts as needed. Only delivered once a
+    /// backend advertises surrounding-text support.
+    DeleteSurrounding { before: usize, after: usize },
+    /// Composition ended for the focused target; any pending preedit is cleared.
+    Disabled,
 }
 
 /// Application-level events sent to the event loop.

--- a/crates/rinch/src/app/debug_commands.rs
+++ b/crates/rinch/src/app/debug_commands.rs
@@ -405,6 +405,36 @@ impl RinchApp {
                 actions.push(AppAction::RequestRedraw);
                 DebugResult::Json { data: json!(null) }
             }
+            DebugCommandKind::Ime {
+                action,
+                text,
+                cursor,
+            } => {
+                // Synthesize a real `PlatformEvent::Ime` and route it through
+                // `handle_event` — exactly the path winit's `WindowEvent::Ime` takes
+                // — so a debug-injected composition drives the focus arbiter and the
+                // focused target's preedit/commit identically to a physical IME.
+                let ime_event = match action.as_str() {
+                    "enable" => Some(rinch_platform::ImeEvent::Enabled),
+                    "preedit" => Some(rinch_platform::ImeEvent::Preedit { text, cursor }),
+                    "commit" => Some(rinch_platform::ImeEvent::Commit(text)),
+                    "disable" => Some(rinch_platform::ImeEvent::Disabled),
+                    other => {
+                        return DebugResult::Error {
+                            message: format!("Unknown ime action: {other}"),
+                        };
+                    }
+                };
+                if let Some(ev) = ime_event {
+                    actions.extend(self.handle_event(
+                        PlatformEvent::Ime(ev),
+                        window_size,
+                        scale_factor,
+                    ));
+                }
+                actions.push(AppAction::RequestRedraw);
+                DebugResult::Json { data: json!(null) }
+            }
             DebugCommandKind::GetCaretPosition {
                 node_id,
                 byte_offset,

--- a/crates/rinch/src/app/event_dispatch.rs
+++ b/crates/rinch/src/app/event_dispatch.rs
@@ -1878,6 +1878,10 @@ impl RinchApp {
             }
             #[cfg(feature = "clipboard")]
             KeyCode::KeyX if ctrl => self.editor_cut(handle),
+            // Paste-and-match-style (Ctrl+Shift+V) must precede plain Ctrl+V — the
+            // `if ctrl` arm below would otherwise also match with Shift held.
+            #[cfg(feature = "clipboard")]
+            KeyCode::KeyV if ctrl && shift => self.editor_paste_plain(handle),
             #[cfg(feature = "clipboard")]
             KeyCode::KeyV if ctrl => self.editor_paste(handle),
             KeyCode::KeyZ if ctrl && shift => handle.command("redo"),
@@ -2097,22 +2101,45 @@ impl RinchApp {
         }
     }
 
-    /// Paste the clipboard over the selection, preferring rich `text/html` and
-    /// falling back to `text/plain`. Returns whether the document changed.
+    /// Paste the clipboard over the selection, preferring rich `text/html`, then a
+    /// raw bitmap image (as a PNG `data:` URL), then `text/plain`. Returns whether
+    /// the document changed.
     #[cfg(feature = "clipboard")]
     fn editor_paste(&self, handle: &crate::editor::EditorHandle) -> bool {
+        // 1. Rich HTML — preserves structure, links, and images referenced by URL.
         if let Ok(html) = crate::clipboard::paste_html()
             && !html.trim().is_empty()
             && handle.replace_selection_with_html(&html)
         {
             return true;
         }
+        // 2. A raw bitmap (a screenshot / "copy image" with no HTML wrapper): encode
+        //    it as a PNG `data:` URL and insert an image node.
+        if crate::clipboard::has_image()
+            && let Ok(img) = crate::clipboard::paste_image()
+            && let Some(url) = image_rgba_to_png_data_url(img.width, img.height, &img.bytes)
+            && handle.insert_image(&url, "")
+        {
+            return true;
+        }
+        // 3. Plain text.
         if let Ok(text) = crate::clipboard::paste_text()
             && !text.is_empty()
         {
             return handle.replace_selection_with_text(&text);
         }
         false
+    }
+
+    /// Paste the clipboard as **plain text**, dropping any rich formatting even when
+    /// `text/html` is on the clipboard (the Ctrl+Shift+V "paste and match style"
+    /// gesture). Returns whether the document changed.
+    #[cfg(feature = "clipboard")]
+    fn editor_paste_plain(&self, handle: &crate::editor::EditorHandle) -> bool {
+        match crate::clipboard::paste_text() {
+            Ok(text) if !text.is_empty() => handle.replace_selection_with_text(&text),
+            _ => false,
+        }
     }
 
     /// Like [`Self::editor_point_address`] but for a **physical** pointer position:
@@ -2730,6 +2757,61 @@ fn block_range_at(
     let content_start = pos.0 - r.parent_offset();
     let content_end = content_start + r.parent().content().size();
     (Pos(content_start), Pos(content_end))
+}
+
+/// Encode `width`×`height` RGBA8 pixels (the clipboard bitmap format) as a
+/// `data:image/png;base64,…` URL for an image node `src`. Returns `None` if the
+/// buffer isn't exactly `width * height * 4` bytes or PNG encoding fails.
+///
+/// `png` and `base64` are guaranteed present here: this is reached only via the
+/// `new-editor` editor paste path, and `new-editor` ⇒ `desktop`/`android`, both of
+/// which enable `dep:png`/`dep:base64`.
+#[cfg(all(feature = "new-editor", feature = "clipboard"))]
+fn image_rgba_to_png_data_url(width: usize, height: usize, rgba: &[u8]) -> Option<String> {
+    use base64::Engine;
+    if width == 0 || height == 0 || rgba.len() != width.checked_mul(height)?.checked_mul(4)? {
+        return None;
+    }
+    let mut png = Vec::new();
+    {
+        let mut encoder = png::Encoder::new(&mut png, width as u32, height as u32);
+        encoder.set_color(png::ColorType::Rgba);
+        encoder.set_depth(png::BitDepth::Eight);
+        let mut writer = encoder.write_header().ok()?;
+        writer.write_image_data(rgba).ok()?;
+    }
+    let b64 = base64::engine::general_purpose::STANDARD.encode(&png);
+    Some(format!("data:image/png;base64,{b64}"))
+}
+
+#[cfg(all(test, feature = "new-editor", feature = "clipboard"))]
+mod paste_image_tests {
+    use super::image_rgba_to_png_data_url;
+
+    #[test]
+    fn encodes_valid_rgba_as_a_png_data_url() {
+        // 2×1 RGBA (red, green) = 8 bytes.
+        let rgba = [255, 0, 0, 255, 0, 255, 0, 255];
+        let url = image_rgba_to_png_data_url(2, 1, &rgba).expect("valid rgba encodes");
+        assert!(url.starts_with("data:image/png;base64,"));
+        // The payload decodes and carries the PNG magic signature.
+        use base64::Engine;
+        let b64 = url.strip_prefix("data:image/png;base64,").unwrap();
+        let png = base64::engine::general_purpose::STANDARD
+            .decode(b64)
+            .expect("base64 decodes");
+        assert_eq!(
+            &png[..8],
+            &[0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n']
+        );
+    }
+
+    #[test]
+    fn rejects_a_mismatched_buffer() {
+        // 2×2 RGBA needs 16 bytes; give it 8 → None (not a panic).
+        assert!(image_rgba_to_png_data_url(2, 2, &[0; 8]).is_none());
+        assert!(image_rgba_to_png_data_url(0, 0, &[]).is_none());
+    }
 }
 
 #[cfg(all(test, feature = "new-editor"))]

--- a/crates/rinch/src/app/event_dispatch.rs
+++ b/crates/rinch/src/app/event_dispatch.rs
@@ -1049,6 +1049,34 @@ impl RinchApp {
                     );
                 }
             }
+            PlatformEvent::Ime(ime) => {
+                // Route IME composition through the focus arbiter (design A10),
+                // exactly like KeyDown: whichever text target holds focus consumes
+                // it. IME is a shared runtime service, not a per-widget path.
+                match self.focus_target {
+                    #[cfg(feature = "new-editor")]
+                    FocusTarget::Editor(container) => {
+                        if let Some(handle) = crate::editor::editor_for(container) {
+                            self.dispatch_editor_ime(&handle, ime);
+                            self.refresh_editor_overlays();
+                            let (w, h) = (window_size.0 as f32, window_size.1 as f32);
+                            self.resolve_and_repaint(w, h);
+                            actions.push(AppAction::RequestRedraw);
+                        } else {
+                            // Focused editor unmounted out from under us.
+                            self.focus_target = FocusTarget::None;
+                        }
+                    }
+                    FocusTarget::Input(node_id) => {
+                        self.dispatch_input_ime(node_id, ime);
+                        actions.push(AppAction::RequestRedraw);
+                    }
+                    // Surface / legacy contenteditable / None ignore IME. (Legacy
+                    // CE is removed at M8 and the new editor replaces it, so wiring
+                    // IME there would be throwaway.)
+                    _ => {}
+                }
+            }
             PlatformEvent::ScaleFactorChanged(_) => {
                 // The shell handles reconfiguring the renderer; we just need a redraw.
                 actions.push(AppAction::RequestRedraw);
@@ -1940,6 +1968,112 @@ impl RinchApp {
         }
     }
 
+    // ── IME (input method editor) ──────────────────────────────────────
+    // Both targets consume the same portable `ImeEvent`; only the rendering of
+    // the preedit differs (the editor's decoration overlay vs the `<input>`'s
+    // `data-preedit` paint splice).
+
+    /// Apply an [`ImeEvent`] to the focused new editor: preedit becomes a
+    /// transient overlay (never in the document), commit clears it and inserts
+    /// the text in one transaction, delete-surrounding deletes around the caret.
+    #[cfg(feature = "new-editor")]
+    fn dispatch_editor_ime(&mut self, handle: &crate::editor::EditorHandle, ime: ImeEvent) {
+        match ime {
+            ImeEvent::Enabled => {}
+            ImeEvent::Preedit { text, cursor } => {
+                handle.ime_set_preedit(&text, cursor);
+            }
+            ImeEvent::Commit(text) => {
+                handle.ime_commit(&text);
+                self.editor_goal_x = None;
+            }
+            ImeEvent::DeleteSurrounding { before, after } => {
+                handle.ime_delete_surrounding(before, after);
+                self.editor_goal_x = None;
+            }
+            ImeEvent::Disabled => {
+                handle.ime_clear_preedit();
+            }
+        }
+    }
+}
+
+/// IME (input method editor) handling for single-line `<input>` text fields.
+///
+/// Ungated: `<input>` IME works without the `new-editor` feature. (The editor
+/// half above is gated because it needs [`EditorHandle`](crate::editor::EditorHandle).)
+impl RinchApp {
+    /// Apply an [`ImeEvent`] to the focused `<input>`: preedit is rendered inline
+    /// at the caret via the `data-preedit` attribute, commit clears it and inserts
+    /// the text, delete-surrounding maps to backward/forward deletes.
+    fn dispatch_input_ime(&mut self, node_id: usize, ime: ImeEvent) {
+        match ime {
+            ImeEvent::Enabled => {}
+            ImeEvent::Preedit { text, cursor } => {
+                self.focused_input_preedit = if text.is_empty() {
+                    None
+                } else {
+                    Some((text, cursor))
+                };
+                self.sync_input_preedit_to_dom(node_id);
+            }
+            ImeEvent::Commit(text) => {
+                self.focused_input_preedit = None;
+                self.sync_input_preedit_to_dom(node_id);
+                if !text.is_empty() {
+                    self.handle_input_edit_command(EditCommand::InsertText(text));
+                }
+            }
+            ImeEvent::DeleteSurrounding { before, after } => {
+                for _ in 0..before {
+                    self.handle_input_edit_command(EditCommand::DeleteBackward);
+                }
+                for _ in 0..after {
+                    self.handle_input_edit_command(EditCommand::DeleteForward);
+                }
+            }
+            ImeEvent::Disabled => {
+                self.focused_input_preedit = None;
+                self.sync_input_preedit_to_dom(node_id);
+            }
+        }
+    }
+
+    /// Write (or clear) the focused `<input>`'s `data-preedit` attribute so the
+    /// paint path renders the composition string inline at the caret.
+    fn sync_input_preedit_to_dom(&self, node_id: usize) {
+        let Some(doc) = &self.doc else { return };
+        let mut d = doc.borrow_mut();
+        if let Some(node) = d.tree.nodes.get_mut(node_id) {
+            match &self.focused_input_preedit {
+                Some((text, _)) => {
+                    node.attributes.insert("data-preedit".into(), text.clone());
+                }
+                None => {
+                    node.attributes.remove("data-preedit");
+                }
+            }
+            node.dirty.insert(rinch_dom::DirtyFlags::PAINT);
+        }
+        d.tree.dirty_nodes.insert(node_id);
+    }
+
+    /// The focused `<input>`'s caret rect in logical window space, for the IME
+    /// candidate box. Approximated at the field's text origin (left padding, full
+    /// height); the exact caret-x is a follow-up.
+    pub(crate) fn input_caret_area(&self, node_id: usize) -> Option<(f32, f32, f32, f32)> {
+        let doc = self.doc.as_ref()?;
+        let d = doc.borrow();
+        let node = d.tree.get(node_id)?;
+        let pad_l = node.computed_style.padding_left.to_px();
+        let (_, _, _, h) = d.query_node_layout(node_id as u64)?;
+        let (ax, ay) = Self::compute_absolute_position(&d.tree, node_id);
+        Some((ax + pad_l, ay, 1.0, h))
+    }
+}
+
+#[cfg(feature = "new-editor")]
+impl RinchApp {
     /// Copy the focused editor's selection to the clipboard as both `text/html`
     /// (rich) and `text/plain` (the fall-back alternative). A no-op for an empty
     /// selection.
@@ -2139,7 +2273,7 @@ impl RinchApp {
 
     /// The caret's `(x, y, height)` in window coordinates for a model `pos` — the
     /// forward geometry used to anchor vertical movement.
-    fn editor_caret_point(
+    pub(crate) fn editor_caret_point(
         &self,
         handle: &crate::editor::EditorHandle,
         pos: rinch_editor_core::Pos,

--- a/crates/rinch/src/app/focus.rs
+++ b/crates/rinch/src/app/focus.rs
@@ -10,6 +10,19 @@
 
 use super::*;
 
+/// The IME state the focus arbiter wants the window to be in. The runtime
+/// ([`crate::shell`]) diffs this against the window's current IME state each tick
+/// and issues a winit `request_ime_update` only on change — so enable/disable and
+/// candidate-box placement follow focus and the caret uniformly across targets.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct ImeState {
+    /// Whether a text target is focused and wants IME composition.
+    pub enabled: bool,
+    /// The caret's logical window-space rect `(x, y, w, h)` for candidate-box
+    /// placement, when known.
+    pub cursor_area: Option<(f32, f32, f32, f32)>,
+}
+
 impl RinchApp {
     /// Switch keyboard/IME focus to `target`, tearing down whatever was focused
     /// before. Returns `true` if the focus target actually changed.
@@ -38,6 +51,7 @@ impl RinchApp {
                 self.focused_input_value.clear();
                 self.focused_input_state = None;
                 self.focused_input_node_id = None;
+                self.focused_input_preedit = None;
             }
             FocusTarget::ContentEditable(prev) => {
                 ce::clear_active_ce_api();
@@ -60,6 +74,36 @@ impl RinchApp {
         self.focus_target = target;
         self.scene_dirty = true;
         true
+    }
+
+    /// The IME state the focused target wants — enable + caret rect for a text
+    /// target, disabled otherwise. The runtime applies it via the window. This is
+    /// the single bridge from focus → the platform IME surface (see
+    /// [`ImeState`]).
+    pub(crate) fn ime_state(&self) -> ImeState {
+        match self.focus_target {
+            #[cfg(feature = "new-editor")]
+            FocusTarget::Editor(container) => {
+                let cursor_area = crate::editor::editor_for(container).and_then(|handle| {
+                    let head = handle.selection().head();
+                    self.editor_caret_point(&handle, head)
+                        .map(|(x, y, h)| (x, y, 1.0, h))
+                });
+                ImeState {
+                    enabled: true,
+                    cursor_area,
+                }
+            }
+            FocusTarget::Input(node_id) => ImeState {
+                enabled: true,
+                cursor_area: self.input_caret_area(node_id),
+            },
+            // Surfaces, the legacy CE, and no focus do not drive desktop IME.
+            _ => ImeState {
+                enabled: false,
+                cursor_area: None,
+            },
+        }
     }
 
     /// Whether a text input element is currently focused.

--- a/crates/rinch/src/app/mod.rs
+++ b/crates/rinch/src/app/mod.rs
@@ -41,7 +41,7 @@ use rinch_editable::{
     Modifiers as EditModifiers, Selection, StringDocument,
 };
 use rinch_platform::{
-    AppAction, Instant, KeyCode, Modifiers, MouseButton, PlatformEvent, UserEvent,
+    AppAction, ImeEvent, Instant, KeyCode, Modifiers, MouseButton, PlatformEvent, UserEvent,
 };
 #[cfg(feature = "gpu")]
 use vello::Scene;
@@ -215,6 +215,11 @@ pub struct RinchApp {
     pub(crate) focused_input_state: Option<EditableState<StringDocument>>,
     /// DOM node ID of the currently focused text input.
     pub(crate) focused_input_node_id: Option<usize>,
+    /// In-progress IME composition (preedit) for the focused `<input>`: the
+    /// composing string and an optional `(begin, end)` byte cursor within it.
+    /// Rendered inline at the input caret as an underlined overlay (via the
+    /// `data-preedit` attribute) and never part of the input's committed value.
+    pub(crate) focused_input_preedit: Option<(String, Option<(usize, usize)>)>,
     /// The single authority for which widget owns keyboard/IME input (design
     /// A10). Kept in lockstep with the per-engine focus state below
     /// (`focused_input_*`, `focused_contenteditable`, the surface/editor
@@ -291,6 +296,7 @@ impl RinchApp {
             focused_input_value: String::new(),
             focused_input_state: None,
             focused_input_node_id: None,
+            focused_input_preedit: None,
             focus_target: FocusTarget::None,
             #[cfg(feature = "new-editor")]
             editor_goal_x: None,
@@ -1465,6 +1471,7 @@ impl RinchApp {
             node.attributes.remove("data-focused");
             node.attributes.remove("data-cursor-pos");
             node.attributes.remove("data-selection-start");
+            node.attributes.remove("data-preedit");
             node.dirty.insert(rinch_dom::DirtyFlags::PAINT);
         }
         d.tree.dirty_nodes.insert(node_id);

--- a/crates/rinch/src/editor/handle.rs
+++ b/crates/rinch/src/editor/handle.rs
@@ -353,6 +353,23 @@ impl EditorHandle {
         }
     }
 
+    /// Insert an image node with `src` (e.g. a `data:` URL) and `alt`, replacing
+    /// the current selection — the image-paste path. Returns whether the document
+    /// changed (the schema rejects an image where inline content isn't allowed).
+    pub fn insert_image(&self, src: &str, alt: &str) -> bool {
+        let cmd = rinch_editor_core::commands::insert_image(src.to_string(), alt.to_string());
+        let mut core = self.inner.borrow_mut();
+        let Some(next) = core.state.run_command(&cmd) else {
+            return false;
+        };
+        let prev = core.state.clone();
+        core.state = next.clone();
+        if let Some(view) = core.view.as_mut() {
+            view.update_dom(&prev, &next);
+        }
+        true
+    }
+
     /// Replace the current selection with plain text (one paragraph per line) —
     /// the plain-text paste path. Returns whether anything was inserted.
     pub fn replace_selection_with_text(&self, text: &str) -> bool {
@@ -685,6 +702,25 @@ mod tests {
             "paste collapses the cursor"
         );
         assert_eq!(h.handle.selection().head(), Pos(3));
+    }
+
+    #[test]
+    fn insert_image_places_an_inline_image_node() {
+        let s = schema();
+        let h = mount(doc_node(&s, vec![para(&s, "ab")]));
+        h.handle.set_selection(Selection::cursor(Pos(2))); // between "a" and "b"
+        assert!(h.handle.insert_image("data:image/png;base64,AAAA", "shot"));
+        // The image lands inline in the paragraph, between the text runs.
+        let p = children(&h, h.container_id)[0];
+        let img = children(&h, p)
+            .into_iter()
+            .find(|&c| tag(&h, c).as_deref() == Some("img"));
+        assert!(img.is_some(), "image node placed inline in the paragraph");
+        let img = img.unwrap();
+        assert_eq!(
+            h.doc.borrow().get_attribute(img, "src").as_deref(),
+            Some("data:image/png;base64,AAAA")
+        );
     }
 
     #[test]

--- a/crates/rinch/src/editor/handle.rs
+++ b/crates/rinch/src/editor/handle.rs
@@ -426,6 +426,70 @@ impl EditorHandle {
             .as_mut()?
             .set_caret_blink_visible(visible)
     }
+
+    // ── IME (input method editor) ────────────────────────────────────────────
+    //
+    // The composition (preedit) is a **view-local overlay** that is never part of
+    // the document (design A5): it is shown at the caret while composing and
+    // discarded on commit or clear. Commit inserts the final text as one ordinary
+    // edit, so undo/history treat it exactly like typing.
+
+    /// Show the IME composition string `text` as a transient overlay at the caret
+    /// (never inserted into the document). An empty `text` clears the overlay.
+    /// `cursor` is the candidate cursor within `text`; the overlay ignores it for
+    /// now (the platform candidate box is placed from the model caret instead). A
+    /// no-op before mount.
+    pub(crate) fn ime_set_preedit(&self, text: &str, _cursor: Option<(usize, usize)>) {
+        if let Some(view) = self.inner.borrow_mut().view.as_mut() {
+            view.set_preedit(text);
+        }
+    }
+
+    /// Clear the IME composition overlay without inserting anything (composition
+    /// cancelled / disabled). A no-op before mount.
+    pub(crate) fn ime_clear_preedit(&self) {
+        if let Some(view) = self.inner.borrow_mut().view.as_mut() {
+            view.set_preedit("");
+        }
+    }
+
+    /// Commit composed `text`: clear the preedit overlay, then insert the text at
+    /// the selection as one ordinary edit (so it joins the undo history like
+    /// typing). An empty commit just clears the overlay.
+    pub(crate) fn ime_commit(&self, text: &str) {
+        if let Some(view) = self.inner.borrow_mut().view.as_mut() {
+            view.set_preedit("");
+        }
+        if !text.is_empty() {
+            self.insert_text(text);
+        }
+    }
+
+    /// Delete `before` characters before the caret and `after` after it — the
+    /// surrounding-text edit some IMEs use to recompose. Clears any preedit first,
+    /// then deletes the clamped `[head - before, head + after)` range in one edit.
+    /// A defensive no-op if the range is empty or the delete is invalid (e.g. it
+    /// would cross a block boundary the schema rejects). Only reached once a backend
+    /// advertises surrounding-text support.
+    pub(crate) fn ime_delete_surrounding(&self, before: usize, after: usize) {
+        if let Some(view) = self.inner.borrow_mut().view.as_mut() {
+            view.set_preedit("");
+        }
+        if before == 0 && after == 0 {
+            return;
+        }
+        self.update(|state| {
+            let head = state.selection.head().0;
+            let from = head.saturating_sub(before);
+            let to = (head + after).min(state.doc.content().size());
+            if from >= to {
+                return None;
+            }
+            let mut tr = state.tr();
+            tr.delete(from, to).ok()?;
+            Some(tr)
+        });
+    }
 }
 
 #[cfg(test)]
@@ -785,6 +849,80 @@ mod tests {
             h.handle.selection().is_empty(),
             "cursor collapses after insert"
         );
+    }
+
+    // ── IME (input method editor) ────────────────────────────────────────────
+
+    #[test]
+    fn ime_preedit_is_view_local_and_commit_inserts_one_edit() {
+        let s = schema();
+        let h = mount(doc_node(&s, vec![para(&s, "ab")]));
+        h.handle.set_selection(Selection::cursor(Pos(3))); // end of "ab"
+
+        // Composing shows a preedit overlay but never touches the document.
+        h.handle.ime_set_preedit("ne", None);
+        assert_eq!(
+            text(&h, children(&h, h.container_id)[0]).as_deref(),
+            Some("ab"),
+            "preedit is a view overlay, not part of the document"
+        );
+
+        // Commit inserts the final text as one ordinary edit.
+        h.handle.ime_commit("ね");
+        assert_eq!(
+            text(&h, children(&h, h.container_id)[0]).as_deref(),
+            Some("abね")
+        );
+        // ...and it's a single undo step, exactly like typing.
+        assert!(h.handle.command("undo"));
+        assert_eq!(
+            text(&h, children(&h, h.container_id)[0]).as_deref(),
+            Some("ab")
+        );
+    }
+
+    #[test]
+    fn ime_clear_and_empty_commit_leave_doc_unchanged() {
+        let s = schema();
+        let h = mount(doc_node(&s, vec![para(&s, "ab")]));
+        h.handle.set_selection(Selection::cursor(Pos(3)));
+
+        h.handle.ime_set_preedit("xy", None);
+        h.handle.ime_clear_preedit(); // composition cancelled
+        h.handle.ime_commit(""); // an empty commit clears, inserts nothing
+        assert_eq!(
+            text(&h, children(&h, h.container_id)[0]).as_deref(),
+            Some("ab")
+        );
+    }
+
+    #[test]
+    fn ime_delete_surrounding_deletes_around_caret() {
+        let s = schema();
+        // doc(paragraph "abcd") — positions 0[p 1 a 2 b 3 c 4 d 5]6.
+        let h = mount(doc_node(&s, vec![para(&s, "abcd")]));
+        h.handle.set_selection(Selection::cursor(Pos(3))); // between "b" and "c"
+        h.handle.ime_delete_surrounding(1, 1); // delete "b" and "c"
+        assert_eq!(
+            text(&h, children(&h, h.container_id)[0]).as_deref(),
+            Some("ad")
+        );
+    }
+
+    #[test]
+    fn ime_methods_are_safe_before_mount() {
+        let s = Rc::new(schema());
+        let h = EditorHandle::unmounted(s.clone(), empty_doc(&s), default_plugins());
+        h.set_selection(Selection::cursor(Pos(1))); // inside the empty paragraph
+        // No view yet → preedit overlay ops are safe no-ops, but commit still edits
+        // the owned state.
+        h.ime_set_preedit("ab", None);
+        h.ime_clear_preedit();
+        h.ime_commit("hi");
+        // "hi" landed in the document even though the editor isn't mounted.
+        let doc = h.doc();
+        assert_eq!(doc.child_count(), 1);
+        assert_eq!(doc.child(0).child(0).text(), Some("hi"));
     }
 
     // ── Deferred mount (create_editor → load → attach) ───────────────────────

--- a/crates/rinch/src/editor/view.rs
+++ b/crates/rinch/src/editor/view.rs
@@ -274,6 +274,17 @@ pub struct RinchDomEditorView {
     /// The last rendered node-selection box `(x, y, w, h)` (pixels rounded), so a
     /// re-run on the same geometry writes nothing (mirrors [`Self::last_caret`]).
     last_node_outline: Option<(i32, i32, i32, i32)>,
+    /// The IME composition (preedit) overlay: a span shown inline at the caret
+    /// with the composing text underlined. The composition is **never** part of
+    /// the document (design A5) — it is a transient view overlay, discarded on the
+    /// next commit or clear. `preedit_text` is the span's text-node child.
+    preedit_node: Option<NodeHandle>,
+    preedit_text: Option<NodeHandle>,
+    /// The active composition string, or `None` when not composing.
+    preedit: Option<String>,
+    /// Last applied preedit `(x, y, text)`, so a re-run on the same composition and
+    /// caret writes nothing (mirrors [`Self::last_caret`]).
+    last_preedit: Option<(i32, i32, String)>,
     /// The decoration set currently projected, for the next diff.
     decorations: DecorationSet,
     /// Set whenever the post-layout pass writes an overlay's geometry (caret,
@@ -321,6 +332,10 @@ impl RinchDomEditorView {
             last_selection: None,
             node_outline: None,
             last_node_outline: None,
+            preedit_node: None,
+            preedit_text: None,
+            preedit: None,
+            last_preedit: None,
             decorations: DecorationSet::empty(),
             overlay_dirty: false,
         };
@@ -384,6 +399,7 @@ impl EditorView for RinchDomEditorView {
         if let rinch_editor_core::Selection::Node(_) = &next.selection {
             self.clear_selection_rects();
             self.hide_caret();
+            self.hide_preedit();
             self.render_node_selection(next);
             return vec![ViewRequest::ScrollSelectionIntoView];
         }
@@ -396,10 +412,12 @@ impl EditorView for RinchDomEditorView {
         // blink loop idles (`set_caret_blink` reports "nothing to blink").
         if !next.selection.is_empty() {
             self.hide_caret();
+            self.hide_preedit();
             return Vec::new();
         }
         let Some((block, flat_byte)) = self.caret_target(&next.doc, next.selection.head()) else {
             self.hide_caret();
+            self.hide_preedit();
             return Vec::new();
         };
         let Some(doc) = self.doc.upgrade() else {
@@ -427,8 +445,22 @@ impl EditorView for RinchDomEditorView {
                 .or_else(|| self.empty_block_caret(&*d, &next.doc, next.selection.head(), block_id))
         };
         match geometry {
-            Some((x, y, height)) => self.position_caret(x, y, height),
-            None => self.hide_caret(),
+            Some((x, y, height)) => {
+                // While composing, the preedit overlay stands in for the caret at
+                // the cursor — show it and hide the blinking caret. Otherwise place
+                // the caret as usual.
+                if let Some(text) = self.preedit.clone() {
+                    self.position_preedit(x, y, height, &text);
+                    self.hide_caret();
+                } else {
+                    self.hide_preedit();
+                    self.position_caret(x, y, height);
+                }
+            }
+            None => {
+                self.hide_preedit();
+                self.hide_caret();
+            }
         }
         vec![ViewRequest::ScrollSelectionIntoView]
     }
@@ -813,6 +845,7 @@ impl RinchDomEditorView {
         self.hide_caret();
         self.clear_selection_rects();
         self.clear_node_selection();
+        self.hide_preedit();
     }
 
     /// Hide the caret (no collapsed cursor in a textblock).
@@ -847,6 +880,88 @@ impl RinchDomEditorView {
             caret.set_style("display", if visible { "block" } else { "none" });
         }
         Some(true)
+    }
+
+    // ── IME composition (preedit) overlay ────────────────────────────────────
+
+    /// Set the IME composition (preedit) string, shown as a transient overlay at
+    /// the caret on the next [`EditorView::update_caret`] pass. The composition is
+    /// **never** part of the document (design A5) — it is discarded on commit or
+    /// clear. An empty `text` clears it.
+    pub(crate) fn set_preedit(&mut self, text: &str) {
+        self.preedit = if text.is_empty() {
+            None
+        } else {
+            Some(text.to_string())
+        };
+    }
+
+    /// Position the IME composition overlay at `(x, y)` in container space — a span
+    /// carrying the composing `text`, underlined, with an opaque background so it
+    /// reads cleanly over any in-flow text it overlaps (the composition is an
+    /// overlay, not part of the document). `height` is the caret line height, used
+    /// to size the overlay box. Reuses one span (created lazily) and skips the
+    /// writes when the composition and caret are unchanged (mirrors
+    /// [`Self::position_caret`]).
+    fn position_preedit(&mut self, x: f32, y: f32, height: f32, text: &str) {
+        let key = (x.round() as i32, y.round() as i32, text.to_string());
+        if self.last_preedit.as_ref() == Some(&key) {
+            return;
+        }
+        self.overlay_dirty = true;
+        self.last_preedit = Some(key);
+        if self.preedit_node.is_none() {
+            let Some(span) = create_element(&self.doc, "span") else {
+                return;
+            };
+            span.set_attribute("data-pm-preedit", "true");
+            span.set_styles(&[
+                ("position", "absolute"),
+                // Preserve composition spacing; size to the content.
+                ("white-space", "pre"),
+                // Opaque so the composition reads cleanly over any text underneath.
+                ("background-color", "#ffffff"),
+                // Underline marks it as an in-progress composition.
+                ("border-bottom", "1px solid #1a73e8"),
+                ("pointer-events", "none"),
+                // Above the in-flow text, the selection highlight, and the caret.
+                ("z-index", "2"),
+            ]);
+            let Some(t) = create_text(&self.doc, text) else {
+                return;
+            };
+            span.append_child(&t);
+            self.root.dom.append_child(&span);
+            self.preedit_text = Some(t);
+            self.preedit_node = Some(span);
+        }
+        if let Some(t) = &self.preedit_text {
+            t.set_text(text);
+        }
+        if let Some(span) = &self.preedit_node {
+            let left = format!("{x}px");
+            let top = format!("{y}px");
+            let lh = format!("{height}px");
+            span.set_styles(&[
+                ("left", &left),
+                ("top", &top),
+                ("height", &lh),
+                ("line-height", &lh),
+                ("display", "inline-block"),
+            ]);
+        }
+    }
+
+    /// Hide the IME composition overlay (composition committed or cleared).
+    fn hide_preedit(&mut self) {
+        if self.last_preedit.is_none() {
+            return;
+        }
+        self.overlay_dirty = true;
+        self.last_preedit = None;
+        if let Some(span) = &self.preedit_node {
+            span.set_style("display", "none");
+        }
     }
 }
 

--- a/crates/rinch/src/shell/android_runtime.rs
+++ b/crates/rinch/src/shell/android_runtime.rs
@@ -216,7 +216,17 @@ fn run_loop(android_app: AndroidApp, mut app: RinchApp) {
             }
         }
 
-        // Drain IME committed text from InputConnection
+        // Drain IME committed text from InputConnection.
+        //
+        // This synthesizes per-character `KeyDown`s rather than a single
+        // `PlatformEvent::Ime(Commit)`. That is deliberate for now: the `Ime`
+        // routing (`handle_event`) intentionally ignores the legacy
+        // contenteditable (it is removed at M8), and `has_focused_contenteditable`
+        // cannot tell a legacy CE apart from the new editor — so emitting `Ime`
+        // here would drop committed text on a focused legacy CE. The new editor
+        // and `<input>` both accept these text `KeyDown`s already. Migrate this to
+        // `ImeEvent::Commit` (one edit, better undo grouping) at M8 once the legacy
+        // CE is gone.
         for text in rinch_android::ime::drain_committed_text() {
             for ch in text.chars() {
                 let actions = app.handle_event(

--- a/crates/rinch/src/shell/rinch_runtime.rs
+++ b/crates/rinch/src/shell/rinch_runtime.rs
@@ -34,7 +34,7 @@ use rinch_core::events;
 #[cfg(feature = "gpu")]
 use rinch_platform::PlatformRenderer;
 use rinch_platform::{
-    AppAction, KeyCode, Modifiers, MouseButton as PlatformMouseButton, PlatformEvent,
+    AppAction, ImeEvent, KeyCode, Modifiers, MouseButton as PlatformMouseButton, PlatformEvent,
     PlatformWindow, UserEvent,
 };
 
@@ -227,6 +227,15 @@ pub struct RinchRuntime {
     last_paint_time: Option<std::time::Instant>,
     /// Recent frame times in ms (ring buffer for FPS averaging).
     frame_times: VecDeque<f64>,
+
+    // ── IME ──────────────────────────────────────────────────────
+    /// Whether IME composition is currently enabled on the window. Mirrors the
+    /// desired state from the focus arbiter so [`Self::sync_ime`] only issues a
+    /// winit `request_ime_update` on an actual change.
+    ime_enabled: bool,
+    /// Last-applied IME cursor area (logical window `x, y, w, h`), to avoid
+    /// re-issuing identical `Update` requests every frame.
+    ime_cursor_area: Option<(f32, f32, f32, f32)>,
 }
 
 impl RinchRuntime {
@@ -260,6 +269,8 @@ impl RinchRuntime {
             devtools_prev_hovered: None,
             last_paint_time: None,
             frame_times: VecDeque::with_capacity(60),
+            ime_enabled: false,
+            ime_cursor_area: None,
         }
     }
 
@@ -1642,6 +1653,30 @@ impl ApplicationHandler for RinchRuntime {
                     modifiers: mods,
                 }
             }
+            WindowEvent::Ime(ime) => {
+                // Translate winit's IME composition events into the portable
+                // `ImeEvent` contract. `handle_event` then routes them through
+                // the focus arbiter, exactly like keyboard input — so the
+                // editor, `<input>`, etc. all consume IME the same way.
+                let ime_event = match ime {
+                    winit::event::Ime::Enabled => ImeEvent::Enabled,
+                    winit::event::Ime::Preedit(text, cursor) => ImeEvent::Preedit { text, cursor },
+                    winit::event::Ime::Commit(text) => ImeEvent::Commit(text),
+                    winit::event::Ime::DeleteSurrounding {
+                        before_bytes,
+                        after_bytes,
+                    } => ImeEvent::DeleteSurrounding {
+                        // winit reports UTF-8 byte counts; the target converts to
+                        // its char-based model. Exact byte→char conversion is only
+                        // needed once we advertise the surrounding-text capability
+                        // (not enabled yet), so this passes the counts through.
+                        before: before_bytes,
+                        after: after_bytes,
+                    },
+                    winit::event::Ime::Disabled => ImeEvent::Disabled,
+                };
+                PlatformEvent::Ime(ime_event)
+            }
             WindowEvent::DragEntered { paths, position } => {
                 let size = self.window_size();
                 let scale = self.scale_factor();
@@ -1738,6 +1773,10 @@ impl ApplicationHandler for RinchRuntime {
             }
         }
 
+        // Reconcile the window's IME state with the focus arbiter (enable on a
+        // focused text target, follow the caret, disable on blur).
+        self.sync_ime();
+
         // Drive the focused editor's caret blink. This is the only thing that
         // arms a timed wake (`WaitUntil`); when nothing is blinking it returns the
         // loop to `Wait` so the app stays idle.
@@ -1767,6 +1806,52 @@ impl RinchRuntime {
             None => event_loop.set_control_flow(ControlFlow::Wait),
         }
     }
+
+    /// Push the focus arbiter's desired IME state to the window. Enables IME with
+    /// a cursor area when a text target is focused, disables it otherwise, and
+    /// moves the candidate-box rect as the caret moves. Diffs against the
+    /// last-applied state so it only issues a `request_ime_update` on a real
+    /// change. This is the single place the winit IME surface is touched; every
+    /// text target (editor, `<input>`, …) feeds it through [`RinchApp::ime_state`].
+    fn sync_ime(&mut self) {
+        use winit::window::{ImeCapabilities, ImeEnableRequest, ImeRequest, ImeRequestData};
+
+        let Some(w) = &self.window else { return };
+        let desired = self.app.ime_state();
+
+        let to_area = |a: (f32, f32, f32, f32)| {
+            let (x, y, width, height) = a;
+            (
+                winit::dpi::LogicalPosition::new(x as f64, y as f64),
+                winit::dpi::LogicalSize::new(width.max(1.0) as f64, height.max(1.0) as f64),
+            )
+        };
+
+        if desired.enabled != self.ime_enabled {
+            if desired.enabled {
+                let area = desired.cursor_area.unwrap_or((0.0, 0.0, 1.0, 16.0));
+                let (pos, size) = to_area(area);
+                let caps = ImeCapabilities::new().with_cursor_area();
+                let data = ImeRequestData::default().with_cursor_area(pos.into(), size.into());
+                if let Some(req) = ImeEnableRequest::new(caps, data) {
+                    let _ = w.window.request_ime_update(ImeRequest::Enable(req));
+                }
+                self.ime_cursor_area = desired.cursor_area;
+            } else {
+                let _ = w.window.request_ime_update(ImeRequest::Disable);
+                self.ime_cursor_area = None;
+            }
+            self.ime_enabled = desired.enabled;
+        } else if desired.enabled && desired.cursor_area != self.ime_cursor_area {
+            if let Some(area) = desired.cursor_area {
+                let (pos, size) = to_area(area);
+                let data = ImeRequestData::default().with_cursor_area(pos.into(), size.into());
+                let _ = w.window.request_ime_update(ImeRequest::Update(data));
+            }
+            self.ime_cursor_area = desired.cursor_area;
+        }
+    }
+
     /// Handle a single native event from the queue.
     fn handle_native_event(&mut self, event: RinchNativeEvent, event_loop: &dyn ActiveEventLoop) {
         let platform_event = match event {


### PR DESCRIPTION
Implements **M6** of the editor rearchitecture: IME (input method editor) support and rich-paste polish, behind the `new-editor` feature (default builds unaffected).

## IME (`5a2155d`)
A shared runtime service routed through the `FocusTarget` arbiter — **not** a per-widget island:
- **`PlatformEvent::Ime(ImeEvent)`** portable contract (`Enabled/Preedit/Commit/DeleteSurrounding/Disabled`). winit `WindowEvent::Ime` translates into it; nothing winit-specific past the runtime boundary.
- **Routing**: `handle_event`'s `Ime` arm dispatches via `match self.focus_target` (Editor / Input), exactly like KeyDown. Surface / legacy-CE / None ignore it (legacy CE is removed at M8).
- **`sync_ime()`**: the runtime diffs the focus arbiter's desired IME state and issues winit `request_ime_update(Enable/Update/Disable)` only on change, following the caret.
- **Editor preedit**: a view-local overlay span at the caret (never in the document); commit clears it and inserts the text as one undoable edit.
- **`<input>` preedit**: spliced into the painted text inline and underlined; the field value is untouched until commit.
- **Fix**: the `<input>` IME methods were mis-gated behind `new-editor` but called from ungated code — split the impl so `<input>` IME builds without the feature.
- **Android**: documented why the commit drain stays on KeyDown until M8.
- **Debug harness**: `DebugCommandKind::Ime` synthesizes a real `PlatformEvent::Ime` through `handle_event` for end-to-end validation.

Validated through the real input path for both the editor and `<input>` on desktop (preedit renders underlined; commit inserts; cancel clears).

## Rich paste (`ae3d071`)
- **Paste-as-plain (Ctrl+Shift+V)**: drops rich formatting even when `text/html` is on the clipboard.
- **Image paste**: a raw bitmap with no HTML wrapper is encoded as a PNG `data:` URL and inserted as an image node (`EditorHandle::insert_image`). Paste order: HTML → bitmap → plain text.

## Tests
4 new IME `EditorHandle` tests + `insert_image` + PNG-encoder tests; 48 rinch editor tests, 290 editor-core, 39 rinch-dom all green; clippy `-D` (unified), wasm, fmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)