### PR TITLE
fix(shell): softbuffer present must write opaque alpha on unwritten pixels

### DIFF
--- a/crates/rinch/src/shell/softbuffer_renderer.rs
+++ b/crates/rinch/src/shell/softbuffer_renderer.rs
@@ -16,7 +16,17 @@ pub struct SoftbufferRenderer {
     surface: softbuffer::Surface<Arc<dyn Window>, Arc<dyn Window>>,
     width: u32,
     height: u32,
-    transparent: bool,
+    /// Whether the surface was actually configured with premultiplied alpha (i.e.
+    /// transparency is honored).
+    ///
+    /// This tracks the *resolved* alpha mode, NOT the requested `transparent`
+    /// flag, because the two can diverge: e.g. the X11 backend does not support
+    /// `Premultiplied`, so a `transparent: true` window still falls back to
+    /// `AlphaMode::Opaque` — under which *every* presented pixel must be opaque or
+    /// softbuffer's `present()` assertion fires. Gating alpha on the request
+    /// instead of the resolved mode would write translucent pixels into an opaque
+    /// surface and panic.
+    premultiplied: bool,
 }
 
 impl SoftbufferRenderer {
@@ -28,7 +38,11 @@ impl SoftbufferRenderer {
         let context = softbuffer::Context::new(window.clone()).unwrap();
         let mut surface = softbuffer::Surface::new(&context, window).unwrap();
 
-        let alpha_mode = if transparent && surface.supports_alpha_mode(AlphaMode::Premultiplied) {
+        // Honor transparency only if the backend actually supports premultiplied
+        // alpha; otherwise fall back to Opaque. Remember the *resolved* choice so
+        // `present_pixels` can uphold the Opaque invariant regardless of request.
+        let premultiplied = transparent && surface.supports_alpha_mode(AlphaMode::Premultiplied);
+        let alpha_mode = if premultiplied {
             AlphaMode::Premultiplied
         } else {
             AlphaMode::Opaque
@@ -46,41 +60,65 @@ impl SoftbufferRenderer {
             surface,
             width,
             height,
-            transparent,
+            premultiplied,
         }
     }
 
     /// Present RGBA8 pixels to the window.
     ///
-    /// `pixels` must be `width * height * 4` bytes in RGBA8 format.
-    /// When transparency is enabled, the alpha channel is passed through
-    /// (premultiplied, matching tiny-skia's internal format).
+    /// `pixels` is `width * height * 4` bytes, RGBA8, tightly packed. The
+    /// softbuffer surface, however, may pad each row to a wider `byte_stride`
+    /// (notably the Wayland backend), so `buffer.pixels()` is generally *longer*
+    /// than the source and must be walked **row by row** via `pixel_rows()`. A
+    /// flat 1:1 index copy would misalign every row past the first and shear the
+    /// image on any padded-stride surface.
+    ///
+    /// Under `AlphaMode::Opaque` every presented pixel must be opaque (softbuffer
+    /// asserts this in `present()`), so the padding columns beyond the source
+    /// width — which the source never covers — are still written opaque here.
+    /// Under premultiplied alpha the source alpha is passed through and the
+    /// padding is left fully transparent.
     pub fn present_pixels(&mut self, pixels: &[u8], width: u32, height: u32) {
         if width != self.width || height != self.height {
             self.resize(width, height);
         }
 
         let mut buffer = self.surface.next_buffer().unwrap();
-        let buf_pixels = buffer.pixels();
 
-        for (i, pixel) in buf_pixels.iter_mut().enumerate() {
-            let src = i * 4;
-            if src + 3 < pixels.len() {
-                pixel.r = pixels[src];
-                pixel.g = pixels[src + 1];
-                pixel.b = pixels[src + 2];
-                pixel.a = if self.transparent {
-                    pixels[src + 3]
+        let w = width as usize;
+        let src_stride = w * 4;
+        let premultiplied = self.premultiplied;
+
+        // `pixel_rows()` yields exactly one row per surface row (length
+        // `byte_stride / 4`); map surface row `y` back to the tightly-packed
+        // source row at `y * width * 4`.
+        for (y, row) in buffer.pixel_rows().enumerate() {
+            let src_offset = y * src_stride;
+            for (x, pixel) in row.iter_mut().enumerate() {
+                let base = src_offset + x * 4;
+                if x < w && base + 3 < pixels.len() {
+                    let a = if premultiplied {
+                        pixels[base + 3]
+                    } else {
+                        0xFF
+                    };
+                    *pixel = softbuffer::Pixel::new_rgba(
+                        pixels[base],
+                        pixels[base + 1],
+                        pixels[base + 2],
+                        a,
+                    );
+                } else if premultiplied {
+                    // Row padding is outside the visible image — keep it clear.
+                    *pixel = softbuffer::Pixel::new_rgba(0, 0, 0, 0);
                 } else {
-                    0xFF
-                };
-            } else if !self.transparent {
-                // Source shorter than the surface (a size/scale mismatch, e.g.
-                // fractional HiDPI): the unwritten pixels must still be opaque or
-                // softbuffer's `AlphaMode::Opaque` present() assertion fails.
-                pixel.a = 0xFF;
+                    // Opaque surface: uncovered/padding pixels must still be opaque
+                    // or `present()` asserts. Color is irrelevant (off-image).
+                    *pixel = softbuffer::Pixel::new_rgba(0, 0, 0, 0xFF);
+                }
             }
         }
+
         buffer.present().unwrap();
     }
 

--- a/crates/rinch/src/shell/softbuffer_renderer.rs
+++ b/crates/rinch/src/shell/softbuffer_renderer.rs
@@ -74,6 +74,11 @@ impl SoftbufferRenderer {
                 } else {
                     0xFF
                 };
+            } else if !self.transparent {
+                // Source shorter than the surface (a size/scale mismatch, e.g.
+                // fractional HiDPI): the unwritten pixels must still be opaque or
+                // softbuffer's `AlphaMode::Opaque` present() assertion fails.
+                pixel.a = 0xFF;
             }
         }
         buffer.present().unwrap();


### PR DESCRIPTION
On a machine with no usable GPU adapter, the desktop shell falls back to the softbuffer CPU renderer — and then **panics on the first frame**:

```
assertion `left == right` failed: pixel at (626, 1249) was not opaque
This is required by `AlphaMode::Opaque` ... left: 0, right: 255
```

`present_pixels` only writes a surface pixel when the source buffer has bytes for it (`if src + 3 < pixels.len()`). When the source is shorter than the surface — a size/scale mismatch, e.g. fractional HiDPI scaling — the trailing pixels are left untouched with `alpha = 0`, which trips softbuffer's `AlphaMode::Opaque` invariant in `present()`.

Force those pixels opaque in the non-transparent case so the CPU path presents instead of panicking.

**Caveat worth a maintainer's eye:** this fixes the symptom, not the root cause — *why* is the source buffer shorter than the surface? I hit this under fractional scaling on Wayland; there may be a real sizing bug upstream of here. But the invariant should hold regardless: `AlphaMode::Opaque` means every pixel must be opaque, including ones we never wrote.

Found while bringing a rinch app up on desktop — it was a hard blocker (no window at all) on a GPU-less box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)