### PR TITLE
fix(layout): flow inline content through display:contents in a block parent (#61)

### DIFF
--- a/crates/rinch-dom/src/ifc.rs
+++ b/crates/rinch-dom/src/ifc.rs
@@ -702,14 +702,14 @@ impl RinchDocument {
             ) {
                 continue;
             }
-            // A `display: contents` element generates no box, so it can't
-            // establish an inline formatting context. When it flattens into a
-            // flex container (sync_display_contents reparents its children there),
-            // those children become flex items — an IFC rooted here would fight
-            // the flattening and overlap them (issue #41). Inside a block
-            // container the existing IFC handling is left unchanged.
+            // A `display: contents` element generates no box, so it can never
+            // establish an inline formatting context — its inline children belong
+            // to the nearest real (block or flex) ancestor. In a flex container
+            // its children blockify into flex items (issue #41); in a block
+            // container that block establishes the IFC over the flattened inline
+            // content (issue #61, handled below). Either way the contents node is
+            // never an IFC root itself.
             if node.computed_style.display == crate::computed_style::values::DisplayValue::Contents
-                && Self::contents_ancestor_is_flex(&self.tree.nodes, id)
             {
                 continue;
             }
@@ -731,7 +731,13 @@ impl RinchDocument {
             // Even a single text child uses IFC — it's a degenerate case with one
             // text range. This avoids needing two measurement paths (standalone vs IFC)
             // and the sync bugs that arise when elements transition between them.
-            if !inline_children.is_empty() {
+            //
+            // `contents_wraps_only_inline` also activates the IFC when the only
+            // inline content lives *behind* `display:contents` wrapper(s) — as
+            // rsx `if`/`match` emit — so a block parent flows that wrapped text
+            // itself instead of leaving it stranded on the phantom wrapper (#61).
+            if !inline_children.is_empty() || Self::contents_wraps_only_inline(&self.tree.nodes, id)
+            {
                 ifc_roots.push(id);
             } else if node.children.is_empty() {
                 // CSS spec: an empty block container that would establish an IFC
@@ -765,30 +771,15 @@ impl RinchDocument {
         }
 
         for root_id in ifc_roots {
-            let children: Vec<usize> = self.tree.nodes[root_id].children.clone();
             let root_taffy = match self.tree.nodes[root_id].taffy_id {
                 Some(t) => t,
                 None => continue,
             };
 
-            // Remove inline children from Taffy (Parley will handle their layout)
-            for &child_id in &children {
-                let child = match self.tree.nodes.get(child_id) {
-                    Some(c) => c,
-                    None => continue,
-                };
-                if child.is_inline() {
-                    if let Some(child_taffy) = child.taffy_id
-                        && let Ok(taffy_children) = self.tree.taffy.children(root_taffy)
-                        && taffy_children.contains(&child_taffy)
-                    {
-                        let _ = self.tree.taffy.remove_child(root_taffy, child_taffy);
-                    }
-                    if let Some(c) = self.tree.nodes.get_mut(child_id) {
-                        c.ifc_root = Some(root_id);
-                    }
-                }
-            }
+            // Remove inline children from Taffy (Parley handles their layout),
+            // flattening through any `display:contents` wrappers so their inline
+            // grandchildren join this root's IFC (issue #61).
+            self.mark_inline_descendants(root_id, root_id, root_taffy);
 
             // Set NodeContext::InlineRoot on the IFC root's Taffy node
             // so the measure function fires for it
@@ -805,23 +796,102 @@ impl RinchDocument {
         }
     }
 
-    /// Whether the nearest non-`display:contents` ancestor of `node_id` is a flex
-    /// container. Used to decide that a `display:contents` node's children are
-    /// flattened into a flex context (so the contents node must not be an IFC
-    /// root). Walks up through chained `display:contents` ancestors.
-    fn contents_ancestor_is_flex(nodes: &slab::Slab<Node>, node_id: usize) -> bool {
+    /// Whether `root_id`'s only inline-level content lives behind one or more
+    /// `display:contents` wrappers (with no block-level content mixed in).
+    ///
+    /// `display:contents` is transparent, so a block container whose children
+    /// are contents wrappers full of inline text must establish the IFC itself
+    /// (issue #61). This is only consulted when `root_id` has no *direct* inline
+    /// children. Returns false when any block-level element is found among the
+    /// flattened content — mixed inline+block behind `display:contents` is out of
+    /// scope here (it needs anonymous-block-box handling) and is left untouched
+    /// rather than regressed.
+    fn contents_wraps_only_inline(nodes: &slab::Slab<Node>, root_id: usize) -> bool {
+        let mut found_contents_inline = false;
+        if Self::scan_contents_children(nodes, root_id, &mut found_contents_inline) {
+            found_contents_inline
+        } else {
+            false
+        }
+    }
+
+    /// Recursively classify `node_id`'s children, descending only through
+    /// `display:contents` wrappers. Sets `found_inline` when inline content is
+    /// seen under a contents wrapper. Returns false as soon as a block-level
+    /// (non-contents) element is encountered.
+    fn scan_contents_children(
+        nodes: &slab::Slab<Node>,
+        node_id: usize,
+        found_inline: &mut bool,
+    ) -> bool {
         use crate::computed_style::values::DisplayValue;
-        let mut cur = nodes.get(node_id).and_then(|n| n.parent);
-        while let Some(anc_id) = cur {
-            match nodes.get(anc_id) {
-                Some(a) if a.computed_style.display == DisplayValue::Contents => {
-                    cur = a.parent;
+        for &child_id in &nodes[node_id].children {
+            let child = match nodes.get(child_id) {
+                Some(c) => c,
+                None => continue,
+            };
+            if child.is_comment() {
+                continue;
+            }
+            if child.computed_style.display == DisplayValue::Contents {
+                if !Self::scan_contents_children(nodes, child_id, found_inline) {
+                    return false;
                 }
-                Some(a) => return a.display_mode == DisplayMode::Flex,
-                None => return false,
+            } else if child.is_inline() {
+                *found_inline = true;
+            } else {
+                // A real block-level box — mixed content, not our case.
+                return false;
             }
         }
-        false
+        true
+    }
+
+    /// Detach the inline descendants of an IFC root from Taffy and mark their
+    /// `ifc_root`, flattening through `display:contents` wrappers.
+    ///
+    /// Direct inline children behave exactly as before (removed from the root's
+    /// Taffy node so Parley lays them out, `ifc_root` set). A `display:contents`
+    /// wrapper generates no box, so it is transparent: it is marked with this
+    /// root's id (so IFC discovery finds this container and paint skips the
+    /// wrapper in the normal tree walk) and recursed into, so its inline
+    /// grandchildren — which `sync_display_contents` reparented into `root_taffy`
+    /// — are detached and joined to this IFC too (issue #61).
+    fn mark_inline_descendants(
+        &mut self,
+        root_id: usize,
+        node_id: usize,
+        root_taffy: taffy::NodeId,
+    ) {
+        use crate::computed_style::values::DisplayValue;
+        let children: Vec<usize> = self.tree.nodes[node_id].children.clone();
+        for child_id in children {
+            let (is_contents, is_inline, child_taffy) = match self.tree.nodes.get(child_id) {
+                Some(c) => (
+                    c.computed_style.display == DisplayValue::Contents,
+                    c.is_inline(),
+                    c.taffy_id,
+                ),
+                None => continue,
+            };
+            if is_contents {
+                if let Some(c) = self.tree.nodes.get_mut(child_id) {
+                    c.ifc_root = Some(root_id);
+                }
+                self.mark_inline_descendants(root_id, child_id, root_taffy);
+            } else if is_inline {
+                if let Some(child_taffy) = child_taffy
+                    && let Ok(taffy_children) = self.tree.taffy.children(root_taffy)
+                    && taffy_children.contains(&child_taffy)
+                {
+                    let _ = self.tree.taffy.remove_child(root_taffy, child_taffy);
+                }
+                if let Some(c) = self.tree.nodes.get_mut(child_id) {
+                    c.ifc_root = Some(root_id);
+                }
+            }
+            // Block-level children are left in place (existing behavior).
+        }
     }
 
     /// Pre-compute layout for inline-block children that were detached from Taffy.
@@ -1377,6 +1447,25 @@ impl RinchDocument {
                         kind: parley::InlineBoxKind::InFlow,
                     });
                     child_positions.push((child_id, LayoutResult::default()));
+                }
+                NodeKind::Element(_)
+                    if child.computed_style.display
+                        == crate::computed_style::values::DisplayValue::Contents =>
+                {
+                    // `display:contents` generates no box — it is transparent.
+                    // Recurse without pushing a style span so its inline
+                    // descendants flow into this IFC in document order (#61).
+                    Self::walk_inline_children(
+                        nodes,
+                        child_id,
+                        builder,
+                        child_positions,
+                        text_ranges,
+                        background_spans,
+                        flat_pos,
+                        scale,
+                        collapse,
+                    );
                 }
                 NodeKind::Comment(_) => {
                     // Skip comments in inline layout

--- a/crates/rinch-dom/src/layout_engine.rs
+++ b/crates/rinch-dom/src/layout_engine.rs
@@ -757,6 +757,30 @@ impl RinchDocument {
     pub(crate) fn read_layout_results(&mut self, node_id: usize) {
         let children: Vec<usize> = self.tree.nodes[node_id].children.clone();
 
+        // A `display: contents` element generates no box. Force its layout to the
+        // origin so every parent-chain accumulation (paint tree-walk, hit-testing,
+        // compute_absolute_position) treats it as fully transparent — its
+        // children's positions are already relative to the nearest real ancestor.
+        // `sync_display_contents` detaches the wrapper's Taffy node and marks it
+        // display:none; that detached node can retain a stale non-zero `location`
+        // (or make `taffy.layout()` return `Err`, skipping the read below), either
+        // of which would otherwise be double-counted onto every descendant.
+        if self.tree.nodes[node_id].computed_style.display
+            == crate::computed_style::DisplayValue::Contents
+        {
+            let node = &mut self.tree.nodes[node_id];
+            let zero = LayoutResult::default();
+            if node.layout != zero {
+                node.prev_layout = node.layout;
+                node.layout = zero;
+                self.tree.paint_dirty_nodes.push(node_id);
+            }
+            for child_id in children {
+                self.read_layout_results(child_id);
+            }
+            return;
+        }
+
         if let Some(taffy_id) = self.tree.nodes[node_id].taffy_id
             && let Ok(taffy_layout) = self.tree.taffy.layout(taffy_id)
         {

--- a/crates/rinch-dom/tests/layout_tests.rs
+++ b/crates/rinch-dom/tests/layout_tests.rs
@@ -682,3 +682,168 @@ fn test_display_contents_flex_gap_inline_children() {
         "c.x must account for b's width + gap (not overlap b)"
     );
 }
+
+/// Issue #61: a **block** container whose inline content lives inside a
+/// `display:contents` wrapper (as emitted by rsx `if`/`match`) must establish
+/// the inline formatting context itself and flow the wrapped text in document
+/// order. Before the fix the phantom contents wrapper was treated as the IFC
+/// root, so the surrounding text nodes were dropped entirely (only inline-block
+/// children with a real box survived).
+#[test]
+fn test_display_contents_block_parent_inline_text() {
+    let mut doc = RinchDocument::new();
+    let body = doc.body();
+    let container = doc.create_element("div");
+    doc.set_attribute(container, "style", "width: 400px; font-size: 16px");
+    doc.append_child(body, container);
+
+    // display:contents wrapper (rsx `if`/`match` emits one of these).
+    let wrapper = doc.create_element("div");
+    doc.set_attribute(wrapper, "style", "display: contents");
+    doc.append_child(container, wrapper);
+
+    // "Hello " <span>bold</span> " world" — text before AND after the span.
+    let t1 = doc.create_text("Hello ");
+    let span = doc.create_element("span");
+    doc.set_attribute(span, "style", "font-weight: bold");
+    let t2 = doc.create_text("bold");
+    let t3 = doc.create_text(" world");
+    doc.append_child(wrapper, t1);
+    doc.append_child(wrapper, span);
+    doc.append_child(span, t2);
+    doc.append_child(wrapper, t3);
+
+    doc.resolve_layout(800.0, 600.0);
+
+    // The block CONTAINER establishes the IFC (not the phantom contents wrapper).
+    let container_node = doc.tree.get(container.0).unwrap();
+    assert!(
+        container_node.text_layout.is_some(),
+        "the block container must be the IFC root"
+    );
+    let text_content = container_node
+        .text_layout
+        .as_ref()
+        .unwrap()
+        .text_content
+        .clone();
+    assert!(
+        text_content.contains("Hello"),
+        "leading text before the span must not be dropped, got {text_content:?}"
+    );
+    assert!(
+        text_content.contains("bold"),
+        "span text must be present, got {text_content:?}"
+    );
+    assert!(
+        text_content.contains("world"),
+        "trailing text after the span must not be dropped, got {text_content:?}"
+    );
+
+    // The display:contents wrapper generates no box → never an IFC root.
+    let wrapper_node = doc.tree.get(wrapper.0).unwrap();
+    assert!(
+        wrapper_node.text_layout.is_none(),
+        "display:contents wrapper must not establish an IFC"
+    );
+}
+
+/// Issue #61: inline-block children inside a `display:contents` wrapper in a
+/// **block** parent must flow inline (adjacent, no overlap), just as they would
+/// without the wrapper.
+#[test]
+fn test_display_contents_block_parent_inline_block() {
+    let mut doc = RinchDocument::new();
+    let body = doc.body();
+    let container = doc.create_element("div");
+    doc.set_attribute(container, "style", "width: 400px");
+    doc.append_child(body, container);
+
+    let wrapper = doc.create_element("div");
+    doc.set_attribute(wrapper, "style", "display: contents");
+    doc.append_child(container, wrapper);
+
+    let a = doc.create_element("span");
+    doc.set_attribute(
+        a,
+        "style",
+        "display: inline-block; width: 50px; height: 20px",
+    );
+    doc.append_child(wrapper, a);
+    let b = doc.create_element("span");
+    doc.set_attribute(
+        b,
+        "style",
+        "display: inline-block; width: 60px; height: 20px",
+    );
+    doc.append_child(wrapper, b);
+
+    doc.resolve_layout(800.0, 600.0);
+
+    let la = doc.tree.get(a.0).unwrap().layout;
+    let lb = doc.tree.get(b.0).unwrap().layout;
+    // Inline flow: a at x=0, b immediately after at x=50 (no gap in block flow),
+    // both on the same line — NOT overlapping.
+    assert_eq!(la.x, 0.0, "a.x");
+    assert_eq!(lb.x, 50.0, "b.x should follow a inline (not overlap)");
+    assert_eq!(la.y, lb.y, "both inline-blocks on the same line");
+    // The transparent contents wrapper must contribute ZERO offset — the
+    // grandchildren's positions are already relative to the real container, so
+    // parent-chain accumulation (paint/hit-test) must not double-count it.
+    let lw = doc.tree.get(wrapper.0).unwrap().layout;
+    assert_eq!(lw.x, 0.0, "contents wrapper must not add an x offset");
+    assert_eq!(lw.y, 0.0, "contents wrapper must not add a y offset");
+    assert!(
+        doc.tree.get(container.0).unwrap().text_layout.is_some(),
+        "the block container must be the IFC root"
+    );
+    assert!(
+        doc.tree.get(wrapper.0).unwrap().text_layout.is_none(),
+        "display:contents wrapper must not establish an IFC"
+    );
+}
+
+/// Issue #61: nested `display:contents` wrappers (as emitted by rsx `else if`
+/// chains) in a block parent must still flow their inline content through the
+/// block container's IFC.
+#[test]
+fn test_display_contents_block_parent_nested_inline() {
+    let mut doc = RinchDocument::new();
+    let body = doc.body();
+    let container = doc.create_element("div");
+    doc.set_attribute(container, "style", "width: 400px; font-size: 16px");
+    doc.append_child(body, container);
+
+    let outer = doc.create_element("div");
+    doc.set_attribute(outer, "style", "display: contents");
+    doc.append_child(container, outer);
+    let inner = doc.create_element("div");
+    doc.set_attribute(inner, "style", "display: contents");
+    doc.append_child(outer, inner);
+
+    let t1 = doc.create_text("Nested ");
+    let t2 = doc.create_text("text");
+    doc.append_child(inner, t1);
+    doc.append_child(inner, t2);
+
+    doc.resolve_layout(800.0, 600.0);
+
+    let container_node = doc.tree.get(container.0).unwrap();
+    assert!(
+        container_node.text_layout.is_some(),
+        "the block container must be the IFC root for nested contents"
+    );
+    let text_content = &container_node.text_layout.as_ref().unwrap().text_content;
+    assert!(
+        text_content.contains("Nested") && text_content.contains("text"),
+        "nested contents text must flow through the container IFC, got {text_content:?}"
+    );
+    assert!(
+        doc.tree.get(outer.0).unwrap().text_layout.is_none(),
+        "outer contents wrapper must not establish an IFC"
+    );
+    assert!(
+        doc.tree.get(inner.0).unwrap().text_layout.is_none(),
+        "inner contents wrapper must not establish an IFC"
+    );
+}

--- a/examples/hello_rinch_dom/src/main.rs
+++ b/examples/hello_rinch_dom/src/main.rs
@@ -63,6 +63,32 @@ fn app() -> NodeHandle {
                 " button to proceed."
             }
 
+            // Issue #61: inline content behind an `if` (emits a display:contents
+            // wrapper) inside a BLOCK parent. The surrounding text must not be
+            // dropped, and inline-block buttons must flow inline (not overlap).
+            div { style: "background-color: #ede7f6; padding: 12px; font-size: 16px; width: 500px",
+                if count.get() >= 0 {
+                    "Behind an if: Hello "
+                    span { style: "color: #6a1b9a; font-weight: bold", "bold" }
+                    " world, then a "
+                    button { style: "width: 60px; height: 24px; background-color: #6a1b9a; color: white", "BTN" }
+                    " and "
+                    button { style: "width: 70px; height: 24px; background-color: #8e24aa; color: white", "BTN2" }
+                    " inline."
+                }
+            }
+
+            // Control: the same content placed directly (no display:contents).
+            div { style: "background-color: #f3e5f5; padding: 12px; font-size: 16px; width: 500px",
+                "Directly placed: Hello "
+                span { style: "color: #6a1b9a; font-weight: bold", "bold" }
+                " world, then a "
+                button { style: "width: 60px; height: 24px; background-color: #6a1b9a; color: white", "BTN" }
+                " and "
+                button { style: "width: 70px; height: 24px; background-color: #8e24aa; color: white", "BTN2" }
+                " inline."
+            }
+
             div { style: "display: flex; flex-direction: row; gap: 8px; align-items: center",
                 button {
                     style: "background-color: #4CAF50; padding: 8px; color: white",


### PR DESCRIPTION
## Summary

Closes #61. A **block** container whose inline content is wrapped in a `display:contents` element — as rsx `if`/`match` emit — laid that content out incorrectly: the surrounding text nodes were **dropped entirely** and only inline-block children survived (and could overlap). This is the block-parent analogue of the flex-gap bug fixed in #41.

**Root cause:** `setup_inline_formatting_contexts` treated the phantom `display:contents` wrapper (display:none in Taffy, its children reparented into the block container) as the inline-formatting-context root. The IFC ended up rooted on a box-less node whose `text_layout` never painted — so the wrapped text vanished.

A `display:contents` element generates no box and can never establish an IFC. The fix makes the wrapper fully transparent to the IFC machinery.

## Changes (`rinch-dom`)

- **`setup_inline_formatting_contexts`** — never treat a `display:contents` node as an IFC root (generalizes the #41 flex-only skip). A block container now detects inline content *through* contents wrappers (`contents_wraps_only_inline`) and becomes the IFC root; `mark_inline_descendants` recursively detaches the flattened inline grandchildren from Taffy and marks their `ifc_root` (and the wrapper's, so IFC discovery finds the container and paint skips the wrapper in the normal tree walk). Mixed inline+block behind contents is left untouched (out of scope — needs anonymous-block-box handling) rather than regressed.
- **`walk_inline_children`** — descends through `display:contents` children without pushing a style span, so wrapped inline content flows into the parent IFC in document order.
- **`read_layout_results`** — forces a `display:contents` node's layout to the origin. Its detached display:none Taffy node can retain a stale non-zero `location` (or make `taffy.layout()` return `Err`), which every parent-chain accumulation (paint tree-walk, hit-testing, `compute_absolute_position`) would otherwise double-count onto every descendant — making the wrapped inline-block buttons render fine but land far from where they hit-test. Also cures the same latent offset for **block** grandchildren in contents wrappers.

## Validation

- 3 new regression tests (inline text, inline-block, nested contents) that **fail before** the fix, plus a wrapper-zero-offset assertion.
- `cargo test --workspace`: **826 pass, 0 fail**; `clippy --workspace --all-targets` and `fmt` clean.
- MCP-validated live in `hello-rinch-dom` (new side-by-side `if`-behind-contents vs direct control demo): text no longer dropped, inline-blocks flow inline with no overlap (identical to the direct control), incremental re-layout stays correct, and the wrapped inline-block buttons are clickable.

## Out of scope (pre-existing, separate)

Inline-block children that sit in a **text flow** inside *any* IFC have a pre-existing hit-test quirk: full-container IFC text-node bounds shadow them, and hit-test omits the container's content-box padding. Confirmed to affect **direct** inline-blocks too (not caused by this change), so it's left as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)