### PR TITLE
chore: auto-register the rinch plugin marketplace for contributors

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "extraKnownMarketplaces": {
+    "rinch": {
+      "source": {
+        "source": "github",
+        "repo": "joeleaver/rinch"
+      },
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "rinch@rinch": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,8 @@ renderer-compare/
 *.swo
 
 # AI tools
-.claude/
+.claude/*
+!.claude/settings.json
 .mcp.json
 .omc/
 


### PR DESCRIPTION
## What

Adds a checked-in `.claude/settings.json` so that opening this repo in Claude Code **automatically offers the rinch skill** — no manual `/plugin marketplace add` / `/plugin install`.

```json
{
  "extraKnownMarketplaces": {
    "rinch": {
      "source": { "source": "github", "repo": "joeleaver/rinch" },
      "autoUpdate": true
    }
  },
  "enabledPlugins": { "rinch@rinch": true }
}
```

- `extraKnownMarketplaces` pre-registers the marketplace from GitHub `joeleaver/rinch` (this repo is itself the plugin marketplace — `.claude-plugin/marketplace.json` → `claude-plugin/`).
- `enabledPlugins` auto-enables `rinch@rinch`, which ships the `rinch` skill (`claude-plugin/skills/rinch/SKILL.md`).
- `autoUpdate: true` keeps it current on startup.

## `.gitignore` change

The whole `.claude/` directory was gitignored, so a settings file there would never be committed. Narrowed to `.claude/*` + a `!.claude/settings.json` exception:

```diff
 # AI tools
-.claude/
+.claude/*
+!.claude/settings.json
 .mcp.json
```

Only the shared team settings file is now tracked; personal `settings.local.json`, plans, and skills under `.claude/` stay local. The existing tracked `.claude/rules/rinch-best-practices.md` is unaffected.

## Contributor experience

Open the repo in Claude Code → marketplace registered + plugin enabled → the **rinch skill** is available (auto-triggers on `rsx!`/`Signal`/`#[component]` code, or `/rinch`). A **one-time trust prompt** still applies on first load — project settings deliberately can't auto-bypass that (plugins run code). Inert for anyone not using Claude Code.

## Notes

- The rinch **MCP server** (`.mcp.json`) is separate and stays gitignored — not part of this change.
- Config-only; no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)