### PR TITLE
feat(gpu): let embedders share the compositor GPU device (#57)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1286,8 +1286,19 @@ registrar.notify_frame_ready();
 rsx! { RenderSurface { surface: Some(surface), style: "flex: 1;" } }
 ```
 
+**Sharing a high-capability GPU device (issue #57):** zero-copy compositing needs your texture on the *same* device rinch composites with (`gpu_handle()` → `device`/`queue`/**`adapter`**). By default that device is created with `Features::default()` / `Limits::default()`. To raise it:
+
+| Entry point | Ownership | Use when |
+|---|---|---|
+| `run_with_gpu_config(component, props, theme, RinchGpuConfig { required_features, required_limits })` | rinch creates the device (surface-compatible adapter) with your extra features/limits | You just need more capability — **recommended**, always presents correctly |
+| `run_with_external_device(component, props, theme, ExternalGpu { instance, adapter, device, queue })` | You create the whole stack; rinch makes only the surface, validates present-support, composites onto your device | You must keep your exact `DeviceDescriptor` |
+
+Construct `wgpu` types from **`rinch::wgpu`** (rinch pins a patched fork — a separate `wgpu` dep won't type-match). Both are `#[cfg(feature = "gpu")]`, re-exported in the prelude. Example: `examples/gpu-device-config` (`RINCH_GPU_MODE=external` toggles the two modes).
+
 **Source files:**
 - `crates/rinch/src/render_surface.rs` — All RenderSurface types and registry
+- `crates/rinch/src/shell/desktop.rs` — `GpuHandle`, `RinchGpuConfig`, `ExternalGpu`, `WgpuRenderer::new` device injection
+- `crates/rinch/src/shell/mod.rs` — `run_with_gpu_config` / `run_with_external_device`
 
 ### Embed API
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2301,6 +2301,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "gpu-device-config"
+version = "0.1.0"
+dependencies = [
+ "pollster",
+ "rinch",
+]
+
+[[package]]
 name = "grid"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/rinch/src/lib.rs
+++ b/crates/rinch/src/lib.rs
@@ -181,9 +181,11 @@ pub mod prelude {
     #[cfg(feature = "gpu")]
     pub use crate::render_surface::{GpuTextureRegistrar, TextureSource};
 
-    // Shared GPU handle for zero-copy compositing
+    // Shared GPU handle + device-sharing entry points for zero-copy compositing
     #[cfg(feature = "gpu")]
-    pub use crate::shell::desktop::{GpuHandle, gpu_handle};
+    pub use crate::shell::desktop::{ExternalGpu, GpuHandle, RinchGpuConfig, gpu_handle};
+    #[cfg(feature = "gpu")]
+    pub use crate::shell::{run_with_external_device, run_with_gpu_config};
 
     // Re-export theme types when the theme feature is enabled
     #[cfg(feature = "theme")]
@@ -214,6 +216,18 @@ pub use shell::{
     inject_platform_event, run, run_on_main_thread, run_rinch, run_rinch_with_window_props,
     run_with_menu, run_with_theme, run_with_window_props, run_with_window_props_and_menu,
 };
+#[cfg(feature = "gpu")]
+pub use shell::{run_with_external_device, run_with_gpu_config};
+
+/// Re-export of the exact `wgpu` rinch links against.
+///
+/// Embedders that share a GPU device with rinch (see [`run_with_gpu_config`],
+/// [`run_with_external_device`], [`gpu_handle`], and
+/// [`render_surface::GpuTextureRegistrar`]) must construct `wgpu` types from
+/// **this** `wgpu` so the types match rinch's (rinch pins a patched fork). Use
+/// `rinch::wgpu::…` rather than a separate `wgpu` dependency.
+#[cfg(feature = "gpu")]
+pub use wgpu;
 
 pub use rinch_core as core;
 /// Reactive primitives (Signal, Effect, Memo, Scope).

--- a/crates/rinch/src/shell/desktop.rs
+++ b/crates/rinch/src/shell/desktop.rs
@@ -10,23 +10,26 @@ use peniko::Color;
 use rinch_platform::{CompositeLayer, PlatformRenderer, PlatformWindow, RenderError};
 use vello::{AaConfig, AaSupport, RenderParams, Renderer as VelloRenderer, RendererOptions, Scene};
 use wgpu::{
-    Backends, CommandEncoderDescriptor, Device, Extent3d, Instance, InstanceDescriptor, Limits,
-    MemoryHints, PresentMode, Queue, Surface, SurfaceConfiguration, Texture, TextureDescriptor,
-    TextureDimension, TextureFormat, TextureUsages, TextureView,
+    Adapter, Backends, CommandEncoderDescriptor, Device, Extent3d, Features, Instance,
+    InstanceDescriptor, Limits, MemoryHints, PresentMode, Queue, Surface, SurfaceConfiguration,
+    Texture, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages, TextureView,
 };
 use winit::window::Window;
 
 // ── GpuHandle ────────────────────────────────────────────────────────────────
 
-/// Shared GPU device and queue handle.
+/// Shared GPU device, queue, and adapter handle.
 ///
-/// Exposed after rinch creates the wgpu renderer so external code (e.g., a game
-/// engine running on a background thread) can share the same GPU device for
-/// zero-copy texture compositing.
+/// Exposed after rinch creates (or adopts) the wgpu renderer so external code
+/// (e.g., a game engine running on a background thread) can share the same GPU
+/// device for zero-copy texture compositing. The `adapter` is included so an
+/// embedder can introspect real device features/limits (e.g. to clamp buffer
+/// sizes against `adapter.limits()`).
 #[derive(Clone)]
 pub struct GpuHandle {
     pub device: Arc<Device>,
     pub queue: Arc<Queue>,
+    pub adapter: Arc<Adapter>,
 }
 
 static GPU_HANDLE: OnceLock<GpuHandle> = OnceLock::new();
@@ -34,10 +37,70 @@ static GPU_HANDLE: OnceLock<GpuHandle> = OnceLock::new();
 /// Get the shared GPU handle, if the renderer has been initialized.
 ///
 /// Returns `None` before `rinch::shell::run()` creates the wgpu device.
-/// After that, returns the `Arc<Device>` and `Arc<Queue>` that rinch uses
-/// internally, allowing external renderers to share the same GPU device.
+/// After that, returns the `Arc<Device>`, `Arc<Queue>`, and `Arc<Adapter>` that
+/// rinch uses internally, allowing external renderers to share the same GPU
+/// device.
 pub fn gpu_handle() -> Option<&'static GpuHandle> {
     GPU_HANDLE.get()
+}
+
+// ── GPU device injection (issue #57) ──────────────────────────────────────────
+
+/// Extra GPU device requirements for rinch's desktop compositor.
+///
+/// By default rinch requests its wgpu device with `Features::default()` /
+/// `Limits::default()`. An embedding application whose own renderer needs a
+/// higher-capability device (extra features, larger storage buffers, more bind
+/// groups, …) can raise those requirements here so that the device rinch
+/// composites with — the one published via [`gpu_handle`] — can also host the
+/// embedder's pipelines and textures for **zero-copy** present.
+///
+/// rinch still creates the instance, picks a surface-compatible adapter, and
+/// owns the device, so surface presentation is always correct. Use this via
+/// [`crate::run_with_gpu_config`]. The requested features/limits are passed
+/// through verbatim — if the adapter cannot satisfy them, device creation fails
+/// loudly rather than silently dropping a capability.
+#[derive(Clone, Default)]
+pub struct RinchGpuConfig {
+    /// Device features to require in addition to rinch's defaults.
+    pub required_features: Features,
+    /// Device limits to require (replaces `Limits::default()`).
+    pub required_limits: Limits,
+}
+
+/// A fully embedder-provided GPU stack for zero-copy present.
+///
+/// When an embedder would rather own device creation with its exact
+/// `DeviceDescriptor`, it can hand the whole stack to rinch via
+/// [`crate::run_with_external_device`]. rinch creates only the window surface
+/// (from the provided `instance`) and validates that `adapter` can present to
+/// it; it does **not** call `request_device`. The provided device becomes the
+/// one published through [`gpu_handle`].
+///
+/// The `instance` must be the one the `adapter`/`device` were created from, so
+/// that the window surface rinch creates is compatible with them.
+#[derive(Clone)]
+pub struct ExternalGpu {
+    pub instance: Instance,
+    pub adapter: Arc<Adapter>,
+    pub device: Arc<Device>,
+    pub queue: Arc<Queue>,
+}
+
+/// How the desktop `WgpuRenderer` should obtain its GPU device.
+pub(crate) enum GpuInit {
+    /// rinch creates the device with the given extra features/limits.
+    Config(RinchGpuConfig),
+    /// The embedder supplies the whole GPU stack.
+    External(ExternalGpu),
+}
+
+static GPU_INIT: OnceLock<GpuInit> = OnceLock::new();
+
+/// Install the GPU initialization strategy. Must be called before the runtime
+/// creates its window (i.e. before `run_*`). A second call is ignored.
+pub(crate) fn set_gpu_init(init: GpuInit) {
+    let _ = GPU_INIT.set(init);
 }
 
 /// A GPU texture layer for zero-copy compositing.
@@ -168,17 +231,28 @@ impl WgpuRenderer {
         let width = width.max(1);
         let height = height.max(1);
 
+        let gpu_init = GPU_INIT.get();
+
+        // Instance: reuse the embedder's when an external device is supplied
+        // (the surface must come from the instance the adapter/device belong to);
+        // otherwise create rinch's own.
+        //
         // Default to GPU-only backends (Vulkan/Metal/DX12). Skip GL/GLES probing
         // which loads Mesa gallium + LLVM (~70MB RSS) but can't run Vello anyway
         // (Vello requires compute shaders). WGPU_BACKEND env var still overrides.
-        let backends =
-            Backends::from_env().unwrap_or(Backends::VULKAN | Backends::METAL | Backends::DX12);
-        let instance = Instance::new(&InstanceDescriptor {
-            backends,
-            flags: wgpu::InstanceFlags::from_build_config().with_env(),
-            backend_options: wgpu::BackendOptions::from_env_or_default(),
-            memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
-        });
+        let instance = match gpu_init {
+            Some(GpuInit::External(g)) => g.instance.clone(),
+            _ => {
+                let backends = Backends::from_env()
+                    .unwrap_or(Backends::VULKAN | Backends::METAL | Backends::DX12);
+                Instance::new(&InstanceDescriptor {
+                    backends,
+                    flags: wgpu::InstanceFlags::from_build_config().with_env(),
+                    backend_options: wgpu::BackendOptions::from_env_or_default(),
+                    memory_budget_thresholds: wgpu::MemoryBudgetThresholds::default(),
+                })
+            }
+        };
 
         // SAFETY: The window outlives the surface — drop order in WgpuRenderer
         // ensures surface is dropped before the window.
@@ -193,12 +267,27 @@ impl WgpuRenderer {
                 .expect("Failed to create surface")
         };
 
-        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-            power_preference: wgpu::PowerPreference::HighPerformance,
-            compatible_surface: Some(&surface),
-            force_fallback_adapter: false,
-        }))
-        .expect("Failed to find adapter");
+        // Adapter: adopt the embedder's, or pick a surface-compatible one.
+        let adapter: Arc<Adapter> = match gpu_init {
+            Some(GpuInit::External(g)) => {
+                assert!(
+                    g.adapter.is_surface_supported(&surface),
+                    "run_with_external_device: the supplied adapter cannot present to \
+                     rinch's window surface. The adapter/device must be created from an \
+                     adapter that supports the target window (create the adapter with a \
+                     compatible surface, or use run_with_gpu_config to let rinch own the device)."
+                );
+                g.adapter.clone()
+            }
+            _ => Arc::new(
+                pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+                    power_preference: wgpu::PowerPreference::HighPerformance,
+                    compatible_surface: Some(&surface),
+                    force_fallback_adapter: false,
+                }))
+                .expect("Failed to find adapter"),
+            ),
+        };
 
         let caps = surface.get_capabilities(&adapter);
 
