### PR TITLE
fix(dom): keep the theme sheet ahead of app CSS in the cascade

### DIFF
--- a/crates/rinch-dom/src/dom_impl/mod.rs
+++ b/crates/rinch-dom/src/dom_impl/mod.rs
@@ -62,6 +62,11 @@ pub struct RinchDocument {
     pub layout_cx: parley::LayoutContext<Brush>,
     /// Stylo CSS engine stylist for CSS cascade and selector matching.
     pub stylist: Stylist,
+    /// The theme stylesheet, held in a stable slot before every app sheet so app
+    /// CSS always cascades over it. Managed by `set_theme_css`.
+    pub(crate) theme_stylesheet: Option<style::stylesheets::DocumentStyleSheet>,
+    /// App author stylesheets, in insertion (source) order.
+    pub(crate) author_stylesheets: Vec<style::stylesheets::DocumentStyleSheet>,
 }
 
 impl Default for RinchDocument {
@@ -103,6 +108,8 @@ impl RinchDocument {
             font_cx: parley::FontContext::new(),
             layout_cx: parley::LayoutContext::new(),
             stylist,
+            theme_stylesheet: None,
+            author_stylesheets: Vec::new(),
         };
 
         // Set up default file-based image loader

--- a/crates/rinch-dom/src/style_resolution/mod.rs
+++ b/crates/rinch-dom/src/style_resolution/mod.rs
@@ -144,11 +144,8 @@ impl RinchDocument {
             .force_stylesheet_origins_dirty(Origin::Author.into());
     }
 
-    /// Load CSS into Stylo's stylesheet system.
-    ///
-    /// Parses the CSS string and adds it to the Stylist for CSS cascade.
-    /// This is the Stylo-based replacement for the old stylesheet system.
-    pub fn load_stylo_css(&mut self, css: &str) {
+    /// Parse a CSS string into an author-origin Stylo stylesheet.
+    fn parse_author_stylesheet(&self, css: &str) -> style::stylesheets::DocumentStyleSheet {
         use style::media_queries::MediaList;
         use style::stylesheets::{
             AllowImportRules, DocumentStyleSheet, Origin, Stylesheet, UrlExtraData,
@@ -159,7 +156,6 @@ impl RinchDocument {
             ::url::Url::parse("about:blank").expect("about:blank is a valid URL"),
         );
 
-        // Parse the CSS into a stylesheet
         let media = ServoArc::new(self.tree.guard.wrap(MediaList::empty()));
         let stylesheet = Stylesheet::from_str(
             css,
@@ -173,14 +169,71 @@ impl RinchDocument {
             AllowImportRules::Yes,
         );
 
-        // Wrap in DocumentStyleSheet for the Stylist
-        let doc_stylesheet = DocumentStyleSheet(ServoArc::new(stylesheet));
+        DocumentStyleSheet(ServoArc::new(stylesheet))
+    }
+
+    /// Load CSS into Stylo's stylesheet system.
+    ///
+    /// Parses the CSS string and appends it to the Stylist for CSS cascade.
+    /// Appended sheets cascade after everything loaded before them, matching
+    /// document source order.
+    pub fn load_stylo_css(&mut self, css: &str) {
+        use style::stylesheets::Origin;
+
+        let doc_stylesheet = self.parse_author_stylesheet(css);
 
         // Add the stylesheet to the stylist
         let guard = self.tree.guard.read();
-        self.stylist.append_stylesheet(doc_stylesheet, &guard);
+        self.stylist
+            .append_stylesheet(doc_stylesheet.clone(), &guard);
+        drop(guard);
+
+        // Track app author sheets in insertion order so the theme sheet can be
+        // re-inserted ahead of them (see `set_theme_css`).
+        self.author_stylesheets.push(doc_stylesheet);
 
         // Mark stylesheets as changed so they'll be flushed on next style computation
+        self.stylist
+            .force_stylesheet_origins_dirty(Origin::Author.into());
+    }
+
+    /// Install (or replace) the theme stylesheet.
+    ///
+    /// The theme sheet occupies a stable slot *before* every app stylesheet, so
+    /// app CSS always cascades over it. This mirrors rinch-web, where the theme
+    /// lives in a single `<style data-rinch-theme>` in `<head>` that is updated
+    /// in place — its document position never changes.
+    ///
+    /// Appending a regenerated theme sheet instead would move it *after* the
+    /// app's `<style>` rules, letting theme `:root` custom properties silently
+    /// win over an app's `:root` overrides of the same variable.
+    pub fn set_theme_css(&mut self, css: &str) {
+        use style::stylesheets::Origin;
+
+        let new_sheet = self.parse_author_stylesheet(css);
+
+        let guard = self.tree.guard.read();
+
+        // Drop the previous theme sheet, if any.
+        if let Some(old) = self.theme_stylesheet.take() {
+            self.stylist.remove_stylesheet(old, &guard);
+        }
+
+        // Re-insert ahead of the first app sheet so app CSS keeps overriding the
+        // theme. With no app sheets yet, appending puts it first anyway.
+        match self.author_stylesheets.first() {
+            Some(first_app) => {
+                self.stylist
+                    .insert_stylesheet_before(new_sheet.clone(), first_app.clone(), &guard);
+            }
+            None => {
+                self.stylist.append_stylesheet(new_sheet.clone(), &guard);
+            }
+        }
+        drop(guard);
+
+        self.theme_stylesheet = Some(new_sheet);
+
         self.stylist
             .force_stylesheet_origins_dirty(Origin::Author.into());
     }
@@ -197,9 +250,10 @@ impl RinchDocument {
 
     /// Update theme CSS variables without duplicating non-`:root` rules.
     /// After calling this, call `recompute_all_styles_full()` to apply the new variables.
+    ///
+    /// Replaces the theme sheet in its stable pre-app slot; see [`Self::set_theme_css`].
     pub fn update_theme_variables(&mut self, css: &str) {
-        // Load CSS variables into Stylo
-        self.load_stylo_css(css);
+        self.set_theme_css(css);
     }
 
     /// Recompute taffy styles for all element nodes, clearing cached style props

--- a/crates/rinch-dom/tests/theme_var_precedence_tests.rs
+++ b/crates/rinch-dom/tests/theme_var_precedence_tests.rs
@@ -1,0 +1,148 @@
+//! Regression: app `:root` custom properties must keep winning over the theme
+//! sheet's `:root` after a runtime theme update (rinch/plotweb native bug).
+
+use rinch_core::dom::DomDocument;
+use rinch_dom::RinchDocument;
+
+// `--rinch-color-accent` is theme-only: the app never overrides it, so it must
+// track theme updates.
+const THEME_V1: &str = ":root { --rinch-color-text: #c9c9c9; --rinch-color-accent: #ff0000; }";
+// A later theme regeneration (e.g. ThemeProvider re-run with different props).
+const THEME_V2: &str = ":root { --rinch-color-text: #c9c9c9; --rinch-color-accent: #0000ff; }";
+
+const APP_CSS: &str = r#"
+:root {
+    --rinch-color-text: #e7e0d8;
+    --pw-color-deep: #1a1714;
+}
+.text { color: var(--rinch-color-text); }
+.deep { color: var(--pw-color-deep); }
+.accent { color: var(--rinch-color-accent); }
+"#;
+
+fn hex(c: Option<peniko::Color>) -> String {
+    let c = c.expect("color should resolve");
+    let rgba = c.to_rgba8();
+    format!("#{:02x}{:02x}{:02x}", rgba.r, rgba.g, rgba.b)
+}
+
+struct Doc {
+    doc: RinchDocument,
+    text: rinch_core::dom::NodeId,
+    deep: rinch_core::dom::NodeId,
+    accent: rinch_core::dom::NodeId,
+}
+
+/// Build a doc the way the native shell does: theme sheet first (via the theme
+/// slot), then the app's `<style>` element.
+fn setup() -> Doc {
+    let mut doc = RinchDocument::new();
+    doc.set_theme_css(THEME_V1);
+
+    let body = doc.body();
+
+    let style_el = doc.create_element("style");
+    let style_text = doc.create_text(APP_CSS);
+    doc.append_child(style_el, style_text);
+    doc.append_child(body, style_el);
+
+    let text = doc.create_element("div");
+    doc.set_attribute(text, "class", "text");
+    doc.append_child(body, text);
+
+    let deep = doc.create_element("div");
+    doc.set_attribute(deep, "class", "deep");
+    doc.append_child(body, deep);
+
+    let accent = doc.create_element("div");
+    doc.set_attribute(accent, "class", "accent");
+    doc.append_child(body, accent);
+
+    doc.resolve_layout(800.0, 600.0);
+    Doc {
+        doc,
+        text,
+        deep,
+        accent,
+    }
+}
+
+impl Doc {
+    fn color_of(&self, id: rinch_core::dom::NodeId) -> String {
+        hex(self.doc.tree.get(id.0).unwrap().computed_style.color)
+    }
+}
+
+#[test]
+fn app_root_var_overrides_theme_var_initially() {
+    let d = setup();
+    assert_eq!(
+        d.color_of(d.text),
+        "#e7e0d8",
+        "app :root should win over the theme sheet (later source order)"
+    );
+}
+
+#[test]
+fn app_root_var_still_overrides_theme_var_after_theme_update() {
+    let mut d = setup();
+
+    // Runtime theme change (ThemeProvider props resolved during render).
+    d.doc.update_theme_variables(THEME_V2);
+    d.doc.recompute_all_styles_full();
+
+    // Non-colliding app var is unaffected — matches the observed symptom.
+    assert_eq!(
+        d.color_of(d.deep),
+        "#1a1714",
+        "app-only var should survive a theme update"
+    );
+
+    assert_eq!(
+        d.color_of(d.text),
+        "#e7e0d8",
+        "app :root must STILL win after a theme update; re-appending the theme \
+         sheet must not jump it ahead of app CSS in the cascade"
+    );
+}
+
+/// The theme slot must still be *live*: variables the app does not override have
+/// to follow theme updates (e.g. a dark-mode toggle).
+#[test]
+fn theme_only_var_follows_theme_updates() {
+    let mut d = setup();
+    assert_eq!(d.color_of(d.accent), "#ff0000", "initial theme accent");
+
+    d.doc.update_theme_variables(THEME_V2);
+    d.doc.recompute_all_styles_full();
+
+    assert_eq!(
+        d.color_of(d.accent),
+        "#0000ff",
+        "theme-only var must track the updated theme sheet"
+    );
+}
+
+/// Repeated theme updates must replace the sheet, not stack copies of it.
+#[test]
+fn repeated_theme_updates_do_not_stack_sheets() {
+    let mut d = setup();
+
+    for _ in 0..5 {
+        d.doc.update_theme_variables(THEME_V1);
+        d.doc.recompute_all_styles_full();
+        d.doc.update_theme_variables(THEME_V2);
+        d.doc.recompute_all_styles_full();
+    }
+
+    assert_eq!(
+        d.color_of(d.text),
+        "#e7e0d8",
+        "app override must survive repeated theme updates"
+    );
+    assert_eq!(
+        d.color_of(d.accent),
+        "#0000ff",
+        "latest theme value must win after repeated updates"
+    );
+}

--- a/crates/rinch/src/app/mod.rs
+++ b/crates/rinch/src/app/mod.rs
@@ -416,7 +416,10 @@ impl RinchApp {
             {
                 let theme_css = rinch_core::get_current_theme_css().unwrap_or_default();
                 if !theme_css.is_empty() {
-                    d.load_css(&theme_css);
+                    // Must go through the theme slot (not load_css) so a later
+                    // theme regeneration replaces this sheet instead of stacking
+                    // a second one after the app's CSS.
+                    d.set_theme_css(&theme_css);
                 }
             }
             // Set viewport size so vh/vw units resolve correctly during DOM construction


### PR DESCRIPTION
## The bug

On native, an app's `:root` override of a variable the theme **also** defines silently loses to the theme's value. Variables only the app defines work fine — that asymmetry is the tell.

Reported from PlotWeb: its `--rinch-color-text: #E7E0D8` rendered as rinch's `#c9c9c9`, and `--rinch-color-border: #3D3733` as `#424242`, while its own `--pw-color-deep` applied correctly.

## Cause — ordering, not custom-property resolution

Stylo's cascade was right all along. `RinchDocument::update_theme_variables()` called `load_stylo_css()`, which does `stylist.append_stylesheet(...)` — appending a **brand-new** theme sheet onto the **end** of the author origin.

Natively that plays out as:

1. Shell loads theme CSS → theme sheet is first. ✅
2. App's `<style>` reaches `maybe_load_style_css` → appended after. **App correctly wins.**
3. The rsx `ThemeProvider` calls `setup_theme_css` *during render* — after `last_theme_css` was snapshotted. Next frame `resolve_and_repaint` sees `theme_changed` → `update_theme_variables` → **the theme sheet is re-appended, now after the app's CSS.** Theme wins from here on.

Only variables the theme re-declares get clobbered, which is exactly the reported asymmetry.

Web never had this: the theme is a single `<style data-rinch-theme>` in `<head>`, updated in place via `set_text_content`, so its document position never moves.

## Fix

Give the theme sheet a **stable slot ahead of every app sheet**, mirroring web's `<head>` placement. Track the theme sheet and app sheets in source order; on update, `remove_stylesheet` the old one and `insert_stylesheet_before` the first app sheet. A new `set_theme_css()` owns that slot and `update_theme_variables()` delegates to it. The initial load in `app/mod.rs` routes through it too — otherwise an update would insert *before* the stale initial sheet and the stale one would win.

No specificity changes, no app-side workaround.

## Tests

`crates/rinch-dom/tests/theme_var_precedence_tests.rs`. Against the unfixed code the repro fails exactly as reported:

```
test app_root_var_overrides_theme_var_initially ... ok
test app_root_var_still_overrides_theme_var_after_theme_update ... FAILED
  left: "#c9c9c9"   right: "#e7e0d8"
```

Two guards are included deliberately, since "make the theme always lose" would be the easy wrong fix:
- `theme_only_var_follows_theme_updates` — dark-mode toggles must still apply.
- `repeated_theme_updates_do_not_stack_sheets`.

```
rinch-dom: 40 + 34 + 39 + 24 + 26 passed; 0 failed
rinch --features theme: 11 + 2 passed; 0 failed
clippy -p rinch-dom -p rinch --all-targets: clean
```

Note `theme` is not a default feature, so `cargo test -p rinch` alone does not compile the changed `app/mod.rs` block — it needs `--features theme`.

## Verified in a real app

Confirmed beyond the unit tests: PlotWeb's native window was driven via the rinch MCP with this branch patched in. The label that previously computed to `#c9c9c9` now computes to `#e7e0d8` — the app's value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dfj82yEkQviGePivgrBpUH