### PR TITLE
fix(editor): canonical mark order + load-empty repair + overlay styles; collab fuzz

### DIFF
--- a/crates/rinch-editor-collab/src/projection.rs
+++ b/crates/rinch-editor-collab/src/projection.rs
@@ -419,6 +419,11 @@ fn marks_at(schema: &Schema, spans: &[SpanMark], i: usize) -> Result<Vec<Mark>> 
             out.push(Mark::new(mt.clone(), attrs));
         }
     }
+    // Canonical (mark-type-name) order, matching `Mark::add_to_set`. `spans` is sorted
+    // by `(start, end, name)`, so a char covered by two marks with *different* extents
+    // would otherwise come out in span-start order, not name order — and the rebuilt
+    // node would compare unequal (mark-`Vec` order) to the edited model.
+    out.sort_by(|a, b| a.type_name().cmp(b.type_name()));
     Ok(out)
 }
 

--- a/crates/rinch-editor-collab/tests/fuzz.rs
+++ b/crates/rinch-editor-collab/tests/fuzz.rs
@@ -1,0 +1,299 @@
+//! Seeded, deterministic fuzz/property tests for the collab adapter.
+//!
+//! Two invariants are stress-tested over thousands of random flat-text edits:
+//!
+//! 1. **`model ≡ project(model)`** — after EVERY local edit, the CRDT must read
+//!    back (`projected_doc`) as *exactly* the editor model that produced it. This is
+//!    the load-bearing invariant of the whole design (a `project_change` bug shows up
+//!    here as a model/CRDT mismatch on some random edit).
+//! 2. **Convergence** — N peers make concurrent random edits and relay their
+//!    incremental deltas (interleaved, FIFO so a change's deps always precede it).
+//!    Once every peer has seen every delta, all peers must project to the *identical*
+//!    document. This is the exact incremental-delta path pimble / `EditorHandle` use.
+//!
+//! Deterministic (a fixed-seed xorshift PRNG) so any failure reproduces from its
+//! `(seed, peers, rounds)` triple.
+
+use std::rc::Rc;
+
+use rinch_editor_collab::CollabSession;
+use rinch_editor_core::model::Fragment;
+use rinch_editor_core::{EditorState, Node, Pos, Schema, Selection, default_plugins};
+
+/// xorshift64* — tiny, deterministic, no deps.
+struct Rng(u64);
+impl Rng {
+    fn new(seed: u64) -> Rng {
+        Rng(seed ^ 0x9E37_79B9_7F4A_7C15)
+    }
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+    fn below(&mut self, n: usize) -> usize {
+        if n == 0 {
+            0
+        } else {
+            (self.next() % n as u64) as usize
+        }
+    }
+    /// True `pct`% of the time.
+    fn chance(&mut self, pct: u64) -> bool {
+        self.next() % 100 < pct
+    }
+}
+
+fn schema() -> Rc<Schema> {
+    Rc::new(Schema::starter_kit())
+}
+
+/// `doc(paragraph("start"))` — the shared initial document.
+fn initial_state(schema: &Rc<Schema>) -> EditorState {
+    let para = schema
+        .branch(
+            "paragraph",
+            Fragment::from_node(schema.text("start").unwrap()),
+        )
+        .unwrap();
+    let doc = schema.branch("doc", Fragment::from_node(para)).unwrap();
+    EditorState::create(schema.clone(), doc, default_plugins())
+}
+
+fn doc_size(state: &EditorState) -> usize {
+    state.doc.content().size()
+}
+
+/// A valid (resolvable, text-biased) position somewhere in the document.
+fn random_pos(rng: &mut Rng, state: &EditorState) -> Pos {
+    let size = doc_size(state);
+    let raw = 1 + rng.below(size.max(1));
+    Selection::near(&state.doc, Pos(raw.min(size)), 1).head()
+}
+
+/// A short run of mixed-width characters (ascii + multibyte BMP + astral) — stresses
+/// the codepoint↔char position equivalence the projection relies on.
+fn random_text(rng: &mut Rng) -> String {
+    const ALPHABET: &[char] = &['a', 'b', 'c', ' ', 'é', 'ö', '猫', 'Z', '7', '🐱'];
+    let len = 1 + rng.below(3);
+    (0..len)
+        .map(|_| ALPHABET[rng.below(ALPHABET.len())])
+        .collect()
+}
+
+/// Apply one random *flat-scope* edit (insert / delete / mark / split / block-type)
+/// to `state`. Returns `None` (skip) when the random selection makes the op invalid
+/// — the fuzz tolerates skips. Never produces non-flat content, so `record_local`
+/// never hits the A22 `Unsupported` boundary.
+fn random_edit(rng: &mut Rng, state: &EditorState) -> Option<EditorState> {
+    match rng.below(9) {
+        // Insert text (weighted — the common case).
+        0..=3 => {
+            let p = random_pos(rng, state);
+            let mut tr = state.tr();
+            tr.set_selection(Selection::cursor(p));
+            tr.insert_text(&random_text(rng)).ok()?;
+            Some(state.apply(tr))
+        }
+        // Delete a (non-empty) range.
+        4 => {
+            let a = random_pos(rng, state).0;
+            let b = random_pos(rng, state).0;
+            let (lo, hi) = (a.min(b), a.max(b));
+            if lo == hi {
+                return None;
+            }
+            let mut tr = state.tr();
+            tr.delete(lo, hi).ok()?;
+            Some(state.apply(tr))
+        }
+        // Toggle an inline mark over a range.
+        5 => {
+            let a = random_pos(rng, state).0;
+            let b = random_pos(rng, state).0;
+            let (lo, hi) = (a.min(b), a.max(b));
+            let mut tr = state.tr();
+            tr.set_selection(Selection::text(Pos(lo), Pos(hi)));
+            let placed = state.apply(tr);
+            let cmd = [
+                "toggleBold",
+                "toggleItalic",
+                "toggleUnderline",
+                "toggleStrike",
+                "toggleCode",
+            ][rng.below(5)];
+            placed.run(cmd)
+        }
+        // Split the current textblock.
+        6 => {
+            let p = random_pos(rng, state);
+            let mut tr = state.tr();
+            tr.set_selection(Selection::cursor(p));
+            state.apply(tr).run("splitBlock")
+        }
+        // Set the block type (paragraph / heading / code_block — all flat).
+        _ => {
+            let p = random_pos(rng, state);
+            let mut tr = state.tr();
+            tr.set_selection(Selection::cursor(p));
+            let placed = state.apply(tr);
+            let cmd = [
+                "setParagraph",
+                "setHeading1",
+                "setHeading2",
+                "setHeading3",
+                "setCodeBlock",
+            ][rng.below(5)];
+            placed.run(cmd)
+        }
+    }
+}
+
+/// The canonical "two docs are the same model" check.
+fn same(a: &Node, b: &Node) -> bool {
+    a == b
+}
+
+/// Run one fuzz trial: `peers` peers, `rounds` interleaved edit/deliver steps, then a
+/// flush, asserting the two invariants throughout.
+fn fuzz_trial(seed: u64, peers: usize, rounds: usize) {
+    let schema = schema();
+    let mut rng = Rng::new(seed);
+
+    // All peers start from peer 0's snapshot, so they share one CRDT lineage.
+    let init = initial_state(&schema);
+    let mut host = CollabSession::new(&init).unwrap();
+    let snapshot = host.snapshot();
+
+    let mut states: Vec<EditorState> = Vec::with_capacity(peers);
+    let mut sessions: Vec<CollabSession> = Vec::with_capacity(peers);
+    states.push(init.clone());
+    sessions.push(host);
+    for _ in 1..peers {
+        states.push(init.clone());
+        sessions.push(CollabSession::from_bytes(&snapshot).unwrap());
+    }
+
+    // A global FIFO of every delta produced (production order is a topological order
+    // of the change DAG, so FIFO delivery always satisfies dependencies). `seen[p]`
+    // is how many of the queue's deltas peer `p` has integrated.
+    let mut queue: Vec<Vec<u8>> = Vec::new();
+    let mut seen = vec![0usize; peers];
+
+    let mut edits = 0usize;
+    for _ in 0..rounds {
+        // 60% make a local edit, 40% deliver a pending delta.
+        if rng.chance(60) {
+            let p = rng.below(peers);
+            let Some(next) = random_edit(&mut rng, &states[p]) else {
+                continue;
+            };
+            // Project the local change and check the load-bearing invariant.
+            sessions[p]
+                .record_local(&states[p].doc, &next.doc)
+                .expect("flat edit projects cleanly");
+            let projected = sessions[p].projected_doc(&schema).unwrap();
+            if !same(&projected, &next.doc) {
+                use rinch_editor_core::serialize::node_to_html;
+                panic!(
+                    "model ≡ project(model) violated on a local edit \
+                     (seed={seed}, peer={p}, edit#{edits})\n\
+                     BEFORE: {}\n  MODEL: {}\nPROJECTED: {}",
+                    node_to_html(&states[p].doc),
+                    node_to_html(&next.doc),
+                    node_to_html(&projected),
+                );
+            }
+            states[p] = next;
+            let delta = sessions[p].save_incremental();
+            if !delta.is_empty() {
+                queue.push(delta);
+            }
+            edits += 1;
+        } else {
+            // Deliver the next unseen delta to a random peer (FIFO per peer).
+            let q = rng.below(peers);
+            if seen[q] < queue.len() {
+                let delta = queue[seen[q]].clone();
+                seen[q] += 1;
+                if let Some(next) = sessions[q]
+                    .integrate_incremental(&states[q], &delta)
+                    .expect("delta integrates")
+                {
+                    // A remote integration also lands the model at project(CRDT).
+                    assert!(
+                        same(&sessions[q].projected_doc(&schema).unwrap(), &next.doc),
+                        "model ≡ project(model) violated after integrate (seed={seed}, peer={q})"
+                    );
+                    states[q] = next;
+                }
+            }
+        }
+    }
+
+    // Flush: every peer integrates every remaining delta.
+    for q in 0..peers {
+        while seen[q] < queue.len() {
+            let delta = queue[seen[q]].clone();
+            seen[q] += 1;
+            if let Some(next) = sessions[q]
+                .integrate_incremental(&states[q], &delta)
+                .expect("delta integrates on flush")
+            {
+                states[q] = next;
+            }
+        }
+    }
+
+    // Convergence: every peer projects to the identical document, and that document
+    // is what its own model holds (model ≡ project, post-flush).
+    let reference = sessions[0].projected_doc(&schema).unwrap();
+    for q in 0..peers {
+        let projected = sessions[q].projected_doc(&schema).unwrap();
+        assert!(
+            same(&projected, &reference),
+            "peers diverged after flush (seed={seed}, peer {q} vs peer 0)"
+        );
+        assert!(
+            same(&states[q].doc, &reference),
+            "peer {q}'s model disagrees with its CRDT after flush (seed={seed})"
+        );
+    }
+
+    assert!(
+        edits > 0,
+        "trial should have made at least one edit (seed={seed})"
+    );
+}
+
+#[test]
+fn fuzz_two_peers_converge() {
+    for seed in 1..=24u64 {
+        fuzz_trial(seed, 2, 220);
+    }
+}
+
+#[test]
+fn fuzz_three_peers_converge() {
+    for seed in 100..=118u64 {
+        fuzz_trial(seed, 3, 320);
+    }
+}
+
+#[test]
+fn fuzz_four_peers_converge() {
+    for seed in 200..=214u64 {
+        fuzz_trial(seed, 4, 400);
+    }
+}
+
+#[test]
+fn fuzz_many_peers_converge() {
+    // A few wider trials: more peers, longer runs, to shake out tail cases.
+    for seed in 300..=305u64 {
+        fuzz_trial(seed, 6, 500);
+    }
+}