@@ -210,24 +299,39 @@ impl WgpuRenderer {
             caps.formats[0]
         };
 
-        let (raw_device, raw_queue) =
-            pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
-                label: Some("rinch-dom device"),
-                required_features: wgpu::Features::default(),
-                required_limits: Limits::default(),
-                memory_hints: MemoryHints::MemoryUsage,
-                trace: wgpu::Trace::default(),
-                experimental_features: wgpu::ExperimentalFeatures::default(),
-            }))
-            .expect("Failed to create device");
-
-        let device = Arc::new(raw_device);
-        let queue = Arc::new(raw_queue);
+        // Device/Queue: adopt the embedder's, or create one — optionally with
+        // the embedder's extra features/limits (issue #57).
+        let (device, queue) = match gpu_init {
+            Some(GpuInit::External(g)) => (g.device.clone(), g.queue.clone()),
+            other => {
+                let (features, limits) = match other {
+                    Some(GpuInit::Config(cfg)) => {
+                        (cfg.required_features, cfg.required_limits.clone())
+                    }
+                    _ => (Features::default(), Limits::default()),
+                };
+                let (raw_device, raw_queue) =
+                    pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+                        label: Some("rinch-dom device"),
+                        required_features: features,
+                        required_limits: limits,
+                        memory_hints: MemoryHints::MemoryUsage,
+                        trace: wgpu::Trace::default(),
+                        experimental_features: wgpu::ExperimentalFeatures::default(),
+                    }))
+                    .expect(
+                        "Failed to create device (the adapter may not support the \
+                         features/limits requested via run_with_gpu_config)",
+                    );
+                (Arc::new(raw_device), Arc::new(raw_queue))
+            }
+        };
 
         // Publish the shared GPU handle for external renderers
         let _ = GPU_HANDLE.set(GpuHandle {
             device: device.clone(),
             queue: queue.clone(),
+            adapter: adapter.clone(),
         });
 
         let surface_config = SurfaceConfiguration {

--- a/crates/rinch/src/shell/mod.rs
+++ b/crates/rinch/src/shell/mod.rs
@@ -321,3 +321,76 @@ pub fn run_with_window_props_and_menu<F>(
         rinch_runtime::run_rinch_with_window_props_and_menu(component, props, native_menu);
     }
 }
