### PR TITLE
fix(web): deliver native <select>/checkbox/radio changes to oninput/onchange (#95)

### DIFF
--- a/crates/rinch-web/Cargo.toml
+++ b/crates/rinch-web/Cargo.toml
@@ -26,7 +26,7 @@ wasm-bindgen = "0.2"
 js-sys = "0.3"
 web-sys = { version = "0.3", features = [
     "Window", "Document", "Element", "HtmlElement", "HtmlInputElement",
-    "HtmlTextAreaElement", "HtmlHeadElement",
+    "HtmlTextAreaElement", "HtmlSelectElement", "HtmlHeadElement",
     "Node", "NodeList", "Text", "Comment",
     "CssStyleDeclaration", "DomRect", "DomRectList",
     "Event", "MouseEvent", "KeyboardEvent",

--- a/crates/rinch-web/src/event_delegation.rs
+++ b/crates/rinch-web/src/event_delegation.rs
@@ -1246,11 +1246,26 @@ pub fn setup_event_delegation(doc: &WebDocument) {
     let browser_doc2 = browser_doc.clone();
     let input_closure = Closure::wrap(Box::new(move |event: web_sys::Event| {
         if let Some(target) = event.target() {
-            // Try HtmlInputElement first
+            // Extract the control's user-visible value. Every native form
+            // control fires `input` on user modification, so this one listener
+            // covers text inputs, textareas, <select>, and checkbox/radio —
+            // provided we read the right property off each.
             let value = if let Ok(input) = target.clone().dyn_into::<web_sys::HtmlInputElement>() {
-                Some(input.value())
+                // Checkbox/radio carry their state in `.checked`; their `.value`
+                // is the static attribute (e.g. "on"), which never changes. Emit
+                // the boolean as "true"/"false" so a Fn(String) handler can
+                // observe toggles (a text input keeps delivering its `.value`).
+                match input.type_().as_str() {
+                    "checkbox" | "radio" => Some(input.checked().to_string()),
+                    _ => Some(input.value()),
+                }
             } else if let Ok(textarea) = target.clone().dyn_into::<web_sys::HtmlTextAreaElement>() {
                 Some(textarea.value())
+            } else if let Ok(select) = target.clone().dyn_into::<web_sys::HtmlSelectElement>() {
+                // A native <select> fires `input` on selection change; deliver
+                // the selected option's value. Without this, `oninput`/`onchange`
+                // on a <select> were silently dropped (issue #95).
+                Some(select.value())
             } else {
                 None
             };


### PR DESCRIPTION
Closes #95.

## Problem

In a `rinch-web` app, a native `<select>` couldn't report its selection to the reactive layer — neither `oninput` nor `onchange` ever fired, so the selected value was silently unobservable. Checkbox/radio had a related gap: their `.checked` state was unreadable (the handler read the static `.value` attribute, e.g. `"on"`).

## Root cause

The document-level `input` delegation in `crates/rinch-web/src/event_delegation.rs` only extracted a value from `HtmlInputElement`/`HtmlTextAreaElement`. A `<select>` (`HtmlSelectElement`) *does* fire an `input` event, so the listener ran — but it fell into the `else { None }` arm and discarded the event.

## Fix

Extend the single `input` listener (browsers fire `input` on all these controls):

- Add an `HtmlSelectElement` arm → deliver `select.value()`.
- For `HtmlInputElement`, read `.checked` (as `"true"`/`"false"`) for `checkbox`/`radio`; keep `.value` for everything else.
- Enable the `HtmlSelectElement` `web-sys` feature.

Both `oninput` and `onchange` now work, because the `rsx!` macro maps both onto the same `data-oninput` handler. A separate `change` listener was deliberately **not** added — it would double-fire the handler given that mapping.

## Verification

Built `ui-zoo-web` with a temporary native `<select>` + checkbox + radio panel, served with `trunk`, and drove it in Chromium (Playwright):

| Action | Signal readout |
|---|---|
| Select "Beta" then "Gamma" | `select: b` → `select: c` |
| Check the checkbox | `check: true` |
| Select radio #2 | `radio: true` |
| Uncheck the checkbox | `check: false` |

Zero console errors. The temp panel was reverted; only the two `rinch-web` files change. `cargo check --target wasm32-unknown-unknown`, `cargo fmt --check`, and clippy all pass (pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)