### PR TITLE
feat(core,editor): cross-platform timers + an EditorHandle change hook

### DIFF
--- a/crates/rinch-core/src/lib.rs
+++ b/crates/rinch-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod match_dom;
 pub mod reactive;
 pub mod reconcile;
 pub mod show;
+pub mod timer;
 pub mod virtual_list;
 
 // Re-export image loading types
@@ -39,6 +40,9 @@ pub use reconcile::{ListOp, diff_keyed};
 pub use main_thread::{
     MainCallbackId, cancel_main_callback, park_main_callback, resume_main_callback,
 };
+
+// Re-export cross-platform timers
+pub use timer::{TimeoutHandle, clear_timeout, fire_timeout, set_timeout, set_timer_backend};
 
 // Re-export reactive types for convenience
 pub use reactive::{

--- a/crates/rinch-core/src/timer.rs
+++ b/crates/rinch-core/src/timer.rs
@@ -1,0 +1,236 @@
+//! Cross-platform one-shot timers.
+//!
+//! rinch-core is platform-agnostic, so *scheduling* is pluggable while the
+//! callback lives in the shared main-thread registry ([`crate::main_thread`]):
+//!
+//! - **Native** works out of the box: a **single** shared timer thread sleeps
+//!   until the earliest pending deadline (a min-heap of timers), then hops each
+//!   fired id back to the main thread via the runtime's cross-thread dispatcher
+//!   (see [`set_cross_thread_dispatcher`](crate::set_cross_thread_dispatcher)).
+//!   One daemon thread serves every timer — arming N timers does not spawn N
+//!   threads, so a debounce that re-arms on every keystroke stays cheap.
+//! - **Web** has no threads, so `rinch-web` installs a backend
+//!   ([`set_timer_backend`]) that drives `window.setTimeout`.
+//!
+//! The callback is parked via [`park_main_callback`](crate::park_main_callback),
+//! so only its id crosses the thread boundary and it need not be `Send` — it can
+//! capture `Rc`-based signals / editor handles.
+//!
+//! ```ignore
+//! let t = rinch_core::set_timeout(300, move || save(editor.doc()));
+//! rinch_core::clear_timeout(t); // debounce: cancel and re-arm
+//! ```
+
+use std::sync::Mutex;
+
+use crate::main_thread::{
+    MainCallbackId, cancel_main_callback, park_main_callback, resume_main_callback,
+};
+
+/// Schedules [`fire_timeout`] for `id` to run **on the main thread** after
+/// `delay_ms`. Installed by the platform shell via [`set_timer_backend`].
+type TimerBackend = fn(id: u64, delay_ms: u32);
+
+static BACKEND: Mutex<Option<TimerBackend>> = Mutex::new(None);
+
+/// A scheduled timeout. Pass to [`clear_timeout`] to cancel it.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct TimeoutHandle(MainCallbackId);
+
+/// Install the platform's timer scheduler. Called by the runtime at startup;
+/// `rinch-web` installs a `window.setTimeout` backend. On native a built-in
+/// shared-thread scheduler is used when no backend is installed.
+pub fn set_timer_backend(backend: TimerBackend) {
+    *BACKEND.lock().unwrap() = Some(backend);
+}
+
+/// Run `cb` on the main (UI) thread after `delay_ms` milliseconds.
+///
+/// Call from the main thread: the callback is parked in the main-thread registry
+/// and invoked there, so it needn't be `Send` and may capture `Rc`-based UI state.
+/// The native scheduler additionally requires the runtime's cross-thread
+/// dispatcher to be registered (it hops the fired id back onto the main thread).
+pub fn set_timeout(delay_ms: u32, cb: impl FnOnce() + 'static) -> TimeoutHandle {
+    let id = park_main_callback::<()>(move |()| cb());
+    schedule(id.raw(), delay_ms);
+    TimeoutHandle(id)
+}
+
+/// Cancel a scheduled timeout. Idempotent, and safe to call after it has fired.
+///
+/// This drops the parked callback; the underlying platform wake may still occur,
+/// but [`fire_timeout`] then finds nothing to run.
+pub fn clear_timeout(handle: TimeoutHandle) {
+    cancel_main_callback(handle.0);
+}
+
+/// Run the callback parked for `id`, if it hasn't been cancelled.
+///
+/// Called by the timer backend **on the main thread** when the delay elapses.
+/// This is a backend entry point (needed public so `rinch-web` can call it), not
+/// app API — prefer [`set_timeout`] / [`clear_timeout`].
+#[doc(hidden)]
+pub fn fire_timeout(id: u64) {
+    resume_main_callback(MainCallbackId::from_raw(id), ());
+}
+
+fn schedule(id: u64, delay_ms: u32) {
+    if let Some(backend) = *BACKEND.lock().unwrap() {
+        backend(id, delay_ms);
+        return;
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    native::schedule(id, delay_ms);
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = (id, delay_ms);
+        tracing::warn!(
+            "set_timeout: no timer backend installed — the callback will never fire. \
+             The web runtime installs one at startup."
+        );
+    }
+}
+
+/// Built-in native scheduler: a single shared daemon thread driving a min-heap of
+/// deadlines. Sleeps (`Condvar::wait_timeout`) until the nearest deadline, is
+/// woken when a nearer timer is armed, and hops each fired id to the main thread.
+/// Cancelled ids stay in the heap and simply no-op when [`fire_timeout`] finds
+/// nothing parked — so cancellation costs nothing here.
+#[cfg(not(target_arch = "wasm32"))]
+mod native {
+    use std::cmp::Reverse;
+    use std::collections::BinaryHeap;
+    use std::sync::{Condvar, Mutex, OnceLock};
+    use std::time::{Duration, Instant};
+
+    use crate::reactive::run_on_main_thread;
+
+    struct Scheduler {
+        /// Min-heap by deadline (`Reverse` flips the max-heap); ties broken by id.
+        heap: Mutex<BinaryHeap<Reverse<(Instant, u64)>>>,
+        wake: Condvar,
+    }
+
+    static SCHEDULER: OnceLock<&'static Scheduler> = OnceLock::new();
+
+    fn scheduler() -> &'static Scheduler {
+        SCHEDULER.get_or_init(|| {
+            let sched: &'static Scheduler = Box::leak(Box::new(Scheduler {
+                heap: Mutex::new(BinaryHeap::new()),
+                wake: Condvar::new(),
+            }));
+            std::thread::Builder::new()
+                .name("rinch-timer".into())
+                .spawn(move || run(sched))
+                .expect("failed to spawn rinch-timer thread");
+            sched
+        })
+    }
+
+    pub(super) fn schedule(id: u64, delay_ms: u32) {
+        let deadline = Instant::now() + Duration::from_millis(u64::from(delay_ms));
+        let sched = scheduler();
+        sched.heap.lock().unwrap().push(Reverse((deadline, id)));
+        // Wake the timer thread: a newly-armed timer may be sooner than what it is
+        // currently sleeping for.
+        sched.wake.notify_one();
+    }
+
+    fn run(sched: &'static Scheduler) {
+        let mut heap = sched.heap.lock().unwrap();
+        loop {
+            let now = Instant::now();
+            // Fire every timer whose deadline has passed.
+            while let Some(&Reverse((deadline, id))) = heap.peek() {
+                if deadline <= now {
+                    heap.pop();
+                    // Hop back to the main thread; `fire_timeout` resumes the
+                    // parked (cancel-aware) callback there.
+                    run_on_main_thread(move || super::fire_timeout(id));
+                } else {
+                    break;
+                }
+            }
+            // Sleep until the next deadline, or indefinitely if none, until woken.
+            heap = match heap.peek() {
+                Some(&Reverse((deadline, _))) => {
+                    let dur = deadline.saturating_duration_since(Instant::now());
+                    sched.wake.wait_timeout(heap, dur).unwrap().0
+                }
+                None => sched.wake.wait(heap).unwrap(),
+            };
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::rc::Rc;
+
+    /// Drive timers synchronously: record what was scheduled, fire it on demand.
+    /// (Mirrors what a real backend does, minus the waiting.)
+    fn install_manual_backend() {
+        fn manual(id: u64, _delay_ms: u32) {
+            SCHEDULED.with(|s| s.borrow_mut().push(id));
+        }
+        set_timer_backend(manual);
+    }
+
+    thread_local! {
+        static SCHEDULED: std::cell::RefCell<Vec<u64>> = const { std::cell::RefCell::new(Vec::new()) };
+    }
+
+    fn drain_and_fire() {
+        let ids: Vec<u64> = SCHEDULED.with(|s| std::mem::take(&mut *s.borrow_mut()));
+        for id in ids {
+            fire_timeout(id);
+        }
+    }
+
+    #[test]
+    fn fires_once_and_can_be_cancelled() {
+        install_manual_backend();
+
+        // Fires when the deadline arrives.
+        let hits = Rc::new(std::cell::Cell::new(0));
+        let h = hits.clone();
+        set_timeout(10, move || h.set(h.get() + 1));
+        drain_and_fire();
+        assert_eq!(hits.get(), 1);
+
+        // One-shot: firing again does nothing (the callback was taken).
+        drain_and_fire();
+        assert_eq!(hits.get(), 1);
+
+        // Cancelled timers never run — the debounce case.
+        let h2 = hits.clone();
+        let t = set_timeout(10, move || h2.set(h2.get() + 100));
+        clear_timeout(t);
+        drain_and_fire();
+        assert_eq!(hits.get(), 1, "cleared timeout must not fire");
+
+        // clear_timeout after firing is a harmless no-op.
+        clear_timeout(t);
+    }
+
+    #[test]
+    fn callback_need_not_be_send_and_may_be_re_armed() {
+        install_manual_backend();
+
+        // An `Rc` capture — the whole point of parking main-thread-side.
+        let log = Rc::new(std::cell::RefCell::new(Vec::<&'static str>::new()));
+
+        let l = log.clone();
+        let first = set_timeout(5, move || l.borrow_mut().push("first"));
+        // Debounce: cancel and re-arm before the deadline.
+        clear_timeout(first);
+        let l = log.clone();
+        set_timeout(5, move || l.borrow_mut().push("second"));
+
+        drain_and_fire();
+        assert_eq!(*log.borrow(), vec!["second"]);
+    }
+}

--- a/crates/rinch-core/tests/native_timer.rs
+++ b/crates/rinch-core/tests/native_timer.rs
@@ -1,0 +1,82 @@
+#![cfg(not(target_arch = "wasm32"))]
+//! The built-in **native** timer scheduler, end to end.
+//!
+//! This lives in `tests/` (its own process) on purpose: the timer backend is
+//! global state, and the unit tests in `timer.rs` install a manual backend. Here
+//! no backend is installed, so `set_timeout` exercises the real native path —
+//! worker thread sleeps, then hops back to the main thread via the runtime's
+//! cross-thread dispatcher.
+
+use std::collections::VecDeque;
+use std::rc::Rc;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use rinch_core::{clear_timeout, register_main_thread, set_cross_thread_dispatcher, set_timeout};
+
+/// A closure the (simulated) runtime must run on the main thread.
+type Job = Box<dyn FnOnce() + Send>;
+
+/// Stands in for the runtime's event loop: closures queued from worker threads,
+/// drained on the main thread.
+static QUEUE: OnceLock<Mutex<VecDeque<Job>>> = OnceLock::new();
+
+fn queue() -> &'static Mutex<VecDeque<Job>> {
+    QUEUE.get_or_init(|| Mutex::new(VecDeque::new()))
+}
+
+fn dispatcher(f: Job) {
+    queue().lock().unwrap().push_back(f);
+}
+
+/// Pump the dispatcher queue on this (main) thread until `done` or the deadline.
+fn pump_until(done: impl Fn() -> bool, timeout: Duration) -> bool {
+    let start = Instant::now();
+    loop {
+        while let Some(job) = queue().lock().unwrap().pop_front() {
+            job();
+        }
+        if done() {
+            return true;
+        }
+        if start.elapsed() > timeout {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(2));
+    }
+}
+
+#[test]
+fn native_scheduler_fires_on_the_main_thread_and_honours_cancel() {
+    register_main_thread();
+    set_cross_thread_dispatcher(dispatcher);
+
+    let main_thread = std::thread::current().id();
+
+    // An `Rc` capture: the callback is parked main-thread-side and must never be
+    // required to be `Send`. This would not compile if it were.
+    let fired_on = Rc::new(std::cell::Cell::new(None::<std::thread::ThreadId>));
+
+    let f = fired_on.clone();
+    set_timeout(20, move || f.set(Some(std::thread::current().id())));
+
+    assert!(
+        pump_until(|| fired_on.get().is_some(), Duration::from_secs(5)),
+        "native timer never fired"
+    );
+    assert_eq!(
+        fired_on.get(),
+        Some(main_thread),
+        "callback must run on the main thread, not the sleeping worker"
+    );
+
+    // A cancelled timer must stay silent even after its deadline passes.
+    let ran = Rc::new(std::cell::Cell::new(false));
+    let r = ran.clone();
+    let h = set_timeout(20, move || r.set(true));
+    clear_timeout(h);
+
+    // Pump well past the deadline; nothing should run.
+    let _ = pump_until(|| false, Duration::from_millis(200));
+    assert!(!ran.get(), "cleared timeout must not fire");
+}

--- a/crates/rinch-editor-view/src/handle.rs
+++ b/crates/rinch-editor-view/src/handle.rs
@@ -49,6 +49,12 @@ struct EditorCore {
     view: Option<RinchDomEditorView>,
     schema: Rc<Schema>,
     plugins: Vec<Rc<dyn Plugin>>,
+    /// Invoked after a local edit changes the document — see
+    /// [`EditorHandle::on_change`]. Held behind an `Rc` so the notifier can clone
+    /// it out and invoke it with **no** borrow held: the callback commonly
+    /// re-enters the handle (an autosave reads `doc()`), which would otherwise
+    /// panic with a `RefCell` double-borrow.
+    on_change: Option<Rc<dyn Fn()>>,
     /// The collaboration session + outbound delta sink, when this editor is
     /// collaborating (design M9). `None` for a non-collaborative editor — the
     /// common case — so the mutation path's collab hook is a cheap early return.
@@ -67,13 +73,18 @@ impl EditorCore {
     /// helper: a remote change is already in the shared CRDT, so it must be stored
     /// and re-projected *without* recording it back onto the CRDT (which would echo
     /// it to peers and double-apply).
-    fn commit(&mut self, prev: EditorState, next: EditorState) {
+    ///
+    /// Returns whether the **document** changed (a selection-only edit leaves the
+    /// same doc `Rc`), which is what drives [`EditorHandle::on_change`].
+    fn commit(&mut self, prev: EditorState, next: EditorState) -> bool {
+        let doc_changed = !prev.doc.same_ref(&next.doc);
         self.state = next.clone();
         if let Some(view) = self.view.as_mut() {
             view.update_dom(&prev, &next);
         }
         #[cfg(feature = "collaboration")]
         self.record_local(&prev, &next);
+        doc_changed
     }
 
     /// Project a just-applied local change onto the CRDT and broadcast the delta to
@@ -146,6 +157,7 @@ impl EditorHandle {
                 view: None,
                 schema,
                 plugins,
+                on_change: None,
                 #[cfg(feature = "collaboration")]
                 collab: None,
             })),
@@ -171,6 +183,7 @@ impl EditorHandle {
                 view: Some(view),
                 schema,
                 plugins,
+                on_change: None,
                 #[cfg(feature = "collaboration")]
                 collab: None,
             })),
@@ -212,7 +225,11 @@ impl EditorHandle {
         };
         let prev = core.state.clone();
         let next = core.state.apply(tr);
-        core.commit(prev, next);
+        let doc_changed = core.commit(prev, next);
+        drop(core);
+        if doc_changed {
+            self.notify_change();
+        }
         true
     }
 
