### PR TITLE
feat(editor): M9 wiring — drive collaboration from EditorHandle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -709,7 +709,7 @@ The editor ships its own default light/dark stylesheet (`editor/styles.rs`, inje
 
 Real-time collaborative editing is a feature-gated adapter, **not** part of the model. The pure `rinch-editor-core` model stays renderer- and CRDT-agnostic; `rinch-editor-collab` projects it onto an **Automerge** CRDT so concurrent edits converge, then translates remote CRDT changes back into editor `Step`s. This crate is the **only** thing in the workspace that links `automerge`.
 
-It is gated purely behind the optional `collaboration` feature, so **default builds — desktop AND web — link zero automerge**. The adapter itself is pure model↔CRDT logic with no platform deps and is **wasm-compatible** (a wasm app supplies a randomness source for the transitive `automerge → uuid`, e.g. `uuid`/`getrandom` `js` feature), so a future Rust web editor view can reuse this *same* adapter rather than bridging to a separate JS CRDT.
+It is gated behind the optional `collaboration` feature (which implies `desktop`, since the editor wiring lives there), so **default builds — desktop AND web — link zero automerge**. The adapter itself is pure model↔CRDT logic with no platform deps and is **wasm-compatible** (a wasm app supplies a randomness source for the transitive `automerge → uuid`, e.g. `uuid`/`getrandom` `js` feature), so a future Rust web editor view can reuse this *same* adapter rather than bridging to a separate JS CRDT.
 
 Enable with `features = ["collaboration"]` on the `rinch` facade (or depend on `rinch-editor-collab` directly).
 
@@ -732,6 +732,28 @@ let delta = a.save_incremental();
 if let Some(next) = b.integrate_incremental(&b_state, &delta)? { b_state = next; }
 // `next` applies the remote change as a non-undoable `origin=remote` transaction.
 ```
+
+**The desktop editor wires this in for you** (M9) — you do not drive `CollabSession` directly. Every local edit through an `EditorHandle` projects + broadcasts automatically; a peer's delta integrates + re-projects through `collab_receive`. One peer **hosts** (owns the starting document), the others **join** from its snapshot. The transport is the app's concern — `outbound` carries bytes out, `post_remote_delta` carries them back in from any thread:
+
+```rust
+// Host: project the current doc onto a fresh CRDT, hand peers a join snapshot.
+let snapshot = host.start_collaboration_host(move |delta| transport.send(delta))?;
+// Guest: adopt the host's document and collaborate.
+guest.start_collaboration_guest(&snapshot, move |delta| transport.send(delta))?;
+// Inbound from a network thread (marshals onto the main thread); from the prelude:
+post_remote_delta(container_id, delta_bytes);
+```
+
+| `EditorHandle` collab method | Purpose |
+|---|---|
+| `start_collaboration_host(outbound) -> Result<Vec<u8>, CollabError>` | Host a fresh session; returns the join snapshot |
+| `start_collaboration_guest(&snapshot, outbound) -> Result<(), CollabError>` | Join from a host snapshot (adopts its document) |
+| `collab_receive(&delta) -> bool` | Integrate a peer's delta (main thread, `try_borrow_mut`-soft); re-projects, does **not** re-broadcast |
+| `is_collaborating()` / `stop_collaboration()` | Query / detach the session |
+| `collab_snapshot() -> Option<Vec<u8>>` | Current shared-doc snapshot for a *late*-joining guest |
+| `collab_take_error() -> Option<CollabError>` | Take a fail-loud A22 projection error (the CRDT is left untouched — projection is all-or-nothing) |
+
+Free functions `collab_receive_for(container_id, &delta)` (main thread) and `post_remote_delta(container_id, delta)` (any thread) route an inbound delta to a registered editor. Runnable two-pane in-process loopback: `examples/collab-editor-demo`.
 
 `CollabPlugin` (key `"collab"`) folds collab bookkeeping (version + unconfirmed local steps) into `EditorState`; `rebase_steps(steps, &mapping)` is the ProseMirror rebase primitive (`Step::map`); `CollabDoc::patches_to_remote_ops` / `remote_ops_since` expose the surgical patch→`RemoteOp` translation. The session itself integrates via converged rebuild (`to_doc`), which is provably convergent.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,6 +1051,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "collab-editor-demo"
+version = "0.1.0"
+dependencies = [
+ "rinch",
+ "rinch-editor-core",
+]
+
+[[package]]
 name = "color"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/rinch-editor-collab/src/project.rs
+++ b/crates/rinch-editor-collab/src/project.rs
@@ -62,23 +62,38 @@ impl CollabDoc {
         let post_mid = an - prefix - suffix; // changed post blocks
         let common = pre_mid.min(post_mid);
 
-        // Reconcile the overlapping changed blocks in place (keeps identity).
-        for k in 0..common {
-            let target = read_block(after.child(prefix + k))?;
-            self.reconcile_block(prefix + k, &target)?;
+        // Validation pre-pass (design A22 fail-loud must be all-or-nothing): read and
+        // validate EVERY block this change will touch — the `after` blocks to
+        // reconcile/insert, and the `before` blocks to delete — BEFORE issuing any
+        // CRDT write. A mixed flat/non-flat change (e.g. pasting or loading a list
+        // while collaborating) then leaves the CRDT *exactly* at the prior converged
+        // state and returns `Unsupported`, instead of partially mutating it and
+        // wedging the session in a half-projected state.
+        let mut targets = Vec::with_capacity(post_mid);
+        for k in 0..post_mid {
+            targets.push(read_block(after.child(prefix + k))?);
         }
-        // Insert the extra post blocks (e.g. the tail of a split).
-        for k in common..post_mid {
-            let target = read_block(after.child(prefix + k))?;
-            self.insert_block(prefix + k, &target)?;
+        for idx in prefix + common..prefix + pre_mid {
+            // Validate (and discard) each block being deleted — fail loud if non-flat.
+            read_block(before.child(idx))?;
+        }
+
+        // Writes — past here only an automerge I/O error can fail, not a content one.
+        // Reconcile the overlapping changed blocks in place (keeps identity).
+        for (k, target) in targets.iter().take(common).enumerate() {
+            self.reconcile_block(prefix + k, target)?;
+        }
+        // Insert the extra post blocks (e.g. the tail of a split). `targets` has
+        // exactly `post_mid` entries, so skipping `common` yields indices
+        // `common..post_mid`.
+        for (k, target) in targets.iter().enumerate().skip(common) {
+            self.insert_block(prefix + k, target)?;
         }
         // Delete the extra pre blocks (e.g. a join, or a block deletion). `common` is
         // the min, so at most one of insert/delete runs; when this runs the CRDT
         // indices still match `before`'s. Delete from the end so earlier indices stay
         // valid.
         for idx in (prefix + common..prefix + pre_mid).rev() {
-            // Validate the deleted block was itself flat (fail loud, not silent).
-            let _ = read_block(before.child(idx))?;
             self.delete_block(idx)?;
         }
         Ok(())

--- a/crates/rinch-editor-collab/tests/collab.rs
+++ b/crates/rinch-editor-collab/tests/collab.rs
@@ -472,6 +472,42 @@ fn nested_content_fails_loud() {
     );
 }
 
+#[test]
+fn unsupported_change_does_not_partially_mutate() {
+    // design A22 fail-loud must be all-or-nothing: a mixed flat/non-flat change
+    // (the kind a paste / load-html produces while collaborating) must leave the
+    // CRDT EXACTLY at the prior converged state, not half-projected.
+    let schema = Rc::new(Schema::starter_kit());
+    let before = doc_of(&schema, vec![para(&schema, "alpha"), para(&schema, "beta")]);
+    let mut cdoc = rinch_editor_collab::CollabDoc::from_doc(&before).unwrap();
+    let original = norm(&cdoc.to_doc(&schema).unwrap());
+
+    // `after` mutates the FIRST (reconcilable) block AND appends a non-flat block —
+    // so a naive in-order projection would write block 0 before failing on the
+    // blockquote, leaving the CRDT half-mutated.
+    let inner = schema
+        .branch("paragraph", Fragment::from_node(schema.text("q").unwrap()))
+        .unwrap();
+    let bq = schema
+        .branch("blockquote", Fragment::from_node(inner))
+        .unwrap();
+    let after = doc_of(
+        &schema,
+        vec![para(&schema, "ALPHA"), para(&schema, "beta"), bq],
+    );
+
+    let err = cdoc.project_change(&before, &after).unwrap_err();
+    assert!(
+        matches!(err, rinch_editor_collab::CollabError::Unsupported(_)),
+        "the blockquote must fail loud, got {err:?}"
+    );
+    assert_eq!(
+        original,
+        norm(&cdoc.to_doc(&schema).unwrap()),
+        "an unsupported change must not partially mutate the CRDT (block 0 stays \"alpha\")"
+    );
+}
+
 fn all_text(node: &Node) -> String {
     if let Some(t) = node.text() {
         return t.to_string();

--- a/crates/rinch/Cargo.toml
+++ b/crates/rinch/Cargo.toml
@@ -143,8 +143,10 @@ image-network = ["dep:ureq"]
 a11y = ["desktop", "rinch-editor-core/a11y", "dep:accesskit", "dep:accesskit_unix"]
 # Derive serde on the editor's durable wire shape (DocNode / BlockData).
 serde = ["rinch-editor-core/serde"]
-# Collaborative editing (M9): the Step↔Automerge adapter (rinch-editor-collab). The
-# ONLY thing in the workspace that links automerge — opt-in, so it stays out of every
-# default build (desktop AND web). The adapter is wasm-compatible, so a future Rust web
-# view can reuse it (the web app supplies a wasm randomness source for automerge→uuid).
-collaboration = ["dep:rinch-editor-collab"]
+# Collaborative editing (M9): the Step↔Automerge adapter (rinch-editor-collab) wired
+# into the desktop editor's `EditorHandle`. The ONLY thing in the workspace that links
+# automerge — opt-in, so it stays out of every default build (desktop AND web). Implies
+# `desktop` because the wiring lives in the desktop editor; the adapter crate itself is
+# desktop-independent and wasm-compatible, so a future Rust web view can reuse it (the
+# web app supplies a wasm randomness source for automerge→uuid).
+collaboration = ["desktop", "dep:rinch-editor-collab"]

--- a/crates/rinch/src/editor/collab.rs
+++ b/crates/rinch/src/editor/collab.rs
@@ -1,0 +1,63 @@
+//! Real-time collaboration wiring for the desktop editor (the `collaboration`
+//! feature, M9).
+//!
+//! The pure model↔CRDT adapter lives in
+//! [`rinch-editor-collab`](rinch_editor_collab); this module is the thin seam that
+//! drives it from an [`EditorHandle`](super::EditorHandle):
+//!
+//! * **outbound** — every *local* edit funnels through `EditorCore::commit`
+//!   (`handle.rs`), which projects the `before → after` change onto the CRDT
+//!   ([`CollabSession::record_local`](rinch_editor_collab::CollabSession::record_local))
+//!   and hands the resulting delta to this bridge's `outbound` sink.
+//! * **inbound** — a peer's delta arrives via
+//!   [`EditorHandle::collab_receive`](super::EditorHandle::collab_receive), which
+//!   merges it into the CRDT, rebuilds the model from the *converged* CRDT, and
+//!   re-projects the host. A remote integration is applied as a non-undoable,
+//!   remote-origin transaction and is **not** re-broadcast (it is already shared).
+//!
+//! The transport itself is left to the caller (design §2: "transport is the app's
+//! concern"). The seam is a pair of closures/calls: `outbound` carries bytes out,
+//! [`post_remote_delta`](super::post_remote_delta) carries bytes back in from any
+//! thread. The in-process loopback in `examples/collab-editor-demo` wires two
+//! handles to each other directly; a network transport forwards the same bytes over
+//! a socket / data channel.
+//!
+//! This driver uses **immediate projection + converged rebuild**, so it deliberately
+//! does *not* add [`CollabPlugin`](rinch_editor_collab::CollabPlugin) to the editor's
+//! plugins — the version/unconfirmed-steps bookkeeping that plugin folds is only
+//! meaningful for a future throttled / rebase-based driver.
+
+use rinch_editor_collab::{CollabError, CollabSession};
+
+/// The collaboration state attached to one editor: its CRDT session plus the sink
+/// that carries outbound deltas to peers.
+pub(super) struct CollabBridge {
+    /// This editor's model↔CRDT projection and sync lifecycle.
+    pub(super) session: CollabSession,
+    /// Where to send a delta produced by a *local* edit. Invoked on the main
+    /// thread, immediately after the edit is projected onto the CRDT. For a real
+    /// transport it forwards bytes to the network thread (e.g. over an
+    /// `mpsc::Sender`); for the in-process loopback demo it calls the peer handle's
+    /// [`collab_receive`](super::EditorHandle::collab_receive) directly.
+    ///
+    /// It must **not** re-enter the same handle (the handle is borrowed while the
+    /// edit is committed) — a real transport just enqueues bytes, and the loopback
+    /// targets the *other* handle.
+    pub(super) outbound: Box<dyn Fn(Vec<u8>)>,
+    /// The last projection error. Per design A22 the staged scope is flat
+    /// text-blocks + marks; an edit outside it fails loud rather than silently
+    /// diverging. Surfaced (and cleared) via
+    /// [`EditorHandle::collab_take_error`](super::EditorHandle::collab_take_error).
+    pub(super) last_error: Option<CollabError>,
+}
+
+impl CollabBridge {
+    /// Attach `session` with the given outbound delta sink.
+    pub(super) fn new(session: CollabSession, outbound: Box<dyn Fn(Vec<u8>)>) -> CollabBridge {
+        CollabBridge {
+            session,
+            outbound,
+            last_error: None,
+        }
+    }
+}

--- a/crates/rinch/src/editor/handle.rs
+++ b/crates/rinch/src/editor/handle.rs
@@ -27,6 +27,11 @@ use rinch_editor_core::{
     EditorState, EditorView, Node, Plugin, Pos, Schema, Selection, Transaction,
 };
 
+#[cfg(feature = "collaboration")]
+use rinch_editor_collab::{CollabError, CollabSession};
+
+#[cfg(feature = "collaboration")]
+use super::collab::CollabBridge;
 use super::view::RinchDomEditorView;
 
 /// The owned editor: its state, its desktop projection, and the schema/plugins
@@ -43,6 +48,58 @@ struct EditorCore {
     view: Option<RinchDomEditorView>,
     schema: Rc<Schema>,
     plugins: Vec<Rc<dyn Plugin>>,
+    /// The collaboration session + outbound delta sink, when this editor is
+    /// collaborating (design M9). `None` for a non-collaborative editor — the
+    /// common case — so the mutation path's collab hook is a cheap early return.
+    #[cfg(feature = "collaboration")]
+    collab: Option<CollabBridge>,
+}
+
+impl EditorCore {
+    /// Commit a freshly-applied `next` state over `prev`: store it, re-project the
+    /// host, and — when collaborating — record the local change onto the CRDT and
+    /// broadcast the resulting delta. The single landing spot for every **local**
+    /// edit (`update`/`command`/`load_doc`/`insert_image` all funnel through here).
+    ///
+    /// The remote integration path
+    /// ([`EditorHandle::collab_receive`]) deliberately does **not** go through this
+    /// helper: a remote change is already in the shared CRDT, so it must be stored
+    /// and re-projected *without* recording it back onto the CRDT (which would echo
+    /// it to peers and double-apply).
+    fn commit(&mut self, prev: EditorState, next: EditorState) {
+        self.state = next.clone();
+        if let Some(view) = self.view.as_mut() {
+            view.update_dom(&prev, &next);
+        }
+        #[cfg(feature = "collaboration")]
+        self.record_local(&prev, &next);
+    }
+
+    /// Project a just-applied local change onto the CRDT and broadcast the delta to
+    /// peers. A no-op when not collaborating, or for a selection-only edit (the
+    /// document is the same `Rc`, so there is nothing to project).
+    #[cfg(feature = "collaboration")]
+    fn record_local(&mut self, prev: &EditorState, next: &EditorState) {
+        let Some(bridge) = self.collab.as_mut() else {
+            return;
+        };
+        if prev.doc.same_ref(&next.doc) {
+            return;
+        }
+        match bridge.session.record_local(&prev.doc, &next.doc) {
+            Ok(()) => {
+                let delta = bridge.session.save_incremental();
+                if !delta.is_empty() {
+                    (bridge.outbound)(delta);
+                }
+            }
+            // Design A22 fail-loud: an edit outside the staged flat-text scope
+            // (a table, a nested block) cannot be projected. Surface it rather than
+            // silently diverging; apps should keep such edits out of a collab
+            // session for now.
+            Err(e) => bridge.last_error = Some(e),
+        }
+    }
 }
 
 /// A cloneable handle to an editor (design A7). Cheap to [`Clone`] (an `Rc`), so a
@@ -79,6 +136,8 @@ impl EditorHandle {
                 view: None,
                 schema,
                 plugins,
+                #[cfg(feature = "collaboration")]
+                collab: None,
             })),
         }
     }
@@ -102,6 +161,8 @@ impl EditorHandle {
                 view: Some(view),
                 schema,
                 plugins,
+                #[cfg(feature = "collaboration")]
+                collab: None,
             })),
         }
     }
@@ -141,10 +202,7 @@ impl EditorHandle {
         };
         let prev = core.state.clone();
         let next = core.state.apply(tr);
-        core.state = next.clone();
-        if let Some(view) = core.view.as_mut() {
-            view.update_dom(&prev, &next);
-        }
+        core.commit(prev, next);
         true
     }
 
@@ -156,10 +214,7 @@ impl EditorHandle {
             return false;
         };
         let prev = core.state.clone();
-        core.state = next.clone();
-        if let Some(view) = core.view.as_mut() {
-            view.update_dom(&prev, &next);
-        }
+        core.commit(prev, next);
         true
     }
 
@@ -317,10 +372,7 @@ impl EditorHandle {
         let mut core = self.inner.borrow_mut();
         let prev = core.state.clone();
         let next = EditorState::create(core.schema.clone(), doc, core.plugins.clone());
-        core.state = next.clone();
-        if let Some(view) = core.view.as_mut() {
-            view.update_dom(&prev, &next);
-        }
+        core.commit(prev, next);
     }
 
     /// Parse `html` (schema-whitelisted) and load it as the document. Returns
@@ -379,10 +431,7 @@ impl EditorHandle {
             return false;
         };
         let prev = core.state.clone();
-        core.state = next.clone();
-        if let Some(view) = core.view.as_mut() {
-            view.update_dom(&prev, &next);
-        }
+        core.commit(prev, next);
         true
     }
 
@@ -522,6 +571,146 @@ impl EditorHandle {
             tr.delete(from, to).ok()?;
             Some(tr)
         });
+    }
+}
+
+// ── Collaboration (design M9, the `collaboration` feature) ───────────────────
+//
+// One [`CollabSession`] per editor. A local edit is projected onto the CRDT and
+// broadcast (the `commit` → `record_local` path above); a peer's delta arrives via
+// `collab_receive`, which integrates it and re-projects without re-broadcasting. The
+// transport is the caller's concern: `outbound` carries bytes out, `collab_receive`
+// (or the thread-safe [`post_remote_delta`](super::post_remote_delta)) carries them
+// back in.
+#[cfg(feature = "collaboration")]
+impl EditorHandle {
+    /// Start collaborating as the **host** of a fresh session: project this
+    /// editor's current document onto a new CRDT and return a snapshot peers join
+    /// from (via [`Self::start_collaboration_guest`]). `outbound` carries each delta
+    /// produced by a *local* edit to peers; it is invoked on the main thread right
+    /// after the edit is projected. Returns the join snapshot, or a [`CollabError`]
+    /// if the current document is outside the staged flat-text scope (design A22).
+    ///
+    /// `outbound` runs while this handle is borrowed, so it must **not** synchronously
+    /// re-enter the *same* handle — forward the bytes to a transport/channel or to a
+    /// *peer* handle ([`Self::collab_receive`] is borrow-soft, but the mutation
+    /// methods are not).
+    pub fn start_collaboration_host(
+        &self,
+        outbound: impl Fn(Vec<u8>) + 'static,
+    ) -> Result<Vec<u8>, CollabError> {
+        let mut core = self.inner.borrow_mut();
+        let mut session = CollabSession::new(&core.state)?;
+        let snapshot = session.snapshot();
+        core.collab = Some(CollabBridge::new(session, Box::new(outbound)));
+        Ok(snapshot)
+    }
+
+    /// Join an existing collaboration as a **guest** from a host's `snapshot` (from
+    /// [`Self::start_collaboration_host`]): adopt the host's converged document and
+    /// attach a session whose CRDT already matches it, so both peers start from the
+    /// same content. `outbound` carries this guest's local deltas back to peers.
+    /// Returns a [`CollabError`] if the snapshot is unreadable or its content is
+    /// outside the staged scope.
+    pub fn start_collaboration_guest(
+        &self,
+        snapshot: &[u8],
+        outbound: impl Fn(Vec<u8>) + 'static,
+    ) -> Result<(), CollabError> {
+        let session = CollabSession::from_bytes(snapshot)?;
+        // Adopt the host's document first (no session attached yet, so this load is
+        // not recorded back onto the CRDT), then attach the matching session.
+        let schema = self.inner.borrow().schema.clone();
+        let doc = session.projected_doc(&schema)?;
+        self.load_doc(doc);
+        self.inner.borrow_mut().collab = Some(CollabBridge::new(session, Box::new(outbound)));
+        Ok(())
+    }
+
+    /// Integrate a remote `delta` from a peer: merge it into the CRDT, rebuild the
+    /// model from the *converged* CRDT, and re-project the host. The change is
+    /// applied as a non-undoable, remote-origin transaction and is **not**
+    /// re-broadcast (it is already in the shared CRDT). Returns whether the document
+    /// changed. A no-op (returns `false`) if this editor isn't collaborating.
+    ///
+    /// Must run on the main thread — a network transport should marshal received
+    /// bytes through [`post_remote_delta`](super::post_remote_delta) rather than
+    /// calling this directly off-thread.
+    ///
+    /// Uses `try_borrow_mut`, so the degenerate case of an `outbound` sink wired to
+    /// re-enter the *same* handle (instead of the peer / a channel) degrades to a
+    /// no-op `false` rather than panicking.
+    pub fn collab_receive(&self, delta: &[u8]) -> bool {
+        // `outbound` runs while a local edit holds this handle's borrow; a self-
+        // wired sink that calls back in here would otherwise hit an already-borrowed
+        // panic. Fail soft instead.
+        let Ok(mut core) = self.inner.try_borrow_mut() else {
+            return false;
+        };
+        if core.collab.is_none() {
+            return false;
+        }
+        let prev = core.state.clone();
+        // `prev` is an owned clone, so borrowing the bridge mutably here doesn't
+        // conflict with reading/writing `core.state`/`core.view` afterwards.
+        let result = core
+            .collab
+            .as_mut()
+            .unwrap()
+            .session
+            .integrate_incremental(&prev, delta);
+        match result {
+            Ok(Some(next)) => {
+                core.state = next.clone();
+                if let Some(view) = core.view.as_mut() {
+                    view.update_dom(&prev, &next);
+                }
+                true
+            }
+            Ok(None) => false,
+            Err(e) => {
+                if let Some(bridge) = core.collab.as_mut() {
+                    bridge.last_error = Some(e);
+                }
+                false
+            }
+        }
+    }
+
+    /// Whether this editor currently has a collaboration session attached.
+    pub fn is_collaborating(&self) -> bool {
+        self.inner.borrow().collab.is_some()
+    }
+
+    /// A snapshot of the shared document **as it stands now**, for a *late-joining*
+    /// peer: hand it to a new guest's [`Self::start_collaboration_guest`] so they
+    /// adopt the current content (not just the host's original document). `None`
+    /// when this editor isn't collaborating. Assumes a reliable, ordered delta
+    /// transport between existing peers — the full Automerge sync protocol (for
+    /// lossy / out-of-order reconciliation) is not yet exposed through the handle.
+    pub fn collab_snapshot(&self) -> Option<Vec<u8>> {
+        self.inner
+            .borrow_mut()
+            .collab
+            .as_mut()
+            .map(|b| b.session.snapshot())
+    }
+
+    /// Detach the collaboration session (stop projecting and broadcasting). The
+    /// document is unchanged; subsequent edits are local-only again.
+    pub fn stop_collaboration(&self) {
+        self.inner.borrow_mut().collab = None;
+    }
+
+    /// Take (and clear) the most recent collaboration error — e.g. an edit outside
+    /// the staged flat-text scope that could not be projected (design A22). `None`
+    /// when not collaborating or no error is pending.
+    pub fn collab_take_error(&self) -> Option<CollabError> {
+        self.inner
+            .borrow_mut()
+            .collab
+            .as_mut()
+            .and_then(|b| b.last_error.take())
     }
 }
 
@@ -1024,5 +1213,274 @@ mod tests {
             doc.borrow().text_content(blocks[0]).as_deref(),
             Some("before mount")
         );
+    }
+
+    // ── Collaboration (design M9, the `collaboration` feature) ───────────────
+    //
+    // Two real `EditorHandle`s (each over its own mock host) wired into a single
+    // in-process loopback — the exact seam the two-pane demo uses. The convergence
+    // assertions exercise the whole wiring: a local edit's `record_local` →
+    // `save_incremental` → `outbound`, and the peer's `collab_receive` →
+    // `integrate_incremental` → re-projection.
+    #[cfg(feature = "collaboration")]
+    mod collab {
+        use super::*;
+        use std::cell::Cell;
+
+        /// The concatenated text of every block in a handle's document, blocks
+        /// joined by `\n` — a cheap, layout-free convergence probe.
+        fn doc_text(h: &EditorHandle) -> String {
+            fn collect(n: &Node, out: &mut String) {
+                if let Some(t) = n.text() {
+                    out.push_str(t);
+                    return;
+                }
+                for i in 0..n.child_count() {
+                    collect(n.child(i), out);
+                }
+            }
+            let doc = h.doc();
+            let mut s = String::new();
+            for i in 0..doc.child_count() {
+                if i > 0 {
+                    s.push('\n');
+                }
+                collect(doc.child(i), &mut s);
+            }
+            s
+        }
+
+        /// Wire `host` and `guest` into a synchronous in-process loopback: each
+        /// side's outbound delta is delivered straight to the other's
+        /// `collab_receive`. Returns after the guest has adopted the host's
+        /// document.
+        fn loopback(host: &EditorHandle, guest: &EditorHandle) {
+            let guest_in = guest.clone();
+            let snapshot = host
+                .start_collaboration_host(move |delta| {
+                    guest_in.collab_receive(&delta);
+                })
+                .expect("host projects its document");
+            let host_in = host.clone();
+            guest
+                .start_collaboration_guest(&snapshot, move |delta| {
+                    host_in.collab_receive(&delta);
+                })
+                .expect("guest joins from the snapshot");
+        }
+
+        #[test]
+        fn guest_adopts_host_document_on_join() {
+            let s = schema();
+            let host = mount(doc_node(&s, vec![para(&s, "shared title")])).handle;
+            let guest = mount(doc_node(&s, vec![para(&s, "stale local")])).handle;
+            loopback(&host, &guest);
+            assert_eq!(
+                doc_text(&guest),
+                "shared title",
+                "the guest adopts the host's converged document"
+            );
+            assert!(host.is_collaborating() && guest.is_collaborating());
+        }
+
+        #[test]
+        fn local_edits_converge_both_directions() {
+            let s = schema();
+            let host = mount(doc_node(&s, vec![para(&s, "hello")])).handle;
+            let guest = mount(doc_node(&s, vec![para(&s, "")])).handle;
+            loopback(&host, &guest);
+
+            // Type in the host → the guest converges.
+            host.set_selection(Selection::cursor(Pos(6))); // end of "hello"
+            assert!(host.insert_text(" world"));
+            assert_eq!(doc_text(&host), "hello world");
+            assert_eq!(
+                doc_text(&guest),
+                "hello world",
+                "host edit reached the guest"
+            );
+
+            // Type in the guest → the host converges.
+            guest.set_selection(Selection::cursor(Pos(1))); // start of the block
+            assert!(guest.insert_text("X"));
+            assert_eq!(doc_text(&guest), "Xhello world");
+            assert_eq!(
+                doc_text(&host),
+                "Xhello world",
+                "guest edit reached the host"
+            );
+        }
+
+        #[test]
+        fn marks_converge() {
+            let s = schema();
+            let host = mount(doc_node(&s, vec![para(&s, "abcd")])).handle;
+            let guest = mount(doc_node(&s, vec![para(&s, "")])).handle;
+            loopback(&host, &guest);
+
+            host.set_selection(Selection::text(Pos(1), Pos(5)));
+            assert!(host.command("toggleBold"));
+            // The guest's projected document carries the bold mark on the run.
+            let guest_doc = guest.doc();
+            let run = guest_doc.child(0).child(0);
+            assert_eq!(run.text(), Some("abcd"));
+            assert!(
+                !run.marks().is_empty(),
+                "the bold mark projected through the CRDT to the guest"
+            );
+        }
+
+        #[test]
+        fn concurrent_edits_converge() {
+            let s = schema();
+            let host = mount(doc_node(&s, vec![para(&s, "hello")])).handle;
+            let guest = mount(doc_node(&s, vec![para(&s, "")])).handle;
+
+            // Buffer deltas instead of delivering them, so both peers edit against
+            // the same base — a genuine concurrent edit.
+            let to_guest: Rc<RefCell<Vec<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
+            let to_host: Rc<RefCell<Vec<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
+            let tg = to_guest.clone();
+            let snapshot = host
+                .start_collaboration_host(move |d| tg.borrow_mut().push(d))
+                .unwrap();
+            let th = to_host.clone();
+            guest
+                .start_collaboration_guest(&snapshot, move |d| th.borrow_mut().push(d))
+                .unwrap();
+
+            // Concurrent: host appends, guest prepends — neither has seen the other.
+            host.set_selection(Selection::cursor(Pos(6)));
+            assert!(host.insert_text("H"));
+            guest.set_selection(Selection::cursor(Pos(1)));
+            assert!(guest.insert_text("G"));
+
+            // Exchange both deltas.
+            for d in to_guest.borrow_mut().drain(..) {
+                guest.collab_receive(&d);
+            }
+            for d in to_host.borrow_mut().drain(..) {
+                host.collab_receive(&d);
+            }
+
+            // Automerge convergence: identical documents on both peers.
+            let h = doc_text(&host);
+            let g = doc_text(&guest);
+            assert_eq!(h, g, "concurrent edits converge to one document");
+            assert!(
+                h.contains('H') && h.contains('G'),
+                "both edits survived: {h}"
+            );
+        }
+
+        #[test]
+        fn integrating_a_remote_delta_does_not_echo() {
+            let s = schema();
+            let host = mount(doc_node(&s, vec![para(&s, "ab")])).handle;
+            let guest = mount(doc_node(&s, vec![para(&s, "")])).handle;
+
+            let guest_in = guest.clone();
+            let snapshot = host
+                .start_collaboration_host(move |d| {
+                    guest_in.collab_receive(&d);
+                })
+                .unwrap();
+            // Count the guest's outbound emissions: integrating the host's delta
+            // must NOT produce one (no echo / infinite loop).
+            let guest_emits = Rc::new(Cell::new(0usize));
+            let ge = guest_emits.clone();
+            guest
+                .start_collaboration_guest(&snapshot, move |_d| ge.set(ge.get() + 1))
+                .unwrap();
+
+            host.set_selection(Selection::cursor(Pos(3)));
+            assert!(host.insert_text("c"));
+            assert_eq!(doc_text(&guest), "abc", "host edit applied on the guest");
+            assert_eq!(
+                guest_emits.get(),
+                0,
+                "integrating a remote delta must not broadcast one back"
+            );
+        }
+
+        #[test]
+        fn selection_only_change_broadcasts_nothing() {
+            let s = schema();
+            let host = mount(doc_node(&s, vec![para(&s, "abc")])).handle;
+            let emits = Rc::new(Cell::new(0usize));
+            let e = emits.clone();
+            host.start_collaboration_host(move |_d| e.set(e.get() + 1))
+                .unwrap();
+
+            host.set_selection(Selection::cursor(Pos(2)));
+            assert_eq!(emits.get(), 0, "moving the cursor broadcasts nothing");
+            assert!(host.insert_text("X"));
+            assert_eq!(emits.get(), 1, "a text edit broadcasts exactly one delta");
+        }
+
+        #[test]
+        fn stop_collaboration_silences_broadcasts() {
+            let s = schema();
+            let host = mount(doc_node(&s, vec![para(&s, "ab")])).handle;
+            let emits = Rc::new(Cell::new(0usize));
+            let e = emits.clone();
+            host.start_collaboration_host(move |_d| e.set(e.get() + 1))
+                .unwrap();
+            assert!(host.is_collaborating());
+
+            host.stop_collaboration();
+            assert!(!host.is_collaborating());
+            host.set_selection(Selection::cursor(Pos(3)));
+            assert!(host.insert_text("c"));
+            assert_eq!(emits.get(), 0, "a detached editor broadcasts nothing");
+        }
+
+        #[test]
+        fn late_joiner_adopts_current_content_via_snapshot() {
+            let s = schema();
+            let host = mount(doc_node(&s, vec![para(&s, "hello")])).handle;
+            let guest = mount(doc_node(&s, vec![para(&s, "")])).handle;
+            loopback(&host, &guest);
+
+            // Edit AFTER the original join snapshot.
+            host.set_selection(Selection::cursor(Pos(6)));
+            assert!(host.insert_text(" world"));
+            assert_eq!(doc_text(&guest), "hello world");
+
+            // A third peer joins late from the host's CURRENT snapshot — it must
+            // adopt the edited content, not the host's original document.
+            let late = mount(doc_node(&s, vec![para(&s, "stale")])).handle;
+            let snapshot = host.collab_snapshot().expect("host is collaborating");
+            late.start_collaboration_guest(&snapshot, |_d| {}).unwrap();
+            assert_eq!(
+                doc_text(&late),
+                "hello world",
+                "a late joiner adopts the current shared document"
+            );
+        }
+
+        #[test]
+        fn unsupported_local_edit_fails_loud_without_touching_the_peer() {
+            let s = schema();
+            let host = mount(doc_node(&s, vec![para(&s, "ok")])).handle;
+            let guest = mount(doc_node(&s, vec![para(&s, "")])).handle;
+            loopback(&host, &guest);
+            assert_eq!(doc_text(&guest), "ok");
+
+            // A bullet list is a nested block — outside the staged flat-text scope.
+            assert!(host.load_html("<ul><li><p>item</p></li></ul>"));
+
+            // The host's model changed locally, but the projection failed loud (the
+            // CRDT was left untouched, all-or-nothing) so the peer received nothing.
+            assert!(
+                host.collab_take_error().is_some(),
+                "an unsupported edit surfaces a fail-loud error"
+            );
+            assert_eq!(
+                doc_text(&guest),
+                "ok",
+                "the peer is untouched by an unsupported local edit (no partial sync)"
+            );
+        }
     }
 }

--- a/crates/rinch/src/editor/mod.rs
+++ b/crates/rinch/src/editor/mod.rs
@@ -13,6 +13,8 @@
 #[cfg(feature = "a11y")]
 pub(crate) mod a11y;
 mod blink;
+#[cfg(feature = "collaboration")]
+mod collab;
 mod component;
 mod handle;
 mod registry;
@@ -26,6 +28,12 @@ pub use handle::EditorHandle;
 pub use registry::{
     begin_drag, drag_anchor, editor_for, end_drag, unregister_editor, update_all_carets,
 };
+#[cfg(feature = "collaboration")]
+pub use registry::{collab_receive_for, post_remote_delta};
+/// The collaboration error type (re-exported from `rinch-editor-collab`) returned by
+/// the [`EditorHandle`] collaboration methods.
+#[cfg(feature = "collaboration")]
+pub use rinch_editor_collab::CollabError;
 pub use view::RinchDomEditorView;
 pub(crate) use virtualization::{
     post_layout as virtualization_post_layout, pre_layout as virtualization_pre_layout,

--- a/crates/rinch/src/editor/registry.rs
+++ b/crates/rinch/src/editor/registry.rs
@@ -92,3 +92,27 @@ pub fn update_all_carets(focused: Option<usize>) -> bool {
     }
     moved
 }
+
+/// Deliver a remote collaboration `delta` to the editor mounted at `container_id`
+/// (design M9). A no-op if no such editor is mounted or it isn't collaborating.
+/// **Must be called on the main thread** — use [`post_remote_delta`] from a
+/// transport thread. Returns whether the editor's document changed.
+#[cfg(feature = "collaboration")]
+pub fn collab_receive_for(container_id: usize, delta: &[u8]) -> bool {
+    match editor_for(container_id) {
+        Some(handle) => handle.collab_receive(delta),
+        None => false,
+    }
+}
+
+/// Post a remote collaboration `delta` to the editor at `container_id` from **any**
+/// thread — the `Send`-safe inbound entry point for a network transport. The delta
+/// is marshalled onto the main thread (via
+/// [`run_on_main_thread`](crate::shell::run_on_main_thread)), where it is integrated
+/// and the editor re-projected; the runtime is woken so the change paints promptly.
+#[cfg(feature = "collaboration")]
+pub fn post_remote_delta(container_id: usize, delta: Vec<u8>) {
+    crate::shell::run_on_main_thread(move || {
+        collab_receive_for(container_id, &delta);
+    });
+}

--- a/crates/rinch/src/lib.rs
+++ b/crates/rinch/src/lib.rs
@@ -172,6 +172,11 @@ pub mod prelude {
     #[cfg(feature = "desktop")]
     pub use crate::editor::{Editor, EditorHandle, create_editor};
 
+    // Collaborative editing (M9): the editor's collab error type + the thread-safe
+    // inbound route a network transport posts received deltas through.
+    #[cfg(feature = "collaboration")]
+    pub use crate::editor::{CollabError, collab_receive_for, post_remote_delta};
+
     // Desktop-only GPU types for render surfaces
     #[cfg(feature = "gpu")]
     pub use crate::render_surface::{GpuTextureRegistrar, TextureSource};

--- a/docs/src/guide/contenteditable.md
+++ b/docs/src/guide/contenteditable.md
@@ -194,9 +194,58 @@ shows the same pattern inside the component showcase. The shape is always:
 `create_editor()` once, clone the handle into each button's `onclick`, and place a
 single `Editor {}` for the surface.
 
+## Collaboration (optional, `collaboration` feature)
+
+Two editors can share one live document. Enable the `collaboration` feature and the
+editor projects every local edit onto an [Automerge](https://automerge.org) CRDT,
+broadcasts the resulting delta, and rebuilds the model from a peer's delta when one
+arrives — so concurrent edits converge. The CRDT adapter
+([`rinch-editor-collab`](https://docs.rs/rinch-editor-collab)) is the only thing in a
+rinch app that links automerge; default builds link none of it.
+
+```toml
+rinch = { workspace = true, features = ["desktop", "collaboration"] }
+```
+
+One peer **hosts** (it owns the starting document); the others **join** from a
+snapshot of it. Each side supplies an `outbound` closure — where to send a delta a
+local edit produced — and feeds a peer's delta back in with `collab_receive`:
+
+```rust
+// Host: project the current document onto a fresh CRDT and hand peers a snapshot.
+let snapshot = host.start_collaboration_host(move |delta| transport.send(delta))?;
+
+// Guest: adopt the host's document and start collaborating.
+guest.start_collaboration_guest(&snapshot, move |delta| transport.send(delta))?;
+
+// When a delta arrives from the network, apply it on the main thread:
+guest.collab_receive(&delta_bytes);
+```
+
+The transport is yours to pick — the seam is just bytes in and bytes out — and it
+should deliver deltas **reliably and in order** (the seam carries incremental
+Automerge changes; the full sync protocol for lossy/out-of-order resync is not yet
+exposed through the handle). From a background socket/data-channel thread, use the
+`Send`-safe entry point, which marshals the delta onto the main thread for you:
+
+```rust
+use rinch::prelude::*;
+post_remote_delta(editor_container_id, delta_bytes); // any thread → main
+```
+
+`is_collaborating()`, `stop_collaboration()`, `collab_snapshot()` (a fresh snapshot
+for a *late*-joining peer to `start_collaboration_guest` from), and
+`collab_take_error()` round out the API. The first milestone covers **flat
+text-blocks + marks** (paragraphs, headings, code blocks, bold/italic/link/…); an
+edit outside that scope fails loud rather than silently diverging —
+`collab_take_error()` surfaces it, and the CRDT is left untouched (the local edit is
+not projected). A runnable two-pane loopback (both editors in one window, no network)
+lives at `examples/collab-editor-demo/src/main.rs`.
+
 ## Where to go next
 
 - [Rich-Text Editor](./editor.md) — the document model, schema, transactions,
   commands, history, and the view seam in depth.
 - `examples/markdown-editor` — a standalone editor app (great for MCP-driven
   iteration; built with the `debug` feature).
+- `examples/collab-editor-demo` — two editors sharing one CRDT, live.

--- a/examples/collab-editor-demo/Cargo.toml
+++ b/examples/collab-editor-demo/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "collab-editor-demo"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+rinch = { workspace = true, features = ["desktop", "collaboration", "debug"] }
+rinch-editor-core = { workspace = true }

--- a/examples/collab-editor-demo/src/main.rs
+++ b/examples/collab-editor-demo/src/main.rs
@@ -1,0 +1,89 @@
+//! Live collaborative editing demo (M9). Two **independent** `EditorHandle`s share
+//! one document through the `rinch-editor-collab` Step↔Automerge adapter.
+//!
+//! There is no network here — the two editors are wired into a synchronous,
+//! in-process **loopback**: each side's outbound delta is delivered straight to the
+//! other's [`EditorHandle::collab_receive`]. Because that delivery happens
+//! synchronously inside the originating keystroke, a single layout/repaint pass
+//! updates *both* panes. A real network app keeps this exact seam and only swaps the
+//! loopback for a transport (the outbound closure sends bytes to a socket; the
+//! receiver calls `rinch::post_remote_delta` from its thread).
+//!
+//! Click into either pane and type — the edit converges in the other. The shared
+//! content is deliberately **flat** (headings, paragraphs, marks): the staged collab
+//! scope (design A22) is flat text-blocks + marks, so lists/blockquotes/tables are
+//! out of scope for now and would fail loud.
+
+use rinch::prelude::*;
+use rinch_editor_core::{Pos, Selection};
+
+const PANE_LABEL: &str = "font-family: sans-serif; font-size: 13px; font-weight: 600; color: #57606a; text-transform: uppercase; letter-spacing: 0.04em;";
+const PANE_COL: &str = "flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 8px;";
+
+#[component]
+fn app() -> NodeHandle {
+    // Two editors, each over its own fresh document. `create_editor` makes them
+    // empty; the host pane loads the shared content via its `Editor { content }`.
+    let host = create_editor();
+    let guest = create_editor();
+
+    let tree = rsx! {
+        div {
+            style: "min-height: 100vh; padding: 28px; background: #f6f8fa; display: flex; flex-direction: column; gap: 16px;",
+            div {
+                style: "font-family: sans-serif;",
+                h2 { style: "margin: 0 0 4px; color: #1f2328;", "Collaborative editing" }
+                p {
+                    style: "margin: 0; color: #57606a; font-size: 14px;",
+                    "Two independent editors sharing one Automerge CRDT. Click into either pane and type — the edit converges in the other."
+                }
+            }
+            div {
+                style: "display: flex; gap: 24px; align-items: stretch;",
+                // Editor A — the host.
+                div {
+                    style: PANE_COL,
+                    div { style: PANE_LABEL, "Editor A · host" }
+                    Editor {
+                        editor: host.clone(),
+                        content: "<h1>Shared notes</h1>\
+                            <p>Type in <strong>either</strong> pane — every keystroke syncs through the CRDT.</p>\
+                            <p>Marks travel too: <strong>bold</strong>, <em>italic</em>.</p>",
+                    }
+                }
+                // Editor B — the guest (adopts the host's content on join).
+                div {
+                    style: PANE_COL,
+                    div { style: PANE_LABEL, "Editor B · guest" }
+                    Editor { editor: guest.clone(), content: "" }
+                }
+            }
+        }
+    };
+
+    // The `Editor` components rendered synchronously while the tree above was built,
+    // so the host has already loaded its content. Wire the loopback now: the host
+    // projects its (loaded) document onto a fresh CRDT and the guest joins from the
+    // snapshot — adopting the host's content — then each side relays its local
+    // deltas to the other.
+    let guest_in = guest.clone();
+    let snapshot = host
+        .start_collaboration_host(move |delta| {
+            guest_in.collab_receive(&delta);
+        })
+        .expect("host content is flat (A22 scope)");
+    let host_in = host.clone();
+    guest
+        .start_collaboration_guest(&snapshot, move |delta| {
+            host_in.collab_receive(&delta);
+        })
+        .expect("snapshot is valid flat content");
+
+    // Park a cursor in the host so the first click+type is obvious.
+    host.set_selection(Selection::cursor(Pos(1)));
+    tree
+}
+
+fn main() {
+    run("Collaborative Editor Demo", 1100, 720, app);
+}


### PR DESCRIPTION
Wires the standalone `rinch-editor-collab` Step↔Automerge adapter (merged in #69) into the desktop editor's `EditorHandle` — the "not wired yet" gap from M9. Every local edit projects onto the CRDT and broadcasts; a peer's delta integrates and re-projects. Closure-based transport seam (the design leaves transport to the app) plus a two-pane in-process loopback demo.

## What landed
- **One local-edit choke point** — `update`/`command`/`load_doc`/`insert_image` funnel through `EditorCore::commit` → `record_local` (project `before→after` onto the CRDT) → `save_incremental` → `outbound`. Selection-only edits skip projection (`same_ref`).
- **Remote integration is a separate path** — `collab_receive` → `integrate_incremental` → set state + re-project, deliberately **not** through `commit`, so a remote change never echoes back or double-applies. `try_borrow_mut`-soft so a self-wired sink can't panic.
- **`EditorHandle` API** — `start_collaboration_host`/`_guest`, `collab_receive`, `is_collaborating`, `stop_collaboration`, `collab_snapshot` (late-join), `collab_take_error`; registry `collab_receive_for` (main-thread) + `post_remote_delta` (Send-safe, marshals onto the main thread via `run_on_main_thread`).
- **`collaboration` now implies `desktop`** (the wiring lives in the desktop editor); default + web builds still link **zero** automerge.
- **`examples/collab-editor-demo`** — two independent editors sharing one CRDT, live in one window (synchronous loopback).

## Verification
- **MCP-validated bidirectional** in the real renderer: typed in A → appeared in B; typed in B → appeared in A; mid-word insertion → character-level CRDT merge; bold/italic preserved.
- **10 new tests**; `test --workspace` = 767 pass / 0 fail. Gates: fmt, `clippy --workspace --all-targets -D warnings`, default rinch `cargo tree` 0 automerge, editor-core + ui-zoo-web wasm.
- **3-lens adversarial review** (`verify-m9-collab-wiring`): 0 must-fix, 11 false-positives dropped, 3 should-fix applied — most notably `project_change` is now **all-or-nothing** (validate every touched block before any CRDT write) so a mixed flat/non-flat edit can't partially mutate the CRDT.

Staged scope is flat text-blocks + marks (design A22); an edit outside it fails loud and the CRDT is left untouched.

Resume after this: **M10 web view** (`rinch-web` `WebEditorView`, closes #51) — reuses this same adapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)