### PR TITLE
feat(macros): rsx ergonomics fixes — match-arm let, Option child, empty rsx!{}, single-emission text, friendly prop-Default error (#102)

### DIFF
--- a/claude-plugin/skills/rinch/SKILL.md
+++ b/claude-plugin/skills/rinch/SKILL.md
@@ -157,9 +157,14 @@ use rinch::prelude::*;  // Includes all components, theme, signals, etc.
 // use rinch_theme::*;
 ```
 
-## Rule 6b: `rsx!` works in ANY crate that depends on `rinch-core`
+## Rule 6b: `rsx!`/`#[component]` come from the facade or `rinch-macros` — `rinch-core` alone is macro-free
 
-The `rsx!` macro generates code using `rinch::core::` paths. In end-user crates, `rinch` is the facade crate. In internal crates, add a shim to `lib.rs`:
+`rsx!` and `#[component]` are **defined in `rinch-macros`** and re-exported by the `rinch` facade (prelude + crate root). **`rinch-core` does not provide them** — a crate that depends only on `rinch-core` gets `NodeHandle`/`Signal`/`RenderScope`/`Component`/`show_dom`, but NOT the macros.
+
+To use rsx in an **internal** crate (one that can't pull in the whole facade) you need **two** things:
+
+1. Depend on `rinch-macros` and bring the macros into scope: `use rinch_macros::{rsx, component};`
+2. Add a shim to `lib.rs` so the macro's generated `rinch::core::…` paths resolve:
 
 ```rust
 extern crate self as rinch;
@@ -169,7 +174,9 @@ pub mod core {
 }
 ```
 
-**Do NOT fall back to imperative code** because you think rsx won't work in a particular crate.
+The shim alone is **not** enough — it only supplies the paths the *generated code* references, not the macros themselves.
+
+**Do NOT fall back to imperative code** in an app crate because you think rsx won't work — the facade gives you `rsx!` directly. (Going macro-free *is* legitimate for internal crates that implement `Component` by hand against `rinch_core::{Component, dom::{NodeHandle, RenderScope}}` — e.g. `rinch-editor-view`'s `Editor` uses no macros and no shim.)
 
 ## Rule 7: State architecture
 
@@ -235,6 +242,29 @@ input { oninput: move |value: String| name.set(value) }
 
 `onclick` takes no arguments: `button { onclick: move || do_thing() }`
 
+### Raw form controls (`<input type=checkbox/radio>`, `<select>`)
+
+- **Keyword attributes need `r#`:** write `r#type: "email"` — the macro unraws it to the real `type` attribute (same for any Rust-keyword name, e.g. `r#for`).
+- **`checked` is reactive:** `checked: {|| flag.get()}` on a raw `<input>` tracks the signal. (Under the hood the macro writes the string `"true"`/`"false"`; the web backend maps that to the attribute's presence *and* mirrors the live `.checked` property, so it stays correct even after the user toggles the box.)
+- **`oninput` is always `Fn(String)`, but the string depends on the element:**
+
+  | Element | `oninput` (and `onchange`) receives |
+  |---|---|
+  | text `<input>` / `<textarea>` | its `.value` |
+  | `<input type=checkbox>` / `radio` | `"true"` / `"false"` — the `.checked` state, **not** the `value` attribute |
+  | `<select>` | the selected option's `value` |
+
+  A radio group is handled **per-radio**: only the radio that becomes checked fires `oninput` (with `"true"`).
+
+```rust
+let agree = Signal::new(false);
+input {
+    r#type: "checkbox",
+    checked: {|| agree.get()},
+    oninput: move |v: String| agree.set(v == "true"),
+}
+```
+
 ## Rule 11: Cross-thread signals use `send()`, not `set()`
 
 `set()` and `update()` panic off the main thread.
@@ -299,6 +329,89 @@ rsx! {
 ```
 
 No special syntax needed — conditions, iterators, and scrutinees are auto-wrapped in Effects.
+
+## Rule 15: Every PascalCase `#[component]` prop must have a working default
+
+A PascalCase `#[component]` generates a props struct with a `Default` impl, and the rsx call-site fills any prop you omit via `..Default::default()`. The default for each field is chosen by the field type's name:
+
+- **Known types default for free** — `String`→`""`, `bool`→`false`, `Option<_>`→`None`, `Vec<_>`→`[]`, integers/floats→`0`, `Callback`/`InputCallback`→no-op. So `Vec<T>`/`Option<T>` props do **not** require `T: Default`.
+- **`Signal<T>` / `Memo<T>`** default to `Signal::new(T::default())`, so the **inner `T`** must impl `Default`.
+- **Anything else** — a domain enum, a custom struct, a type alias, even a fully-qualified `std::vec::Vec<_>` — **must impl `Default`** (even if you always pass the prop). If it doesn't, the compile error points right at that field and says the prop type must implement `Default` — add `#[derive(Default)]` (with `#[default]` on one enum variant).
+
+```rust
+// A domain enum used as a prop must derive Default with a #[default] variant:
+#[derive(Clone, Default, PartialEq)]
+enum Variant { #[default] Filled, Light }
+
+#[component]
+fn Badge(variant: Variant, label: String) -> NodeHandle { /* … */ }
+```
+
+(Only **PascalCase** `#[component]` fns generate a props struct. A lowercase `#[component]` fn just injects `__scope` — no struct, no `Default` requirement.)
+
+## Rule 16: Reactive `{|| }` and event closures re-run — don't consume non-`Copy` captures, and clone one per closure
+
+Rule 4 (Signals are `Copy`, never clone them) only covers `Copy` values. For **non-`Copy`** captures (`String`, `Vec`, `EditorHandle`, a domain struct), two `move`-closure facts bite — because a reactive `{|| }` compiles to `create_effect(FnMut)` that **re-runs** on every dependency change, and event handlers are `Fn`:
+
+**(a) A single reactive/handler closure must not *consume* (move out) a captured non-`Copy` value** — the next run would have nothing left. `error[E0507]: cannot move out of X, a captured variable in an FnMut/Fn closure`. Fix: clone (or borrow) it **inside** the body, per run. (Write `{|| expr}` **without** your own `move`: the macro already wraps reactive closures in a `move` effect, and a second `move` you add makes an inner closure that moves a non-`Copy` capture out of the re-running effect. `Copy` captures like `Signal`s are unaffected — that's why `{move || format!("{}", count.get())}` is fine.)
+
+```rust
+let title = String::from("Report");           // not Copy
+// `decorate(s: String) -> String` takes its argument by value (consumes it)
+// ✗ E0507 — a reactive closure re-runs, but this moves `title` out on the first run
+span { {|| decorate(title)} }
+// ✓ hand it a fresh clone each run
+span { {|| decorate(title.clone())} }
+```
+
+**(b) A non-`Copy` binding moved into one closure can't be reused in another** in the same render. `error[E0382]: use of moved value`. Fix: one `.clone()` per capturing closure.
+
+```rust
+let ed_a = editor.clone();   // EditorHandle: not Copy
+let ed_b = editor.clone();
+button { onclick: move || ed_a.command("undo"), "Undo" }
+button { onclick: move || ed_b.command("redo"), "Redo" }
+```
+
+`Signal`/`Memo`/ints/bools are `Copy` — capture and reuse them in any number of closures with no `.clone()` (Rule 4).
+
+## Rule 17: Build complex, list, or optional children in plain Rust, then embed them
+
+`match`/`if`/`for` in rsx are reactive (Rule 14), but an arm *body* is a node **expression**, not a statement block. When an arm needs setup, do the work in plain Rust and embed the result via `{…}`.
+
+**`match` dispatch** — a `match` (like `if`/`for`) arm body can do per-branch setup with a `let` block, then yield an rsx node:
+
+```rust
+rsx! {
+    div {
+        match field.widget {
+            Widget::Text   => { let k = field.key.clone(); input { oninput: move |v: String| set(&k, v) } }
+            Widget::Toggle => input { r#type: "checkbox" },
+            _              => "",   // an empty arm renders nothing (empty text node)
+        }
+    }
+}
+```
+
+(Inside an rsx `match`/`if`/`for` body you write rsx nodes directly — `input { … }`, not `rsx! { input { … } }`. You *can* still lift a complex `match` out to a plain-Rust `let control = match … { … };` returning `rsx!{…}` per arm and embed `{control}` — both work.)
+
+**Lists** — `IntoNode` is implemented for `NodeHandle` **and `Vec<NodeHandle>`** (the vec is wrapped in a `display:contents` box), so build a dynamic child list in plain Rust and embed it:
+
+```rust
+let items: Vec<NodeHandle> = data.iter().map(|d| rsx! { li { {d.name.clone()} } }).collect();
+rsx! { ul { {items} } }
+```
+
+**Optional child** — `Option<NodeHandle>` is `IntoNode` too, so a present-or-absent child embeds directly (`Some` renders, `None` renders nothing):
+
+```rust
+let note: Option<NodeHandle> = hint.map(|t| rsx! { p { class: "hint", {t} } });
+rsx! { section { {note} } }
+```
+
+(For a child that *toggles reactively*, use `if`/`if let` in rsx instead — e.g. `if let Some(x) = signal.get() { … {x} … }`, which is fine because `Signal` is `Copy`.)
+
+**"Render nothing"** — `rsx! {}` (empty) produces an empty node, so it's a valid "nothing" branch (`_ => rsx! {}` when a `match` is lifted out; inside an rsx `match`/`if`, an empty arm is just `""`). rsx also takes a **single root node** — wrap siblings in one parent.
 
 ## Iterating & Debugging: rinch-debug + MCP server
 
@@ -385,3 +498,6 @@ Before finishing any rinch code:
 - [ ] Controlled inputs have both `value_fn` and `oninput`
 - [ ] For loops have `key:` on items
 - [ ] Cross-thread updates use `send()` / `update_send()`
+- [ ] Non-`Copy` captures (`String`, `EditorHandle`, …) are cloned once per closure and never *consumed* inside a reactive/handler closure (Rule 16)
+- [ ] Custom enum/struct props derive `Default` (Rule 15)
+- [ ] `Option<NodeHandle>`/`Vec<NodeHandle>` children are embedded directly as `{node}`; `match` arms use `let` blocks inline where needed (Rule 17)

--- a/crates/rinch-core/src/component_prop.rs
+++ b/crates/rinch-core/src/component_prop.rs
@@ -1,0 +1,30 @@
+//! `DefaultProp` — the default used by `#[component]`-generated props structs.
+//!
+//! A PascalCase `#[component]` fills any prop the caller omits via
+//! `..Default::default()`, so every prop type needs a default. For prop types
+//! the macro doesn't special-case, its generated `Default` impl defaults the
+//! field through this trait, so a prop type that forgets `Default` produces a
+//! rinch-specific, actionable message (via `#[diagnostic::on_unimplemented]`)
+//! pointing at the offending field — instead of a bare `E0277` deep inside
+//! generated code.
+
+/// Blanket-implemented for every `T: Default`. The `#[component]` macro calls
+/// `<T as DefaultProp>::default_prop()` for prop types it doesn't recognize, so
+/// a non-`Default` prop type fails with a clear, framework-specific error.
+#[diagnostic::on_unimplemented(
+    message = "`#[component]` prop type `{Self}` must implement `Default`",
+    label = "this prop's type needs `Default`",
+    note = "a `#[component]` fills omitted props via `..Default::default()`, so every prop type needs a default",
+    note = "add `#[derive(Default)]` to the type — for an enum, put `#[default]` on one unit variant"
+)]
+pub trait DefaultProp: Sized {
+    /// Produce the default value for a component prop of this type.
+    fn default_prop() -> Self;
+}
+
+impl<T: Default> DefaultProp for T {
+    #[inline]
+    fn default_prop() -> Self {
+        T::default()
+    }
+}

--- a/crates/rinch-core/src/dom/traits.rs
+++ b/crates/rinch-core/src/dom/traits.rs
@@ -63,6 +63,20 @@ impl IntoNode for Vec<NodeHandle> {
     }
 }
 
+impl IntoNode for Option<NodeHandle> {
+    /// A present-or-absent child: `Some(node)` renders the node, `None` renders
+    /// nothing. Routed through the `Vec<NodeHandle>` impl (a 0-or-1 list) so a
+    /// `maybe.map(|t| rsx! { … })` embeds directly as `{maybe}` — no
+    /// `.into_iter().collect::<Vec<_>>()` dance. For a child that toggles
+    /// reactively, prefer an `if`/`if let` in rsx instead.
+    #[inline]
+    fn into_node(self, scope: &mut RenderScope) -> NodeHandle {
+        self.into_iter()
+            .collect::<Vec<NodeHandle>>()
+            .into_node(scope)
+    }
+}
+
 // Implement IntoNode for numeric types
 macro_rules! impl_into_node_for_display {
     ($($ty:ty),*) => {

--- a/crates/rinch-core/src/lib.rs
+++ b/crates/rinch-core/src/lib.rs
@@ -1,5 +1,6 @@
 //! Core types and traits for rinch.
 
+pub mod component_prop;
 pub mod context;
 pub mod dom;
 pub mod element;
@@ -14,6 +15,7 @@ pub mod show;
 pub mod virtual_list;
 
 // Re-export image loading types
+pub use component_prop::DefaultProp;
 pub use image::{ImageLoadResult, ImageLoader};
 
 // Re-export element types for convenience

--- a/crates/rinch-dom/src/paint/skia_painter.rs
+++ b/crates/rinch-dom/src/paint/skia_painter.rs
@@ -118,12 +118,9 @@ fn gradient_to_paint(gradient: &Gradient) -> Option<Paint<'static>> {
         }
         GradientKind::Sweep(_) => {
             // Sweep gradients not supported by tiny-skia; fall back to first stop color
-            if let Some(first) = gradient.stops.first() {
-                let color = first.color.to_alpha_color::<Srgb>();
-                tiny_skia::Shader::SolidColor(to_skia_color(color))
-            } else {
-                return None;
-            }
+            let first = gradient.stops.first()?;
+            let color = first.color.to_alpha_color::<Srgb>();
+            tiny_skia::Shader::SolidColor(to_skia_color(color))
         }
     };
 

--- a/crates/rinch-macros/src/dom_codegen/mod.rs
+++ b/crates/rinch-macros/src/dom_codegen/mod.rs
@@ -164,15 +164,18 @@ pub fn node_to_dom(node: &RsxNode, ctx: &mut DomCodegenContext) -> TokenStream2 
                     __scope.create_text(#text)
                 }
             } else if let Some(closure) = get_closure_expr(expr) {
-                // Closure expression - create text node and effect that updates it directly
+                // Reactive closure: create an EMPTY text node and let an effect
+                // fill it. `create_effect` runs the effect immediately (Effect::new),
+                // so the initial value is set right away — the same single-emission
+                // pattern the attribute codegen uses. Emitting the user closure
+                // once (not once for the initial value and again in the effect)
+                // avoids running its body twice on mount (double-firing side
+                // effects) and keeps reactive text consistent with reactive
+                // attributes (issue #102).
                 let text_var = ctx.next_var("text");
                 quote! {
                     {
-                        // Create text node with initial value from closure
-                        let #text_var = __scope.create_text(
-                            &::std::string::ToString::to_string(&(#closure)())
-                        );
-                        // Effect updates text node directly via DOM API
+                        let #text_var = __scope.create_text("");
                         let __text_clone = #text_var.clone();
                         __scope.create_effect(move || {
                             __text_clone.set_text(

--- a/crates/rinch-macros/src/lib.rs
+++ b/crates/rinch-macros/src/lib.rs
@@ -92,6 +92,11 @@ use node::RsxNode;
 /// ```
 #[proc_macro]
 pub fn rsx(input: TokenStream) -> TokenStream {
+    // An empty body renders nothing — an empty text node. Lets a `match`/`if`
+    // fallback arm be `rsx! {}` instead of `rsx! { "" }` (issue #102).
+    if input.is_empty() {
+        return quote::quote! { __scope.create_text("") }.into();
+    }
     let node = syn::parse_macro_input!(input as RsxNode);
     let mut ctx = dom_codegen::DomCodegenContext::new();
     dom_codegen::node_to_dom(&node, &mut ctx).into()
@@ -143,7 +148,8 @@ pub fn rsx(input: TokenStream) -> TokenStream {
 /// - `children: &[NodeHandle]` is special — wired to Component::render's children, not a field
 /// - A manual `Default` impl is generated with per-field defaults for known types
 ///   (String, bool, Option, Vec, numeric, Callback, InputCallback).
-///   Unknown types fall back to `Default::default()`.
+///   Other types must impl `Default` (defaulted through `rinch_core::DefaultProp`,
+///   which reports a clear, field-pointed error if `Default` is missing).
 /// - `Component`, `RenderScope`, and `NodeHandle` must be in scope (via `use rinch::prelude::*`)
 #[proc_macro_attribute]
 pub fn component(_attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -286,9 +292,12 @@ fn generate_component(func: syn::ItemFn) -> TokenStream {
 /// - `Signal<T>` → `Signal::new(T::default())` (requires `T: Default`)
 /// - `Memo<T>` → `Memo::new(|| T::default())` (requires `T: Default`)
 ///
-/// Unknown types fall back to `Default::default()`.
+/// Unrecognized types are defaulted through `rinch_core::DefaultProp` (a blanket
+/// impl over `T: Default`), spanned at the field so a missing `Default` reports a
+/// clear, field-pointed error instead of a bare `E0277` in generated code.
 fn type_default_expr(ty: &syn::Type) -> proc_macro2::TokenStream {
-    use quote::quote;
+    use quote::{quote, quote_spanned};
+    use syn::spanned::Spanned;
 
     if let syn::Type::Path(type_path) = ty
         && let Some(segment) = type_path.path.segments.last()
@@ -307,15 +316,17 @@ fn type_default_expr(ty: &syn::Type) -> proc_macro2::TokenStream {
             "InputCallback" => return quote! { InputCallback::new(|_: String| {}) },
             "Signal" => {
                 if let Some(inner) = generic_arg(&segment.arguments) {
-                    return quote! {
-                        Signal::new(<#inner as ::std::default::Default>::default())
+                    // The inner `T` must impl Default (route it through DefaultProp
+                    // so a missing `Default` on `T` gets the actionable message).
+                    return quote_spanned! { inner.span() =>
+                        Signal::new(<#inner as rinch::core::DefaultProp>::default_prop())
                     };
                 }
             }
             "Memo" => {
                 if let Some(inner) = generic_arg(&segment.arguments) {
-                    return quote! {
-                        Memo::new(|| <#inner as ::std::default::Default>::default())
+                    return quote_spanned! { inner.span() =>
+                        Memo::new(|| <#inner as rinch::core::DefaultProp>::default_prop())
                     };
                 }
             }
@@ -323,10 +334,13 @@ fn type_default_expr(ty: &syn::Type) -> proc_macro2::TokenStream {
         }
     }
 
-    // Unknown type: fall back to Default trait.
-    // If the type doesn't impl Default and the user doesn't provide this prop,
-    // they'll get a compile error pointing to this specific field.
-    quote! { ::std::default::Default::default() }
+    // Unrecognized type: default it through `DefaultProp` (a blanket impl over
+    // `T: Default`). Spanning the call at the field's type means a prop type that
+    // forgets `Default` fails with rinch's `#[diagnostic::on_unimplemented]`
+    // message pointed right at the offending field, not deep in generated code.
+    quote_spanned! { ty.span() =>
+        <#ty as rinch::core::DefaultProp>::default_prop()
+    }
 }
 
 /// Extract the first generic type argument from a path-segment's `<T, ...>`.

--- a/crates/rinch-macros/src/node.rs
+++ b/crates/rinch-macros/src/node.rs
@@ -180,7 +180,8 @@ pub struct RsxMatchArm {
     pub pattern: Pat,
     /// Optional `if` guard expression.
     pub guard: Option<Expr>,
-    /// RSX children for this arm (always a single-element vec from parsing).
+    /// RSX children for this arm. Usually a single node; a braced `{ let …; node }`
+    /// body yields leading statement(s) + node(s), like an `if`/`for` body.
     pub children: Vec<RsxNode>,
 }
 
@@ -219,8 +220,26 @@ impl Parse for RsxMatchArm {
         // =>
         input.parse::<Token![=>]>()?;
 
-        // Parse arm body as a single RsxNode
-        let child: RsxNode = input.parse()?;
+        // Parse the arm body. Normally one node (`0 => div { … }`), but a braced
+        // block whose content starts with `let` is parsed as rsx children
+        // (leading statements + node) so an arm can do per-branch setup — the
+        // same shape `if`/`for` bodies already accept. `generate_children_body`
+        // collapses the statements + node(s) into one NodeHandle. A non-`let`
+        // brace (`{ expr }`, `{|| … }`) keeps the single-node behavior.
+        let children = if input.peek(token::Brace) {
+            let ahead = input.fork();
+            let inner;
+            syn::braced!(inner in ahead);
+            if inner.peek(Token![let]) {
+                let content;
+                syn::braced!(content in input);
+                parse_rsx_children(&content)?
+            } else {
+                vec![input.parse::<RsxNode>()?]
+            }
+        } else {
+            vec![input.parse::<RsxNode>()?]
+        };
 
         // Optional trailing comma
         if input.peek(Token![,]) {
@@ -230,7 +249,7 @@ impl Parse for RsxMatchArm {
         Ok(RsxMatchArm {
             pattern,
             guard,
-            children: vec![child],
+            children,
         })
     }
 }
@@ -590,6 +609,41 @@ mod tests {
             RsxNode::MatchBlock(match_block) => {
                 assert_eq!(match_block.arms.len(), 2);
                 assert!(matches!(&match_block.arms[0].children[0], RsxNode::Text(_)));
+            }
+            _ => panic!("Expected MatchBlock"),
+        }
+    }
+
+    #[test]
+    fn parse_match_arm_with_let_block() {
+        // A braced arm body starting with `let` parses as statements + node,
+        // like an if/for body (issue #102 Gap 2).
+        let input = r#"match x.get() { 0 => { let k = 1; div { "a" } }, _ => "b" }"#;
+        let node = parse_str::<RsxNode>(input).unwrap();
+        match node {
+            RsxNode::MatchBlock(mb) => {
+                assert_eq!(mb.arms.len(), 2);
+                assert_eq!(mb.arms[0].children.len(), 2);
+                assert!(matches!(&mb.arms[0].children[0], RsxNode::Statement(_)));
+                assert!(matches!(&mb.arms[0].children[1], RsxNode::Element(_)));
+                // The non-block arm is unchanged (single node).
+                assert_eq!(mb.arms[1].children.len(), 1);
+                assert!(matches!(&mb.arms[1].children[0], RsxNode::Text(_)));
+            }
+            _ => panic!("Expected MatchBlock"),
+        }
+    }
+
+    #[test]
+    fn parse_match_arm_braced_expr_stays_single_node() {
+        // A braced arm body that is NOT a `let` block keeps single-node behavior
+        // (reactive embed) — no regression from the Gap 2 change.
+        let input = r#"match x.get() { 0 => {|| count.get()}, _ => div {} }"#;
+        let node = parse_str::<RsxNode>(input).unwrap();
+        match node {
+            RsxNode::MatchBlock(mb) => {
+                assert_eq!(mb.arms[0].children.len(), 1);
+                assert!(matches!(&mb.arms[0].children[0], RsxNode::Expr(_)));
             }
             _ => panic!("Expected MatchBlock"),
         }


### PR DESCRIPTION
Addresses the **fixable** gotchas in #102. The verification I ran (a workflow checking each claim against source) found several of the issue's claims were overstated, so I fixed what's genuinely fixable and kept the inherent ones documented in the skill. Each fix was compile- and runtime-verified.

## Code fixes

- **`match` arms accept a braced `let` block** (Gap 2) — this was an *inconsistency*: `if`/`for` bodies already allow leading `let` statements, `match` arms didn't. The brace branch now parses a `let`-leading body via `parse_rsx_children`, so `W::X => { let k = …; node }` works. `generate_children_body` already collapses statements + node into one `NodeHandle`, so there's no codegen change — and a non-`let` brace (`{ expr }`, `{|| … }`) keeps its single-node behavior (regression-tested).
- **`impl IntoNode for Option<NodeHandle>`** (Gap 4) — routed through the `Vec<NodeHandle>` impl (a 0-or-1 list), so a present-or-absent child embeds directly as `{opt}` instead of `.into_iter().collect::<Vec<_>>()`.
- **`rsx! {}` (empty) → empty text node** (Gap 5) — was a parse error; now a valid "render nothing" branch.
- **Reactive text emits the user closure once** (Gap 3) — previously the closure was emitted twice (initial value + effect), running its body **twice on mount** (double-firing side effects) and giving `{move || …}` on text a different error than on attributes. Now it creates an empty text node and lets the immediately-run effect fill it, exactly like the attribute codegen. (It does **not** make `{move || …consume…}` compile — that's inherent: the inner `move` moves a non-`Copy` capture out of the re-running effect.)
- **Friendly missing-`Default` diagnostic** (Gap 1) — a `#[component]` prop type that forgets `Default` now fails with a rinch-specific `#[diagnostic::on_unimplemented]` message from the new `rinch_core::DefaultProp`, spanned at the offending field:
  ```
  error: `#[component]` prop type `NoDefault` must implement `Default`
   --> src/main.rs:7:14
  7 | fn Bad(kind: NoDefault) -> NodeHandle {
    |              ^^^^^^^^^ this prop's type needs `Default`
  ```
  instead of a bare `E0277` deep in generated code.

## Skill docs
Updates `claude-plugin/skills/rinch/SKILL.md` (Rules 15/16/17) to describe the improved behavior rather than the old workarounds. The inherent gotchas from #102 (non-`Copy` captures in re-running closures; raw form-control `oninput` payloads; `rinch-core` being macro-free) stay documented.

## Verification
- **Runtime (rinch MCP tools)** on a desktop harness: reactive text renders `count: 0` and updates to `1`/`2` across clicks (Gap 3 no regression); `Some`/`None`/empty/match-`let` node paths all render correctly.
- Gap 1 diagnostic confirmed by compiling a non-`Default` prop; Gap 2 covered by new parser unit tests.
- `cargo build`/`clippy --all-targets -D warnings`/`test` green across the workspace; `rinch-web` and `ui-zoo-web` build on `wasm32-unknown-unknown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