@@ -224,8 +241,52 @@ impl EditorHandle {
             return false;
         };
         let prev = core.state.clone();
-        core.commit(prev, next);
+        let doc_changed = core.commit(prev, next);
+        drop(core);
+        if doc_changed {
+            self.notify_change();
+        }
         true
+    }
+
+    /// Register a callback invoked after a **local edit changes the document**.
+    /// Replaces any previously registered callback.
+    ///
+    /// This is the cross-platform way to know the user edited — for autosave,
+    /// dirty-marking or word counts. There is no DOM `input` event to listen for:
+    /// the editor is model-first and deliberately never `contenteditable`.
+    ///
+    /// Fires for every edit path — [`update`](Self::update) (which typing, paste
+    /// and IME commit all funnel through), [`command`](Self::command) and
+    /// [`insert_image`](Self::insert_image). It does **not** fire for:
+    /// - selection-only changes (the document is unchanged),
+    /// - [`load_doc`](Self::load_doc) / [`load_html`](Self::load_html) — a
+    ///   programmatic load is not a user edit, and firing would make an autosave
+    ///   consumer immediately re-save freshly loaded content,
+    /// - remote collaboration integration ([`collab_receive`](Self::collab_receive)),
+    ///   which is already in the shared CRDT.
+    ///
+    /// The callback runs with no internal borrow held, so it may freely re-enter
+    /// the handle (e.g. call [`doc`](Self::doc) to serialize for a save).
+    ///
+    /// ```ignore
+    /// let editor = create_editor();
+    /// editor.on_change({
+    ///     let editor = editor.clone();
+    ///     move || schedule_autosave(editor.doc())
+    /// });
+    /// ```
+    pub fn on_change(&self, cb: impl Fn() + 'static) {
+        self.inner.borrow_mut().on_change = Some(Rc::new(cb));
+    }
+
+    /// Invoke the change callback, if any, with **no borrow held** — the callback
+    /// commonly re-enters the handle, which would otherwise double-borrow.
+    fn notify_change(&self) {
+        let cb = self.inner.borrow().on_change.clone();
+        if let Some(cb) = cb {
+            cb();
+        }
     }
 
     /// Whether the named command currently applies (toolbar enablement).
