### PR TITLE
fix(editor): insert horizontal rule / table at a cursor inside a paragraph

### DIFF
--- a/crates/rinch-editor-core/src/commands/mod.rs
+++ b/crates/rinch-editor-core/src/commands/mod.rs
@@ -504,7 +504,7 @@ pub fn insert_horizontal_rule() -> Command {
             .create_node("horizontal_rule", Attrs::new(), Fragment::empty())
             .ok()?;
         let mut tr = state.tr();
-        tr.replace_selection_with(hr).ok()?;
+        tr.insert_block(hr).ok()?;
         Some(tr)
     })
 }
@@ -546,7 +546,7 @@ pub fn insert_table(rows: usize, cols: usize) -> Command {
     command_tr(move |state| {
         let table = build_table(state.schema(), rows, cols)?;
         let mut tr = state.tr();
-        tr.replace_selection_with(table).ok()?;
+        tr.insert_block(table).ok()?;
         Some(tr)
     })
 }
@@ -1470,6 +1470,45 @@ mod tests {
                 .iter()
                 .any(|n| n.type_name() == "horizontal_rule")
         );
+    }
+
+    #[test]
+    fn insert_block_at_a_cursor_inside_a_textblock() {
+        // End of the paragraph → the rule goes after it: [p "ab"][hr].
+        let mut s = editor("ab");
+        s.selection = Selection::cursor(Pos(3));
+        let end = s.run("insertHorizontalRule").expect("hr at para end");
+        assert_eq!(end.doc.child_count(), 2);
+        assert_eq!(end.doc.child(0).type_name(), "paragraph");
+        assert_eq!(end.doc.child(1).type_name(), "horizontal_rule");
+        assert_eq!(all_text(end.doc.child(0)), "ab");
+
+        // Start of the paragraph → the rule goes before it: [hr][p "ab"].
+        let mut s = editor("ab");
+        s.selection = Selection::cursor(Pos(1));
+        let start = s.run("insertHorizontalRule").expect("hr at para start");
+        assert_eq!(start.doc.child_count(), 2);
+        assert_eq!(start.doc.child(0).type_name(), "horizontal_rule");
+        assert_eq!(start.doc.child(1).type_name(), "paragraph");
+        assert_eq!(all_text(start.doc.child(1)), "ab");
+
+        // Interior → split the paragraph around the rule: [p "a"][hr][p "b"].
+        let mut s = editor("ab");
+        s.selection = Selection::cursor(Pos(2));
+        let mid = s.run("insertHorizontalRule").expect("hr mid para");
+        assert_eq!(mid.doc.child_count(), 3);
+        assert_eq!(mid.doc.child(0).type_name(), "paragraph");
+        assert_eq!(mid.doc.child(1).type_name(), "horizontal_rule");
+        assert_eq!(mid.doc.child(2).type_name(), "paragraph");
+        assert_eq!(all_text(mid.doc.child(0)), "a");
+        assert_eq!(all_text(mid.doc.child(2)), "b");
+
+        // A table inserts the same way at an interior cursor (the user's bug).
+        let mut s = editor("ab");
+        s.selection = Selection::cursor(Pos(2));
+        let tbl = s.run("insertTable").expect("table mid para");
+        assert_eq!(tbl.doc.child_count(), 3);
+        assert_eq!(tbl.doc.child(1).type_name(), "table");
     }
 
     #[test]

--- a/crates/rinch-editor-core/src/state/transaction.rs
+++ b/crates/rinch-editor-core/src/state/transaction.rs
@@ -325,6 +325,53 @@ impl Transaction {
         Ok(self)
     }
 
+    /// Insert a **block-level** `node` (horizontal rule, table) at the current
+    /// selection, opening a block gap for it: delete any selected range, then place
+    /// the node before or after the enclosing textblock — splitting the textblock when
+    /// the cursor is in its interior. Unlike [`Self::replace_selection_with`] (which
+    /// drops the node *at* the selection, so a block node only fits when the selection
+    /// already spans a doc-level block gap), this handles the common case of a collapsed
+    /// cursor inside a paragraph. Leaves the cursor just after the inserted node.
+    pub fn insert_block(&mut self, node: Node) -> Result<&mut Self, StepError> {
+        let from = self.cur_selection.from().0;
+        let to = self.cur_selection.to().0;
+        if from != to {
+            self.delete(from, to)?;
+        }
+        let size = node.node_size();
+        // `from` is the (post-delete) collapsed cursor — the deletion start is invariant
+        // under its own delete, so it stays valid.
+        let r = self
+            .doc
+            .resolve(Pos(from))
+            .map_err(|e| StepError::new(e.to_string()))?;
+        let gap = if r.depth() < 1 {
+            // Already a doc-level gap (no enclosing textblock).
+            from
+        } else if r.parent_offset() == 0 {
+            // Start of the textblock — insert directly before it (no split).
+            r.before(r.depth())
+                .ok_or_else(|| StepError::new("no position before block"))?
+        } else if r.parent_offset() == r.parent().content().size() {
+            // End of the textblock — insert directly after it (no split).
+            r.after(r.depth())
+                .ok_or_else(|| StepError::new("no position after block"))?
+        } else {
+            // Interior — split the textblock; the gap is just before the second half.
+            self.split(from, 1, None)?;
+            let mapped = self.mapping().map(from, 1);
+            let r2 = self
+                .doc
+                .resolve(Pos(mapped))
+                .map_err(|e| StepError::new(e.to_string()))?;
+            r2.before(r2.depth())
+                .ok_or_else(|| StepError::new("no position at split boundary"))?
+        };
+        self.replace_with(gap, gap, Fragment::from_node(node))?;
+        self.set_selection(Selection::near(&self.doc, Pos(gap + size), 1));
+        Ok(self)
+    }
+
     /// Delete the current (non-empty) selection. A no-op for a collapsed cursor.
     pub fn delete_selection(&mut self) -> Result<&mut Self, StepError> {
         let from = self.cur_selection.from().0;


### PR DESCRIPTION
## Summary

The **Insert Horizontal Rule** and **Insert Table** toolbar buttons did nothing when the cursor was inside a paragraph (the normal case).

`insertHorizontalRule`/`insertTable` used `Transaction::replace_selection_with`, which drops the node *at* the selection — a block node only fits when the selection already spans a doc-level gap between blocks (the unit tests pin this: `Selection::text(Pos(4), Pos(4))` "at the doc-level gap after the para"). With a collapsed cursor inside a paragraph, a block can't sit in the textblock's inline content, the replace step fails, and the command is a silent no-op.

## Fix

Add `Transaction::insert_block(node)`: it deletes any selection, then places the node **before/after the enclosing textblock**, splitting the textblock when the cursor is in its interior (`[p "a"][hr][p "b"]`). Point `insertHorizontalRule`/`insertTable` at it. Shared in `rinch-editor-core`, so desktop and web both gain it.

## Validation

- New unit test covers the cursor at the **start**, **end**, and **interior** of a paragraph, plus a table at an interior cursor.
- Validated live on desktop (markdown-editor via MCP): the HR splits the paragraph at the caret, and a 3×3 table inserts.
- All 228 editor-core tests pass; `clippy --workspace --all-targets -D warnings` and `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)