--- a/crates/rinch-editor-core/src/model/mark.rs
+++ b/crates/rinch-editor-core/src/model/mark.rs
@@ -48,9 +48,15 @@ impl Mark {
     /// Add this mark to `set`, returning the new set. If an existing mark equals
     /// this one the set is returned unchanged; marks this one *excludes* are
     /// dropped; if an existing mark excludes this one the set is returned unchanged
-    /// (the mark cannot be added). Port of ProseMirror's `Mark.addToSet` (without
-    /// the rank-based ordering — the new mark is appended, which preserves set
-    /// membership; ordering is not load-bearing for our value model).
+    /// (the mark cannot be added). Port of ProseMirror's `Mark.addToSet`.
+    ///
+    /// The mark is inserted in **canonical mark-type-name order** (not appended), so a
+    /// node's mark `Vec` is deterministic regardless of the order marks were toggled.
+    /// `Node`/`Fragment` equality is mark-order-sensitive (a `Vec` compare), and the
+    /// collab projection reconstructs marks name-sorted — so without a canonical order
+    /// the same logical mark *set* would compare unequal and break the
+    /// `model ≡ project(model)` invariant. (A fuzz over random mark toggles caught
+    /// exactly this.)
     pub fn add_to_set(&self, set: &[Mark]) -> Vec<Mark> {
         let mut copy: Option<Vec<Mark>> = None;
         for (i, other) in set.iter().enumerate() {
@@ -70,7 +76,12 @@ impl Mark {
             }
         }
         let mut copy = copy.unwrap_or_else(|| set.to_vec());
-        copy.push(self.clone());
+        // Insert in canonical (type-name) order so the set stays sorted.
+        let at = copy
+            .iter()
+            .position(|m| m.type_name() > self.type_name())
+            .unwrap_or(copy.len());
+        copy.insert(at, self.clone());
         copy
     }
 

--- a/crates/rinch/src/editor/handle.rs
+++ b/crates/rinch/src/editor/handle.rs
@@ -19,7 +19,7 @@ use std::rc::{Rc, Weak};
 
 use rinch_core::dom::{DomDocument, NodeHandle, RenderScope};
 use rinch_editor_core::commands::{current_block_type, in_node_type, is_mark_active};
-use rinch_editor_core::model::Slice;
+use rinch_editor_core::model::{Fragment, Slice};
 use rinch_editor_core::serialize::{
     slice_from_html, slice_from_text, slice_to_html, slice_to_text,
 };
@@ -100,6 +100,15 @@ impl EditorCore {
             Err(e) => bridge.last_error = Some(e),
         }
     }
