### PR TITLE
feat(editor): indent/outdent paragraphs + fix nested-list rendering

### DIFF
--- a/crates/rinch-editor-core/src/commands/mod.rs
+++ b/crates/rinch-editor-core/src/commands/mod.rs
@@ -369,6 +369,69 @@ fn build_sink(state: &EditorState, item_type: &str) -> Option<Transaction> {
     tr.doc_changed().then_some(tr)
 }
 
+/// Maximum textblock indent depth (a defensive clamp).
+const MAX_INDENT: i64 = 12;
+
+/// Increase (`delta > 0`) or decrease (`delta < 0`) the `indent` attribute of every
+/// indentable textblock (paragraph / heading) overlapping the selection, clamped to
+/// `[0, MAX_INDENT]`. Applies only when at least one block's indent actually changes,
+/// so outdent at indent 0 is a no-op (the toolbar button stays disabled). Blocks
+/// without an `indent` attr (e.g. code blocks) are skipped.
+fn adjust_indent(delta: i64) -> Command {
+    command_tr(move |state| {
+        let (from, to) = (state.selection.from().0, state.selection.to().0);
+        // `(position-before-block, current indent)` for each indentable textblock
+        // (paragraph / heading — the types that declare an `indent` attr).
+        let mut targets: Vec<(usize, i64)> = Vec::new();
+        state
+            .doc
+            .nodes_between(from, to, &mut |node, pos, _parent| {
+                if matches!(node.type_name(), "paragraph" | "heading") {
+                    targets.push((pos, node.attrs().get_int("indent").unwrap_or(0)));
+                }
+                true
+            });
+        if targets.is_empty() {
+            return None;
+        }
+        let mut tr = state.tr();
+        // `SetNodeAttrStep` has an empty position map, so the collected `pos` values
+        // stay valid across every step — no remapping needed.
+        for (pos, cur) in targets {
+            let next = (cur + delta).clamp(0, MAX_INDENT);
+            if next != cur {
+                tr.set_node_attr(pos, "indent", crate::AttrValue::Int(next))
+                    .ok()?;
+            }
+        }
+        tr.doc_changed().then_some(tr)
+    })
+}
+
+/// Lift the selected block range out of its enclosing **list** — like [`lift`], but
+/// gated on being inside a `list_item`, so it never lifts a paragraph out of a
+/// blockquote (that surprise is what made a bare outdent "un-quote" text).
+fn lift_list_item() -> Command {
+    command_tr(|state| {
+        if !in_node_type(state, "list_item") {
+            return None;
+        }
+        build_lift(state)
+    })
+}
+
+/// **Indent**: nest the current list item under its previous sibling when inside a
+/// list, otherwise increase the textblock's indent level.
+pub fn indent() -> Command {
+    chain(vec![sink_list_item("list_item"), adjust_indent(1)])
+}
+
+/// **Outdent**: un-nest the current list item when inside a list, otherwise decrease
+/// the textblock's indent level. Unlike a bare [`lift`], it leaves blockquotes alone.
+pub fn outdent() -> Command {
+    chain(vec![lift_list_item(), adjust_indent(-1)])
+}
+
 // ===================================================================
 // Structure & deletion
 // ===================================================================
