### PR TITLE
feat(rinch-http): cross-platform callback-based HTTP client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,12 +1105,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
 name = "cookie-factory"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
 dependencies = [
  "futures",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -1449,6 +1475,12 @@ name = "debug_timer"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da220af51a1a335e9a930beaaef53d261e41ea9eecfb3d973a3ddae1a7284b9c"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "derive_more"
@@ -3495,6 +3527,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4245,6 +4283,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4690,6 +4734,7 @@ dependencies = [
  "rinch-editable",
  "rinch-editor-core",
  "rinch-editor-view",
+ "rinch-http",
  "rinch-macros",
  "rinch-platform",
  "rinch-renderer",
@@ -4701,7 +4746,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tray-icon",
- "ureq",
  "vello",
  "wasm-bindgen",
  "web-sys",
@@ -4848,6 +4892,18 @@ dependencies = [
  "rinch-core",
  "rinch-editor-collab",
  "rinch-editor-core",
+]
+
+[[package]]
+name = "rinch-http"
+version = "0.1.0"
+dependencies = [
+ "js-sys",
+ "rinch-core",
+ "ureq",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -5974,6 +6030,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-skia"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6404,12 +6490,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d39cb1dbab692d82a977c0392ffac19e188bd9186a9f32806f0aaa859d75585a"
 dependencies = [
  "base64",
+ "cookie_store",
  "flate2",
  "log",
  "percent-encoding",
  "rustls",
  "rustls-pki-types",
  "ureq-proto",
+ "url",
  "utf-8",
  "webpki-roots",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ repository = "https://github.com/user/rinch"
 # Internal crates
 rinch = { path = "crates/rinch", default-features = false }
 rinch-core = { path = "crates/rinch-core" }
+rinch-http = { path = "crates/rinch-http" }
 rinch-macros = { path = "crates/rinch-macros" }
 rinch-renderer = { path = "crates/rinch-renderer" }
 rinch-theme = { path = "crates/rinch-theme" }

--- a/crates/rinch-http/Cargo.toml
+++ b/crates/rinch-http/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "rinch-http"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Cross-platform callback-based HTTP client for rinch (web fetch / native ureq)"
+
+[dependencies]
+rinch-core = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+ureq = { version = "3", features = ["cookies"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+js-sys = "0.3"
+web-sys = { version = "0.3", features = [
+    "Request", "RequestInit", "RequestCredentials", "Response", "Headers", "Window",
+] }

--- a/crates/rinch-http/src/error.rs
+++ b/crates/rinch-http/src/error.rs
@@ -1,0 +1,33 @@
+//! HTTP client error type.
+
+use std::fmt;
+
+/// Errors from an HTTP request.
+///
+/// Each variant carries a human-readable message. Note that a non-2xx HTTP
+/// response (e.g. 404, 500) is **not** an error — it is returned as an
+/// `Ok(Response { status, .. })` so callers can read error bodies. Only a
+/// failure to complete the request (transport, malformed request, or an
+/// unreadable body) surfaces as an `HttpError`.
+#[derive(Debug, Clone)]
+pub enum HttpError {
+    /// A transport-level failure: DNS resolution, connection refused, TLS,
+    /// timeout, or (on web) a rejected fetch promise.
+    Network(String),
+    /// The request could not be constructed (e.g. an invalid URL or header).
+    InvalidRequest(String),
+    /// The response was received but its body could not be read/decoded.
+    Body(String),
+}
+
+impl fmt::Display for HttpError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            HttpError::Network(msg) => write!(f, "http network error: {msg}"),
+            HttpError::InvalidRequest(msg) => write!(f, "http invalid request: {msg}"),
+            HttpError::Body(msg) => write!(f, "http body error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for HttpError {}

--- a/crates/rinch-http/src/lib.rs
+++ b/crates/rinch-http/src/lib.rs
@@ -1,0 +1,194 @@
+//! Cross-platform, callback-based HTTP client for rinch.
+//!
+//! One [`fetch`] function works on both targets:
+//!
+//! - **Native** (`cfg(not(target_arch = "wasm32"))`): a blocking [`ureq`] request
+//!   runs on a spawned `std::thread`.
+//! - **Web** (`cfg(target_arch = "wasm32")`): `web_sys::fetch` runs on the single
+//!   browser thread.
+//!
+//! On **both** platforms the `on_done` callback is invoked on the main (UI)
+//! thread, so consumers can update rinch [`Signal`](rinch_core::Signal)s directly
+//! with `.set()` from inside the callback. On native this is arranged via
+//! [`rinch_core::run_on_main_thread`]; on web the callback already runs on the UI
+//! thread.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use rinch_http::{fetch, Request};
+//!
+//! fetch(Request::get("https://example.com/api/thing"), move |result| {
+//!     match result {
+//!         Ok(resp) if resp.ok() => { /* resp.text() */ }
+//!         Ok(resp) => { /* non-2xx: read error body from resp.text() */ }
+//!         Err(e) => { /* transport failure */ }
+//!     }
+//! });
+//! ```
+
+mod error;
+
+pub use error::HttpError;
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native;
+#[cfg(not(target_arch = "wasm32"))]
+pub use native::{clear_cookies, fetch, fetch_blocking};
+
+#[cfg(target_arch = "wasm32")]
+mod wasm;
+#[cfg(target_arch = "wasm32")]
+pub use wasm::fetch;
+
+/// HTTP request method.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Method {
+    Get,
+    Post,
+    Put,
+    Delete,
+    Patch,
+}
+
+impl Method {
+    /// The uppercase HTTP method token (`"GET"`, `"POST"`, ...).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Method::Get => "GET",
+            Method::Post => "POST",
+            Method::Put => "PUT",
+            Method::Delete => "DELETE",
+            Method::Patch => "PATCH",
+        }
+    }
+}
+
+/// How credentials (cookies, HTTP auth) are sent with a request.
+///
+/// This mirrors the Fetch API's `credentials` mode and only has meaning on the
+/// **web** target. On native it is accepted but ignored (ureq's cookie handling
+/// is governed by its own agent configuration).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Credentials {
+    /// Never send credentials.
+    Omit,
+    /// Send credentials only for same-origin requests (the default).
+    SameOrigin,
+    /// Always send credentials, including cross-origin.
+    Include,
+}
+
+/// An HTTP request to be issued by [`fetch`].
+///
+/// Build one with the [`Request::get`] / [`post`](Request::post) /
+/// [`put`](Request::put) / [`delete`](Request::delete) / [`patch`](Request::patch)
+/// constructors, then chain [`header`](Request::header), [`body`](Request::body) /
+/// [`body_str`](Request::body_str), and [`credentials`](Request::credentials).
+#[derive(Debug, Clone)]
+pub struct Request {
+    pub method: Method,
+    pub url: String,
+    pub headers: Vec<(String, String)>,
+    pub body: Option<Vec<u8>>,
+    pub credentials: Credentials,
+}
+
+impl Request {
+    fn new(method: Method, url: impl Into<String>) -> Self {
+        Self {
+            method,
+            url: url.into(),
+            headers: Vec::new(),
+            body: None,
+            credentials: Credentials::SameOrigin,
+        }
+    }
+
+    /// A `GET` request to `url`.
+    pub fn get(url: impl Into<String>) -> Self {
+        Self::new(Method::Get, url)
+    }
+
+    /// A `POST` request to `url`.
+    pub fn post(url: impl Into<String>) -> Self {
+        Self::new(Method::Post, url)
+    }
+
+    /// A `PUT` request to `url`.
+    pub fn put(url: impl Into<String>) -> Self {
+        Self::new(Method::Put, url)
+    }
+
+    /// A `DELETE` request to `url`.
+    pub fn delete(url: impl Into<String>) -> Self {
+        Self::new(Method::Delete, url)
+    }
+
+    /// A `PATCH` request to `url`.
+    pub fn patch(url: impl Into<String>) -> Self {
+        Self::new(Method::Patch, url)
+    }
+
+    /// Add a request header.
+    pub fn header(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.headers.push((key.into(), value.into()));
+        self
+    }
+
+    /// Set the request body from raw bytes.
+    pub fn body(mut self, body: Vec<u8>) -> Self {
+        self.body = Some(body);
+        self
+    }
+
+    /// Set the request body from a string (UTF-8 bytes).
+    pub fn body_str(mut self, body: &str) -> Self {
+        self.body = Some(body.as_bytes().to_vec());
+        self
+    }
+
+    /// Set the credentials mode (web-only meaning; ignored on native).
+    pub fn credentials(mut self, credentials: Credentials) -> Self {
+        self.credentials = credentials;
+        self
+    }
+}
+
+/// An HTTP response returned to the [`fetch`] callback.
+#[derive(Debug, Clone)]
+pub struct Response {
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    pub body: Vec<u8>,
+}
+
+impl Response {
+    /// Whether the status code is in the 2xx success range.
+    pub fn ok(&self) -> bool {
+        (200..300).contains(&self.status)
+    }
+
+    /// The response body decoded as UTF-8 (lossily).
+    pub fn text(&self) -> String {
+        String::from_utf8_lossy(&self.body).into_owned()
+    }
+
+    /// The first value of the response header named `name` (case-insensitive).
+    pub fn header(&self, name: &str) -> Option<&str> {
+        self.headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.as_str())
+    }
+}
+
+/// The result callback for [`fetch`].
+///
+/// It is invoked on the main (UI) thread on both targets and never crosses a
+/// thread boundary (on native it is parked main-thread-side while only the result
+/// is dispatched back — see the `native` module), so it does **not** need to be
+/// `Send`. This lets callbacks capture `!Send` UI state such as `Rc`-based editor
+/// handles or `Signal`s over them.
+pub trait HttpCallback: FnOnce(Result<Response, HttpError>) + 'static {}
+impl<F> HttpCallback for F where F: FnOnce(Result<Response, HttpError>) + 'static {}

--- a/crates/rinch-http/src/native.rs
+++ b/crates/rinch-http/src/native.rs
@@ -1,0 +1,170 @@
+//! Native (non-wasm) HTTP implementation backed by blocking `ureq`.
+//!
+//! [`fetch_blocking`] is the core: a synchronous request on the **calling** thread
+//! using the shared process-wide agent (cookie jar + connection pool). It is the
+//! right entry point for code already running off the main thread — e.g. rinch's
+//! `NetworkImageLoader`, which runs on the image-decode thread and shares this
+//! agent so authenticated image URLs carry the session cookie.
+//!
+//! The asynchronous [`fetch`] layers UI-thread delivery on top: it runs
+//! `fetch_blocking` on a spawned thread and resumes the callback on the main (UI)
+//! thread via rinch-core's main-thread callback parking
+//! ([`park_main_callback`](rinch_core::park_main_callback)). The callback is parked
+//! main-thread-side and only the (`Send`) id + result cross the thread boundary, so
+//! it need not be `Send` and can capture `!Send` UI state (an `Rc`-based editor
+//! handle, a `Signal`).
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use rinch_core::{park_main_callback, resume_main_callback, run_on_main_thread};
+
+use crate::{Credentials, HttpCallback, HttpError, Method, Request, Response};
+
+/// Issue `request` off the calling thread and deliver the result to `on_done` on
+/// the main (UI) thread.
+///
+/// Call from the main thread (the one the rinch runtime registered via
+/// `register_main_thread`): `on_done` is parked main-thread-side and resumed there,
+/// so it is invoked on the main thread and need not be `Send`. The result is hopped
+/// back via the runtime's cross-thread dispatcher, which must be registered.
+pub fn fetch(request: Request, on_done: impl HttpCallback) {
+    // Park the (!Send) callback on the main thread; only the id + Send result
+    // travel to the worker and back.
+    let id = park_main_callback::<Result<Response, HttpError>>(on_done);
+    std::thread::spawn(move || {
+        let result = fetch_blocking(request);
+        run_on_main_thread(move || resume_main_callback(id, result));
+    });
+}
+
+/// Issue `request` **synchronously on the calling thread** and return the result.
+///
+/// The blocking core [`fetch`] builds on. Because it neither spawns a thread nor
+/// touches the main-thread machinery, it is safe (and intended) to call from a
+/// worker thread that wants to share the process-wide agent — its cookie jar,
+/// connection pool and timeouts. rinch's `NetworkImageLoader` uses this so image
+/// loads reuse the app's session instead of a fresh, cookie-less agent per call.
+pub fn fetch_blocking(request: Request) -> Result<Response, HttpError> {
+    match request.credentials {
+        // `Omit`: use a throwaway agent with its own empty cookie jar, so no
+        // cookies are sent or persisted — matching the web `credentials: "omit"`
+        // mode rather than silently attaching the shared jar's cookies.
+        Credentials::Omit => do_request(&ureq::Agent::new_with_config(agent_config()), request),
+        // `SameOrigin` (default) / `Include` share the process-wide agent + jar.
+        Credentials::SameOrigin | Credentials::Include => do_request(agent(), request),
+    }
+}
+
+/// Clear the shared agent's cookie jar — e.g. on logout / session reset.
+///
+/// A no-op if no request has been made yet (the agent is created lazily). Only
+/// affects the shared agent used by non-`Omit` requests.
+pub fn clear_cookies() {
+    if let Some(agent) = AGENT.get() {
+        agent.cookie_jar_lock().clear();
+    }
+}
+
+/// The process-wide agent.
+///
+/// Shared (rather than built per request) for two reasons: ureq's **cookie jar
+/// lives on the agent**, so session cookies only persist across requests if the
+/// agent does — and a fresh agent per request also throws away connection
+/// pooling/keep-alive. `Agent` is internally `Arc`-based, so sharing it across the
+/// request threads is cheap and its jar is shared.
+static AGENT: OnceLock<ureq::Agent> = OnceLock::new();
+
+fn agent() -> &'static ureq::Agent {
+    AGENT.get_or_init(|| ureq::Agent::new_with_config(agent_config()))
+}
+
+fn agent_config() -> ureq::config::Config {
+    ureq::config::Config::builder()
+        // Do NOT treat non-2xx as an error: a 404/500 with a body round-trips into
+        // `Ok(Response { .. })` so callers can read error JSON out of 4xx/5xx bodies.
+        .http_status_as_error(false)
+        // ureq defaults to NO timeouts. A general HTTP primitive must not let a
+        // hung/half-open server block a request thread (and leak its parked
+        // callback) forever, so impose sane connect + overall ceilings.
+        .timeout_connect(Some(Duration::from_secs(30)))
+        .timeout_global(Some(Duration::from_secs(60)))
+        .build()
+}
+
+fn do_request(agent: &ureq::Agent, request: Request) -> Result<Response, HttpError> {
+    let url = request.url.as_str();
+
+    // `get`/`delete` produce a bodyless builder (`.call()`); `post`/`put`/`patch`
+    // produce a body builder (`.send(..)`). Both yield `Result<http::Response<Body>>`.
+    let response = match request.method {
+        Method::Get => {
+            let mut builder = agent.get(url);
+            for (k, v) in &request.headers {
+                builder = builder.header(k, v);
+            }
+            builder.call()
+        }
+        Method::Delete => {
+            let mut builder = agent.delete(url);
+            for (k, v) in &request.headers {
+                builder = builder.header(k, v);
+            }
+            builder.call()
+        }
+        Method::Post | Method::Put | Method::Patch => {
+            let mut builder = match request.method {
+                Method::Post => agent.post(url),
+                Method::Put => agent.put(url),
+                _ => agent.patch(url),
+            };
+            for (k, v) in &request.headers {
+                builder = builder.header(k, v);
+            }
+            match request.body {
+                Some(bytes) => builder.send(&bytes[..]),
+                None => builder.send_empty(),
+            }
+        }
+    };
+
+    let response = response.map_err(map_ureq_error)?;
+
+    let status = response.status().as_u16();
+
+    let headers = response
+        .headers()
+        .iter()
+        .map(|(name, value)| {
+            (
+                name.as_str().to_string(),
+                value.to_str().unwrap_or_default().to_string(),
+            )
+        })
+        .collect();
+
+    let body = response
+        .into_body()
+        .read_to_vec()
+        .map_err(|e| HttpError::Body(e.to_string()))?;
+
+    Ok(Response {
+        status,
+        headers,
+        body,
+    })
+}
+
+/// Map a ureq error to [`HttpError`].
+///
+/// With `http_status_as_error(false)`, a non-2xx status never reaches here. URL /
+/// request-construction failures map to [`HttpError::InvalidRequest`] (matching the
+/// web target, which reports the same class as `InvalidRequest`); everything else
+/// is a transport/protocol failure ([`HttpError::Network`]).
+fn map_ureq_error(err: ureq::Error) -> HttpError {
+    match err {
+        ureq::Error::BadUri(msg) => HttpError::InvalidRequest(msg),
+        ureq::Error::Http(e) => HttpError::InvalidRequest(e.to_string()),
+        other => HttpError::Network(other.to_string()),
+    }
+}

--- a/crates/rinch-http/src/wasm.rs
+++ b/crates/rinch-http/src/wasm.rs
@@ -1,0 +1,111 @@
+//! Web (wasm32) HTTP implementation backed by `web_sys::fetch`.
+//!
+//! The request is issued against the browser's Fetch API. Everything runs on the
+//! single web thread, so `on_done` is invoked directly (NOT via
+//! `rinch_core::run_on_main_thread`, whose `Send` bound a JS-capturing callback
+//! cannot satisfy) — it is already on the UI thread.
+
+use wasm_bindgen::JsCast;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::{JsFuture, spawn_local};
+use web_sys::{Request as WebRequest, RequestCredentials, RequestInit, Response as WebResponse};
+
+use crate::{Credentials, HttpCallback, HttpError, Request, Response};
+
+/// Issue `request` via `web_sys::fetch` and deliver the result to `on_done`.
+///
+/// `on_done` runs on the single web thread (the UI thread), so it can update
+/// rinch signals directly.
+pub fn fetch(request: Request, on_done: impl HttpCallback) {
+    spawn_local(async move {
+        let result = do_fetch(request).await;
+        on_done(result);
+    });
+}
+
+async fn do_fetch(request: Request) -> Result<Response, HttpError> {
+    let init = RequestInit::new();
+    init.set_method(request.method.as_str());
+    init.set_credentials(match request.credentials {
+        Credentials::Omit => RequestCredentials::Omit,
+        Credentials::SameOrigin => RequestCredentials::SameOrigin,
+        Credentials::Include => RequestCredentials::Include,
+    });
+
+    if let Some(body) = &request.body {
+        // Copy the bytes into a JS Uint8Array (a valid fetch BufferSource body).
+        let array = js_sys::Uint8Array::from(&body[..]);
+        init.set_body(&array.into());
+    }
+
+    let web_request = WebRequest::new_with_str_and_init(&request.url, &init)
+        .map_err(|e| HttpError::InvalidRequest(js_err(&e)))?;
+
+    let headers = web_request.headers();
+    for (k, v) in &request.headers {
+        headers
+            .set(k, v)
+            .map_err(|e| HttpError::InvalidRequest(js_err(&e)))?;
+    }
+
+    let window = web_sys::window()
+        .ok_or_else(|| HttpError::Network("no global `window` available".to_string()))?;
+
+    let resp_value = JsFuture::from(window.fetch_with_request(&web_request))
+        .await
+        .map_err(|e| HttpError::Network(js_err(&e)))?;
+
+    let resp: WebResponse = resp_value
+        .dyn_into()
+        .map_err(|_| HttpError::Network("fetch result is not a Response".to_string()))?;
+
+    let status = resp.status();
+
+    let headers = collect_headers(&resp.headers());
+
+    // Read the body as raw bytes via `array_buffer()` so `Response.body: Vec<u8>`
+    // is byte-accurate — a binary payload (image, gzip, protobuf) survives intact,
+    // matching the native target. (Text/JSON callers just `resp.text()` on top.)
+    let buffer_promise = resp
+        .array_buffer()
+        .map_err(|e| HttpError::Body(js_err(&e)))?;
+    let buffer_value = JsFuture::from(buffer_promise)
+        .await
+        .map_err(|e| HttpError::Body(js_err(&e)))?;
+    let body = js_sys::Uint8Array::new(&buffer_value).to_vec();
+
+    Ok(Response {
+        status,
+        headers,
+        body,
+    })
+}
+
+/// Collect a `web_sys::Headers` into a `Vec<(name, value)>`.
+///
+/// `Headers` is a JS-iterable of `[name, value]` pairs; we walk it via
+/// `js_sys::try_iter`. Any malformed entry is skipped rather than failing the
+/// whole request.
+fn collect_headers(headers: &web_sys::Headers) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    if let Ok(Some(iter)) = js_sys::try_iter(headers) {
+        for entry in iter.flatten() {
+            // Each entry is a 2-element array: [name, value].
+            let pair: js_sys::Array = match entry.dyn_into() {
+                Ok(a) => a,
+                Err(_) => continue,
+            };
+            let name = pair.get(0).as_string();
+            let value = pair.get(1).as_string();
+            if let (Some(name), Some(value)) = (name, value) {
+                out.push((name, value));
+            }
+        }
+    }
+    out
+}
+
+/// Render a `JsValue` error into a debug string.
+fn js_err(e: &JsValue) -> String {
+    format!("{e:?}")
+}

