### PR TITLE
fix(web): reflect form-control value/checked to the DOM property, not just the attribute (#100)

### DIFF
--- a/crates/rinch-components/src/checkbox.rs
+++ b/crates/rinch-components/src/checkbox.rs
@@ -168,10 +168,17 @@ impl Component for Checkbox {
             label_node.append_child(&label_span);
         }
 
-        // If reactive checked_fn is provided, create an Effect to toggle checked class
+        // If reactive checked_fn is provided, create an Effect that toggles both
+        // the label's checked class AND the native <input>'s `checked` state. The
+        // input is toggled by *presence* (set "" / remove) so it stays correct on
+        // both backends: on web `set_attribute` mirrors it onto the live `.checked`
+        // property (issue #100) — without this, the accessible/native checked
+        // state (and `:checked`, native form submission) goes stale on a
+        // programmatic update; on desktop the attribute drives `:checked`.
         if let Some(ref checked_fn) = self.checked_fn {
             let checked_fn = checked_fn.clone();
             let label_clone = label_node.clone();
+            let input_clone = input.clone();
             let base_class = self.base_class_string();
 
             __scope.create_effect(move || {
@@ -179,8 +186,10 @@ impl Component for Checkbox {
                 if is_checked {
                     label_clone
                         .set_attribute("class", &format!("{} rinch-checkbox--checked", base_class));
+                    input_clone.set_attribute("checked", "");
                 } else {
                     label_clone.set_attribute("class", &base_class);
+                    input_clone.remove_attribute("checked");
                 }
             });
         }

--- a/crates/rinch-components/src/password_input.rs
+++ b/crates/rinch-components/src/password_input.rs
@@ -196,14 +196,6 @@ impl PasswordInput {
     }
 }
 
-/// HTML-escape a string for safe use in attributes.
-fn html_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
-}
-
 impl Component for PasswordInput {
     fn render(&self, __scope: &mut RenderScope, _children: &[NodeHandle]) -> NodeHandle {
         let container_class = self.class_string();
@@ -258,19 +250,24 @@ impl Component for PasswordInput {
         let input_type = if initial_visible { "text" } else { "password" };
         input.set_attribute("type", input_type);
 
-        // Reactive value binding (following TextInput pattern)
+        // Reactive value binding (matching the TextInput pattern). The value is
+        // written raw, never HTML-escaped: `set_attribute` goes through the DOM
+        // API (not HTML parsing), so escaping is both unnecessary and corrupting —
+        // and on web it is now mirrored onto the live `value` *property*, where an
+        // escaped string would display literal entities and double-escape on every
+        // keystroke (issue #100).
         if let Some(ref value_fn) = self.value_fn {
             let initial_value = value_fn();
-            input.set_attribute("value", &html_escape(&initial_value));
+            input.set_attribute("value", &initial_value);
 
             let value_fn = value_fn.clone();
             let input_clone = input.clone();
             __scope.create_effect(move || {
                 let current_value = value_fn();
-                input_clone.set_attribute("value", &html_escape(&current_value));
+                input_clone.set_attribute("value", &current_value);
             });
         } else if !initial_password.is_empty() {
-            input.set_attribute("value", &html_escape(&initial_password));
+            input.set_attribute("value", &initial_password);
         }
 
         // Reactive visibility binding — toggles type attribute
@@ -284,7 +281,7 @@ impl Component for PasswordInput {
         }
 
         if !self.placeholder.is_empty() {
-            input.set_attribute("placeholder", &html_escape(&self.placeholder));
+            input.set_attribute("placeholder", &self.placeholder);
         }
         if self.disabled {
             input.set_attribute("disabled", "");

--- a/crates/rinch-components/src/radio.rs
+++ b/crates/rinch-components/src/radio.rs
@@ -252,10 +252,18 @@ impl Component for Radio {
             label_node.append_child(&body);
         }
 
-        // If reactive checked_fn is provided, create an Effect to toggle checked class
+        // If reactive checked_fn is provided, create an Effect that toggles both
+        // the label's checked class AND the native <input>'s `checked` state. The
+        // input is toggled by *presence* (set "" / remove) so it stays correct on
+        // both backends: on web `set_attribute` mirrors it onto the live `.checked`
+        // property (issue #100) — without this, the accessible/native checked
+        // state goes stale on a programmatic update (and, for a radio group,
+        // unchecking must clear the property so native state stays exclusive); on
+        // desktop the attribute drives `:checked`.
         if let Some(ref checked_fn) = self.checked_fn {
             let checked_fn = checked_fn.clone();
             let label_clone = label_node.clone();
+            let input_clone = input.clone();
             let base_class = self.base_class_string();
 
             __scope.create_effect(move || {
@@ -263,8 +271,10 @@ impl Component for Radio {
                 if is_checked {
                     label_clone
                         .set_attribute("class", &format!("{} rinch-radio--checked", base_class));
+                    input_clone.set_attribute("checked", "");
                 } else {
                     label_clone.set_attribute("class", &base_class);
+                    input_clone.remove_attribute("checked");
                 }
             });
         }

--- a/crates/rinch-components/src/switch.rs
+++ b/crates/rinch-components/src/switch.rs
@@ -165,10 +165,17 @@ impl Component for Switch {
             label_node.append_child(&label_span);
         }
 
-        // If reactive checked_fn is provided, create an Effect to toggle checked class
+        // If reactive checked_fn is provided, create an Effect that toggles both
+        // the label's checked class AND the native <input>'s `checked` state. The
+        // input is toggled by *presence* (set "" / remove) so it stays correct on
+        // both backends: on web `set_attribute` mirrors it onto the live `.checked`
+        // property (issue #100) — without this, the accessible/native checked
+        // state (and `:checked`, native form submission) goes stale on a
+        // programmatic update; on desktop the attribute drives `:checked`.
         if let Some(ref checked_fn) = self.checked_fn {
             let checked_fn = checked_fn.clone();
             let label_clone = label_node.clone();
+            let input_clone = input.clone();
             let base_class = self.base_class_string();
 
             __scope.create_effect(move || {
@@ -176,8 +183,10 @@ impl Component for Switch {
                 if is_checked {
                     label_clone
                         .set_attribute("class", &format!("{} rinch-switch--checked", base_class));
+                    input_clone.set_attribute("checked", "");
                 } else {
                     label_clone.set_attribute("class", &base_class);
+                    input_clone.remove_attribute("checked");
                 }
             });
         }

--- a/crates/rinch-macros/src/dom_codegen/html.rs
+++ b/crates/rinch-macros/src/dom_codegen/html.rs
@@ -161,6 +161,21 @@ pub fn element_to_dom_html(element: &RsxElement, ctx: &mut DomCodegenContext) ->
                 #elem_var
             }
         }
+    } else if tag == "select" {
+        // A `<select>`'s `value` is a live property that only takes effect once
+        // its `<option>` children exist, and the reactive `value:` effect runs at
+        // creation — so append the children BEFORE the attribute effects, else the
+        // initial selected value is dropped on the web backend (issue #100).
+        quote! {
+            {
+                let #elem_var = __scope.create_element(#tag);
+                #(#children_code)*
+                #(#attr_code)*
+                #(#event_code)*
+                #shorthand_code
+                #elem_var
+            }
+        }
     } else {
         quote! {
             {

--- a/crates/rinch-web/Cargo.toml
+++ b/crates/rinch-web/Cargo.toml
@@ -26,7 +26,7 @@ wasm-bindgen = "0.2"
 js-sys = "0.3"
 web-sys = { version = "0.3", features = [
     "Window", "Document", "Element", "HtmlElement", "HtmlInputElement",
-    "HtmlTextAreaElement", "HtmlSelectElement", "HtmlHeadElement",
+    "HtmlTextAreaElement", "HtmlSelectElement", "HtmlOptionElement", "HtmlHeadElement",
     "Node", "NodeList", "Text", "Comment",
     "CssStyleDeclaration", "DomRect", "DomRectList",
     "Event", "MouseEvent", "KeyboardEvent",

--- a/crates/rinch-web/src/web_document.rs
+++ b/crates/rinch-web/src/web_document.rs
@@ -104,6 +104,86 @@ fn is_svg_tag(tag: &str) -> bool {
     )
 }
 
+/// Mirror an attribute onto the live DOM *property* for the form-control
+/// attributes that browsers reflect asymmetrically (`value`, `checked`,
+/// `selected`, `indeterminate`).
+///
+/// For `<input>`/`<textarea>`/`<select>`/`<option>` the attribute only seeds the
+/// control's *default* value. Once the user edits the control it becomes "dirty"
+/// and the browser no longer mirrors the attribute into the property, so a
+/// reactive `value:`/`checked:` binding that writes the attribute would silently
+/// stop updating the displayed value. Writing the property keeps the control in
+/// sync with the signal even after it has been typed into / toggled (issue #100).
+///
+/// The property is only written when it actually differs from the requested
+/// value. For `value` that avoids resetting the caret to the end on the common
+/// echo path (user types → `oninput` → signal → effect re-writes the same
+/// string); for the boolean properties it just skips redundant DOM writes.
+fn sync_reflected_property(node: &web_sys::Node, name: &str, value: &str) {
+    match name {
+        "value" => {
+            // Each control type exposes value()/set_value(); write only when it
+            // differs (the `!= value` guard avoids a caret reset on the echo path).
+            if let Some(input) = node.dyn_ref::<web_sys::HtmlInputElement>() {
+                // A file input's value setter throws `InvalidStateError` for any
+                // non-empty string (the browser forbids setting a file path
+                // programmatically), and web-sys' `set_value` is not a `catch`
+                // binding — the exception would unwind uncaught across the wasm
+                // boundary. Only `""` is permitted (it clears the selection), so
+                // skip any other value on a file input.
+                let settable = input.type_() != "file" || value.is_empty();
+                if settable && input.value() != value {
+                    input.set_value(value);
+                }
+            } else if let Some(textarea) = node.dyn_ref::<web_sys::HtmlTextAreaElement>()
+                && textarea.value() != value
+            {
+                textarea.set_value(value);
+            } else if let Some(select) = node.dyn_ref::<web_sys::HtmlSelectElement>()
+                && select.value() != value
+            {
+                select.set_value(value);
+            }
+        }
+        "checked" => {
+            if let Some(input) = node.dyn_ref::<web_sys::HtmlInputElement>() {
+                let on = attr_is_truthy(value);
+                if input.checked() != on {
+                    input.set_checked(on);
+                }
+            }
+        }
+        "indeterminate" => {
+            if let Some(input) = node.dyn_ref::<web_sys::HtmlInputElement>() {
+                let on = attr_is_truthy(value);
+                if input.indeterminate() != on {
+                    input.set_indeterminate(on);
+                }
+            }
+        }
+        "selected" => {
+            if let Some(option) = node.dyn_ref::<web_sys::HtmlOptionElement>() {
+                let on = attr_is_truthy(value);
+                if option.selected() != on {
+                    option.set_selected(on);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Truthiness for HTML boolean-ish attributes as rinch emits them.
+///
+/// rinch writes these via two conventions: the `rsx!` macro stringifies a `bool`
+/// closure to `"true"`/`"false"`, while components set the bare presence form
+/// (`""`, matching HTML where a present boolean attribute is true regardless of
+/// value). Treat everything as "on" except the explicit falsey strings so both
+/// conventions round-trip — in particular an empty string means *present* (true).
+fn attr_is_truthy(value: &str) -> bool {
+    !matches!(value, "false" | "0")
+}
+
 /// Get the `__nid` JS property from a browser node.
 pub(crate) fn get_nid(node: &web_sys::Node) -> Option<NodeId> {
     js_sys::Reflect::get(node, &"__nid".into())
@@ -376,22 +456,83 @@ impl DomDocument for WebDocument {
     fn set_text_content(&mut self, node: NodeId, text: &str) {
         if let Some(n) = self.nodes.get(&node.0) {
             n.set_text_content(Some(text));
+            // A <textarea>'s child text is its *default value*, which the browser
+            // stops mirroring onto the live `value` property once the control is
+            // user-edited — the same dirty-flag asymmetry `set_attribute("value")`
+            // handles for other controls (issue #100). So when a textarea's text
+            // changes — set directly on it, or (the reactive `textarea { {|| … } }`
+            // case) on one of its child text nodes — re-sync its value property.
+            let textarea = if let Some(ta) = n.dyn_ref::<web_sys::HtmlTextAreaElement>() {
+                Some(ta.clone())
+            } else if let Some(parent) = n.parent_node() {
+                parent.dyn_into::<web_sys::HtmlTextAreaElement>().ok()
+            } else {
+                None
+            };
+            if let Some(ta) = textarea {
+                let content = ta.text_content().unwrap_or_default();
+                if ta.value() != content {
+                    ta.set_value(&content);
+                }
+            }
         }
     }
 
     fn set_attribute(&mut self, node: NodeId, name: &str, value: &str) {
-        if let Some(n) = self.nodes.get(&node.0)
-            && let Ok(el) = n.clone().dyn_into::<web_sys::Element>()
-        {
-            el.set_attribute(name, value).ok();
+        if let Some(n) = self.nodes.get(&node.0) {
+            if let Ok(el) = n.clone().dyn_into::<web_sys::Element>() {
+                match name {
+                    // Boolean content attributes follow HTML *presence* semantics:
+                    // a present attribute is true regardless of its string value.
+                    // The rsx macro stringifies a `bool` closure to `"true"`/
+                    // `"false"`, so writing the literal string would leave
+                    // `checked="false"` *present* — meaning `defaultChecked` stays
+                    // true, `[checked]` selectors match, and `form.reset()` would
+                    // re-check it, all contradicting the property synced below.
+                    // Mirror truthiness onto presence instead.
+                    "checked" | "selected" => {
+                        if attr_is_truthy(value) {
+                            el.set_attribute(name, "").ok();
+                        } else {
+                            el.remove_attribute(name).ok();
+                        }
+                    }
+                    // `indeterminate` is a property-only flag with no HTML content
+                    // attribute; don't materialize a bogus one (the property is
+                    // synced below).
+                    "indeterminate" => {}
+                    _ => {
+                        el.set_attribute(name, value).ok();
+                    }
+                }
+            }
+            // A handful of attributes are reflected *asymmetrically* onto a live
+            // DOM property on form controls (`value`, `checked`, `selected`,
+            // `indeterminate`). Writing the attribute alone only sets the
+            // control's *default*: the moment the user edits the control it goes
+            // "dirty" and the browser stops mirroring the attribute into the
+            // property. A reactive `value:`/`checked:` binding would then silently
+            // stop updating what is displayed. Mirror the property too so
+            // signal-driven updates keep working after the control has been typed
+            // into / toggled (issue #100).
+            sync_reflected_property(n, name, value);
         }
     }
 
     fn remove_attribute(&mut self, node: NodeId, name: &str) {
-        if let Some(n) = self.nodes.get(&node.0)
-            && let Ok(el) = n.clone().dyn_into::<web_sys::Element>()
-        {
-            el.remove_attribute(name).ok();
+        if let Some(n) = self.nodes.get(&node.0) {
+            if let Ok(el) = n.clone().dyn_into::<web_sys::Element>() {
+                el.remove_attribute(name).ok();
+            }
+            // Keep the reflected property in sync when the attribute is removed,
+            // otherwise a dirtied control keeps showing the stale property (#100).
+            match name {
+                "value" => sync_reflected_property(n, "value", ""),
+                "checked" | "selected" | "indeterminate" => {
+                    sync_reflected_property(n, name, "false")
+                }
+                _ => {}
+            }
         }
     }
 
@@ -744,5 +885,26 @@ impl DomDocument for WebDocument {
             }
         }
         out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn attr_truthiness_covers_both_emit_conventions() {
+        // The rsx! macro stringifies bool closures.
+        assert!(attr_is_truthy("true"));
+        assert!(!attr_is_truthy("false"));
+        // Components use the HTML presence form: an empty string is *present*,
+        // hence true (e.g. `input.set_attribute("checked", "")`).
+        assert!(attr_is_truthy(""));
+        // Other falsey spellings.
+        assert!(!attr_is_truthy("0"));
+        // Anything else (a stray value on a boolean attribute) is still "on",
+        // matching HTML's "present attribute = true" rule.
+        assert!(attr_is_truthy("on"));
+        assert!(attr_is_truthy("checked"));
     }
 }


### PR DESCRIPTION
Closes #100.

## Problem

On the **web backend**, a reactive `value:`/`checked:` binding wrote only the DOM **attribute**. Browsers reflect `value`/`checked`/`selected`/`indeterminate` *asymmetrically* on form controls: the attribute is only the control's *default*. The moment the user edits the control (makes it "dirty"), the browser stops mirroring the attribute into the live property, so every subsequent reactive `set_attribute("value", …)` no longer changes what's displayed — signal and DOM silently fall out of sync.

## Fix

The fix lives in **`WebDocument::set_attribute`/`remove_attribute`** — not the rsx macro the issue proposed. The macro is backend-agnostic (`NodeHandle.set_attribute` → `DomDocument`), so fixing the backend catches **every** caller at once (raw rsx `value:`/`checked:` **and** component `value_fn`/`checked_fn`), and leaves desktop (`RinchDocument`, which paints inputs from the attribute and has no property/attribute split) untouched.

- `sync_reflected_property()` mirrors the value onto the live property (`set_value`/`set_checked`/`set_indeterminate`/`set_selected`), guarded by "only write when it differs" so the oninput echo path doesn't reset the caret.
- `attr_is_truthy()` handles both emit conventions (the macro's `"true"/"false"` and components' bare-presence `""`), with a unit test.
- Boolean attrs (`checked`/`selected`) normalized to HTML **presence** semantics (no more `checked="false"` in the DOM); `indeterminate` is property-only.
- Adds the `HtmlOptionElement` web-sys feature.

## Regressions caught by adversarial review (fixed here)

- **`<input type=file>`** — `set_value` throws `InvalidStateError` for a non-empty value and (web-sys' binding isn't `catch`) would unwind **uncaught** across the wasm boundary. Guarded (`type_() != "file" || value.is_empty()`).
- **`PasswordInput` double-escaping** — it HTML-escaped `value` before `set_attribute`; harmless while it only hit the ignored attribute, but once mirrored to the `.value` property it displayed literal entities and compounded per keystroke. `set_attribute` is the DOM API (not HTML parsing), so the escape is removed from value **and** placeholder, and the dead `html_escape` helper deleted.

## Related follow-ups (same PR)

- **`Checkbox`/`Switch`/`Radio`** `checked_fn` effects now also drive the native `<input>.checked` (were label-class-only, so `.checked`/`:checked`/a11y/native-form-submit went stale on programmatic updates). Toggled by presence — correct on web (property mirror) and desktop (`:checked`).
- **raw `textarea { {|| … } }`** — `set_text_content` re-syncs the textarea's `.value` when its default-value text (or a reactive child text node) changes.
- **raw `<select value=…>`** — the rsx codegen appends `<option>` children before the reactive `value:` effect so the initial selected value applies (a `<select>` value is a property with no content attribute).

## Verification

- **End-to-end in a real browser (trunk + Playwright)**: dirtied `value:`/`checked:`, component `value_fn`, dirtied checkbox, `PasswordInput` with `&<>"`, file-input no-crash, checkbox/switch native `.checked` both directions, textarea-after-edit, and `<select>` initial+change — all pass, each with a negative control, zero console errors.
- `cargo build --workspace` (native) + `rinch-web` on `wasm32-unknown-unknown` green; pre-commit CI suite (fmt + workspace clippy `-D warnings` + wasm + tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
