### PR TITLE
feat(embed): expose the Embed API on wasm32/WebGPU (#97)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4764,6 +4764,7 @@ version = "0.1.0"
 dependencies = [
  "thiserror 1.0.69",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
@@ -4808,6 +4809,7 @@ dependencies = [
  "tracing",
  "url",
  "vello",
+ "web-time",
  "web_atoms",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rinch-renderer = { path = "crates/rinch-renderer" }
 rinch-theme = { path = "crates/rinch-theme" }
 rinch-components = { path = "crates/rinch-components" }
 rinch-tabler-icons = { path = "crates/rinch-tabler-icons" }
-rinch-dom = { path = "crates/rinch-dom" }
+rinch-dom = { path = "crates/rinch-dom", default-features = false }
 rinch-editor-core = { path = "crates/rinch-editor-core" }
 rinch-editor-collab = { path = "crates/rinch-editor-collab" }
 rinch-editor-view = { path = "crates/rinch-editor-view" }

--- a/crates/rinch-core/Cargo.toml
+++ b/crates/rinch-core/Cargo.toml
@@ -16,3 +16,6 @@ test-util = []
 [dependencies]
 thiserror.workspace = true
 tracing.workspace = true
+# Wall/monotonic clock that works on wasm32-unknown-unknown (JS Date/performance.now).
+# On native it re-exports std::time verbatim, so this is zero-cost off the web.
+web-time = "1"

--- a/crates/rinch-core/src/reactive/poll.rs
+++ b/crates/rinch-core/src/reactive/poll.rs
@@ -5,7 +5,7 @@
 //! once per frame via [`drain_polls`].
 
 use std::cell::RefCell;
-use std::time::Instant;
+use web_time::Instant;
 
 use super::Signal;
 use super::is_main_thread;

--- a/crates/rinch-dom/Cargo.toml
+++ b/crates/rinch-dom/Cargo.toml
@@ -9,6 +9,9 @@ rinch-core = { workspace = true }
 slab = "0.4"
 taffy = "0.9"
 bitflags = "2"
+# Monotonic/wall clock usable on wasm32-unknown-unknown (layout perf timers + CSS
+# transition/animation clocks). Re-exports std::time on native — zero cost off web.
+web-time = "1"
 tracing = { workspace = true }
 parley = { workspace = true }
 vello = { workspace = true }

--- a/crates/rinch-dom/src/dom_impl/mod.rs
+++ b/crates/rinch-dom/src/dom_impl/mod.rs
@@ -309,7 +309,7 @@ impl RinchDocument {
     /// Advance all active CSS transitions by one frame.
     /// Returns true if any transitions are still active (caller should keep polling).
     pub fn tick_transitions(&mut self) -> bool {
-        use std::time::SystemTime;
+        use web_time::SystemTime;
         let current_time_ms = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap_or_default()
@@ -394,7 +394,7 @@ impl RinchDocument {
     /// Advance all active CSS animations by one frame.
     /// Returns true if any animations are still active (caller should keep polling).
     pub fn tick_animations(&mut self) -> bool {
-        use std::time::SystemTime;
+        use web_time::SystemTime;
         let current_time_ms = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap_or_default()

--- a/crates/rinch-dom/src/image_cache.rs
+++ b/crates/rinch-dom/src/image_cache.rs
@@ -131,6 +131,16 @@ impl ImageLoader for FileImageLoader {
 ///
 /// When complete, the result is pushed to the global pending queue.
 /// Call [`ImageCache::drain_pending()`] from the main thread to collect results.
+///
+/// On `wasm32-unknown-unknown` there are no OS threads (`std::thread::spawn` would
+/// panic), so file/remote loads are a no-op there. Synchronous `data:` URIs never
+/// reach this path — they are decoded inline via [`decode_data_uri`] — so embedded
+/// (base64) images still render on the web. (issue #97)
+#[cfg(target_arch = "wasm32")]
+pub fn request_image_load(_src: String, _loader: Arc<dyn ImageLoader>) {}
+
+/// Spawn a background thread to load and decode an image (native).
+#[cfg(not(target_arch = "wasm32"))]
 pub fn request_image_load(src: String, loader: Arc<dyn ImageLoader>) {
     std::thread::spawn(move || {
         let result = loader.load(&src);

--- a/crates/rinch-dom/src/layout_engine.rs
+++ b/crates/rinch-dom/src/layout_engine.rs
@@ -17,7 +17,7 @@ impl RinchDocument {
     /// Text nodes are measured using Parley for accurate text layout.
     pub fn resolve_layout(&mut self, width: f32, height: f32) {
         let perf = std::env::var("RINCH_PERF").is_ok();
-        let t0 = std::time::Instant::now();
+        let t0 = web_time::Instant::now();
 
         let old_viewport = self.tree.viewport;
         self.tree.viewport = crate::layout::Viewport { width, height };
@@ -40,7 +40,7 @@ impl RinchDocument {
 
         // Resolve Stylo styles and apply to Taffy nodes (only if dirty)
         if self.tree.styles_dirty {
-            let t = std::time::Instant::now();
+            let t = web_time::Instant::now();
             self.resolve_styles();
             if perf {
                 eprintln!(
@@ -48,7 +48,7 @@ impl RinchDocument {
                     t.elapsed().as_secs_f64() * 1000.0
                 );
             }
-            let t = std::time::Instant::now();
+            let t = web_time::Instant::now();
             self.apply_stylo_styles_to_taffy();
             if perf {
                 eprintln!(
@@ -72,7 +72,7 @@ impl RinchDocument {
         // For these, skip Taffy but still rebuild the affected IFC text layouts.
         if !self.tree.layout_dirty {
             if !self.tree.dirty_ifc_text_roots.is_empty() {
-                let t = std::time::Instant::now();
+                let t = web_time::Instant::now();
                 self.sync_dirty_text_contexts();
                 let mut temp_layout_cx = std::mem::take(&mut self.layout_cx);
                 self.build_ifc_layouts(&mut temp_layout_cx);
@@ -114,7 +114,7 @@ impl RinchDocument {
             self.tree.dirty_ifc_text_roots.clear();
 
             // Handle display:contents by rebuilding taffy children for affected nodes
-            let t = std::time::Instant::now();
+            let t = web_time::Instant::now();
             self.sync_display_contents();
             if perf {
                 eprintln!(
@@ -124,7 +124,7 @@ impl RinchDocument {
             }
 
             // Detect and set up inline formatting contexts
-            let t = std::time::Instant::now();
+            let t = web_time::Instant::now();
             self.setup_inline_formatting_contexts();
             if perf {
                 eprintln!(
@@ -135,7 +135,7 @@ impl RinchDocument {
 
             // Pre-compute layout for inline-block children that were detached from Taffy.
             // They need their own subtree measured so walk_inline_children can read dimensions.
-            let t = std::time::Instant::now();
+            let t = web_time::Instant::now();
             self.compute_inline_block_layouts();
             if perf {
                 eprintln!(
@@ -145,7 +145,7 @@ impl RinchDocument {
             }
 
             // Sync font-size from parent elements to text node contexts
-            let t = std::time::Instant::now();
+            let t = web_time::Instant::now();
             self.sync_text_contexts();
             if perf {
                 eprintln!(
@@ -157,7 +157,7 @@ impl RinchDocument {
             self.tree.ifc_dirty = false;
         } else {
             // IFC structure unchanged — only sync text contexts for dirty nodes
-            let t = std::time::Instant::now();
+            let t = web_time::Instant::now();
             self.sync_dirty_text_contexts();
             if perf {
                 eprintln!(
@@ -187,7 +187,7 @@ impl RinchDocument {
         // Only invalidated when an IFC root's text content changes.
         let ifc_measure_cache = RefCell::new(std::mem::take(&mut self.tree.ifc_measure_cache));
 
-        let t = std::time::Instant::now();
+        let t = web_time::Instant::now();
         self.tree
             .taffy
             .compute_layout_with_measure(
@@ -371,7 +371,7 @@ impl RinchDocument {
         }
 
         // Read layout results back into nodes
-        let t = std::time::Instant::now();
+        let t = web_time::Instant::now();
         self.read_layout_results(self.tree.root_id);
         if perf {
             eprintln!(
@@ -388,7 +388,7 @@ impl RinchDocument {
 
         // Build inline layouts for IFC roots (rebuild with final widths and store)
         // Temporarily take layout_cx out to avoid borrow conflict
-        let t = std::time::Instant::now();
+        let t = web_time::Instant::now();
         let mut temp_layout_cx = std::mem::take(&mut self.layout_cx);
         self.build_ifc_layouts(&mut temp_layout_cx);
         self.layout_cx = temp_layout_cx;
@@ -401,7 +401,7 @@ impl RinchDocument {
         }
 
         // Copy cached text layouts to nodes (use the exact layouts from measurement)
-        let t = std::time::Instant::now();
+        let t = web_time::Instant::now();
         self.copy_cached_text_layouts(text_layout_cache.into_inner());
         if perf {
             eprintln!(

--- a/crates/rinch-dom/src/style_resolution/mod.rs
+++ b/crates/rinch-dom/src/style_resolution/mod.rs
@@ -622,7 +622,7 @@ impl RinchDocument {
 
     /// Get a monotonic timestamp in milliseconds for transition timing.
     fn current_time_ms(&self) -> f64 {
-        use std::time::SystemTime;
+        use web_time::SystemTime;
         SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap_or_default()

--- a/crates/rinch-test/Cargo.toml
+++ b/crates/rinch-test/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 description = "MCP-based test harness for rinch applications (Playwright for rinch)"
 
 [dependencies]
-rinch-dom = { workspace = true }
+rinch-dom = { workspace = true, features = ["software-renderer"] }
 rmcp = { version = "0.13", features = ["server", "transport-io", "macros"] }
 tokio = { workspace = true }
 serde = { version = "1", features = ["derive"] }

--- a/crates/rinch/Cargo.toml
+++ b/crates/rinch/Cargo.toml
@@ -140,6 +140,19 @@ android-gpu = [
     "dep:vello", "dep:wgpu",
     "dep:pollster",
 ]
+# wasm-safe GPU embed (issue #97): the platform-agnostic Embed API — `RinchApp`
+# (layout + Vello scene) + `RinchContext`/`build_scene` + wgpu/vello — WITHOUT the
+# desktop windowing stack (no winit / softbuffer / muda / tokio). The consumer owns
+# the wgpu Device/Queue/Surface and composites the returned Vello scene over its own
+# WebGPU render. Mirrors how `android` builds `app` without winit, minus native deps.
+# rinch-dom comes in with default-features off (workspace root), so tiny-skia/swash
+# (`software-renderer`) stay out — the embed path is Vello-only.
+embed = [
+    "dep:rinch-dom", "dep:rinch-editable", "dep:parley",
+    "dep:peniko",
+    "rinch-platform/renderer",
+    "dep:vello", "dep:wgpu",
+]
 file-dialogs = ["rfd"]
 clipboard = ["dep:rinch-clipboard"]
 system-tray = ["tray-icon", "gtk", "ksni"]

--- a/crates/rinch/src/app/event_dispatch.rs
+++ b/crates/rinch/src/app/event_dispatch.rs
@@ -1668,7 +1668,7 @@ impl RinchApp {
 
         let anchor;
 
-        #[cfg(any(feature = "gpu", feature = "android-gpu"))]
+        #[cfg(any(feature = "gpu", feature = "android-gpu", feature = "embed"))]
         let snapshot = {
             let mut painter = VelloPainter::new();
             let mut d = doc.borrow_mut();
@@ -1692,7 +1692,7 @@ impl RinchApp {
             painter
         };
 
-        #[cfg(not(any(feature = "gpu", feature = "android-gpu")))]
+        #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
         let (snapshot_pixels, snapshot_width, snapshot_height) = {
             let mut d = doc.borrow_mut();
             let d = &mut *d;
@@ -1730,13 +1730,13 @@ impl RinchApp {
 
         self.active_dnd = Some(ActiveDrag {
             node_id,
-            #[cfg(any(feature = "gpu", feature = "android-gpu"))]
+            #[cfg(any(feature = "gpu", feature = "android-gpu", feature = "embed"))]
             snapshot,
-            #[cfg(not(any(feature = "gpu", feature = "android-gpu")))]
+            #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
             snapshot_pixels,
-            #[cfg(not(any(feature = "gpu", feature = "android-gpu")))]
+            #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
             snapshot_width,
-            #[cfg(not(any(feature = "gpu", feature = "android-gpu")))]
+            #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
             snapshot_height,
             anchor,
             cursor,

--- a/crates/rinch/src/app/mod.rs
+++ b/crates/rinch/src/app/mod.rs
@@ -23,9 +23,9 @@ use rinch_core::dom::{DomDocument, NodeHandle, RenderScope, clear_render_scope, 
 use rinch_core::events;
 use rinch_dom::RinchDocument;
 use rinch_dom::paint::painter::Painter;
-#[cfg(not(any(feature = "gpu", feature = "android-gpu")))]
+#[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
 use rinch_dom::paint::skia_painter::TinySkiaPainter;
-#[cfg(any(feature = "gpu", feature = "android-gpu"))]
+#[cfg(any(feature = "gpu", feature = "android-gpu", feature = "embed"))]
 use rinch_dom::paint::vello_painter::VelloPainter;
 use rinch_dom::text_query::byte_offset_from_position;
 #[cfg(feature = "debug")]
@@ -36,7 +36,7 @@ use rinch_editable::{EditCommand, EditableDocument, EditableState, Selection, St
 use rinch_platform::{
     AppAction, ImeEvent, Instant, KeyCode, Modifiers, MouseButton, PlatformEvent, UserEvent,
 };
-#[cfg(any(feature = "gpu", feature = "android-gpu"))]
+#[cfg(any(feature = "gpu", feature = "android-gpu", feature = "embed"))]
 use vello::Scene;
 
 /// Viewport rectangle as (x, y, width, height) in logical pixels.
@@ -65,16 +65,16 @@ pub(crate) struct ActiveDrag {
     /// The draggable source element.
     pub node_id: usize,
     /// Captured painting of the source element's subtree (at origin).
-    #[cfg(any(feature = "gpu", feature = "android-gpu"))]
+    #[cfg(any(feature = "gpu", feature = "android-gpu", feature = "embed"))]
     pub snapshot: VelloPainter,
     /// Captured RGBA pixels of the source element's subtree (software backend).
-    #[cfg(not(any(feature = "gpu", feature = "android-gpu")))]
+    #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
     pub snapshot_pixels: Vec<u8>,
     /// Width of the snapshot pixmap in physical pixels.
-    #[cfg(not(any(feature = "gpu", feature = "android-gpu")))]
+    #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
     pub snapshot_width: u32,
     /// Height of the snapshot pixmap in physical pixels.
-    #[cfg(not(any(feature = "gpu", feature = "android-gpu")))]
+    #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
     pub snapshot_height: u32,
     /// Offset within element where the grab happened (physical px, relative to element top-left).
     pub anchor: (f32, f32),
@@ -159,10 +159,10 @@ pub struct RinchApp {
     /// The document (shared with RenderScope).
     pub(crate) doc: Option<Rc<RefCell<RinchDocument>>>,
     /// GPU painter (reused across frames). Wraps vello::Scene.
-    #[cfg(any(feature = "gpu", feature = "android-gpu"))]
+    #[cfg(any(feature = "gpu", feature = "android-gpu", feature = "embed"))]
     pub(crate) painter: VelloPainter,
     /// Software painter (reused across frames). Uses tiny-skia for CPU rendering.
-    #[cfg(not(any(feature = "gpu", feature = "android-gpu")))]
+    #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
     pub(crate) skia_painter: Option<TinySkiaPainter>,
     /// Parley layout context for paint-time text layout (debug screenshots).
     #[cfg(feature = "debug")]
@@ -197,7 +197,7 @@ pub struct RinchApp {
     /// Text rendering scale for HiDPI/mobile (applied to Parley font sizes).
     pub(crate) text_scale: f32,
     /// Whether we have a previous frame's pixels for dirty region caching.
-    #[cfg(not(any(feature = "gpu", feature = "android-gpu")))]
+    #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
     pub(crate) has_previous_frame: bool,
     /// The data-oninput handler ID for the currently focused text input.
     pub(crate) focused_input_handler_id: Option<usize>,
@@ -252,9 +252,9 @@ impl RinchApp {
             component: Some(Box::new(component)),
             _render_scope: None,
             doc: None,
-            #[cfg(any(feature = "gpu", feature = "android-gpu"))]
+            #[cfg(any(feature = "gpu", feature = "android-gpu", feature = "embed"))]
             painter: VelloPainter::new(),
-            #[cfg(not(any(feature = "gpu", feature = "android-gpu")))]
+            #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
             skia_painter: None,
             #[cfg(feature = "debug")]
             paint_layout_cx: parley::LayoutContext::new(),
@@ -272,7 +272,7 @@ impl RinchApp {
             modifiers: Modifiers::default(),
             scene_dirty: true,
             text_scale: 1.0,
-            #[cfg(not(any(feature = "gpu", feature = "android-gpu")))]
+            #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
             has_previous_frame: false,
             focused_input_handler_id: None,
             focused_input_value: String::new(),
@@ -531,7 +531,7 @@ impl RinchApp {
                 // Force full repaint — recompute_all_styles_full() updates computed
                 // styles but doesn't populate paint_dirty_nodes, so the software
                 // renderer's dirty region optimization would skip most of the screen.
-                #[cfg(not(any(feature = "gpu", feature = "android-gpu")))]
+                #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
                 {
                     self.has_previous_frame = false;
                 }
@@ -573,7 +573,7 @@ impl RinchApp {
             if d.tree.full_repaint_needed {
                 d.tree.full_repaint_needed = false;
                 self.scene_dirty = true;
-                #[cfg(not(any(feature = "gpu", feature = "android-gpu")))]
+                #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
                 {
                     self.has_previous_frame = false;
                 }
@@ -778,7 +778,7 @@ impl RinchApp {
     ///
     /// The scene is painted via the `Painter` trait and a reference to the
     /// underlying `vello::Scene` is returned for the GPU renderer.
-    #[cfg(any(feature = "gpu", feature = "android-gpu"))]
+    #[cfg(any(feature = "gpu", feature = "android-gpu", feature = "embed"))]
     pub fn build_scene(&mut self, scale: f64, size: (u32, u32)) -> &Scene {
         if !self.scene_dirty {
             return self.painter.scene();
@@ -829,7 +829,7 @@ impl RinchApp {
     ///
     /// Returns (pixels, width, height) in RGBA8 format. The painter is lazily
     /// created on first call and resized as needed.
-    #[cfg(not(any(feature = "gpu", feature = "android-gpu")))]
+    #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
     pub fn build_pixels(
         &mut self,
         scale: f64,
@@ -1032,7 +1032,7 @@ impl RinchApp {
     /// Blit premultiplied RGBA source pixels onto a destination buffer with
     /// alpha compositing (source-over). `dx`/`dy` can be negative for partially
     /// off-screen overlays.
-    #[cfg(not(any(feature = "gpu", feature = "android-gpu")))]
+    #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
     #[allow(clippy::too_many_arguments)]
     fn blit_drag_overlay(
         dst: &mut [u8],

--- a/crates/rinch/src/embed.rs
+++ b/crates/rinch/src/embed.rs
@@ -88,6 +88,15 @@ pub struct RinchContextConfig {
     /// Optional theme configuration. When `None`, the default theme is used
     /// (if the `theme` feature is enabled).
     pub theme: Option<ThemeProviderProps>,
+    /// Fonts (TTF/OTF bytes) to register **before** the component mounts, so the
+    /// very first layout/paint pass has glyphs.
+    ///
+    /// This is the correct hook for environments with no system fonts — most
+    /// importantly **wasm32/WebGPU**, where the platform provides no fallback
+    /// font and text would otherwise render as zero glyphs. (Registering a font
+    /// *after* [`RinchContext::new`] via [`register_font`](RinchContext::register_font)
+    /// is too late for the initial mount.)
+    pub fonts: Vec<&'static [u8]>,
 }
 
 // ── RinchContext ──────────────────────────────────────────────────────────────
@@ -128,6 +137,13 @@ impl RinchContext {
         let _ = &config.theme; // suppress unused warning when theme feature is off
 
         let mut app = RinchApp::new(component);
+
+        // Register any pre-mount fonts BEFORE mounting so the initial layout/paint
+        // pass has glyphs (essential on wasm, which has no system fonts). These are
+        // drained onto the document's render font context during mount_component.
+        for font in &config.fonts {
+            app.register_font_data(font);
+        }
 
         let width = config.width.max(1);
         let height = config.height.max(1);
@@ -270,14 +286,16 @@ impl RinchContext {
         self.app.has_focused_input() || self.app.has_focused_contenteditable()
     }
 
-    /// Register font data for text rendering.
+    /// Register font data for text rendering **after** the initial mount.
     ///
     /// Useful in environments without system fonts (e.g. WASM, embedded).
-    /// Must be called **before** [`new`](RinchContext::new) returns, so
-    /// use [`RinchContext::register_font_post_init`] if you need to add
-    /// fonts after creation, or pre-register on the app before mounting.
+    /// The font applies to subsequent layout/paint passes, not the mount that
+    /// already happened inside [`new`](RinchContext::new). To have glyphs on the
+    /// **first** frame — which is mandatory on wasm/WebGPU, where there is no
+    /// system fallback font — supply the font via
+    /// [`RinchContextConfig::fonts`] instead.
     ///
-    /// For pre-init font registration, create the `RinchApp` manually.
+    /// The data should be a TrueType (`.ttf`) or OpenType (`.otf`) font file.
     pub fn register_font(&mut self, data: &'static [u8]) {
         self.app.register_font_data(data);
     }

--- a/crates/rinch/src/lib.rs
+++ b/crates/rinch/src/lib.rs
@@ -42,13 +42,13 @@
 //! | [`create_context`] | Share state across components |
 //! | [`use_context`] | Access shared context values |
 
-#[cfg(any(feature = "desktop", feature = "android"))]
+#[cfg(any(feature = "desktop", feature = "android", feature = "embed"))]
 pub mod app;
 /// The ProseMirror-style desktop rich-text editor view. Part of the `desktop`
 /// feature; implements `rinch_editor_core::EditorView` over rinch-dom primitives.
 #[cfg(feature = "desktop")]
 pub mod editor;
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "gpu", feature = "embed"))]
 pub mod embed;
 #[cfg(feature = "desktop")]
 pub mod menu;
@@ -157,7 +157,7 @@ pub mod prelude {
     pub use rinch_core::virtual_list;
 
     // Embed API for game engine integration
-    #[cfg(feature = "gpu")]
+    #[cfg(any(feature = "gpu", feature = "embed"))]
     pub use crate::embed::{
         GameViewport, LayoutRect, RinchContext, RinchContextConfig, RinchOverlayRenderer,
     };
@@ -226,7 +226,7 @@ pub use shell::{run_with_external_device, run_with_gpu_config};
 /// [`render_surface::GpuTextureRegistrar`]) must construct `wgpu` types from
 /// **this** `wgpu` so the types match rinch's (rinch pins a patched fork). Use
 /// `rinch::wgpu::…` rather than a separate `wgpu` dependency.
-#[cfg(feature = "gpu")]
+#[cfg(any(feature = "gpu", feature = "embed"))]
 pub use wgpu;
 
 pub use rinch_core as core;

--- a/crates/rinch/src/render_surface.rs
+++ b/crates/rinch/src/render_surface.rs
@@ -186,7 +186,7 @@ pub enum SurfaceMouseButton {
     Middle,
 }
 
-#[cfg(any(feature = "desktop", feature = "android"))]
+#[cfg(any(feature = "desktop", feature = "android", feature = "embed"))]
 impl SurfaceMouseButton {
     /// Convert from platform MouseButton.
     pub fn from_platform(button: rinch_platform::MouseButton) -> Self {

--- a/examples/game-embed/src/main.rs
+++ b/examples/game-embed/src/main.rs
@@ -789,6 +789,8 @@ impl App {
                     primary_color: Some("blue".into()),
                     ..Default::default()
                 }),
+                // Desktop has system fonts; no embedded font needed here.
+                fonts: Vec::new(),
             },
             game_ui,
         );

--- a/examples/render-test/Cargo.toml
+++ b/examples/render-test/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 [dependencies]
 rinch = { workspace = true, features = ["desktop", "components", "theme"] }
 rinch-core = { workspace = true }
-rinch-dom = { workspace = true }
+rinch-dom = { workspace = true, features = ["software-renderer"] }
 png = "0.17"
 wgpu = { workspace = true, optional = true }
 pollster = { version = "0.4", optional = true }


### PR DESCRIPTION
Closes #97 (pending browser pixel-verification — see caveat below).

Enables the platform-agnostic **Embed API** (`RinchContext` / `build_scene` → `vello::Scene`) on **`wasm32-unknown-unknown`**, so a web app can composite a rinch UI over its **own** app-owned WebGPU render — the same *game-owns-the-device* pattern as `examples/game-embed`, now in the browser. No DOM overlay; Vello → texture → blit.

## Feasibility was the risk — it's now proven empirically

The issue flagged stylo-on-wasm as the main unknown (the layout/text/Vello stack had never been built for wasm). Building it settles it:

| Built for `wasm32-unknown-unknown` | Result |
|---|---|
| `rinch-dom` (stylo 0.11 + parley + taffy + vello 0.7 + naga + the patched wgpu fork) | ✅ compiles |
| whole `rinch` crate with `--features embed` | ✅ compiles |
| `getrandom` / `tokio` / `mio` / `socket2` in the wasm tree | absent — no hidden break |

Even the `joeleaver/wgpu-fork` builds on wasm; a consumer on stock crates.io `wgpu` 27 (official WebGPU support) is if anything a safer path.

## What changed (pure Cargo + `#[cfg]` surgery — no logic rewrites)

- **New standalone `embed` feature** — turns on `app` + `embed` + `build_scene` + vello + wgpu **without** `desktop` (no winit/softbuffer/muda/tokio). Admits the feature in the `app` / `embed` / `build_scene` cfg gates (`lib.rs`, `app/mod.rs`, `app/event_dispatch.rs`, `render_surface.rs`). Mirrors how `android` already builds `app` without winit.
- **Minimality** — `rinch-dom` declared `default-features = false` at the workspace root so tiny-skia/swash (`software-renderer`) drop out of the wasm tree; `rinch-test` + `render-test` re-enable it explicitly. Verified the wasm embed tree carries **none** of tiny-skia/winit/softbuffer/muda/tokio.

## Runtime correctness (a green compile still panicked on frame 1)

- **Time** — 17 raw `std::time::{Instant,SystemTime}` clock calls in `rinch-dom` (`layout_engine`, `dom_impl`, `style_resolution`) and `rinch-core` (`reactive/poll`) now route through **`web_time`** (re-exports `std::time` on native → zero cost off-web). `resolve_layout` calls `Instant::now()` unconditionally, so without this the embed app panics on its first frame.
- **Threads** — the image-cache background `thread::spawn` is gated off on wasm; `data:` URIs still decode inline, so embedded images keep working.
- **Fonts** — added `RinchContextConfig.fonts`, registered **before** mount, so first-frame text has glyphs on wasm (no system fonts). The old `register_font()` was post-mount and silently produced blank/tofu text; its docs are fixed (dropped the phantom `register_font_post_init` link).

## Verification

All exit 0 (+ the repo pre-commit hook ran fmt/clippy/build/tests green):
```
cargo build -p rinch --no-default-features --features embed --target wasm32-unknown-unknown
cargo check -p rinch                                   # desktop, no regression
cargo check -p rinch --no-default-features --features gpu
cargo check -p rinch-test -p render-test
cargo check -p game-embed
```

## Caveat / follow-ups

- **Real pixels in a WebGPU browser need `navigator.gpu`** — not verifiable headless in CI; left for consumers (happy to pair with Playweft on a branch test).
- WebGPU note: use **`Rgba8Unorm`** (not `Bgra8Unorm`) for the overlay's `STORAGE_BINDING` intermediate — the wasm analogue of the DX12 storage fix the wgpu fork carries. Vello needs a real WebGPU (compute) device, not WebGL2.
- No `examples/webgpu-embed-web` yet (deferred — didn't want to ship example code that can't be runtime-verified here).
- 5 benign dead-code warnings in the embed config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)