+}
+
+/// A minimal valid document — `doc(paragraph())` — used to keep the editor in a
+/// renderable, editable state when a load would otherwise yield a block-less doc.
+/// `None` only if the schema lacks `paragraph`/`doc` (not the case for the starter
+/// kit), in which case the caller keeps the original doc.
+fn empty_paragraph_doc(schema: &Schema) -> Option<Node> {
+    let para = schema.branch("paragraph", Fragment::empty()).ok()?;
+    schema.branch("doc", Fragment::from_node(para)).ok()
 }
 
 /// A cloneable handle to an editor (design A7). Cheap to [`Clone`] (an `Rc`), so a
@@ -368,15 +377,26 @@ impl EditorHandle {
     /// Replace the document with `doc`, resetting selection and history (a fresh
     /// load, not an undoable edit). The host diffs from the old content to the new,
     /// so unchanged leading blocks are reused. Works before focus.
+    ///
+    /// A **block-less** `doc` (zero children — e.g. from parsing empty/whitespace
+    /// HTML, since `Schema::branch` does not fill required content) is repaired to a
+    /// single empty paragraph, so the editor is never left with no textblock to
+    /// render or place a caret in.
     pub fn load_doc(&self, doc: Node) {
         let mut core = self.inner.borrow_mut();
+        let doc = if doc.child_count() == 0 {
+            empty_paragraph_doc(&core.schema).unwrap_or(doc)
+        } else {
+            doc
+        };
         let prev = core.state.clone();
         let next = EditorState::create(core.schema.clone(), doc, core.plugins.clone());
         core.commit(prev, next);
     }
 
-    /// Parse `html` (schema-whitelisted) and load it as the document. Returns
-    /// `false` if it does not parse into valid top-level document content.
+    /// Parse `html` (schema-whitelisted) and load it as the document. Empty or
+    /// whitespace-only `html` loads a single empty paragraph (via [`Self::load_doc`]),
+    /// not a block-less doc. Returns `false` only if `html` fails to parse at all.
     pub fn load_html(&self, html: &str) -> bool {
         let schema = self.inner.borrow().schema.clone();
         let Ok(slice) = slice_from_html(&schema, html) else {
@@ -846,6 +866,46 @@ mod tests {
             .iter()
             .any(|&c| tag(&h, c).as_deref() == Some("strong"));
         assert!(has_strong, "bold inline survived the load");
+    }
+
+    #[test]
+    fn load_html_empty_keeps_one_empty_paragraph() {
+        let s = schema();
+        let h = mount(doc_node(&s, vec![para(&s, "old")]));
+        // Empty HTML must NOT leave a block-less doc (no textblock to render or
+        // place a caret in) — it loads a single empty paragraph instead.
+        assert!(h.handle.load_html(""));
+        let doc = h.handle.doc();
+        assert_eq!(doc.child_count(), 1, "one block, not zero");
+        assert_eq!(doc.child(0).type_name(), "paragraph");
+        assert_eq!(doc.child(0).child_count(), 0, "the paragraph is empty");
+
+        // The host re-projected to exactly one (empty) <p>.
+        let blocks = children(&h, h.container_id);
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(tag(&h, blocks[0]).as_deref(), Some("p"));
+
+        // And the cursor can be placed in it (a block-less doc would have no valid
+        // position here).
+        h.handle.set_selection(Selection::cursor(Pos(1)));
+        assert!(h.handle.insert_text("x"));
+        assert_eq!(
+            text(&h, children(&h, h.container_id)[0]).as_deref(),
+            Some("x")
+        );
+    }
+
+    #[test]
+    fn load_doc_blockless_is_repaired() {
+        // A directly-constructed block-less doc (Schema::branch does not fill
+        // required content) is repaired to one empty paragraph by load_doc.
+        let s = schema();
+        let h = mount(doc_node(&s, vec![para(&s, "old")]));
+        let blockless = s.branch("doc", Fragment::empty()).unwrap();
+        assert_eq!(blockless.child_count(), 0);
+        h.handle.load_doc(blockless);
+        assert_eq!(h.handle.doc().child_count(), 1);
+        assert_eq!(h.handle.doc().child(0).type_name(), "paragraph");
     }
 
     #[test]
@@ -1481,6 +1541,117 @@ mod tests {
                 "ok",
                 "the peer is untouched by an unsupported local edit (no partial sync)"
             );
+        }
+
+        /// Seeded fuzz over the real `EditorHandle` wiring: two handles relay random
+        /// edits (via the `outbound` sink) and integrate them (`collab_receive`) in
+        /// interleaved order, then must converge to the *identical* document
+        /// (structural — marks included, which is what the mark-order fix guarantees).
+        #[test]
+        fn fuzz_handle_wiring_converges() {
+            struct Rng(u64);
+            impl Rng {
+                fn new(s: u64) -> Rng {
+                    Rng(s ^ 0x9E37_79B9_7F4A_7C15)
+                }
+                fn next(&mut self) -> u64 {
+                    let mut x = self.0;
+                    x ^= x << 13;
+                    x ^= x >> 7;
+                    x ^= x << 17;
+                    self.0 = x;
+                    x
+                }
+                fn below(&mut self, n: usize) -> usize {
+                    if n == 0 {
+                        0
+                    } else {
+                        (self.next() % n as u64) as usize
+                    }
+                }
+            }
+
+            for seed in 0..6u64 {
+                let s = schema();
+                let host = mount(doc_node(&s, vec![para(&s, "start")])).handle;
+                let guest = mount(doc_node(&s, vec![para(&s, "")])).handle;
+                // Each peer's outbound pushes into the OTHER peer's inbox.
+                let to_host: Rc<RefCell<Vec<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
+                let to_guest: Rc<RefCell<Vec<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
+                let tg = to_guest.clone();
+                let snap = host
+                    .start_collaboration_host(move |d| tg.borrow_mut().push(d))
+                    .unwrap();
+                let th = to_host.clone();
+                guest
+                    .start_collaboration_guest(&snap, move |d| th.borrow_mut().push(d))
+                    .unwrap();
+
+                let peers = [&host, &guest];
+                let inbox = [&to_host, &to_guest]; // inbox[p] = deltas destined for peer p
+                let mut seen = [0usize, 0usize];
+                let mut rng = Rng::new(seed);
+
+                let deliver = |p: usize, seen: &mut [usize; 2]| {
+                    let delta = {
+                        let q = inbox[p].borrow();
+                        (seen[p] < q.len()).then(|| q[seen[p]].clone())
+                    };
+                    if let Some(d) = delta {
+                        seen[p] += 1;
+                        peers[p].collab_receive(&d);
+                    }
+                };
+
+                for _ in 0..140 {
+                    if rng.below(100) < 65 {
+                        let p = rng.below(2);
+                        let h = peers[p];
+                        let doc = h.doc();
+                        let size = doc.content().size();
+                        let pos = 1 + rng.below(size.max(1));
+                        h.set_selection(Selection::near(&doc, Pos(pos.min(size)), 1));
+                        match rng.below(5) {
+                            0..=2 => {
+                                h.insert_text(["a", "b", " ", "猫", "Z"][rng.below(5)]);
+                            }
+                            3 => {
+                                h.command(
+                                    ["toggleBold", "toggleItalic", "toggleStrike", "toggleCode"]
+                                        [rng.below(4)],
+                                );
+                            }
+                            _ => {
+                                h.command(
+                                    ["setHeading1", "setParagraph", "splitBlock"][rng.below(3)],
+                                );
+                            }
+                        }
+                    } else {
+                        deliver(rng.below(2), &mut seen);
+                    }
+                }
+                // Flush both inboxes.
+                for p in 0..2 {
+                    while seen[p] < inbox[p].borrow().len() {
+                        deliver(p, &mut seen);
+                    }
+                }
+
+                // Compare via HTML, not `Node` equality: each handle has its OWN
+                // `Schema` instance (`create_editor`/`mount` make one per editor), and
+                // `Node` equality compares `NodeType` by interned-pointer identity, so
+                // structurally-identical docs from different schemas compare unequal.
+                // HTML is schema-independent and captures text + marks + block type, so
+                // it's the faithful cross-handle convergence check. (Full structural
+                // convergence under one schema is proven by the adapter fuzz.)
+                use rinch_editor_core::serialize::node_to_html;
+                assert_eq!(
+                    node_to_html(&host.doc()),
+                    node_to_html(&guest.doc()),
+                    "handles diverged (seed={seed})"
+                );
+            }
         }
     }
 }

