### PR TITLE
fix(editor): preserve whitespace + give empty blocks a line box (web)

### DIFF
--- a/crates/rinch-editor-view/src/styles.rs
+++ b/crates/rinch-editor-view/src/styles.rs
@@ -35,6 +35,13 @@ pub(crate) const DEFAULT_EDITOR_CSS: &str = r#"
   padding: 16px 20px;
   border: 1px solid #d0d7de;
   border-radius: 10px;
+  /* Preserve the model's whitespace exactly (inherited by every textblock). Without
+     this the browser collapses trailing spaces and runs of spaces, so a space typed
+     at end of line is invisible until the next character, and — worse — the rendered
+     text no longer matches the model 1:1, throwing off the DOM-offset → model-byte
+     caret mapping. `pre-wrap` still wraps at spaces; `break-word` wraps long words. */
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
   /* The caret and selection overlays are children positioned absolutely relative
      to the container, so it must be a positioned stacking context. These live here
      (not as inline styles set by the view) so a consumer's `style:` prop on the
@@ -54,6 +61,18 @@ pub(crate) const DEFAULT_EDITOR_CSS: &str = r#"
 /* ── Body text ─────────────────────────────────────────────────────────── */
 [data-pm-editor] p { margin: 0 0 0.75em; }
 [data-pm-editor] a { color: #0969da; text-decoration: underline; }
+
+/* An *empty* textblock (e.g. the paragraph created by pressing Enter on a blank
+   line) has no inline content, so the browser gives it no line box and it collapses
+   to zero height — the new line is invisible until a character is typed. Reserve one
+   line height so an empty block occupies a line and its caret lands correctly. `1lh`
+   is the element's own line height, so headings reserve their (taller) line. */
+[data-pm-editor] p:empty,
+[data-pm-editor] h1:empty, [data-pm-editor] h2:empty, [data-pm-editor] h3:empty,
+[data-pm-editor] h4:empty, [data-pm-editor] h5:empty, [data-pm-editor] h6:empty,
+[data-pm-editor] blockquote:empty, [data-pm-editor] li:empty,
+[data-pm-editor] td:empty, [data-pm-editor] th:empty,
+[data-pm-editor] pre:empty { min-height: 1lh; }
 
 /* ── Inline marks ──────────────────────────────────────────────────────── */
 [data-pm-editor] strong, [data-pm-editor] b { font-weight: 700; }


### PR DESCRIPTION
## Summary

Fixes a class of web-editor rendering/caret bugs caused by the default editor stylesheet leaving textblocks at `white-space: normal`, so the browser collapsed whitespace and gave empty blocks no line box. Reported:

1. **Enter on a blank line** created an empty `<p>` with **zero height** — no visible new line until a character was typed.
2. **A space at end of line** was collapsed (zero width) — invisible, and the caret didn't advance, until the next character.
3. **Editing near a word/space boundary** desynced the DOM from the model: a collapsed space made the rendered text differ from the model text, throwing off the DOM-offset → model-byte caret mapping (e.g. backspace appeared to delete a space the model kept).

## Fix (shared editor stylesheet)

- `white-space: pre-wrap; overflow-wrap: break-word;` on `[data-pm-editor]` (inherited by every textblock). The DOM text now matches the model **exactly**, so trailing/leading/multiple spaces render and every DOM offset maps 1:1 to a model position — which is what fixes #2, #3, and the rest of the class. `pre-wrap` still wraps at spaces; `break-word` wraps long words.
- `min-height: 1lh` on empty textblocks (`p`/`h1`…`h6`/`blockquote`/`li`/`td`/`th`/`pre``:empty`) so an empty block occupies one line and its caret lands correctly.

## Validation

Real browser (Playwright): the space caret advances immediately (613→618px); an empty paragraph after Enter is 26px tall; backspace at a word boundary leaves DOM **and** model both `"abcd"` (no desync — verified via the copy serializer, which reads the model).

Desktop (rinch-dom/Parley) verified via MCP: text wraps normally and Enter/typing are unchanged — the shared stylesheet change is safe for both renderers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)