--- a/crates/rinch-http/tests/native_roundtrip.rs
+++ b/crates/rinch-http/tests/native_roundtrip.rs
@@ -1,0 +1,273 @@
+#![cfg(not(target_arch = "wasm32"))]
+//! Native round-trip test: a throwaway `TcpListener` serves canned HTTP/1.1
+//! responses, and `rinch_http::fetch` must deliver them to the callback on the
+//! **main** thread.
+//!
+//! Native `fetch` parks the callback main-thread-side and dispatches only the
+//! result back via `rinch_core`'s cross-thread dispatcher, so the test simulates
+//! the rinch runtime: it registers this thread as main, installs a queueing
+//! dispatcher, and pumps that queue to drive completion. It is a single `#[test]`
+//! on a single thread so the main-thread registration and the per-thread pending
+//! registry stay consistent (parallel test threads would not).
+//!
+//! The key assertion is that a 404-with-body comes back as
+//! `Ok(Response { status: 404, .. })` — non-2xx is NOT an error.
+
+use std::collections::VecDeque;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::mpsc;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use rinch_core::{register_main_thread, set_cross_thread_dispatcher};
+use rinch_http::{HttpError, Request, Response, fetch};
+
+/// A closure the (simulated) runtime must run on the main thread.
+type Job = Box<dyn FnOnce() + Send>;
+
+/// Closures the (simulated) runtime must run on the main thread.
+static QUEUE: OnceLock<Mutex<VecDeque<Job>>> = OnceLock::new();
+
+fn queue() -> &'static Mutex<VecDeque<Job>> {
+    QUEUE.get_or_init(|| Mutex::new(VecDeque::new()))
+}
+
+fn dispatcher(f: Job) {
+    queue().lock().unwrap().push_back(f);
+}
+
+/// Spawn a one-shot server on 127.0.0.1:0 that writes `response` to the first
+/// connection, and return the URL to hit it.
+fn serve_once(response: &'static str) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local_addr");
+    std::thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut buf = [0u8; 1024];
+            let _ = stream.read(&mut buf);
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.flush();
+        }
+    });
+    format!("http://{addr}/")
+}
+
+/// Spawn a one-shot server that reads the **full** request (headers + body, via
+/// Content-Length) and echoes it back verbatim as the 200 body, so a test can
+/// assert the request line / headers / body the client actually sent. Reading in a
+/// loop (rather than a single `read`) is required: a POST's headers and body can
+/// arrive in separate TCP segments, and ureq keep-alive means no EOF to wait on.
+fn serve_echo() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local_addr");
+    std::thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            // Safety net so a malformed request can never hang the test thread.
+            let _ = stream.set_read_timeout(Some(Duration::from_secs(2)));
+            let mut data: Vec<u8> = Vec::new();
+            let mut buf = [0u8; 1024];
+            loop {
+                // Once headers are in, wait for the declared body to arrive too.
+                if let Some(hdr_end) = data.windows(4).position(|w| w == b"\r\n\r\n") {
+                    let headers = String::from_utf8_lossy(&data[..hdr_end]);
+                    let content_len = headers
+                        .lines()
+                        .find_map(|l| {
+                            let l = l.to_ascii_lowercase();
+                            l.strip_prefix("content-length:")
+                                .and_then(|v| v.trim().parse::<usize>().ok())
+                        })
+                        .unwrap_or(0);
+                    if data.len() >= hdr_end + 4 + content_len {
+                        break;
+                    }
+                }
+                match stream.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => data.extend_from_slice(&buf[..n]),
+                    Err(_) => break,
+                }
+            }
+            let req = String::from_utf8_lossy(&data).to_string();
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                req.len(),
+                req
+            );
+            let _ = stream.write_all(resp.as_bytes());
+            let _ = stream.flush();
+        }
+    });
+    format!("http://{addr}/echo")
+}
+
+fn response_str(status_line: &str, body: &str) -> &'static str {
+    let raw = format!(
+        "HTTP/1.1 {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        status_line,
+        body.len(),
+        body
+    );
+    // Leak to get a 'static str for the one-shot server closure.
+    Box::leak(raw.into_boxed_str())
+}
+
+/// Pump the dispatch queue (running queued main-thread closures on this thread)
+/// until `rx` yields a value or the timeout elapses.
+fn pump_recv(
+    rx: &mpsc::Receiver<Result<Response, HttpError>>,
+    timeout: Duration,
+) -> Result<Response, HttpError> {
+    let start = Instant::now();
+    loop {
+        while let Some(job) = queue().lock().unwrap().pop_front() {
+            job();
+        }
+        if let Ok(v) = rx.try_recv() {
+            return v;
+        }
+        assert!(
+            start.elapsed() < timeout,
+            "callback not delivered within timeout"
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
+/// Serve two sequential connections on one port: the first response carries
+/// `set_cookie`, the second echoes back whatever `Cookie:` header the client sent.
+/// Returns the base URL.
+fn serve_cookie_pair(set_cookie: &'static str) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local_addr");
+    std::thread::spawn(move || {
+        // 1st request: hand out the cookie.
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut buf = [0u8; 2048];
+            let _ = stream.read(&mut buf);
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nSet-Cookie: {}\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+                set_cookie
+            );
+            let _ = stream.write_all(resp.as_bytes());
+            let _ = stream.flush();
+        }
+        // 2nd request: echo the Cookie header the agent sent back to us.
+        if let Ok((mut stream, _)) = listener.accept() {
+            let mut buf = [0u8; 2048];
+            let n = stream.read(&mut buf).unwrap_or(0);
+            let req = String::from_utf8_lossy(&buf[..n]).to_string();
+            let echoed = req
+                .lines()
+                .find(|l| l.to_ascii_lowercase().starts_with("cookie:"))
+                .unwrap_or("cookie: <none>")
+                .to_string();
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                echoed.len(),
+                echoed
+            );
+            let _ = stream.write_all(resp.as_bytes());
+            let _ = stream.flush();
+        }
+    });
+    format!("http://{addr}")
+}
+
+/// The shared agent must carry ureq's cookie jar across requests — without this a
+/// cookie-session login can never authenticate a later request on native.
+///
+/// Not a separate `#[test]`: each test fn runs on its own thread, but the parked
+/// callbacks live in a *main-thread-local* registry while the dispatcher queue is
+/// global — so a second test's pump could drain (and drop) this one's completion.
+/// Everything shares one test fn on one thread.
+fn cookie_jar_persists_across_requests() {
+    let base = serve_cookie_pair("sid=abc123; Path=/");
+
+    // 1st request receives the Set-Cookie.
+    let (tx1, rx1) = mpsc::channel();
+    fetch(Request::get(format!("{base}/login")), move |res| {
+        tx1.send(res).unwrap()
+    });
+    let first = pump_recv(&rx1, Duration::from_secs(5)).expect("first request ok");
+    assert_eq!(first.status, 200);
+
+    // 2nd request must send it back — proving the jar lives on the shared agent.
+    let (tx2, rx2) = mpsc::channel();
+    fetch(Request::get(format!("{base}/me")), move |res| {
+        tx2.send(res).unwrap()
+    });
+    let second = pump_recv(&rx2, Duration::from_secs(5)).expect("second request ok");
+    assert_eq!(second.status, 200);
+    assert!(
+        second.text().contains("sid=abc123"),
+        "cookie was not resent on the follow-up request (got {:?}) — the agent's \
+         jar is not persisting, so session auth would break on native",
+        second.text()
+    );
+}
+
+#[test]
+fn native_roundtrip_delivers_on_main_thread() {
+    // Simulate the rinch runtime: this thread is "main"; cross-thread dispatch
+    // queues closures for us to pump.
+    register_main_thread();
+    set_cross_thread_dispatcher(dispatcher);
+
+    // 200 with a JSON body.
+    {
+        let body = r#"{"hello":"world"}"#;
+        let url = serve_once(response_str("200 OK", body));
+        let (tx, rx) = mpsc::channel();
+        fetch(Request::get(url), move |res| tx.send(res).unwrap());
+        let resp = pump_recv(&rx, Duration::from_secs(5)).expect("transport ok");
+        assert_eq!(resp.status, 200);
+        assert!(resp.ok());
+        assert_eq!(resp.text(), body);
+        assert_eq!(resp.header("Content-Type"), Some("application/json"));
+    }
+
+    // 404 with a body must come back as Ok(Response), not Err.
+    {
+        let body = r#"{"error":"not found"}"#;
+        let url = serve_once(response_str("404 Not Found", body));
+        let (tx, rx) = mpsc::channel();
+        fetch(Request::get(url), move |res| tx.send(res).unwrap());
+        let resp = pump_recv(&rx, Duration::from_secs(5)).expect("404 must be Ok(Response)");
+        assert_eq!(resp.status, 404);
+        assert!(!resp.ok());
+        assert_eq!(resp.text(), body);
+    }
+
+    // POST with a body and a custom header: the request line, header and body must
+    // all reach the server (the echo server reflects the raw request back).
+    {
+        let url = serve_echo();
+        let (tx, rx) = mpsc::channel();
+        fetch(
+            Request::post(url)
+                .header("X-Test", "hello")
+                .body_str(r#"{"k":"v"}"#),
+            move |res| tx.send(res).unwrap(),
+        );
+        let resp = pump_recv(&rx, Duration::from_secs(5)).expect("post transport ok");
+        assert_eq!(resp.status, 200);
+        let echoed = resp.text();
+        assert!(
+            echoed.starts_with("POST "),
+            "method reached server: {echoed:?}"
+        );
+        assert!(
+            echoed.to_ascii_lowercase().contains("x-test: hello"),
+            "custom header reached server: {echoed:?}"
+        );
+        assert!(
+            echoed.contains(r#"{"k":"v"}"#),
+            "request body reached server: {echoed:?}"
+        );
+    }
+
+    // Session cookies must survive across requests (shared agent = shared jar).
+    cookie_jar_persists_across_requests();
+}

--- a/crates/rinch/Cargo.toml
+++ b/crates/rinch/Cargo.toml
@@ -57,7 +57,9 @@ rinch-editor-core = { workspace = true, optional = true }
 # link — so default builds (desktop AND web) link zero automerge.
 rinch-editor-view = { workspace = true, optional = true }
 rinch-video = { workspace = true, optional = true }
-ureq = { version = "3", optional = true }
+# HTTP client for the network image loader (image-network). Standalone, opt-in:
+# nothing else in the facade depends on it, so default builds link no HTTP stack.
+rinch-http = { workspace = true, optional = true }
 memory-stats = { version = "1.2", optional = true }
 # Accessibility (M7b) — `accesskit` core types are platform-neutral; the per-platform
 # adapter (`accesskit_unix` etc.) lives in the target tables below. Gated by `a11y`.
@@ -161,7 +163,7 @@ theme = ["dep:rinch-theme", "rinch-core/theme"]
 components = ["theme", "dep:rinch-components"]
 debug = ["dep:rinch-debug"]
 video = ["dep:rinch-video"]
-image-network = ["dep:ureq"]
+image-network = ["dep:rinch-http"]
 # Editor accessibility (M7b): derive an accesskit TreeUpdate from EditorState and
 # push it through a per-platform adapter. Linux uses accesskit_unix (AT-SPI); other
 # desktop platforms fall back to a no-op bridge until their adapters land.

--- a/crates/rinch/src/app/mod.rs
+++ b/crates/rinch/src/app/mod.rs
@@ -395,7 +395,7 @@ impl RinchApp {
         doc.borrow_mut().tree.text_scale = self.text_scale;
 
         // Set up network image loader if feature enabled (replaces default FileImageLoader)
-        #[cfg(feature = "image-network")]
+        #[cfg(all(feature = "image-network", not(target_arch = "wasm32")))]
         {
             doc.borrow_mut().tree.image_loader =
                 Some(std::sync::Arc::new(crate::image_loader::NetworkImageLoader));

--- a/crates/rinch/src/image_loader.rs
+++ b/crates/rinch/src/image_loader.rs
@@ -1,27 +1,37 @@
 //! Network-capable image loader (optional, requires `image-network` feature).
+//!
+//! HTTP(S) image loads go through [`rinch_http::fetch_blocking`] rather than a
+//! private ureq call, so they share the app's one HTTP agent — its cookie jar,
+//! connection pool and timeouts. Concretely, an image behind the same
+//! cookie-session the app logged in with now loads authenticated, instead of
+//! going out on a fresh, cookie-less agent. This runs on the image-decode worker
+//! thread (`ImageLoader::load` is called off the main thread), which is exactly
+//! what the blocking entry point is for.
 
-#[cfg(feature = "image-network")]
+// Network image loading is a native concern: image loads run on a background
+// thread via `std::thread::spawn` (a no-op on wasm, where the browser fetches
+// `<img>` itself), and the shared blocking client lives on the native target.
+#[cfg(all(feature = "image-network", not(target_arch = "wasm32")))]
 use rinch_core::image::{ImageLoadResult, ImageLoader};
 
 /// Image loader that supports both local files and HTTP(S) URLs.
 ///
 /// Enabled with the `image-network` feature flag.
 /// Falls back to filesystem loading for non-URL paths.
-#[cfg(feature = "image-network")]
+#[cfg(all(feature = "image-network", not(target_arch = "wasm32")))]
 pub struct NetworkImageLoader;
 
-#[cfg(feature = "image-network")]
+#[cfg(all(feature = "image-network", not(target_arch = "wasm32")))]
 impl ImageLoader for NetworkImageLoader {
     fn load(&self, src: &str) -> ImageLoadResult {
         if src.starts_with("http://") || src.starts_with("https://") {
-            match ureq::get(src).call() {
-                Ok(resp) => match resp.into_body().read_to_vec() {
-                    Ok(bytes) => ImageLoadResult::Loaded(bytes),
-                    Err(e) => ImageLoadResult::Failed(format!(
-                        "Failed to read response body for {}: {}",
-                        src, e
-                    )),
-                },
+            // Share the app's HTTP agent (cookie jar + connection pool) instead of
+            // a fresh per-call agent, so authenticated image URLs carry the session.
+            match rinch_http::fetch_blocking(rinch_http::Request::get(src)) {
+                Ok(resp) if resp.ok() => ImageLoadResult::Loaded(resp.body),
+                Ok(resp) => {
+                    ImageLoadResult::Failed(format!("HTTP {} loading image {}", resp.status, src))
+                }
                 Err(e) => {
                     ImageLoadResult::Failed(format!("HTTP request failed for {}: {}", src, e))
                 }


### PR DESCRIPTION
Adds `rinch-http`: one `fetch(request, on_done)` API over `web_sys::fetch` (wasm) and blocking `ureq` (native), so an app can make requests from code shared by both backends.

Motivated by porting a real rinch app (PlotWeb) to desktop — `api.rs` was its last hard dependency on `web_sys`. Every design call below came from that port hitting the wall in practice.

### Worth review

- **The callback runs on the main/UI thread on both targets**, so consumers can update Signals with `.set()` inside it.
- **`HttpCallback` deliberately does not require `Send`.** The obvious native impl — box `on_done` and ship it to the UI thread — forces `Send`, which makes the API unusable for the common case: a callback capturing `!Send` UI state (an `Rc`-based editor handle, or a `Signal` over one — note `Signal<T>` is only `Send` if `T` is). Instead the callback is parked in a main-thread-local registry and only `(id, result)` — both `Send` — crosses the boundary. So the bound is plain `FnOnce + 'static` on both targets.
- **One process-wide `ureq::Agent`** (`OnceLock`). ureq's cookie jar lives on the agent, so a per-request agent silently drops session cookies — a cookie-session login succeeds and every later request goes out unauthenticated. Sharing it also restores connection pooling. Enables ureq's non-default `cookies` feature.
- **Non-2xx is not an error** (`http_status_as_error(false)`): a 404/500 with a body round-trips as `Ok(Response { status, body })`, because callers read error JSON out of 4xx bodies. Only transport failures are `Err`.

Also adds `rinch_core::run_on_main_thread(f)` — runs inline on the main thread, else dispatches via the registered cross-thread dispatcher.

### Tests

Native integration test over a throwaway `TcpListener`: asserts a 200 body, that a **404 comes back as `Ok`**, and that the shared agent **resends a `Set-Cookie`** on the follow-up request. It simulates the runtime (`register_main_thread` + a queueing dispatcher) and pumps it. Kept in a single test fn on purpose — the pending registry is main-thread-local while the dispatcher queue is global, so a second `#[test]` (own thread) could drain and drop this one's completion.

Builds clean for native and `wasm32-unknown-unknown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)