+
+/// Run a rinch application, raising the compositor GPU device's features/limits.
+///
+/// By default rinch requests its wgpu device with `Features::default()` /
+/// `Limits::default()`. When an embedding application's own renderer needs a
+/// higher-capability device — so it can create its pipelines and textures on
+/// **rinch's** device and hand back a `TextureView` for zero-copy present (see
+/// [`create_render_surface`](crate::render_surface::create_render_surface) and
+/// [`GpuTextureRegistrar`](crate::render_surface::GpuTextureRegistrar)) — pass a
+/// [`RinchGpuConfig`](crate::shell::desktop::RinchGpuConfig) here.
+///
+/// rinch still owns the instance, picks a surface-compatible adapter, and
+/// creates the device, so window presentation is always correct. After startup,
+/// obtain the shared device via [`gpu_handle`](crate::gpu_handle).
+///
+/// # Example
+///
+/// ```ignore
+/// use rinch::prelude::*;
+/// use rinch::shell::desktop::RinchGpuConfig;
+///
+/// let mut limits = wgpu::Limits::default();
+/// limits.max_storage_buffers_per_shader_stage = 32;
+/// let gpu = RinchGpuConfig {
+///     required_features: wgpu::Features::FLOAT32_FILTERABLE,
+///     required_limits: limits,
+/// };
+/// run_with_gpu_config(app, WindowProps::default(), None, gpu);
+/// ```
+#[cfg(feature = "gpu")]
+pub fn run_with_gpu_config<F>(
+    component: F,
+    props: WindowProps,
+    theme: Option<ThemeProviderProps>,
+    gpu: crate::shell::desktop::RinchGpuConfig,
+) where
+    F: FnOnce(&mut RenderScope) -> NodeHandle + 'static,
+{
+    crate::shell::desktop::set_gpu_init(crate::shell::desktop::GpuInit::Config(gpu));
+    run_with_window_props(component, props, theme);
+}
+
+/// Run a rinch application on an embedder-provided GPU device.
+///
+/// The embedder creates the whole GPU stack with its own `DeviceDescriptor` and
+/// hands it to rinch via [`ExternalGpu`](crate::shell::desktop::ExternalGpu).
+/// rinch creates only the window surface (from the provided `instance`),
+/// validates that the adapter can present to it, and composites directly onto
+/// the provided device — no `request_device`, no CPU readback. The provided
+/// device is published through [`gpu_handle`](crate::gpu_handle).
+///
+/// Prefer this when the embedder must keep its exact device descriptor; prefer
+/// [`run_with_gpu_config`] when it only needs to raise features/limits and would
+/// rather let rinch own device creation (which guarantees surface
+/// compatibility).
+///
+/// # Panics
+///
+/// Panics if the supplied adapter cannot present to rinch's window surface. The
+/// adapter/device must be created from an adapter that supports the target
+/// window (on multi-GPU systems, create the adapter with a compatible surface).
+#[cfg(feature = "gpu")]
+pub fn run_with_external_device<F>(
+    component: F,
+    props: WindowProps,
+    theme: Option<ThemeProviderProps>,
+    gpu: crate::shell::desktop::ExternalGpu,
+) where
+    F: FnOnce(&mut RenderScope) -> NodeHandle + 'static,
+{
+    crate::shell::desktop::set_gpu_init(crate::shell::desktop::GpuInit::External(gpu));
+    run_with_window_props(component, props, theme);
+}

