### PR TITLE
fix(ci): resolve cargo-doc output-name collision that fails the Pages build

### DIFF
--- a/crates/rinch-test-cli/Cargo.toml
+++ b/crates/rinch-test-cli/Cargo.toml
@@ -8,6 +8,11 @@ description = "CLI client for the rinch test harness"
 [[bin]]
 name = "rinch-test"
 path = "src/main.rs"
+# Skip rustdoc for this CLI binary: its doc output name (`rinch_test`) collides
+# with the `rinch-test` library crate, and under `cargo doc --workspace` the two
+# doc units race on the same output file and fail the Pages build. The binary
+# name is unchanged; only its (uninteresting) rustdoc is omitted.
+doc = false
 
 [dependencies]
 serde_json = "1"


### PR DESCRIPTION
The `rinch-test-cli` `[[bin]]` is named `rinch-test`; its rustdoc output (`rinch_test`) collides with the `rinch-test` library crate. Under `cargo doc --workspace` (the Documentation/Pages `build` job) the two doc units race on the same output file and fail the build.

Fix: `doc = false` on the CLI binary. The binary name is unchanged (nothing that invokes `rinch-test` is affected); only its uninteresting rustdoc is skipped, and the collision disappears. Verified locally: `cargo doc --no-deps --workspace --document-private-items` no longer reports the collision and the `rinch-test` lib still documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)