### PR TITLE
fix(web): Enter fires data-onsubmit only without Shift, and preventDefault

### DIFF
--- a/crates/rinch-web/src/event_delegation.rs
+++ b/crates/rinch-web/src/event_delegation.rs
@@ -1187,8 +1187,10 @@ pub fn setup_event_delegation(doc: &WebDocument) {
         if events::dispatch_keyboard_event(&key_data) {
             event.prevent_default();
             event.stop_propagation();
-        } else if event.key() == "Enter" {
-            // Check if the target element (or ancestor) has data-onsubmit
+        } else if event.key() == "Enter" && !event.shift_key() {
+            // Enter (without Shift) fires the nearest ancestor's data-onsubmit,
+            // matching a native form submit. Shift+Enter is left alone so
+            // multiline inputs (a textarea) can insert a newline.
             if let Some(target) = event.target()
                 && let Ok(el) = target.dyn_into::<web_sys::Element>()
             {
@@ -1197,6 +1199,9 @@ pub fn setup_event_delegation(doc: &WebDocument) {
                     if let Some(handler_str) = el.get_attribute("data-onsubmit")
                         && let Ok(handler_id) = handler_str.parse::<usize>()
                     {
+                        // Prevent the browser from also inserting a newline
+                        // (in a textarea) or running a native form submit.
+                        event.prevent_default();
                         events::dispatch_event(events::EventHandlerId(handler_id));
                         break;
                     }

--- a/crates/rinch-web/src/event_delegation.rs
+++ b/crates/rinch-web/src/event_delegation.rs
@@ -1187,10 +1187,12 @@ pub fn setup_event_delegation(doc: &WebDocument) {
         if events::dispatch_keyboard_event(&key_data) {
             event.prevent_default();
             event.stop_propagation();
-        } else if event.key() == "Enter" && !event.shift_key() {
+        } else if event.key() == "Enter" && !event.shift_key() && !event.is_composing() {
             // Enter (without Shift) fires the nearest ancestor's data-onsubmit,
             // matching a native form submit. Shift+Enter is left alone so
-            // multiline inputs (a textarea) can insert a newline.
+            // multiline inputs (a textarea) can insert a newline. During an IME
+            // composition the Enter that commits the candidate is skipped
+            // (isComposing) so it confirms the text instead of submitting.
             if let Some(target) = event.target()
                 && let Ok(el) = target.dyn_into::<web_sys::Element>()
             {


### PR DESCRIPTION
## Problem

`rinch-web`'s keydown delegation fired the nearest ancestor's `data-onsubmit` on **any** `Enter` press and never called `preventDefault`. Two bugs fall out of that when the submit target is (or contains) a `<textarea>`:

- **Shift+Enter submits** instead of inserting a newline — you can't type multiline input.
- **Plain Enter both submits and leaves a stray newline** in the field, because the default textarea insertion still runs.

Desktop rinch's `handle_enter` already treats Enter-in-an-input as a submit; the web path just didn't guard Shift or prevent the default.

## Fix

- Guard the branch with `!event.shift_key()` so **Shift+Enter falls through** to the browser (newline in a textarea).
- Call `event.prevent_default()` once a `data-onsubmit` handler is found, so **plain Enter** submits cleanly without inserting a newline or running a native form submit.

Four lines, no API change.

## Verification

- `cargo check -p rinch-web --target wasm32-unknown-unknown` — clean.
- `cargo test -p rinch-web` — 6 passed.

## Context

Unblocks PlotWeb's migration off its forked web backend onto `rinch-web`: PlotWeb's custom delegation had an app-specific special case (Enter in `.feedback-reply-input` → click the sibling send button + `preventDefault`). With this fix, the plain `onsubmit:` on the reply container works correctly under `rinch-web`, so the fork's special case can be deleted with no app-side handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)