--- a/docs/src/guide/game-engine.md
+++ b/docs/src/guide/game-engine.md
@@ -97,6 +97,47 @@ registrar.notify_frame_ready();
 
 `GpuTextureRegistrar` is also `Send + Sync + Clone`. The texture must be created on the same `wgpu::Device` (available via `gpu_handle()`).
 
+> **Use `rinch::wgpu`.** rinch pins a patched `wgpu` fork. Construct every `wgpu` type you hand back to rinch (`TextureView`, config features/limits, …) from `rinch::wgpu::…`, not a separately-pinned `wgpu` dependency, or the types won't match.
+
+### Sharing a High-Capability GPU Device
+
+Zero-copy compositing requires your texture to live on **the same device rinch composites with**. By default rinch requests that device with `Features::default()` / `Limits::default()`. If your renderer needs more (extra features, larger storage buffers, more bind groups, …), raise the device's requirements at startup so the shared device — the one published via `gpu_handle()` — can host your pipelines too.
+
+**Let rinch own the device (recommended).** rinch still creates the instance, picks a *surface-compatible* adapter, and creates the device, so presentation is always correct — you only add the capabilities you need:
+
+```rust
+use rinch::prelude::*;
+use rinch::wgpu;
+
+let gpu = RinchGpuConfig {
+    required_features: wgpu::Features::FLOAT32_FILTERABLE,
+    required_limits: wgpu::Limits {
+        max_storage_buffers_per_shader_stage: 32, // wgpu default is 8
+        ..Default::default()
+    },
+};
+run_with_gpu_config(app, WindowProps::default(), None, gpu);
+```
+
+After startup, `gpu_handle()` returns the shared `device`, `queue`, **and `adapter`** (use `adapter.limits()` to clamp, e.g. `max_buffer_size = min(adapter, 2 GiB)`). The requested features/limits are passed through verbatim — if the adapter can't satisfy them, device creation fails loudly rather than silently dropping a capability.
+
+**Bring your own device.** If you must keep your renderer's exact `DeviceDescriptor`, build the whole GPU stack and hand it to rinch. rinch creates only the window surface (from your `instance`), validates that your adapter can present to it, and composites directly onto your device — no `request_device`, no CPU readback:
+
+```rust
+use std::sync::Arc;
+use rinch::prelude::*;
+
+let gpu = ExternalGpu {
+    instance,                    // rinch creates the window surface from this
+    adapter: Arc::new(adapter),  // must be able to present to the window
+    device: Arc::new(device),
+    queue: Arc::new(queue),
+};
+run_with_external_device(app, WindowProps::default(), None, gpu);
+```
+
+The provided device is published through `gpu_handle()`. On a single-GPU machine a headless adapter (`compatible_surface: None`) usually presents fine; on multi-GPU systems create the adapter from a surface-compatible one, or prefer `run_with_gpu_config` (which guarantees compatibility). See the `gpu-device-config` example for both modes.
+
 ### Layout Size
 
 Query the surface's current layout dimensions (set by CSS/Taffy) to match your render resolution:

--- a/examples/gpu-device-config/Cargo.toml
+++ b/examples/gpu-device-config/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "gpu-device-config"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+# `gpu` enables the wgpu/Vello compositor; `debug` exposes the MCP bridge.
+rinch = { workspace = true, features = ["desktop", "gpu", "debug", "components", "theme"] }
+# Only needed for the `external` mode's block_on device creation. `wgpu` itself
+# comes from rinch::wgpu (the exact patched fork rinch links).
+pollster = "0.4"

--- a/examples/gpu-device-config/src/main.rs
+++ b/examples/gpu-device-config/src/main.rs
@@ -1,0 +1,166 @@
+//! Issue #57 — share rinch's compositor GPU device with the embedding app.
+//!
+//! An embedding application whose own renderer needs a higher-capability wgpu
+//! device (extra features, larger storage buffers, more bind groups, …) can
+//! raise those requirements so that the device rinch composites with — the one
+//! published via [`gpu_handle`] — can also host the embedder's pipelines and
+//! textures for **zero-copy** present (no GPU→CPU→GPU readback).
+//!
+//! This example proves the enabler two ways (pick with `RINCH_GPU_MODE`):
+//!
+//!   * **`config`** (default) — start rinch with [`run_with_gpu_config`],
+//!     bumping `max_storage_buffers_per_shader_stage` from the wgpu default of 8
+//!     to 32. rinch owns the device.
+//!   * **`external`** — the embedder builds the whole GPU stack with its own
+//!     `DeviceDescriptor` (as `arvx-render`'s `new_headless` does) and hands it
+//!     to rinch via [`run_with_external_device`]. rinch composites onto that
+//!     exact device.
+//!
+//! Either way the panel reads the *resolved* device back out of [`gpu_handle`]
+//! and confirms the shared device carries the raised limit and that the
+//! embedder can create GPU resources on it.
+//!
+//! For the full zero-copy present loop (register a `wgpu::TextureView` the
+//! compositor samples directly), see the `game-embed` and `render-test`
+//! examples plus `RenderSurfaceHandle::gpu_registrar()` / `set_texture_source`.
+
+use rinch::prelude::*;
+// `rinch::wgpu` is the exact (patched) wgpu rinch links against — construct GPU
+// config types from it so they match rinch's, not a separately-pinned wgpu.
+use rinch::wgpu;
+
+#[component]
+fn app() -> NodeHandle {
+    // The renderer is created before the component mounts, so the shared handle
+    // is available here.
+    let handle = gpu_handle().expect("gpu_handle available after the renderer starts");
+    let device_limits = handle.device.limits();
+    let adapter_info = handle.adapter.get_info();
+    let has_f32_filterable = handle
+        .device
+        .features()
+        .contains(wgpu::Features::FLOAT32_FILTERABLE);
+
+    // Prove the embedder can allocate GPU resources on rinch's device.
+    let probe = handle.device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("embedder-probe-buffer"),
+        size: 256,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let allocated_ok = probe.size() == 256;
+
+    let rows = vec![
+        ("adapter".to_string(), adapter_info.name.clone()),
+        ("backend".to_string(), format!("{:?}", adapter_info.backend)),
+        (
+            "max_storage_buffers_per_shader_stage".to_string(),
+            format!(
+                "{} (wgpu default is 8)",
+                device_limits.max_storage_buffers_per_shader_stage
+            ),
+        ),
+        (
+            "max_bind_groups".to_string(),
+            device_limits.max_bind_groups.to_string(),
+        ),
+        (
+            "FLOAT32_FILTERABLE feature".to_string(),
+            has_f32_filterable.to_string(),
+        ),
+        (
+            "allocated storage buffer on shared device".to_string(),
+            if allocated_ok { "OK" } else { "FAILED" }.to_string(),
+        ),
+    ];
+
+    rsx! {
+        div {
+            style: "display:flex; flex-direction:column; gap:12px; padding:24px; \
+                    font-family: system-ui, sans-serif;",
+            h1 { style: "margin:0; font-size:20px;", "Shared GPU device (issue #57)" }
+            p {
+                style: "margin:0; color:#555; font-size:13px;",
+                "run_with_gpu_config raised the compositor device's limits. \
+                 These values are read back from gpu_handle()."
+            }
+            div {
+                style: "display:flex; flex-direction:column; gap:6px; margin-top:8px;",
+                for row in rows.clone() {
+                    div {
+                        key: row.0.clone(),
+                        style: "display:flex; gap:8px; font-size:14px;",
+                        span { style: "min-width:340px; color:#333; font-weight:600;", {row.0.clone()} }
+                        span { style: "color:#0a7;", {row.1.clone()} }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// The elevated limits both modes request (the arvx headline: 8 → 32).
+fn required_limits() -> wgpu::Limits {
+    wgpu::Limits {
+        max_storage_buffers_per_shader_stage: 32,
+        ..Default::default()
+    }
+}
+
+fn main() {
+    let props = WindowProps {
+        title: "GPU device config".into(),
+        width: 720,
+        height: 380,
+        ..Default::default()
+    };
+
+    let external = std::env::var("RINCH_GPU_MODE").as_deref() == Ok("external");
+    if external {
+        run_external(app, props);
+    } else {
+        // rinch owns the device — it picks a surface-compatible adapter and
+        // requests it with our raised limits.
+        let gpu = RinchGpuConfig {
+            required_features: wgpu::Features::empty(),
+            required_limits: required_limits(),
+        };
+        run_with_gpu_config(app, props, None, gpu);
+    }
+}
+
+/// Build the whole GPU stack ourselves (the embedder-owns-the-device path) and
+/// hand it to rinch. This mirrors an app like `arvx-render` that keeps its exact
+/// device descriptor.
+fn run_external(app: fn(&mut RenderScope) -> NodeHandle, props: WindowProps) {
+    use std::sync::Arc;
+
+    let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+        backends: wgpu::Backends::from_env()
+            .unwrap_or(wgpu::Backends::VULKAN | wgpu::Backends::METAL | wgpu::Backends::DX12),
+        ..Default::default()
+    });
+    // Headless adapter — no surface yet (rinch owns the window). On a single-GPU
+    // system this is the same physical device that can present to that window.
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::HighPerformance,
+        compatible_surface: None,
+        force_fallback_adapter: false,
+    }))
+    .expect("no GPU adapter");
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("embedder device"),
+        required_features: wgpu::Features::empty(),
+        required_limits: required_limits(),
+        ..Default::default()
+    }))
+    .expect("failed to create embedder device");
+
+    let gpu = ExternalGpu {
+        instance,
+        adapter: Arc::new(adapter),
+        device: Arc::new(device),
+        queue: Arc::new(queue),
+    };
+    run_with_external_device(app, props, None, gpu);
+}