@@ -543,6 +604,9 @@ impl EditorHandle {
         };
         let prev = core.state.clone();
         let next = EditorState::create(core.schema.clone(), doc, core.plugins.clone());
+        // Deliberately does not fire `on_change`: loading a document is a
+        // programmatic replace, not a user edit. Firing here would make an
+        // autosave consumer immediately re-save freshly loaded content.
         core.commit(prev, next);
     }
 
@@ -603,7 +667,11 @@ impl EditorHandle {
             return false;
         };
         let prev = core.state.clone();
-        core.commit(prev, next);
+        let doc_changed = core.commit(prev, next);
+        drop(core);
+        if doc_changed {
+            self.notify_change();
+        }
         true
     }
 
@@ -1501,6 +1569,64 @@ mod tests {
             Fragment::from_node(s.branch("paragraph", Fragment::empty()).unwrap()),
         )
         .unwrap()
+    }
+
+    #[test]
+    fn on_change_fires_for_edits_but_not_loads_or_selection() {
+        use std::cell::Cell;
+
+        let s = Rc::new(schema());
+        let h = EditorHandle::unmounted(s.clone(), empty_doc(&s), default_plugins());
+
+        let hits = Rc::new(Cell::new(0u32));
+        h.on_change({
+            let hits = hits.clone();
+            move || hits.set(hits.get() + 1)
+        });
+
+        // A programmatic load is not a user edit — must not fire (otherwise an
+        // autosave consumer would re-save every freshly opened document).
+        assert!(h.load_html("<p>hello world</p>"));
+        assert_eq!(hits.get(), 0, "load_doc/load_html must not fire on_change");
+
+        // Typing (funnels through `update`) is an edit → fires.
+        assert!(h.insert_text("!"));
+        assert_eq!(hits.get(), 1, "an edit must fire on_change");
+
+        // A command that changes the doc → fires.
+        h.set_selection(Selection::text(Pos(1), Pos(3)));
+        let before = hits.get();
+        assert!(h.command("toggleBold"));
+        assert_eq!(hits.get(), before + 1, "a doc-changing command must fire");
+
+        // Selection-only movement leaves the doc identical → must not fire.
+        let before = hits.get();
+        h.set_selection(Selection::cursor(Pos(2)));
+        assert_eq!(hits.get(), before, "selection-only change must not fire");
+    }
+
+    #[test]
+    fn on_change_callback_may_reenter_the_handle() {
+        use std::cell::Cell;
+
+        // The realistic autosave shape: the callback reads the document back out.
+        // This double-borrows the inner RefCell unless the notifier drops its
+        // borrow first, so this test is the regression guard for that.
+        let s = Rc::new(schema());
+        let h = EditorHandle::unmounted(s.clone(), empty_doc(&s), default_plugins());
+
+        let seen = Rc::new(Cell::new(0usize));
+        h.on_change({
+            let h = h.clone();
+            let seen = seen.clone();
+            move || seen.set(h.doc().child_count())
+        });
+
+        assert!(h.insert_text("abc"));
+        assert!(
+            seen.get() > 0,
+            "callback should have read the doc without panicking"
+        );
     }
 
     #[test]