--- a/crates/rinch/src/editor/styles.rs
+++ b/crates/rinch/src/editor/styles.rs
@@ -35,6 +35,12 @@ pub(crate) const DEFAULT_EDITOR_CSS: &str = r#"
   padding: 16px 20px;
   border: 1px solid #d0d7de;
   border-radius: 10px;
+  /* The caret and selection overlays are children positioned absolutely relative
+     to the container, so it must be a positioned stacking context. These live here
+     (not as inline styles set by the view) so a consumer's `style:` prop on the
+     `Editor {}` component can't clobber them and silently break the overlays. */
+  position: relative;
+  z-index: 0;
 }
 
 /* ── Headings ──────────────────────────────────────────────────────────── */

--- a/crates/rinch/src/editor/view.rs
+++ b/crates/rinch/src/editor/view.rs
@@ -349,11 +349,13 @@ impl RinchDomEditorView {
         // polished out of the box — injected once per document.
         super::styles::ensure_default_styles(&doc);
         container.set_attribute("data-pm-type", state.doc.type_name());
-        // The caret and selection overlays are positioned absolutely relative to the
-        // container. A non-`auto` `z-index` makes the container a CSS stacking
-        // context, so the selection rects (`z-index: -1`) paint *behind* the in-flow
-        // text and the caret (`z-index: 1`) paints in front of it.
-        container.set_styles(&[("position", "relative"), ("z-index", "0")]);
+        // `position: relative` + `z-index: 0` (the containing block + stacking
+        // context the caret/selection overlays need) live in the default stylesheet
+        // on `[data-pm-editor]`, NOT as inline styles here — otherwise a consumer's
+        // `style:` prop on the `Editor {}` component would replace the container's
+        // inline `style` attribute and silently break overlay positioning. The
+        // selection rects (`z-index: -1`) then paint *behind* the in-flow text and
+        // the caret (`z-index: 1`) in front.
         let mut children = Vec::with_capacity(state.doc.child_count());
         for i in 0..state.doc.child_count() {
             if let Some(child) = ViewDesc::build(state.doc.child(i), &doc) {


### PR DESCRIPTION
Hardens the M9 collaboration adapter and fixes two editor sharp edges, driven by a new **seeded convergence fuzz** that caught a real bug the manual testing missed.

## The bug the fuzz found
A multi-peer convergence fuzz over the collab adapter immediately flagged a `model ≡ project(model)` violation: marks round-tripped through the CRDT in a **different order** than the editor model held them. Because `Node` equality is mark-order-sensitive, any document with overlapping marks (e.g. bold+strike) violated the invariant the whole design rests on.

- **editor-core** — `Mark::add_to_set` now inserts in canonical mark-type-name order instead of appending, so a node's mark `Vec` is deterministic.
- **editor-collab** — the projection's `marks_at` sorts a char's marks by name to match (it previously came out in span-start order). Together these make `model ≡ project` hold *exactly*.

## The fuzz
`crates/rinch-editor-collab/tests/fuzz.rs` (new): N peers, thousands of random flat-text edits (insert/delete/mark/split/block-type, incl. multibyte + astral chars), interleaved FIFO delta relay. Asserts **both** invariants — `model ≡ project(model)` after every local edit, and full structural convergence after flush (2/3/4/6 peers, 60 trials). Plus a handle-wiring fuzz over the real `EditorHandle` path.

## Two editor sharp edges (found integrating the editor into a real third-party app)
- `EditorHandle::load_doc`/`load_html` now repair a block-less doc (e.g. `load_html("")`) to a single empty paragraph, so the editor is never left with no textblock to type into (`Schema::branch` doesn't fill required content).
- The container's `position:relative`/`z-index:0` (the caret/selection overlay stacking context) moved from inline `set_styles` into the default stylesheet on `[data-pm-editor]`, so a consumer's `style:` prop on `Editor {}` can't clobber them and silently break overlays.

## Verification
- New fuzz + 4 new editor tests; `cargo test --workspace` green.
- `clippy --workspace --all-targets -D warnings`, editor-core all-features + wasm + empty dep-gate, default rinch links 0 automerge, fmt.
- End-to-end re-validated in a real third-party app (two processes, one server, release build): a concurrent **bold + bold/italic** edit from two peers converges identically through the live transport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)