### PR DESCRIPTION
Closes #57.

## Problem

Zero-copy present requires an embedder's textures to live on the **same** `wgpu::Device` rinch composites with. But `WgpuRenderer::new` hardcoded `Features::default()` / `Limits::default()`, and there was no way to inject an externally-created device — so a high-feature embedder (arvx) whose pipelines require extra features/limits was forced into a per-frame GPU→CPU→GPU readback. `GpuHandle` also only exposed `device` + `queue` (no adapter to introspect real limits).

## What this adds

Two `gpu`-gated entry points, both funneling through a `GPU_INIT` static that `WgpuRenderer::new` consults:

| Entry point | Ownership | Use when |
|---|---|---|
| `run_with_gpu_config(component, props, theme, RinchGpuConfig { required_features, required_limits })` | rinch creates the device (surface-compatible adapter) with the embedder's extra features/limits | You just need more capability — **recommended**, always presents correctly |
| `run_with_external_device(component, props, theme, ExternalGpu { instance, adapter, device, queue })` | Embedder owns device creation with its exact `DeviceDescriptor`; rinch makes only the surface, asserts the adapter can present, composites onto that device | You must keep your exact descriptor |

Requested features/limits pass through **verbatim** — device creation fails loud if the adapter can't satisfy them, rather than silently dropping a capability.