--- a/crates/rinch-web/src/lib.rs
+++ b/crates/rinch-web/src/lib.rs
@@ -124,6 +124,27 @@ impl RootHandle {
 // One-time page-global setup
 // ============================================================================
 
+/// The web timer backend: schedule `fire_timeout(id)` via `window.setTimeout`.
+///
+/// Only `id` is captured, so the parked callback stays in rinch-core's
+/// main-thread registry. The closure is created with `Closure::once_into_js`,
+/// which hands ownership to the JS GC and drops the boxed `FnOnce` after it fires
+/// — so, unlike `Closure::forget()`, arming thousands of timers over a long
+/// session does not leak a closure per timer. A cancelled timeout
+/// (`clear_timeout`) still wakes here, then finds nothing parked and no-ops.
+fn web_set_timeout(id: u64, delay_ms: u32) {
+    use wasm_bindgen::JsCast;
+    use wasm_bindgen::closure::Closure;
+
+    let cb = Closure::once_into_js(move || rinch_core::fire_timeout(id));
+    if let Some(window) = web_sys::window() {
+        let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(
+            cb.unchecked_ref(),
+            delay_ms as i32,
+        );
+    }
+}
+
 /// First-mount-only global init shared by every mount. Clearing handlers/context
 /// must NOT run per-root, or a second island would wipe the first.
 fn ensure_global_init() {
@@ -136,6 +157,11 @@ fn ensure_global_init() {
         // Clear stale handlers/context from any previous run of this wasm module.
         events::clear_handlers();
         rinch_core::clear_context();
+
+        // Drive `rinch_core::set_timeout` off `window.setTimeout`. The browser has
+        // no threads, so rinch-core's built-in shared-thread scheduler cannot run
+        // here — the web runtime supplies the scheduling half.
+        rinch_core::set_timer_backend(web_set_timeout);
 
         // Theme CSS is page-global (one shared `<style>`). On any signal change
         // (e.g. dark-mode toggle), refresh it once — regardless of which root

--- a/crates/rinch/src/lib.rs
+++ b/crates/rinch/src/lib.rs
@@ -122,6 +122,9 @@ pub mod prelude {
     pub use android_activity::AndroidApp;
     pub use rinch_core::element::*;
     pub use rinch_core::{Memo, Scope, Signal, batch, derived, untracked};
+    // Cross-platform one-shot timers (debounce / throttle / delayed work) and the
+    // helper to run a closure on the main (UI) thread from a background thread.
+    pub use rinch_core::{TimeoutHandle, clear_timeout, run_on_main_thread, set_timeout};
     // Context and stores for sharing state across components
     pub use rinch_core::{
         create_context, create_store, try_use_context, try_use_store, use_context, use_store,


### PR DESCRIPTION
> **Stacked on #107** (uses `rinch_core::run_on_main_thread` from it). Review/merge that first; base retargets to `main` once it lands.

The two primitives an app needs to autosave a model-first editor — neither of which rinch had, which forced a consuming app (PlotWeb) into web-only DOM hacks that silently no-op on desktop: a document `keyup` listener and `window.setTimeout`.

### 1. `rinch_core::set_timeout(delay_ms, cb) -> TimeoutHandle` / `clear_timeout`

rinch had no timer API at all. rinch-core is strictly platform-agnostic (deps: `thiserror`, `tracing`), so a `web_sys` timer can't live there — instead the **callback bookkeeping** lives in core and the **scheduling** is pluggable, mirroring the existing `set_cross_thread_dispatcher` hook:

- **Native works out of the box**: a worker sleeps, then hops back via the cross-thread dispatcher core already has. No new deps (std only).
- **Web**: `rinch-web` installs a `window.setTimeout` backend at init (the browser has no threads).

The callback is parked in a main-thread-local registry and only its `id` travels, so it **needn't be `Send`** — it can capture `Rc`-based signals/editor handles (same trick as #107).

### 2. `EditorHandle::on_change(cb)`

Fires after a **local edit changes the document**. There was previously no cross-platform way to observe edits: the editor is model-first and deliberately never `contenteditable`, so there's no DOM `input` event to listen for.

Deliberately does **not** fire for:
- selection-only changes (document unchanged),
- `load_doc`/`load_html` — a programmatic load isn't a user edit; firing would make an autosave consumer immediately re-save freshly loaded content,
- remote collab integration (already in the shared CRDT).

`commit` now reports whether the *document* (not just the selection) changed, and the notification fires **only after the internal borrow is released** — the callback almost always re-enters the handle (an autosave reads `doc()`), which would otherwise panic on a `RefCell` double-borrow. There's a regression test for exactly that.

### Tests
Timer: unit tests (fires once, cancel honoured, `Rc` capture compiles) **plus** an integration test in its own process — the unit tests install a manual backend, so the built-in native scheduler would otherwise never be exercised. It asserts the callback runs on the *main* thread, not the sleeping worker.
Editor: fires on edits, not on `load_doc`, not on selection-only; and the re-entrancy guard.

Verified end-to-end in a real desktop app: type → `on_change` → debounce → authenticated PUT → persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)