@@ -871,9 +934,9 @@ impl Plugin for BaseCommandsPlugin {
             ("toggleOrderedList", toggle_list("ordered_list")),
             ("wrapInBlockquote", wrap_in("blockquote")),
             ("liftListItem", lift()),
-            ("outdent", lift()),
+            ("outdent", outdent()),
             ("sinkListItem", sink_list_item("list_item")),
-            ("indent", sink_list_item("list_item")),
+            ("indent", indent()),
             ("insertHorizontalRule", insert_horizontal_rule()),
             ("insertHardBreak", insert_hard_break()),
             ("insertTable", insert_table(3, 3)),
@@ -1509,6 +1572,40 @@ mod tests {
         let tbl = s.run("insertTable").expect("table mid para");
         assert_eq!(tbl.doc.child_count(), 3);
         assert_eq!(tbl.doc.child(1).type_name(), "table");
+    }
+
+    #[test]
+    fn indent_and_outdent_a_paragraph() {
+        let mut s = editor("hello");
+        s.selection = Selection::cursor(Pos(2));
+        // Indent bumps the paragraph's `indent` attr 0 → 1 → 2.
+        let i1 = s.run("indent").expect("indent applies");
+        assert_eq!(i1.doc.child(0).attrs().get_int("indent"), Some(1));
+        let i2 = i1.run("indent").expect("indent applies again");
+        assert_eq!(i2.doc.child(0).attrs().get_int("indent"), Some(2));
+        // Outdent steps it back down to 0.
+        let o1 = i2.run("outdent").expect("outdent applies");
+        assert_eq!(o1.doc.child(0).attrs().get_int("indent"), Some(1));
+        let o2 = o1.run("outdent").expect("outdent applies");
+        assert_eq!(o2.doc.child(0).attrs().get_int("indent"), Some(0));
+        // Outdent at indent 0 is a no-op (so the toolbar button can stay disabled).
+        assert!(o2.run("outdent").is_none());
+    }
+
+    #[test]
+    fn outdent_does_not_unquote_a_blockquote() {
+        let mut s = editor("quoted");
+        s.selection = Selection::cursor(Pos(2));
+        let bq = s.run("wrapInBlockquote").expect("wrap applies");
+        assert!(
+            bq.doc
+                .content()
+                .iter()
+                .any(|n| n.type_name() == "blockquote")
+        );
+        // Outdent inside the (un-indented) blockquote must do nothing — not lift the
+        // paragraph out of the quote (the old generic-`lift` surprise).
+        assert!(bq.run("outdent").is_none());
     }
 
     #[test]

--- a/crates/rinch-editor-core/src/commands/mod.rs
+++ b/crates/rinch-editor-core/src/commands/mod.rs
@@ -93,9 +93,10 @@ pub fn can_lift(state: &EditorState) -> bool {
     build_lift_dispatch(state).is_some()
 }
 
-/// Whether the indent (sink list item) command currently applies.
+/// Whether the indent (sink list item) command currently applies — in a list or task
+/// list.
 pub fn can_sink(state: &EditorState) -> bool {
-    build_sink(state, "list_item").is_some()
+    build_sink_dispatch(state).is_some()
 }
 
 // ===================================================================
@@ -309,9 +310,17 @@ fn build_lift(state: &EditorState) -> Option<Transaction> {
     if range.depth == 0 {
         return None;
     }
-    // Try lifting to each target from one level out (depth-1) down to the doc;
-    // the schema gate rejects invalid targets, so the first that applies wins.
-    for target in (0..range.depth).rev() {
+    // Never lift across an isolating boundary (a table cell): content lifted out of a
+    // cell would tear it from its table. The floor is the deepest isolating ancestor
+    // at-or-above the range's parent; only targets below that are allowed. If the
+    // range's own parent is isolating, no lift applies. Mirrors PM's `liftTarget`.
+    let floor = (1..=range.depth)
+        .filter(|&d| r_from.node(d).node_type().is_isolating())
+        .max()
+        .unwrap_or(0);
+    // Try lifting to each target from one level out (depth-1) down to `floor`; the
+    // schema gate rejects invalid targets, so the first that applies wins.
+    for target in (floor..range.depth).rev() {
         let mut tr = state.tr();
         if tr.lift(&range, target).is_ok() && tr.doc_changed() {
             return Some(tr);
@@ -451,6 +460,26 @@ fn build_lift_dispatch(state: &EditorState) -> Option<Transaction> {
 /// up sibling sublists.
 pub fn sink_list_item(item_type: &'static str) -> Command {
     command_tr(move |state| build_sink(state, item_type))
+}
+
+/// The Tab / sink-list-item command: nest the current list **or task** item under its
+/// previous sibling. Unlike the Indent button (`indent`), a plain paragraph is left
+/// untouched — Tab never margin-indents a textblock outside a list.
+pub fn sink_list_item_any() -> Command {
+    command_tr(build_sink_dispatch)
+}
+
+/// Sink the current item, picking `list_item` vs `task_item` from context. Returns
+/// `None` outside any list (so Tab is a no-op there) or on a first item with nothing to
+/// nest under.
+fn build_sink_dispatch(state: &EditorState) -> Option<Transaction> {
+    if in_node_type(state, "list_item") {
+        build_sink(state, "list_item")
+    } else if in_node_type(state, "task_item") {
+        build_sink(state, "task_item")
+    } else {
+        None
+    }
 }
 
 /// Build the sink (indent) transaction.
@@ -1205,7 +1234,7 @@ impl Plugin for BaseCommandsPlugin {
             ("wrapInBlockquote", wrap_in("blockquote")),
             ("liftListItem", lift()),
             ("outdent", outdent()),
-            ("sinkListItem", sink_list_item("list_item")),
+            ("sinkListItem", sink_list_item_any()),
             ("indent", indent()),
             ("insertHorizontalRule", insert_horizontal_rule()),
             ("insertHardBreak", insert_hard_break()),
@@ -2301,6 +2330,44 @@ mod tests {
     }
 
     #[test]
+    fn tab_sink_list_item_nests_a_task_item_and_skips_plain_paragraphs() {
+        // Tab (sinkListItem) and can_sink must handle task lists, matching the Indent
+        // button / Shift-Tab — but Tab must still be a no-op (never margin-indent) on a
+        // plain paragraph.
+        let s = Rc::new(Schema::starter_kit());
+        let item_a = s
+            .branch("task_item", Fragment::from_node(p_of(&s, "a")))
+            .unwrap();
+        let item_b = s
+            .branch("task_item", Fragment::from_node(p_of(&s, "b")))
+            .unwrap();
+        let tl = s
+            .branch("task_list", Fragment::from_children(vec![item_a, item_b]))
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(tl)).unwrap();
+        let mut state = EditorState::create(s, doc, default_plugins());
+        state.selection = Selection::cursor(Pos(cursor_in_para(&state.doc, "b")));
+
+        assert!(can_sink(&state), "can_sink is true inside a task list");
+        let nested = state.run("sinkListItem").expect("Tab nests the task item");
+        assert_eq!(nested.doc.child(0).type_name(), "task_list");
+        assert_eq!(nested.doc.child(0).child_count(), 1, "b nested under a");
+        assert!(
+            !any_margin_indent(&nested.doc),
+            "Tab nests, never margin-indents"
+        );
+
+        // Tab in a plain paragraph does nothing (the button would margin-indent; Tab won't).
+        let mut plain = editor("hi");
+        plain.selection = Selection::cursor(Pos(2));
+        assert!(!can_sink(&plain), "can_sink is false outside a list");
+        assert!(
+            plain.run("sinkListItem").is_none(),
+            "Tab is a no-op in a plain paragraph"
+        );
+    }
+
+    #[test]
     fn indent_first_task_item_is_a_noop() {
         // The first (only) task item has no previous sibling to nest under. Indent must be
         // a true no-op — in particular it must NOT margin-indent the item's paragraph.
@@ -2375,6 +2442,20 @@ mod tests {
             state.run("indent").is_none(),
             "indenting a paragraph inside a table cell is a no-op"
         );
+        // Shift-Tab in the first cell makes tab_cell fall through to liftListItem, and
+        // sinkListItem likewise — both MUST be no-ops in a cell. liftListItem in
+        // particular previously unwrapped the paragraph out of the cell and DELETED the
+        // whole table; the isolating-boundary guard in `build_lift` now forbids it.
+        assert!(
+            state.run("liftListItem").is_none(),
+            "liftListItem must not lift a paragraph out of a table cell"
+        );
+        assert!(
+            state.run("sinkListItem").is_none(),
+            "sinkListItem is a no-op inside a table cell"
+        );
+        // The starting doc is unchanged — the table is intact.
+        assert_eq!(state.doc.child(0).type_name(), "table");
     }
 
     #[test]

--- a/crates/rinch-editor-core/src/commands/mod.rs
+++ b/crates/rinch-editor-core/src/commands/mod.rs
@@ -373,63 +373,93 @@ fn build_sink(state: &EditorState, item_type: &str) -> Option<Transaction> {
 const MAX_INDENT: i64 = 12;
 
 /// Increase (`delta > 0`) or decrease (`delta < 0`) the `indent` attribute of every
-/// indentable textblock (paragraph / heading) overlapping the selection, clamped to
-/// `[0, MAX_INDENT]`. Applies only when at least one block's indent actually changes,
-/// so outdent at indent 0 is a no-op (the toolbar button stays disabled). Blocks
-/// without an `indent` attr (e.g. code blocks) are skipped.
-fn adjust_indent(delta: i64) -> Command {
-    command_tr(move |state| {
-        let (from, to) = (state.selection.from().0, state.selection.to().0);
-        // `(position-before-block, current indent)` for each indentable textblock
-        // (paragraph / heading — the types that declare an `indent` attr).
-        let mut targets: Vec<(usize, i64)> = Vec::new();
-        state
-            .doc
-            .nodes_between(from, to, &mut |node, pos, _parent| {
-                if matches!(node.type_name(), "paragraph" | "heading") {
-                    targets.push((pos, node.attrs().get_int("indent").unwrap_or(0)));
-                }
-                true
-            });
-        if targets.is_empty() {
-            return None;
+/// indentable textblock overlapping the selection, clamped to `[0, MAX_INDENT]`.
+/// Applies only when at least one block's indent actually changes, so outdent at
+/// indent 0 is a no-op. **Skips a textblock inside a `list_item`** — a list's depth is
+/// controlled by nesting, not a margin (otherwise the bullet would split from its
+/// text). Returns the transaction, or `None` when nothing changed.
+fn build_adjust_indent(state: &EditorState, delta: i64) -> Option<Transaction> {
+    let (from, to) = (state.selection.from().0, state.selection.to().0);
+    // `(position-before-block, current indent)` for each indentable textblock.
+    let mut targets: Vec<(usize, i64)> = Vec::new();
+    state.doc.nodes_between(from, to, &mut |node, pos, parent| {
+        let in_list_item = parent.is_some_and(|p| p.type_name() == "list_item");
+        if matches!(node.type_name(), "paragraph" | "heading") && !in_list_item {
+            targets.push((pos, node.attrs().get_int("indent").unwrap_or(0)));
         }
+        true
+    });
+    if targets.is_empty() {
+        return None;
+    }
+    let mut tr = state.tr();
+    // `SetNodeAttrStep` has an empty position map, so the collected `pos` values stay
+    // valid across every step — no remapping needed.
+    for (pos, cur) in targets {
+        let next = (cur + delta).clamp(0, MAX_INDENT);
+        if next != cur {
+            tr.set_node_attr(pos, "indent", crate::AttrValue::Int(next))
+                .ok()?;
+        }
+    }
+    tr.doc_changed().then_some(tr)
+}
+
+/// **Indent**: when the cursor is in a list, nest the current item under its previous
+/// sibling (a no-op for the first item — there is nothing to nest under). Otherwise
+/// increase the textblock's indent level. Indenting in a list never margin-indents the
+/// item's paragraph; list depth is purely nesting.
+pub fn indent() -> Command {
+    command_tr(|state| {
+        if in_node_type(state, "list_item") {
+            build_sink(state, "list_item")
+        } else {
+            build_adjust_indent(state, 1)
+        }
+    })
+}
+
+/// **Outdent**: when the cursor is in a list, un-nest the current item (lifting it out
+/// of the list entirely at the top level). Otherwise decrease the textblock's indent
+/// level. It leaves blockquotes alone (that un-quote is the Paragraph button's job).
+pub fn outdent() -> Command {
+    command_tr(|state| {
+        if in_node_type(state, "list_item") {
+            build_lift(state)
+        } else {
+            build_adjust_indent(state, -1)
+        }
+    })
+}
+
+/// The **Paragraph** command: set the selected textblock(s) to a plain paragraph and,
+/// because "Paragraph" reads as "normal text", also lift them out of an enclosing
+/// blockquote (un-quote). A heading becomes a paragraph; a quoted paragraph drops out
+/// of the quote. A plain paragraph that is already un-quoted is a no-op.
+pub fn set_paragraph() -> Command {
+    command_tr(|state| {
+        let para_ty = state.schema().node_type("paragraph")?.clone();
+        let (from, to) = (state.selection.from().0, state.selection.to().0);
         let mut tr = state.tr();
-        // `SetNodeAttrStep` has an empty position map, so the collected `pos` values
-        // stay valid across every step — no remapping needed.
-        for (pos, cur) in targets {
-            let next = (cur + delta).clamp(0, MAX_INDENT);
-            if next != cur {
-                tr.set_node_attr(pos, "indent", crate::AttrValue::Int(next))
-                    .ok()?;
+        let _ = tr.set_block_type(from, to, para_ty, Attrs::new());
+        // Un-quote: lift the block(s) out of an enclosing blockquote. The range is
+        // resolved against a snapshot so it doesn't borrow the `tr` we then mutate.
+        if in_node_type(state, "blockquote") {
+            let (from_pos, to_pos) = (tr.selection().from(), tr.selection().to());
+            let doc = tr.doc().clone();
+            if let (Ok(r_from), Ok(r_to)) = (doc.resolve(from_pos), doc.resolve(to_pos))
+                && let Some(range) = block_range_simple(&r_from, &r_to)
+            {
+                for target in (0..range.depth).rev() {
+                    let before = tr.doc().clone();
+                    if tr.lift(&range, target).is_ok() && tr.doc() != &before {
+                        break;
+                    }
+                }
             }
         }
         tr.doc_changed().then_some(tr)
     })
-}
-
-/// Lift the selected block range out of its enclosing **list** — like [`lift`], but
-/// gated on being inside a `list_item`, so it never lifts a paragraph out of a
-/// blockquote (that surprise is what made a bare outdent "un-quote" text).
-fn lift_list_item() -> Command {
-    command_tr(|state| {
-        if !in_node_type(state, "list_item") {
-            return None;
-        }
-        build_lift(state)
-    })
-}
-
-/// **Indent**: nest the current list item under its previous sibling when inside a
-/// list, otherwise increase the textblock's indent level.
-pub fn indent() -> Command {
-    chain(vec![sink_list_item("list_item"), adjust_indent(1)])
-}
-
-/// **Outdent**: un-nest the current list item when inside a list, otherwise decrease
-/// the textblock's indent level. Unlike a bare [`lift`], it leaves blockquotes alone.
-pub fn outdent() -> Command {
-    chain(vec![lift_list_item(), adjust_indent(-1)])
 }
 
 // ===================================================================
@@ -928,7 +958,7 @@ impl Plugin for BaseCommandsPlugin {
             ("toggleSuperscript", toggle_mark("superscript")),
             ("toggleHighlight", toggle_mark("highlight")),
             ("removeLink", remove_link()),
-            ("setParagraph", set_block_type("paragraph", Attrs::new())),
+            ("setParagraph", set_paragraph()),
             ("setCodeBlock", set_block_type("code_block", Attrs::new())),
             ("toggleBulletList", toggle_list("bullet_list")),
             ("toggleOrderedList", toggle_list("ordered_list")),
@@ -1606,6 +1636,43 @@ mod tests {
         // Outdent inside the (un-indented) blockquote must do nothing — not lift the
         // paragraph out of the quote (the old generic-`lift` surprise).
         assert!(bq.run("outdent").is_none());
+    }
+
+    #[test]
+    fn set_paragraph_unquotes_a_blockquote() {
+        let mut s = editor("quoted");
+        s.selection = Selection::cursor(Pos(2));
+        let bq = s.run("wrapInBlockquote").expect("wrap applies");
+        assert!(
+            bq.doc
+                .content()
+                .iter()
+                .any(|n| n.type_name() == "blockquote")
+        );
+        // The Paragraph button lifts the block out of the quote (un-quote).
+        let out = bq.run("setParagraph").expect("setParagraph un-quotes");
+        assert!(
+            !out.doc
+                .content()
+                .iter()
+                .any(|n| n.type_name() == "blockquote"),
+            "blockquote should be gone"
+        );
+        assert_eq!(out.doc.child(0).type_name(), "paragraph");
+        assert_eq!(all_text(out.doc.child(0)), "quoted");
+    }
+
+    #[test]
+    fn indent_first_list_item_is_a_noop() {
+        let mut s = editor("a");
+        s.selection = Selection::cursor(Pos(2));
+        let list = s.run("toggleBulletList").expect("make a list");
+        // The first (only) item has no previous sibling to nest under — indent must do
+        // nothing, and in particular must NOT margin-indent the item's paragraph.
+        assert!(
+            list.run("indent").is_none(),
+            "indent on the first list item is a no-op"
+        );
     }
 
     #[test]

--- a/crates/rinch-editor-core/src/commands/mod.rs
+++ b/crates/rinch-editor-core/src/commands/mod.rs
@@ -20,7 +20,7 @@ use crate::plugin::{Plugin, PluginKey};
 use crate::pos::{Pos, ResolvedPos};
 use crate::state::{EditorState, Transaction};
 use crate::transform::steps::{ReplaceAroundStep, ReplaceStep};
-use crate::transform::{block_range, block_range_simple};
+use crate::transform::{NodeRange, block_range, block_range_simple};
 
 // ===================================================================
 // Toolbar queries — read state, never the host (A6)
@@ -90,7 +90,7 @@ pub fn in_node_type(state: &EditorState, type_name: &str) -> bool {
 
 /// Whether the outdent (lift) command currently applies.
 pub fn can_lift(state: &EditorState) -> bool {
-    build_lift(state).is_some()
+    build_lift_dispatch(state).is_some()
 }
 
 /// Whether the indent (sink list item) command currently applies.
@@ -294,10 +294,11 @@ fn build_wrap_in_list(state: &EditorState, list_type: &str) -> Option<Transactio
     tr.doc_changed().then_some(tr)
 }
 
-/// The outdent / lift command: lift the selected block range out of its enclosing
-/// wrapper (list, blockquote). Tries the deepest valid target first.
+/// The outdent / lift command: lift the selected block out of its enclosing wrapper.
+/// A list/task item is lifted as a whole item (to the outer list, or un-listed at the
+/// outermost level); other blocks (e.g. inside a blockquote) use the generic lift.
 pub fn lift() -> Command {
-    command_tr(build_lift)
+    command_tr(build_lift_dispatch)
 }
 
 /// Build the lift transaction, choosing the shallowest schema-valid target depth.
@@ -319,9 +320,135 @@ fn build_lift(state: &EditorState) -> Option<Transaction> {
     None
 }
 
+/// Outdent / lift for a **list item** — the list-aware port of PM's `liftListItem`.
+///
+/// The generic [`build_lift`] uses a *paragraph*-level range, so lifting a nested
+/// item drops its paragraph into the previous item as a bullet-less continuation
+/// block. This instead uses a *list*-level range (parent = the list, the range covers
+/// the whole item), then dispatches like PM:
+///
+/// * **Nested in a parent list** (`liftToOuterList`): lift the item out by one list,
+///   so it becomes a sibling in the outer list — the schema gate rejects the invalid
+///   targets (a `list_item` can't hold a `list_item`) and keeps the one that lands it
+///   in the outer list.
+/// * **In the outermost list** (`liftOutOfList`): un-list it to top-level block(s) —
+///   the generic paragraph-level lift already does exactly this, so reuse it.
+fn build_lift_list_item(state: &EditorState, item_type: &str) -> Option<Transaction> {
+    let item_ty = state.schema().node_type(item_type)?.clone();
+    let r_from = state.doc.resolve(state.selection.from()).ok()?;
+    let r_to = state.doc.resolve(state.selection.to()).ok()?;
+    let range = block_range(&r_from, &r_to, |n| {
+        n.child_count() > 0 && n.child(0).node_type() == &item_ty
+    })?;
+    if range.depth == 0 {
+        return None;
+    }
+    // PM's dispatch: is the list itself wrapped in another item of the same type? If
+    // not, this is the outermost list — un-list to the top level (generic lift). If so
+    // (`in_parent_list`), the list nests inside an item inside an outer list, so
+    // `range.depth >= 2` is guaranteed below.
+    if r_from.node(range.depth - 1).node_type() != &item_ty {
+        return build_lift(state);
+    }
+
+    // liftToOuterList. If the lifted item has trailing siblings in the same list,
+    // first wrap them into a fresh item so they ride along NESTED under the lifted
+    // item — otherwise the plain lift orphans them into a bullet-less wrapper. The
+    // gap content (the trailing siblings) is dropped into the new item's empty
+    // sublist at insert offset 1. Port of PM's `liftToOuterList`.
+    let list_ty = range.parent().node_type().clone();
+    let list_attrs = range.parent().attrs().clone();
+    let from_pos = range.from.pos();
+    let end = range.end();
+    let end_of_list = r_to.end(range.depth);
+
+    let mut tr = state.tr();
+    let work = if end < end_of_list {
+        let inner_list = Node::new_branch(list_ty, list_attrs, Fragment::empty());
+        let new_item = Node::new_branch(
+            item_ty.clone(),
+            Attrs::new(),
+            Fragment::from_node(inner_list),
+        );
+        let slice = crate::Slice::new(Fragment::from_node(new_item), 1, 0);
+        tr.step(Box::new(ReplaceAroundStep::new(
+            end - 1,
+            end_of_list,
+            end,
+            end_of_list,
+            slice,
+            1,
+            true,
+        )))
+        .ok()?;
+        // Re-span the range over the lifted item plus its now-nested trailing siblings.
+        // PM keeps the original `depth` and re-resolves the *raw* endpoints (the wrap
+        // is balanced, so `end_of_list` still bounds the list's content).
+        let nf = tr.doc().resolve(from_pos).ok()?;
+        let nt = tr.doc().resolve(Pos(end_of_list)).ok()?;
+        NodeRange {
+            from: nf,
+            to: nt,
+            depth: range.depth,
+        }
+    } else {
+        range
+    };
+
+    // Lift the (possibly extended) item range out by one list — `depth - 2` is the
+    // outer list, so the item lands there as a sibling.
+    let target = work.depth - 2;
+    tr.lift(&work, target).ok()?;
+
+    // After the lift, an item that had its OWN trailing sublist now sits directly
+    // before the wrapped trailing-siblings' sublist — two adjacent lists of the same
+    // type. Join them into one (PM's `canJoin` + `join`) so repeated outdents don't
+    // fragment the list. The structural step self-guards against overwriting content.
+    let boundary = tr.mapping().map(end, -1).saturating_sub(1);
+    if can_join_sublists(tr.doc(), boundary) {
+        let _ = tr.step(Box::new(ReplaceStep::structural(
+            boundary - 1,
+            boundary + 1,
+            crate::Slice::empty(),
+        )));
+    }
+
+    tr.doc_changed().then_some(tr)
+}
+
+/// PM's `canJoin`, specialised to the list-merge case: the block boundary at `pos`
+/// sits between two same-type, non-textblock, non-leaf nodes (i.e. two adjacent
+/// sublists). The structural join step itself rejects a schema-invalid merge, so this
+/// only has to gate out unrelated boundaries (text, leaves, mismatched types).
+fn can_join_sublists(doc: &Node, pos: usize) -> bool {
+    let Ok(r) = doc.resolve(Pos(pos)) else {
+        return false;
+    };
+    match (r.node_before(), r.node_after()) {
+        (Some(before), Some(after)) => {
+            !before.is_textblock() && !before.is_leaf() && before.type_name() == after.type_name()
+        }
+        _ => false,
+    }
+}
+
+/// The list-aware lift used by both the `liftListItem` keymap and the Outdent button:
+/// a real list/task item is lifted with [`build_lift_list_item`]; anything else
+/// (e.g. a paragraph in a blockquote) falls back to the generic [`build_lift`].
+fn build_lift_dispatch(state: &EditorState) -> Option<Transaction> {
+    if in_node_type(state, "list_item") {
+        build_lift_list_item(state, "list_item")
+    } else if in_node_type(state, "task_item") {
+        build_lift_list_item(state, "task_item")
+    } else {
+        build_lift(state)
+    }
+}
+
 /// The indent / sink-list-item command: nest the current list item under its
-/// previous sibling. Port of PM's `sinkListItem` (without the `nestedBefore`
-/// merge optimization).
+/// previous sibling. Faithful port of PM's `sinkListItem`, including the
+/// `nestedBefore` merge so repeated indents keep nesting deeper instead of piling
+/// up sibling sublists.
 pub fn sink_list_item(item_type: &'static str) -> Command {
     command_tr(move |state| build_sink(state, item_type))
 }
@@ -343,21 +470,39 @@ fn build_sink(state: &EditorState, item_type: &str) -> Option<Transaction> {
     if node_before.node_type() != &item_ty {
         return None;
     }
-    // Build a `list_item(list())` shell; the ReplaceAroundStep drops the current
-    // item into the inner list, joining onto the previous item.
     let list_ty = parent.node_type().clone();
-    let inner_list = Node::new_branch(list_ty, parent.attrs().clone(), Fragment::empty());
+    // If the previous item already ends with a sublist of this same list type, merge
+    // the current item INTO that existing sublist rather than wrapping it in a fresh
+    // adjacent one (PM's `nestedBefore`). Without this, a second indent leaves the
+    // item the lone child of its own sublist — so it can never nest deeper, and the
+    // doc grows a pile of sibling sublists instead of a clean tree.
+    let nested_before = node_before.child_count() > 0
+        && node_before.child(node_before.child_count() - 1).node_type() == &list_ty;
+    // Slice shell: `item( list( inner ) )`. When merging, `inner` is a fresh empty
+    // item and the slice opens 3 deep (item/list/item) so the gap content drops into
+    // the previous item's existing sublist; otherwise it opens 1 deep (item).
+    let inner = if nested_before {
+        Fragment::from_node(Node::new_branch(
+            item_ty.clone(),
+            Attrs::new(),
+            Fragment::empty(),
+        ))
+    } else {
+        Fragment::empty()
+    };
+    let inner_list = Node::new_branch(list_ty, parent.attrs().clone(), inner);
     let new_item = Node::new_branch(
         item_ty.clone(),
         Attrs::new(),
         Fragment::from_node(inner_list),
     );
-    let slice = crate::Slice::new(Fragment::from_node(new_item), 1, 0);
+    let open_start = if nested_before { 3 } else { 1 };
+    let slice = crate::Slice::new(Fragment::from_node(new_item), open_start, 0);
     let before = range.start();
     let after = range.end();
     let mut tr = state.tr();
     tr.step(Box::new(ReplaceAroundStep::new(
-        before - 1,
+        before - open_start,
         after,
         before,
         after,
@@ -375,16 +520,24 @@ const MAX_INDENT: i64 = 12;
 /// Increase (`delta > 0`) or decrease (`delta < 0`) the `indent` attribute of every
 /// indentable textblock overlapping the selection, clamped to `[0, MAX_INDENT]`.
 /// Applies only when at least one block's indent actually changes, so outdent at
-/// indent 0 is a no-op. **Skips a textblock inside a `list_item`** — a list's depth is
-/// controlled by nesting, not a margin (otherwise the bullet would split from its
-/// text). Returns the transaction, or `None` when nothing changed.
+/// indent 0 is a no-op. **Skips a textblock inside a list/task item** (depth is
+/// controlled by nesting, not a margin — otherwise the bullet/checkbox would split
+/// from its text) **or a table cell**. Returns the transaction, or `None` when nothing
+/// changed.
 fn build_adjust_indent(state: &EditorState, delta: i64) -> Option<Transaction> {
     let (from, to) = (state.selection.from().0, state.selection.to().0);
     // `(position-before-block, current indent)` for each indentable textblock.
     let mut targets: Vec<(usize, i64)> = Vec::new();
     state.doc.nodes_between(from, to, &mut |node, pos, parent| {
-        let in_list_item = parent.is_some_and(|p| p.type_name() == "list_item");
-        if matches!(node.type_name(), "paragraph" | "heading") && !in_list_item {
+        // A textblock inside a list/task item (depth via nesting) or a table cell (Tab
+        // is cell navigation there) isn't margin-indented.
+        let excluded_parent = parent.is_some_and(|p| {
+            matches!(
+                p.type_name(),
+                "list_item" | "task_item" | "table_cell" | "table_header_cell"
+            )
+        });
+        if matches!(node.type_name(), "paragraph" | "heading") && !excluded_parent {
             targets.push((pos, node.attrs().get_int("indent").unwrap_or(0)));
         }
         true
@@ -405,27 +558,32 @@ fn build_adjust_indent(state: &EditorState, delta: i64) -> Option<Transaction> {
     tr.doc_changed().then_some(tr)
 }
 
-/// **Indent**: when the cursor is in a list, nest the current item under its previous
-/// sibling (a no-op for the first item — there is nothing to nest under). Otherwise
-/// increase the textblock's indent level. Indenting in a list never margin-indents the
-/// item's paragraph; list depth is purely nesting.
+/// **Indent**: when the cursor is in a list or task list, nest the current item under
+/// its previous sibling (a no-op for the first item — there is nothing to nest under).
+/// Otherwise increase the textblock's indent level. Indenting in a (task) list never
+/// margin-indents the item's paragraph; list depth is purely nesting.
 pub fn indent() -> Command {
     command_tr(|state| {
         if in_node_type(state, "list_item") {
             build_sink(state, "list_item")
+        } else if in_node_type(state, "task_item") {
+            build_sink(state, "task_item")
         } else {
             build_adjust_indent(state, 1)
         }
     })
 }
 
-/// **Outdent**: when the cursor is in a list, un-nest the current item (lifting it out
-/// of the list entirely at the top level). Otherwise decrease the textblock's indent
-/// level. It leaves blockquotes alone (that un-quote is the Paragraph button's job).
+/// **Outdent**: when the cursor is in a list or task list, un-nest the current item
+/// (lifting it out of the list entirely at the top level). Otherwise decrease the
+/// textblock's indent level. It leaves blockquotes alone (that un-quote is the
+/// Paragraph button's job).
 pub fn outdent() -> Command {
     command_tr(|state| {
         if in_node_type(state, "list_item") {
-            build_lift(state)
+            build_lift_list_item(state, "list_item")
+        } else if in_node_type(state, "task_item") {
+            build_lift_list_item(state, "task_item")
         } else {
             build_adjust_indent(state, -1)
         }
@@ -463,12 +621,15 @@ pub fn set_paragraph() -> Command {
         //    preserves block-boundary positions (same open/close token count).
         let _ = tr.set_block_type(from, to, para_ty, Attrs::new());
 
-        // 3. Reset the indent attribute to 0 on the (now-)paragraphs in range.
+        // 3. Reset the indent attribute to 0 on the (now-)paragraphs in range — but
+        //    only where it isn't already 0, so a plain paragraph stays a true no-op.
         let mut indent_targets: Vec<usize> = Vec::new();
         state
             .doc
             .nodes_between(from, to, &mut |node, pos, _parent| {
-                if matches!(node.type_name(), "paragraph" | "heading") {
+                if matches!(node.type_name(), "paragraph" | "heading")
+                    && node.attrs().get_int("indent").unwrap_or(0) != 0
+                {
                     indent_targets.push(pos);
                 }
                 true
@@ -477,30 +638,54 @@ pub fn set_paragraph() -> Command {
             let _ = tr.set_node_attr(pos, "indent", crate::AttrValue::Int(0));
         }
 
-        // 4. Lift out of every wrapper (blockquote, list) to the document top level.
-        lift_to_top(&mut tr);
+        // 4. Lift every selected block out of its blockquote/list wrappers to the top
+        //    level (never out of a table cell — see `lift_blocks_to_top`).
+        lift_blocks_to_top(&mut tr);
 
         tr.doc_changed().then_some(tr)
     })
 }
 
-/// Lift the current selection's block range out of every enclosing wrapper until it is
-/// a direct child of the document — one wrapper per pass. The transaction maps its
-/// selection forward through each lift, so re-reading `tr.selection()` each pass is
-/// correct. Stops at the top level or when a wrapper can't be lifted.
-fn lift_to_top(tr: &mut Transaction) {
+/// A wrapper the Paragraph reset is allowed to peel off — a blockquote or any list
+/// node. Notably NOT a table cell (or any other isolating container): lifting a
+/// paragraph out of a cell would hoist it out of the table and corrupt the structure.
+fn is_liftable_wrapper(type_name: &str) -> bool {
+    matches!(
+        type_name,
+        "blockquote" | "bullet_list" | "ordered_list" | "list_item" | "task_list" | "task_item"
+    )
+}
+
+/// Lift every textblock in the selection out of its enclosing blockquote/list wrappers
+/// until it is a direct child of the document. Works block-by-block (so a multi-block
+/// selection spanning different wrappers is fully reset), peeling one wrapper per pass
+/// and re-scanning — the transaction maps its selection forward through each lift.
+/// A block whose ancestor chain includes a non-liftable container (e.g. a table cell)
+/// is left untouched, so the Paragraph button never breaks a table.
+fn lift_blocks_to_top(tr: &mut Transaction) {
     loop {
-        let (from, to) = (tr.selection().from(), tr.selection().to());
+        let (from, to) = (tr.selection().from().0, tr.selection().to().0);
         let doc = tr.doc().clone();
-        let (r_from, r_to) = match (doc.resolve(from), doc.resolve(to)) {
-            (Ok(a), Ok(b)) => (a, b),
-            _ => break,
+        // The first textblock in range that is still wrapped (depth >= 2) and whose
+        // every wrapper is liftable. Resolve a point *inside* the block (pos + 1).
+        let mut inside: Option<usize> = None;
+        doc.nodes_between(from, to, &mut |node, pos, _parent| {
+            if inside.is_none()
+                && node.is_textblock()
+                && let Ok(r) = doc.resolve(Pos(pos + 1))
+                && r.depth() >= 2
+                && (1..r.depth()).all(|d| is_liftable_wrapper(r.node(d).type_name()))
+            {
+                inside = Some(pos + 1);
+            }
+            true
+        });
+        let Some(inside) = inside else { break };
+        let Ok(r) = doc.resolve(Pos(inside)) else {
+            break;
         };
-        if r_from.depth() <= 1 {
-            break; // already a top-level block
-        }
-        let range = match block_range_simple(&r_from, &r_to) {
-            Some(r) if r.depth > 0 => r,
+        let range = match block_range_simple(&r, &r) {
+            Some(x) if x.depth > 0 => x,
             _ => break,
         };
         let before = tr.doc().clone();
@@ -1817,6 +2002,460 @@ mod tests {
         assert_eq!(p.doc.child(0).type_name(), "paragraph", "is a paragraph");
         assert!(!doc_has_mark(&p.doc, "bold"), "marks stripped");
         assert_eq!(all_text(p.doc.child(0)), "mixed");
+    }
+
+    /// Position just inside the first `paragraph` whose flattened text equals `text`.
+    fn cursor_in_para(doc: &Node, text: &str) -> usize {
+        let mut found = None;
+        doc.nodes_between(0, doc.content_size(), &mut |node, pos, _| {
+            if found.is_none() && node.type_name() == "paragraph" && all_text(node) == text {
+                found = Some(pos + 1);
+            }
+            true
+        });
+        found.expect("no paragraph with that text")
+    }
+
+    /// True if any paragraph in `doc` carries a non-zero margin `indent` attribute.
+    fn any_margin_indent(doc: &Node) -> bool {
+        let mut found = false;
+        doc.nodes_between(0, doc.content_size(), &mut |node, _, _| {
+            if node.type_name() == "paragraph" && node.attrs().get_int("indent").unwrap_or(0) != 0 {
+                found = true;
+            }
+            true
+        });
+        found
+    }
+
+    /// The single direct sublist child (a list node) of `item`, if any.
+    fn sublist_of<'a>(item: &'a Node, list_ty: &str) -> Option<&'a Node> {
+        item.content().iter().find(|n| n.type_name() == list_ty)
+    }
+
+    fn li(s: &Rc<Schema>, t: &str) -> Node {
+        s.branch("list_item", Fragment::from_node(p_of(s, t)))
+            .unwrap()
+    }
+    fn ul(s: &Rc<Schema>, items: Vec<Node>) -> Node {
+        s.branch("bullet_list", Fragment::from_children(items))
+            .unwrap()
+    }
+
+    #[test]
+    fn outdent_merges_the_lifted_items_own_sublist_with_its_trailing_siblings() {
+        // doc( ul( li(A, ul( li(B, ul(li C)), li D )) ) ): B owns a sublist [C] AND has a
+        // trailing sibling D. Outdenting B would leave B with two adjacent sublists
+        // (ul[C] then ul[D]); the canJoin/join polish merges them into one ul[C, D].
+        let s = Rc::new(Schema::starter_kit());
+        let b = s
+            .branch(
+                "list_item",
+                Fragment::from_children(vec![p_of(&s, "B"), ul(&s, vec![li(&s, "C")])]),
+            )
+            .unwrap();
+        let a = s
+            .branch(
+                "list_item",
+                Fragment::from_children(vec![p_of(&s, "A"), ul(&s, vec![b, li(&s, "D")])]),
+            )
+            .unwrap();
+        let doc = s
+            .branch("doc", Fragment::from_node(ul(&s, vec![a])))
+            .unwrap();
+        let mut st = EditorState::create(s, doc, default_plugins());
+        st.selection = Selection::cursor(Pos(cursor_in_para(&st.doc, "B")));
+
+        let out = st.run("outdent").expect("outdent lifts B");
+        let b_item = out.doc.child(0).child(1); // top list: [A, B]
+        assert_eq!(all_text(b_item.child(0)), "B");
+        // Exactly ONE sublist under B, holding both C and D in order — not two.
+        let sublists: Vec<&Node> = b_item
+            .content()
+            .iter()
+            .filter(|n| n.type_name() == "bullet_list")
+            .collect();
+        assert_eq!(
+            sublists.len(),
+            1,
+            "the two adjacent sublists were joined into one"
+        );
+        assert_eq!(
+            sublists[0].child_count(),
+            2,
+            "C and D share the merged sublist"
+        );
+        assert_eq!(all_text(sublists[0].child(0)), "C");
+        assert_eq!(all_text(sublists[0].child(1)), "D");
+    }
+
+    #[test]
+    fn outdent_nested_list_item_lifts_to_a_sibling_not_a_continuation_paragraph() {
+        // doc( ul( li(A, ul(li B)) ) ); outdent B. B must become a SIBLING list item of
+        // A in the outer list — NOT a bullet-less continuation paragraph of A.
+        let s = Rc::new(Schema::starter_kit());
+        let item_a = s
+            .branch(
+                "list_item",
+                Fragment::from_children(vec![p_of(&s, "A"), ul(&s, vec![li(&s, "B")])]),
+            )
+            .unwrap();
+        let doc = s
+            .branch("doc", Fragment::from_node(ul(&s, vec![item_a])))
+            .unwrap();
+        let mut st = EditorState::create(s, doc, default_plugins());
+        st.selection = Selection::cursor(Pos(cursor_in_para(&st.doc, "B")));
+
+        let out = st.run("outdent").expect("outdent lifts B to a sibling");
+        let top = out.doc.child(0);
+        assert_eq!(top.child_count(), 2, "A and B are now sibling items");
+        for i in 0..2 {
+            let item = top.child(i);
+            assert_eq!(item.type_name(), "list_item");
+            assert_eq!(
+                item.child(0).type_name(),
+                "paragraph",
+                "each item keeps a bullet"
+            );
+        }
+        assert_eq!(all_text(top.child(1)), "B");
+    }
+
+    #[test]
+    fn outdent_nested_item_keeps_its_trailing_siblings_nested_under_it() {
+        // doc( ul( li(A, ul(li C, li D)) ) ); outdent C. C lifts to a sibling of A, and
+        // its trailing sibling D rides along NESTED under C (PM's liftToOuterList) —
+        // never orphaned into a bullet-less wrapper.
+        let s = Rc::new(Schema::starter_kit());
+        let item_a = s
+            .branch(
+                "list_item",
+                Fragment::from_children(vec![
+                    p_of(&s, "A"),
+                    ul(&s, vec![li(&s, "C"), li(&s, "D")]),
+                ]),
+            )
+            .unwrap();
+        let doc = s
+            .branch("doc", Fragment::from_node(ul(&s, vec![item_a])))
+            .unwrap();
+        let mut st = EditorState::create(s, doc, default_plugins());
+        st.selection = Selection::cursor(Pos(cursor_in_para(&st.doc, "C")));
+
+        let out = st.run("outdent").expect("outdent lifts C");
+        let top = out.doc.child(0);
+        assert_eq!(top.child_count(), 2, "A and C are sibling items");
+        let c = top.child(1);
+        assert_eq!(c.child(0).type_name(), "paragraph", "C keeps its bullet");
+        assert_eq!(all_text(c.child(0)), "C");
+        let d_sub = sublist_of(c, "bullet_list").expect("D nested under C");
+        assert_eq!(all_text(d_sub), "D");
+    }
+
+    #[test]
+    fn outdent_outermost_list_item_unlists_it_to_the_top_level() {
+        // doc( ul(li X, li Y) ); outdent Y → Y becomes a top-level paragraph (un-listed).
+        let s = Rc::new(Schema::starter_kit());
+        let doc = s
+            .branch(
+                "doc",
+                Fragment::from_node(ul(&s, vec![li(&s, "X"), li(&s, "Y")])),
+            )
+            .unwrap();
+        let mut st = EditorState::create(s, doc, default_plugins());
+        st.selection = Selection::cursor(Pos(cursor_in_para(&st.doc, "Y")));
+
+        let out = st.run("outdent").expect("outdent un-lists Y");
+        assert_eq!(
+            out.doc.child_count(),
+            2,
+            "the list, then the lifted paragraph"
+        );
+        assert_eq!(out.doc.child(0).type_name(), "bullet_list");
+        assert_eq!(all_text(out.doc.child(0)), "X", "X stays in the list");
+        assert_eq!(out.doc.child(1).type_name(), "paragraph");
+        assert_eq!(all_text(out.doc.child(1)), "Y");
+    }
+
+    #[test]
+    fn indent_then_outdent_round_trips_a_list_item() {
+        // Indent twice to nest deep, then outdent twice — the document returns to a flat
+        // three-item list (the indent merge and the list-aware lift are inverses here).
+        let s = Rc::new(Schema::starter_kit());
+        let doc = s
+            .branch(
+                "doc",
+                Fragment::from_node(ul(&s, vec![li(&s, "A"), li(&s, "B"), li(&s, "C")])),
+            )
+            .unwrap();
+        let mut st = EditorState::create(s, doc, default_plugins());
+        // Indent B under A, then C under A (merges), then C under B (deeper).
+        st.selection = Selection::cursor(Pos(cursor_in_para(&st.doc, "B")));
+        let st = st.run("indent").expect("indent B");
+        let mut st = st;
+        st.selection = Selection::cursor(Pos(cursor_in_para(&st.doc, "C")));
+        let st = st.run("indent").expect("indent C once");
+        let mut st = st;
+        st.selection = Selection::cursor(Pos(cursor_in_para(&st.doc, "C")));
+        let st = st.run("indent").expect("indent C twice");
+        // Now outdent C twice back out to the top level.
+        let mut st = st;
+        st.selection = Selection::cursor(Pos(cursor_in_para(&st.doc, "C")));
+        let st = st.run("outdent").expect("outdent C once");
+        let mut st = st;
+        st.selection = Selection::cursor(Pos(cursor_in_para(&st.doc, "C")));
+        let st = st.run("outdent").expect("outdent C twice");
+
+        let top = st.doc.child(0);
+        assert_eq!(top.type_name(), "bullet_list");
+        // B is still nested under A (we only outdented C); C is back at the top list.
+        let texts: Vec<String> = top.content().iter().map(all_text).collect();
+        assert!(
+            texts.iter().any(|t| t == "C"),
+            "C returned to the top-level list, got {texts:?}"
+        );
+    }
+
+    #[test]
+    fn indent_merges_into_previous_sublist_and_then_nests_deeper() {
+        // doc( bullet_list( list_item(pA, bullet_list(list_item pB)), list_item(pC) ) ):
+        // "A" already owns a sublist holding "B"; "C" is its top-level sibling.
+        let s = Rc::new(Schema::starter_kit());
+        let inner_b = s
+            .branch("list_item", Fragment::from_node(p_of(&s, "B")))
+            .unwrap();
+        let inner_list = s
+            .branch("bullet_list", Fragment::from_node(inner_b))
+            .unwrap();
+        let item_a = s
+            .branch(
+                "list_item",
+                Fragment::from_children(vec![p_of(&s, "A"), inner_list]),
+            )
+            .unwrap();
+        let item_c = s
+            .branch("list_item", Fragment::from_node(p_of(&s, "C")))
+            .unwrap();
+        let bl = s
+            .branch("bullet_list", Fragment::from_children(vec![item_a, item_c]))
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(bl)).unwrap();
+        let mut state = EditorState::create(s, doc, default_plugins());
+
+        // Indent #1: "C" joins "A"'s EXISTING sublist (merge) — not a new adjacent one.
+        state.selection = Selection::cursor(Pos(cursor_in_para(&state.doc, "C")));
+        let s1 = state.run("indent").expect("first indent merges C under A");
+        let top = s1.doc.child(0);
+        assert_eq!(top.child_count(), 1, "C lifted out of the top-level list");
+        let a = top.child(0);
+        let a_sublists = a
+            .content()
+            .iter()
+            .filter(|n| n.type_name() == "bullet_list")
+            .count();
+        assert_eq!(
+            a_sublists, 1,
+            "C merged into A's one sublist, not an adjacent one"
+        );
+        let sub = sublist_of(a, "bullet_list").unwrap();
+        assert_eq!(sub.child_count(), 2, "the sublist now holds both B and C");
+
+        // Indent #2: with B as its previous sibling, "C" now nests DEEPER under B —
+        // proving an item can be indented more than once (the reported bug).
+        let mut s1 = s1;
+        s1.selection = Selection::cursor(Pos(cursor_in_para(&s1.doc, "C")));
+        let s2 = s1.run("indent").expect("second indent nests C under B");
+        let sub = sublist_of(s2.doc.child(0).child(0), "bullet_list").unwrap();
+        assert_eq!(sub.child_count(), 1, "only B remains at the first sublevel");
+        let nested = sublist_of(sub.child(0), "bullet_list").expect("C nested under B");
+        assert_eq!(all_text(nested), "C");
+    }
+
+    #[test]
+    fn indent_in_task_list_nests_and_never_margin_indents() {
+        // doc( task_list( task_item(p"a"), task_item(p"b") ) ); cursor in the 2nd item.
+        let s = Rc::new(Schema::starter_kit());
+        let item_a = s
+            .branch("task_item", Fragment::from_node(p_of(&s, "a")))
+            .unwrap();
+        let item_b = s
+            .branch("task_item", Fragment::from_node(p_of(&s, "b")))
+            .unwrap();
+        let tl = s
+            .branch("task_list", Fragment::from_children(vec![item_a, item_b]))
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(tl)).unwrap();
+        let mut state = EditorState::create(s, doc, default_plugins());
+        state.selection = Selection::cursor(Pos(cursor_in_para(&state.doc, "b")));
+
+        // Indent nests item "b" under item "a" — the top task_list now holds ONE item,
+        // and crucially NO paragraph receives a left margin (the checkbox-split bug).
+        let nested = state.run("indent").expect("indent nests the task item");
+        let tl = nested.doc.child(0);
+        assert_eq!(tl.type_name(), "task_list");
+        assert_eq!(tl.child_count(), 1, "second item nested under the first");
+        assert!(
+            !any_margin_indent(&nested.doc),
+            "task-list indent nests, never margin-indents"
+        );
+    }
+
+    #[test]
+    fn indent_first_task_item_is_a_noop() {
+        // The first (only) task item has no previous sibling to nest under. Indent must be
+        // a true no-op — in particular it must NOT margin-indent the item's paragraph.
+        let s = Rc::new(Schema::starter_kit());
+        let tl = s
+            .branch(
+                "task_list",
+                Fragment::from_node(
+                    s.branch("task_item", Fragment::from_node(p_of(&s, "a")))
+                        .unwrap(),
+                ),
+            )
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(tl)).unwrap();
+        let mut state = EditorState::create(s, doc, default_plugins());
+        state.selection = Selection::cursor(Pos(cursor_in_para(&state.doc, "a")));
+        assert!(
+            state.run("indent").is_none(),
+            "indent on the first task item is a no-op"
+        );
+    }
+
+    #[test]
+    fn outdent_in_task_list_lifts_the_item_out() {
+        // Outdent un-task-lists the item (lifts it to a top-level paragraph) rather than
+        // adjusting a margin — consistent with how setParagraph treats task lists.
+        let s = Rc::new(Schema::starter_kit());
+        let tl = s
+            .branch(
+                "task_list",
+                Fragment::from_node(
+                    s.branch("task_item", Fragment::from_node(p_of(&s, "a")))
+                        .unwrap(),
+                ),
+            )
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(tl)).unwrap();
+        let mut state = EditorState::create(s, doc, default_plugins());
+        state.selection = Selection::cursor(Pos(cursor_in_para(&state.doc, "a")));
+        let out = state
+            .run("outdent")
+            .expect("outdent lifts the task item out");
+        assert!(
+            out.doc
+                .content()
+                .iter()
+                .all(|n| n.type_name() != "task_list"),
+            "task list removed"
+        );
+        assert_eq!(out.doc.child(0).type_name(), "paragraph");
+        assert_eq!(all_text(out.doc.child(0)), "a");
+    }
+
+    #[test]
+    fn indent_paragraph_in_table_cell_is_a_noop() {
+        // The Indent toolbar button must never margin-indent a paragraph that lives in a
+        // table cell (a left margin there would split the text from the cell layout).
+        let s = Rc::new(Schema::starter_kit());
+        let cell = s
+            .branch("table_cell", Fragment::from_node(p_of(&s, "c")))
+            .unwrap();
+        let table = s
+            .branch(
+                "table",
+                Fragment::from_node(s.branch("table_row", Fragment::from_node(cell)).unwrap()),
+            )
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(table)).unwrap();
+        let mut state = EditorState::create(s, doc, default_plugins());
+        state.selection = Selection::cursor(Pos(cursor_in_para(&state.doc, "c")));
+        assert!(
+            state.run("indent").is_none(),
+            "indenting a paragraph inside a table cell is a no-op"
+        );
+    }
+
+    #[test]
+    fn set_paragraph_in_a_table_cell_resets_without_breaking_the_table() {
+        // Paragraph reset inside a cell strips the heading/marks but must keep the cell's
+        // block INSIDE the table — never lift it out (which would corrupt the table).
+        let s = Rc::new(Schema::starter_kit());
+        let cell = s
+            .branch("table_cell", Fragment::from_node(p_of(&s, "c")))
+            .unwrap();
+        let table = s
+            .branch(
+                "table",
+                Fragment::from_node(s.branch("table_row", Fragment::from_node(cell)).unwrap()),
+            )
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(table)).unwrap();
+        let mut state = EditorState::create(s, doc, default_plugins());
+        state.selection = Selection::cursor(Pos(cursor_in_para(&state.doc, "c")));
+
+        let h = state.run("setHeading1").expect("heading in the cell");
+        let reset = h.run("setParagraph").expect("reset in the cell");
+        // The table survives and the cell holds a plain paragraph again.
+        let table = reset
+            .doc
+            .content()
+            .iter()
+            .find(|n| n.type_name() == "table")
+            .expect("table preserved");
+        let cell_block = table.child(0).child(0).child(0);
+        assert_eq!(cell_block.type_name(), "paragraph");
+        assert_eq!(all_text(cell_block), "c");
+    }
+
+    #[test]
+    fn set_paragraph_across_a_table_lifts_outside_blocks_but_keeps_the_table() {
+        // A selection from a top-level blockquote INTO a table cell: the blockquote block
+        // un-quotes to the top level, while the cell's block stays trapped in the table.
+        let s = Rc::new(Schema::starter_kit());
+        let bq = s
+            .branch("blockquote", Fragment::from_node(p_of(&s, "q")))
+            .unwrap();
+        let cell = s
+            .branch("table_cell", Fragment::from_node(p_of(&s, "c")))
+            .unwrap();
+        let table = s
+            .branch(
+                "table",
+                Fragment::from_node(s.branch("table_row", Fragment::from_node(cell)).unwrap()),
+            )
+            .unwrap();
+        let doc = s
+            .branch("doc", Fragment::from_children(vec![bq, table]))
+            .unwrap();
+        let mut state = EditorState::create(s, doc, default_plugins());
+        let from = cursor_in_para(&state.doc, "q");
+        let to = cursor_in_para(&state.doc, "c");
+        state.selection = Selection::text(Pos(from), Pos(to));
+
+        let reset = state.run("setParagraph").expect("setParagraph applies");
+        assert!(
+            reset
+                .doc
+                .content()
+                .iter()
+                .all(|n| n.type_name() != "blockquote"),
+            "blockquote lifted out to the top level"
+        );
+        let table = reset
+            .doc
+            .content()
+            .iter()
+            .find(|n| n.type_name() == "table")
+            .expect("table preserved");
+        let cell_block = table.child(0).child(0).child(0);
+        assert_eq!(
+            cell_block.type_name(),
+            "paragraph",
+            "cell stays in the table"
+        );
+        assert_eq!(all_text(cell_block), "c");
     }
 
     #[test]

--- a/crates/rinch-editor-core/src/commands/mod.rs
+++ b/crates/rinch-editor-core/src/commands/mod.rs
@@ -432,34 +432,89 @@ pub fn outdent() -> Command {
     })
 }
 
-/// The **Paragraph** command: set the selected textblock(s) to a plain paragraph and,
-/// because "Paragraph" reads as "normal text", also lift them out of an enclosing
-/// blockquote (un-quote). A heading becomes a paragraph; a quoted paragraph drops out
-/// of the quote. A plain paragraph that is already un-quoted is a no-op.
+/// The **Paragraph** command — "reset to normal text". It strips *every* kind of
+/// formatting off the selection so the result is plain paragraph text:
+///
+/// 1. removes all inline marks (bold/italic/underline/link/…),
+/// 2. converts the block(s) to paragraphs (heading / code block → paragraph),
+/// 3. resets the indent level to 0,
+/// 4. lifts the block(s) out of every wrapper (blockquote, list) to the top level.
+///
+/// A no-op (returns `None`) only when the selection is already plain top-level
+/// paragraph text with no marks.
 pub fn set_paragraph() -> Command {
     command_tr(|state| {
         let para_ty = state.schema().node_type("paragraph")?.clone();
         let (from, to) = (state.selection.from().0, state.selection.to().0);
         let mut tr = state.tr();
-        let _ = tr.set_block_type(from, to, para_ty, Attrs::new());
-        // Un-quote: lift the block(s) out of an enclosing blockquote. The range is
-        // resolved against a snapshot so it doesn't borrow the `tr` we then mutate.
-        if in_node_type(state, "blockquote") {
-            let (from_pos, to_pos) = (tr.selection().from(), tr.selection().to());
-            let doc = tr.doc().clone();
-            if let (Ok(r_from), Ok(r_to)) = (doc.resolve(from_pos), doc.resolve(to_pos))
-                && let Some(range) = block_range_simple(&r_from, &r_to)
-            {
-                for target in (0..range.depth).rev() {
-                    let before = tr.doc().clone();
-                    if tr.lift(&range, target).is_ok() && tr.doc() != &before {
-                        break;
-                    }
-                }
+
+        // 1. Strip every inline mark over the selection. Mark steps don't shift
+        //    positions, so `from`/`to` stay valid for the block ops below. Iterate the
+        //    schema's marks in a deterministic (sorted) order.
+        let mut mark_names: Vec<String> = state.schema().marks.keys().cloned().collect();
+        mark_names.sort();
+        for name in &mark_names {
+            if let Some(mt) = state.schema().mark_type(name) {
+                remove_marks_of_type(&mut tr, &state.doc, from, to, mt).ok()?;
             }
         }
+
+        // 2. Convert the selected textblock(s) to plain paragraphs. `set_block_type`
+        //    preserves block-boundary positions (same open/close token count).
+        let _ = tr.set_block_type(from, to, para_ty, Attrs::new());
+
+        // 3. Reset the indent attribute to 0 on the (now-)paragraphs in range.
+        let mut indent_targets: Vec<usize> = Vec::new();
+        state
+            .doc
+            .nodes_between(from, to, &mut |node, pos, _parent| {
+                if matches!(node.type_name(), "paragraph" | "heading") {
+                    indent_targets.push(pos);
+                }
+                true
+            });
+        for pos in indent_targets {
+            let _ = tr.set_node_attr(pos, "indent", crate::AttrValue::Int(0));
+        }
+
+        // 4. Lift out of every wrapper (blockquote, list) to the document top level.
+        lift_to_top(&mut tr);
+
         tr.doc_changed().then_some(tr)
     })
+}
+
+/// Lift the current selection's block range out of every enclosing wrapper until it is
+/// a direct child of the document — one wrapper per pass. The transaction maps its
+/// selection forward through each lift, so re-reading `tr.selection()` each pass is
+/// correct. Stops at the top level or when a wrapper can't be lifted.
+fn lift_to_top(tr: &mut Transaction) {
+    loop {
+        let (from, to) = (tr.selection().from(), tr.selection().to());
+        let doc = tr.doc().clone();
+        let (r_from, r_to) = match (doc.resolve(from), doc.resolve(to)) {
+            (Ok(a), Ok(b)) => (a, b),
+            _ => break,
+        };
+        if r_from.depth() <= 1 {
+            break; // already a top-level block
+        }
+        let range = match block_range_simple(&r_from, &r_to) {
+            Some(r) if r.depth > 0 => r,
+            _ => break,
+        };
+        let before = tr.doc().clone();
+        let mut lifted = false;
+        for target in (0..range.depth).rev() {
+            if tr.lift(&range, target).is_ok() && tr.doc() != &before {
+                lifted = true;
+                break;
+            }
+        }
+        if !lifted {
+            break;
+        }
+    }
 }
 
 // ===================================================================
@@ -1049,6 +1104,18 @@ mod tests {
             return t.to_string();
         }
         node.content().iter().map(all_text).collect()
+    }
+
+    /// Whether any inline node in `doc` carries a mark named `name`.
+    fn doc_has_mark(doc: &Node, name: &str) -> bool {
+        let mut found = false;
+        doc.nodes_between(0, doc.content_size(), &mut |node, _, _| {
+            if node.marks().iter().any(|m| m.type_name() == name) {
+                found = true;
+            }
+            true
+        });
+        found
     }
 
     #[test]
@@ -1673,6 +1740,83 @@ mod tests {
             list.run("indent").is_none(),
             "indent on the first list item is a no-op"
         );
+    }
+
+    #[test]
+    fn set_paragraph_resets_each_kind_of_formatting() {
+        // (a) Inline marks are stripped.
+        let mut s = editor("abc");
+        s.selection = Selection::text(Pos(1), Pos(4));
+        let bold = s.run("toggleBold").expect("bold applies");
+        assert!(doc_has_mark(&bold.doc, "bold"));
+        let plain = bold.run("setParagraph").expect("clears marks");
+        assert!(!doc_has_mark(&plain.doc, "bold"), "marks stripped");
+
+        // (b) Heading → paragraph.
+        let mut s = editor("title");
+        s.selection = Selection::cursor(Pos(2));
+        let h = s.run("setHeading1").expect("h1 applies");
+        assert_eq!(h.doc.child(0).type_name(), "heading");
+        let p = h.run("setParagraph").expect("heading → paragraph");
+        assert_eq!(p.doc.child(0).type_name(), "paragraph");
+
+        // (c) List item → top-level paragraph (un-listed).
+        let mut s = editor("item");
+        s.selection = Selection::cursor(Pos(2));
+        let list = s.run("toggleBulletList").expect("list applies");
+        assert!(
+            list.doc
+                .content()
+                .iter()
+                .any(|n| n.type_name() == "bullet_list")
+        );
+        let p = list.run("setParagraph").expect("un-list");
+        assert!(
+            !p.doc
+                .content()
+                .iter()
+                .any(|n| n.type_name() == "bullet_list"),
+            "list removed"
+        );
+        assert_eq!(p.doc.child(0).type_name(), "paragraph");
+        assert_eq!(all_text(p.doc.child(0)), "item");
+
+        // (d) Indent reset to 0.
+        let mut s = editor("ind");
+        s.selection = Selection::cursor(Pos(2));
+        let i = s.run("indent").expect("indent applies");
+        assert_eq!(i.doc.child(0).attrs().get_int("indent"), Some(1));
+        let p = i.run("setParagraph").expect("resets indent");
+        assert_eq!(p.doc.child(0).attrs().get_int("indent"), Some(0));
+    }
+
+    #[test]
+    fn set_paragraph_resets_all_formatting_at_once() {
+        // A bold heading wrapped in a blockquote — one Paragraph click clears it all.
+        let mut s = editor("mixed");
+        s.selection = Selection::text(Pos(1), Pos(6));
+        let b = s.run("toggleBold").expect("bold");
+        let h = b.run("setHeading1").expect("h1");
+        let q = h.run("wrapInBlockquote").expect("quote");
+        assert!(
+            q.doc
+                .content()
+                .iter()
+                .any(|n| n.type_name() == "blockquote")
+        );
+        assert!(doc_has_mark(&q.doc, "bold"));
+
+        let p = q.run("setParagraph").expect("reset to normal text");
+        assert!(
+            !p.doc
+                .content()
+                .iter()
+                .any(|n| n.type_name() == "blockquote"),
+            "un-quoted"
+        );
+        assert_eq!(p.doc.child(0).type_name(), "paragraph", "is a paragraph");
+        assert!(!doc_has_mark(&p.doc, "bold"), "marks stripped");
+        assert_eq!(all_text(p.doc.child(0)), "mixed");
     }
 
     #[test]

--- a/crates/rinch-editor-core/src/model/types.rs
+++ b/crates/rinch-editor-core/src/model/types.rs
@@ -312,10 +312,10 @@ mod tests {
     #[test]
     fn compute_attrs_empty_for_attrless_type() {
         let s = Schema::starter_kit();
-        // paragraph declares no attrs → empty result even if junk is provided
+        // blockquote declares no attrs → empty result even if junk is provided
         let provided = Attrs::from_iter([("junk", AttrValue::Bool(true))]);
         let computed = s
-            .node_type("paragraph")
+            .node_type("blockquote")
             .unwrap()
             .compute_attrs(&provided)
             .unwrap();

--- a/crates/rinch-editor-core/src/model/types.rs
+++ b/crates/rinch-editor-core/src/model/types.rs
@@ -129,6 +129,13 @@ impl NodeType {
         self.0.spec.group.as_deref()
     }
 
+    /// Whether this type is *isolating* — a hard boundary that structural edits
+    /// (lift/wrap/join/delete) must not cross. Table cells are isolating, so content
+    /// can never be lifted out of them (which would tear the cell from its table).
+    pub fn is_isolating(&self) -> bool {
+        self.0.spec.isolating
+    }
+
     /// Whether content of this type may be joined with content of `other` — true
     /// for identical types, or when their content expressions share at least one
     /// acceptable child type. Used by the replace algorithm when merging the open

--- a/crates/rinch-editor-core/src/schema/mod.rs
+++ b/crates/rinch-editor-core/src/schema/mod.rs
@@ -76,6 +76,9 @@ impl Schema {
             NodeSpec::builder("paragraph")
                 .content("inline*")
                 .group("block")
+                // Indent level (0 = flush left); rendered as a left margin. Bumped by
+                // the indent / outdent commands when the cursor isn't in a list.
+                .attr("indent", AttrSpec::optional(AttrValue::Int(0)))
                 .parse_html(vec!["p".into()])
                 .build(),
         );
@@ -87,6 +90,7 @@ impl Schema {
                 .content("inline*")
                 .group("block")
                 .attr("level", AttrSpec::optional(AttrValue::Int(1)))
+                .attr("indent", AttrSpec::optional(AttrValue::Int(0)))
                 .parse_html(vec![
                     "h1".into(),
                     "h2".into(),

--- a/crates/rinch-editor-view/src/styles.rs
+++ b/crates/rinch-editor-view/src/styles.rs
@@ -100,9 +100,12 @@ pub(crate) const DEFAULT_EDITOR_CSS: &str = r#"
 
 /* ── Lists ─────────────────────────────────────────────────────────────── */
 /* `li` is flex so the bullet/number aligns with the first line of its content
-   (rinch-dom renders list markers as block siblings otherwise). */
+   (rinch-dom renders list markers as block siblings otherwise). `flex-wrap: wrap`
+   plus `flex-basis: 100%` on a *nested* list make the sublist break onto its own
+   full-width line and indent below the item, instead of floating beside it. */
 [data-pm-editor] ul, [data-pm-editor] ol { padding-left: 1.6em; margin: 0 0 0.75em; }
-[data-pm-editor] li { display: flex; align-items: baseline; gap: 0.4em; margin: 0.15em 0; }
+[data-pm-editor] li { display: flex; flex-wrap: wrap; align-items: baseline; gap: 0.4em; margin: 0.15em 0; }
+[data-pm-editor] li > ul, [data-pm-editor] li > ol { flex-basis: 100%; margin: 0.15em 0 0; }
 
 /* ── Horizontal rule ───────────────────────────────────────────────────── */
 [data-pm-editor] hr { border: none; border-top: 2px solid #e1e4e8; margin: 1.2em 0; height: 0; }

--- a/crates/rinch-editor-view/src/view.rs
+++ b/crates/rinch-editor-view/src/view.rs
@@ -79,6 +79,17 @@ fn apply_element_attrs(dom: &NodeHandle, node: &Node) {
                 }),
             );
         }
+        // The indent level (set by the indent / outdent commands) renders as a left
+        // margin — 2em per level. Always written (resetting to 0) so outdent clears
+        // the previous value, like the table spans above.
+        "paragraph" | "heading" => {
+            let indent = node.attrs().get_int("indent").unwrap_or(0).max(0);
+            if indent > 0 {
+                dom.set_style("margin-left", &format!("{}em", indent * 2));
+            } else {
+                dom.set_style("margin-left", "0");
+            }
+        }
         _ => {}
     }
 }

--- a/crates/rinch-web/src/editor_input.rs
+++ b/crates/rinch-web/src/editor_input.rs
@@ -526,8 +526,15 @@ fn handle_keydown(event: &web_sys::KeyboardEvent, doc: &web_sys::Document) -> bo
         "Delete" => handle.command("deleteCharForward"),
         "Enter" if !ctrl => handle.command("enter"),
         "Tab" => {
-            handle.tab_cell(shift);
-            true // consume Tab either way — no focus traversal mid-edit
+            // In a table, Tab navigates cells; otherwise it indents / outdents the
+            // current list (or task) item. Consume Tab either way — no focus traversal.
+            let _ = handle.tab_cell(shift)
+                || handle.command(if shift {
+                    "liftListItem"
+                } else {
+                    "sinkListItem"
+                });
+            true
         }
         "ArrowLeft" => handle.move_cursor(
             if ctrl {

--- a/crates/rinch/src/app/event_dispatch.rs
+++ b/crates/rinch/src/app/event_dispatch.rs
@@ -1784,8 +1784,16 @@ impl RinchApp {
             KeyCode::Delete => handle.command("deleteCharForward"),
             KeyCode::Enter if !ctrl => handle.command("enter"),
             // Tab / Shift-Tab move between table cells when the cursor is in a table;
-            // outside a table Tab does nothing here (no focus-traversal in the editor).
-            KeyCode::Tab => handle.tab_cell(shift),
+            // outside a table they indent / outdent the current list (or task) item.
+            // No focus-traversal in the editor either way.
+            KeyCode::Tab => {
+                handle.tab_cell(shift)
+                    || handle.command(if shift {
+                        "liftListItem"
+                    } else {
+                        "sinkListItem"
+                    })
+            }
             // Cursor movement / selection extension (Shift extends, Ctrl = word/doc).
             KeyCode::ArrowLeft => self.move_editor(
                 handle,

--- a/examples/editor-web/src/main.rs
+++ b/examples/editor-web/src/main.rs
@@ -26,6 +26,8 @@ fn app() -> NodeHandle {
     let ed_ul = editor.clone();
     let ed_ol = editor.clone();
     let ed_quote = editor.clone();
+    let ed_indent = editor.clone();
+    let ed_outdent = editor.clone();
     let ed_undo = editor.clone();
     let ed_redo = editor.clone();
 
@@ -51,6 +53,8 @@ fn app() -> NodeHandle {
                 button { id: "tb-ul",        style: btn, onclick: move || { ed_ul.command("toggleBulletList"); },    "• List" }
                 button { id: "tb-ol",        style: btn, onclick: move || { ed_ol.command("toggleOrderedList"); },   "1. List" }
                 button { id: "tb-quote",     style: btn, onclick: move || { ed_quote.command("wrapInBlockquote"); }, "Quote" }
+                button { id: "tb-indent",    style: btn, onclick: move || { ed_indent.command("indent"); },          "Indent" }
+                button { id: "tb-outdent",   style: btn, onclick: move || { ed_outdent.command("outdent"); },        "Outdent" }
                 button { id: "tb-undo",      style: btn, onclick: move || { ed_undo.command("undo"); },              "Undo" }
                 button { id: "tb-redo",      style: btn, onclick: move || { ed_redo.command("redo"); },              "Redo" }
             }

--- a/examples/markdown-editor/src/main.rs
+++ b/examples/markdown-editor/src/main.rs
@@ -139,9 +139,9 @@ fn editor_toolbar(editor: EditorHandle) -> NodeHandle {
 
             {separator(__scope)}
 
-            // Indent / outdent (list items)
-            {toolbar_button(__scope, TablerIcon::IndentIncrease, "Indent (sinkListItem)", move || { ed_indent.command("sinkListItem"); })}
-            {toolbar_button(__scope, TablerIcon::IndentDecrease, "Outdent (liftListItem)", move || { ed_outdent.command("liftListItem"); })}
+            // Indent / outdent — nests list items in a list, else indents the paragraph
+            {toolbar_button(__scope, TablerIcon::IndentIncrease, "Indent", move || { ed_indent.command("indent"); })}
+            {toolbar_button(__scope, TablerIcon::IndentDecrease, "Outdent", move || { ed_outdent.command("outdent"); })}
 
             {separator(__scope)}
 


### PR DESCRIPTION
Addresses two issues found while testing the editor's Indent/Outdent buttons.

## 1. Indent/Outdent now work on paragraphs

The buttons only operated on list items (`sinkListItem`/`liftListItem`), so on a regular paragraph **Indent did nothing**, and **Outdent** (a generic `lift`) surprisingly **un-quoted blockquotes**.

- Added an `indent` integer attribute (default 0) to `paragraph` and `heading`.
- New context-aware `indent`/`outdent` commands: `chain([sink/lift the list item when inside a list, else adjust the indent attr])`.
- The list path uses a new **list-specific** `lift_list_item` (gated on being inside a `list_item`), so outdent no longer lifts a paragraph out of a blockquote.
- The `indent` attr renders as a left margin (2em/level) in the view's `apply_element_attrs` (idempotent, resets to 0 on outdent).
- Repointed the registered `indent`/`outdent` commands and the markdown-editor toolbar buttons; added Indent/Outdent buttons to the `editor-web` demo.

The whole attribute-set path (`SetNodeAttrStep` → `Transaction::set_node_attr`) already existed — this just composes it.

## 2. Nested lists render correctly

Indenting a list item nested it in the model, but on **desktop** the nested `<ul>`/`<ol>` rendered *beside* the parent (the `li { display: flex }` marker-alignment hack laid it out as a flex sibling). Added `flex-wrap: wrap` to `li` and `flex-basis: 100%` to a nested list so it breaks onto its own full-width line and indents below. (Web `li` is `display: list-item`, so nested lists already nest natively there.)

## Validation

- **Desktop** (markdown-editor via MCP): Indent/Outdent shift a paragraph's left margin both ways; indenting a list item nests it below + indented.
- **Web** (editor-web via Playwright, 0 console errors): paragraph indent sets `margin-left: 2em` and outdent clears it; an indented bullet renders as a nested `list-item` **below** its parent (• → ○).
- New unit tests: paragraph indent/outdent (and the no-op at indent 0); outdent leaves a blockquote intact. All 230 editor-core tests pass; `clippy --workspace --all-targets -D warnings` and `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)