Supporting changes:
- `GpuHandle` gains `adapter: Arc<Adapter>` (additive) — embedders clamp limits against `adapter.limits()`.
- `rinch::wgpu` re-exports the exact patched fork so embedder-constructed `wgpu` types type-match rinch's (consistent with the existing `set_texture_source(wgpu::TextureView, …)` API).

This satisfies the issue's asks #1 (external device) **and** #2 (config). Ask #3 (transparent-renderer parity) is left as a follow-up — arvx uses a normal window, and `TransparentWindowRenderer` isn't wired into the runtime.

## Design note

rinch owns the window, so the surface-compatible adapter must be chosen *after* the window exists. `run_with_gpu_config` is therefore the robust primary path (rinch guarantees surface compatibility); `run_with_external_device` supports the embedder-owns-device case with an `is_surface_supported` assertion + clear panic message for the multi-GPU edge.

## Validation

Live on **AMD Radeon 890M (RADV / Vulkan)** via the new `examples/gpu-device-config` (both modes):
- `max_storage_buffers_per_shader_stage: 32` (vs wgpu default **8**) — the raised limit reached the shared compositor device.
- `gpu_handle().adapter` exposed and correct.
- The app allocated a storage buffer on the shared device → **OK** (embedder can create GPU resources on rinch's device — the zero-copy precondition).
- `RINCH_GPU_MODE=external` renders through the embedder's own headless-created device (surface-compat validated).

Gates: `cargo fmt --check`, `clippy --workspace --all-targets`, `test --workspace` all green (pre-commit hook); default (software) build unaffected.

## Docs

- `CLAUDE.md` — RenderSurface section (entry-point table + source files).
- `docs/src/guide/game-engine.md` — new "Sharing a High-Capability GPU Device" subsection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)