### PR TITLE
feat(rinch-ws): cross-platform callback-based WebSocket client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5076,6 +5076,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rinch-ws"
+version = "0.1.0"
+dependencies = [
+ "js-sys",
+ "rinch-core",
+ "tungstenite",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6385,9 +6396,12 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -6500,7 +6514,7 @@ dependencies = [
  "ureq-proto",
  "url",
  "utf-8",
- "webpki-roots",
+ "webpki-roots 1.0.5",
 ]
 
 [[package]]
@@ -6920,6 +6934,15 @@ dependencies = [
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.5",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5081,6 +5081,7 @@ version = "0.1.0"
 dependencies = [
  "js-sys",
  "rinch-core",
+ "rustls",
  "tungstenite",
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ repository = "https://github.com/user/rinch"
 rinch = { path = "crates/rinch", default-features = false }
 rinch-core = { path = "crates/rinch-core" }
 rinch-http = { path = "crates/rinch-http" }
+rinch-ws = { path = "crates/rinch-ws" }
 rinch-macros = { path = "crates/rinch-macros" }
 rinch-renderer = { path = "crates/rinch-renderer" }
 rinch-theme = { path = "crates/rinch-theme" }

--- a/crates/rinch-ws/Cargo.toml
+++ b/crates/rinch-ws/Cargo.toml
@@ -13,6 +13,20 @@ rinch-core = { workspace = true }
 # `rustls-tls-webpki-roots` adds `wss://` support reusing the rustls stack that
 # `rinch-http`'s `ureq` already pulls in.
 tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
+# rustls is not used directly — this dependency exists to enable the `ring` crypto
+# provider feature. tungstenite's `rustls-tls-webpki-roots` turns on the `rustls`
+# dependency but NO provider feature, so rustls has no compiled-in default and
+# `CryptoProvider` resolution panics on the first `wss://` handshake:
+#
+#   Could not automatically determine the process-level CryptoProvider
+#   from Rustls crate features.
+#
+# The panic happens on the connection's worker thread, so it surfaces as a silent
+# hang — no `on_error`, no `on_open`. It was previously masked whenever an app also
+# pulled `rinch-http` (ureq enables `rustls/ring`, and cargo unifies features), which
+# made `wss://` work only by accident of what else was in the graph. Enabling the
+# provider here makes it a property of this crate instead.
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/crates/rinch-ws/Cargo.toml
+++ b/crates/rinch-ws/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "rinch-ws"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Cross-platform callback-based WebSocket client for rinch (web WebSocket / native tungstenite)"
+
+[dependencies]
+rinch-core = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# Synchronous WebSocket client; `tungstenite` is already in the tree (rinch-signaling).
+# `rustls-tls-webpki-roots` adds `wss://` support reusing the rustls stack that
+# `rinch-http`'s `ureq` already pulls in.
+tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+js-sys = "0.3"
+web-sys = { version = "0.3", features = [
+    "WebSocket",
+    "MessageEvent",
+    "CloseEvent",
+    "BinaryType",
+] }
+
+[dev-dependencies]
+rinch-core = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }

--- a/crates/rinch-ws/src/error.rs
+++ b/crates/rinch-ws/src/error.rs
@@ -1,0 +1,40 @@
+//! WebSocket client error type.
+
+use std::fmt;
+
+/// Errors from a WebSocket connection.
+///
+/// Delivered to the [`on_error`](crate::WsHandle::on_error) callback for
+/// asynchronous failures (a connect that never completes, a broken send, a
+/// protocol/transport fault), and returned synchronously from
+/// [`connect`](crate::connect) only for an immediately rejected request (a
+/// malformed URL, or a browser that refuses to construct the socket).
+///
+/// Every variant carries a human-readable message. The type is `Clone + Send`
+/// so it can cross the worker→main-thread boundary on native.
+#[derive(Debug, Clone)]
+pub enum WsError {
+    /// The URL was not a valid `ws://` / `wss://` endpoint, or the platform
+    /// refused to construct the socket from it.
+    InvalidUrl(String),
+    /// The connection could not be established (DNS, refused, TLS handshake,
+    /// or a rejected upgrade).
+    Connect(String),
+    /// An outgoing frame could not be sent.
+    Send(String),
+    /// A transport/protocol fault on an otherwise-open connection.
+    Protocol(String),
+}
+
+impl fmt::Display for WsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            WsError::InvalidUrl(msg) => write!(f, "websocket invalid url: {msg}"),
+            WsError::Connect(msg) => write!(f, "websocket connect error: {msg}"),
+            WsError::Send(msg) => write!(f, "websocket send error: {msg}"),
+            WsError::Protocol(msg) => write!(f, "websocket protocol error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for WsError {}

--- a/crates/rinch-ws/src/lib.rs
+++ b/crates/rinch-ws/src/lib.rs
@@ -1,0 +1,353 @@
+//! Cross-platform, callback-based WebSocket client for rinch.
+//!
+//! One [`connect`] function works on both targets and returns a [`WsHandle`] on
+//! which the consumer registers callbacks and issues sends:
+//!
+//! - **Native** (`cfg(not(target_arch = "wasm32"))`): a synchronous
+//!   [`tungstenite`] client runs its read/write loop on a spawned `std::thread`.
+//! - **Web** (`cfg(target_arch = "wasm32")`): a browser [`web_sys::WebSocket`]
+//!   runs on the single web thread.
+//!
+//! On **both** platforms every callback (`on_open`, `on_message`, `on_close`,
+//! `on_error`) is invoked on the main (UI) thread, so consumers can update rinch
+//! [`Signal`](rinch_core::Signal)s directly with `.set()` from inside them. On
+//! native this is arranged by hopping each event back to the main thread via
+//! [`rinch_core::run_on_main_thread`] — the same transport `rinch-http` uses for
+//! its `fetch` result — where it is dispatched into a main-thread-local registry
+//! of the (`!Send`) callbacks. Only the connection id and the `Send` event
+//! payload cross the thread boundary; the callbacks never leave the main thread,
+//! so they need not be `Send` and may capture `!Send` UI state (`Rc`, `Signal`,
+//! an editor handle). On web the callbacks already run on the UI thread.
+//!
+//! Unlike `rinch-http`'s one-shot `fetch` (a `FnOnce` parked with
+//! [`park_main_callback`](rinch_core::park_main_callback)), a WebSocket is a
+//! long-lived connection that fires its callbacks repeatedly, so `rinch-ws` keeps
+//! its own persistent registry of `FnMut` callbacks keyed by connection id rather
+//! than parking a single continuation.
+//!
+//! # Threading
+//!
+//! [`connect`] must be called on the main (UI) thread — that is where the
+//! callback registry lives and where events are delivered. On native, delivery
+//! relies on the rinch runtime's cross-thread dispatcher (installed at startup);
+//! outside a running rinch app you must register one yourself (see the crate's
+//! integration test).
+//!
+//! # URLs
+//!
+//! The URL must be absolute and use the `ws://` or `wss://` scheme. There is no
+//! `base_url` notion (unlike relative HTTP fetches on web): a browser
+//! `WebSocket` already requires an absolute URL, and the native client has no
+//! page origin to resolve against.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use rinch_ws::{connect, WsMessage};
+//!
+//! let ws = connect("ws://127.0.0.1:3000/feed")?;
+//! ws.on_open(|| { /* connection is up */ })
+//!   .on_message(|msg| match msg {
+//!       WsMessage::Text(t) => { /* handle t */ }
+//!       WsMessage::Binary(b) => { /* handle b */ }
+//!   })
+//!   .on_close(|c| { /* c.code, c.reason */ })
+//!   .on_error(|e| { /* e: WsError */ });
+//!
+//! ws.send_text("hello");
+//! // Dropping `ws` closes the connection.
+//! ```
+
+mod error;
+
+pub use error::WsError;
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native;
+#[cfg(not(target_arch = "wasm32"))]
+use native as backend;
+
+#[cfg(target_arch = "wasm32")]
+mod wasm;
+#[cfg(target_arch = "wasm32")]
+use wasm as backend;
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// A message received over a WebSocket, or ready to be sent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WsMessage {
+    /// A UTF-8 text frame.
+    Text(String),
+    /// A binary frame.
+    Binary(Vec<u8>),
+}
+
+impl WsMessage {
+    /// The text of a [`WsMessage::Text`], or `None` for a binary frame.
+    pub fn as_text(&self) -> Option<&str> {
+        match self {
+            WsMessage::Text(t) => Some(t),
+            WsMessage::Binary(_) => None,
+        }
+    }
+
+    /// The bytes of a [`WsMessage::Binary`], or `None` for a text frame.
+    pub fn as_bytes(&self) -> Option<&[u8]> {
+        match self {
+            WsMessage::Binary(b) => Some(b),
+            WsMessage::Text(_) => None,
+        }
+    }
+}
+
+/// Details of a WebSocket close, delivered to [`WsHandle::on_close`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WsClose {
+    /// The WebSocket close code (RFC 6455). `1006` denotes an abnormal closure
+    /// where no close frame was received.
+    pub code: u16,
+    /// The close reason, if the peer supplied one (often empty).
+    pub reason: String,
+}
+
+/// An event produced by the platform backend and delivered to the registry on
+/// the main thread. `Send` (only plain data), so it can hop worker→main on
+/// native.
+pub(crate) enum WsEvent {
+    Open,
+    Message(WsMessage),
+    Close(WsClose),
+    Error(WsError),
+}
+
+/// The set of callbacks registered for one connection. Stored main-thread-local
+/// so the callbacks may be `!Send`. `on_open` is stored as `FnMut(())` purely so
+/// every slot shares the generic [`invoke`] dispatch path.
+#[derive(Default)]
+struct Handlers {
+    on_open: Option<Box<dyn FnMut(())>>,
+    on_message: Option<Box<dyn FnMut(WsMessage)>>,
+    on_close: Option<Box<dyn FnMut(WsClose)>>,
+    on_error: Option<Box<dyn FnMut(WsError)>>,
+}
+
+thread_local! {
+    /// Callback sets keyed by connection id, on the main (UI) thread. Type-erased
+    /// only by connection; kept thread-local (not global) so the callbacks may be
+    /// `!Send`. Mirrors `rinch_core`'s parked-callback registry, but persistent:
+    /// a WebSocket fires many events over its lifetime.
+    static HANDLERS: RefCell<HashMap<u64, Handlers>> = RefCell::new(HashMap::new());
+}
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Deliver `event` to connection `id`'s callbacks. Called on the main thread —
+/// directly on web, and via [`rinch_core::run_on_main_thread`] on native.
+pub(crate) fn dispatch(id: u64, event: WsEvent) {
+    match event {
+        WsEvent::Open => invoke(id, (), |h| &mut h.on_open),
+        WsEvent::Message(m) => invoke(id, m, |h| &mut h.on_message),
+        WsEvent::Close(c) => invoke(id, c, |h| &mut h.on_close),
+        WsEvent::Error(e) => invoke(id, e, |h| &mut h.on_error),
+    }
+}
+
+/// Invoke one callback slot without holding the registry borrow across the call.
+///
+/// The callback is *taken out* of the registry (releasing the borrow), invoked,
+/// then put back only if the entry still exists and the slot is still empty. This
+/// makes re-entrancy safe: a callback may drop the [`WsHandle`] (which re-enters
+/// the registry to deregister) or register a replacement callback without a
+/// double-borrow panic.
+fn invoke<T: 'static>(
+    id: u64,
+    arg: T,
+    select: impl Fn(&mut Handlers) -> &mut Option<Box<dyn FnMut(T)>>,
+) {
+    let taken = HANDLERS.with(|h| h.borrow_mut().get_mut(&id).and_then(|hs| select(hs).take()));
+    let Some(mut cb) = taken else { return };
+    cb(arg);
+    HANDLERS.with(|h| {
+        if let Some(hs) = h.borrow_mut().get_mut(&id) {
+            let slot = select(hs);
+            if slot.is_none() {
+                *slot = Some(cb);
+            }
+        }
+    });
+}
+
+/// Open a WebSocket connection to `url` (an absolute `ws://` or `wss://` URL).
+///
+/// Returns a [`WsHandle`] immediately; the connection is established
+/// asynchronously and its outcome is reported through the callbacks (`on_open`
+/// on success, `on_error` on failure). Register callbacks on the returned handle
+/// right away — events are only delivered once control returns to the event loop,
+/// so no event can be missed between `connect` and callback registration.
+///
+/// A synchronous `Err` is returned only when the request is rejected outright
+/// (a non-`ws`/`wss` URL, or a browser that refuses to construct the socket).
+///
+/// Must be called on the main (UI) thread; see the [module docs](crate).
+pub fn connect(url: impl Into<String>) -> Result<WsHandle, WsError> {
+    let url = url.into();
+    if !(url.starts_with("ws://") || url.starts_with("wss://")) {
+        return Err(WsError::InvalidUrl(format!(
+            "URL must be absolute and start with ws:// or wss:// (got {url:?})"
+        )));
+    }
+
+    let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    HANDLERS.with(|h| h.borrow_mut().insert(id, Handlers::default()));
+
+    match backend::connect(&url, id) {
+        Ok(backend) => Ok(WsHandle { id, backend }),
+        Err(e) => {
+            HANDLERS.with(|h| {
+                h.borrow_mut().remove(&id);
+            });
+            Err(e)
+        }
+    }
+}
+
+/// A handle to an open (or opening) WebSocket connection.
+///
+/// Register callbacks with [`on_open`](Self::on_open) /
+/// [`on_message`](Self::on_message) / [`on_close`](Self::on_close) /
+/// [`on_error`](Self::on_error) (chainable), send frames with
+/// [`send_text`](Self::send_text) / [`send_bytes`](Self::send_bytes), and end the
+/// connection with [`close`](Self::close). Dropping the handle closes the
+/// connection and deregisters its callbacks.
+///
+/// Not `Send`: it lives on the main (UI) thread alongside its callbacks.
+pub struct WsHandle {
+    id: u64,
+    backend: backend::Backend,
+}
+
+impl WsHandle {
+    /// Register the connection-opened callback (replaces any previous one).
+    pub fn on_open(&self, mut cb: impl FnMut() + 'static) -> &Self {
+        self.set(|h| h.on_open = Some(Box::new(move |()| cb())));
+        self
+    }
+
+    /// Register the message-received callback (replaces any previous one).
+    pub fn on_message(&self, cb: impl FnMut(WsMessage) + 'static) -> &Self {
+        self.set(|h| h.on_message = Some(Box::new(cb)));
+        self
+    }
+
+    /// Register the connection-closed callback (replaces any previous one).
+    ///
+    /// Fires once, whether the close was initiated locally, by the peer, or by an
+    /// abnormal drop (reported with code `1006`).
+    pub fn on_close(&self, cb: impl FnMut(WsClose) + 'static) -> &Self {
+        self.set(|h| h.on_close = Some(Box::new(cb)));
+        self
+    }
+
+    /// Register the error callback (replaces any previous one).
+    pub fn on_error(&self, cb: impl FnMut(WsError) + 'static) -> &Self {
+        self.set(|h| h.on_error = Some(Box::new(cb)));
+        self
+    }
+
+    /// Queue a text frame to be sent. A no-op if the connection is already gone.
+    pub fn send_text(&self, text: impl Into<String>) {
+        self.backend.send_text(text.into());
+    }
+
+    /// Queue a binary frame to be sent. A no-op if the connection is already gone.
+    pub fn send_bytes(&self, bytes: Vec<u8>) {
+        self.backend.send_bytes(bytes);
+    }
+
+    /// Begin a graceful close. The [`on_close`](Self::on_close) callback fires
+    /// once the close completes. Dropping the handle does the same.
+    pub fn close(&self) {
+        self.backend.close();
+    }
+
+    fn set(&self, f: impl FnOnce(&mut Handlers)) {
+        HANDLERS.with(|h| {
+            if let Some(hs) = h.borrow_mut().get_mut(&self.id) {
+                f(hs);
+            }
+        });
+    }
+}
+
+impl Drop for WsHandle {
+    fn drop(&mut self) {
+        self.backend.close();
+        HANDLERS.with(|h| {
+            h.borrow_mut().remove(&self.id);
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn connect_rejects_non_ws_scheme() {
+        for url in ["http://example.com", "https://example.com/x", "example.com", ""] {
+            match connect(url) {
+                Err(WsError::InvalidUrl(_)) => {}
+                Err(e) => panic!("expected InvalidUrl for {url:?}, got {e:?}"),
+                Ok(_) => panic!("expected InvalidUrl for {url:?}, got Ok"),
+            }
+        }
+    }
+
+    #[test]
+    fn message_accessors() {
+        let t = WsMessage::Text("hi".to_string());
+        assert_eq!(t.as_text(), Some("hi"));
+        assert_eq!(t.as_bytes(), None);
+
+        let b = WsMessage::Binary(vec![1, 2, 3]);
+        assert_eq!(b.as_bytes(), Some(&[1u8, 2, 3][..]));
+        assert_eq!(b.as_text(), None);
+    }
+
+    #[test]
+    fn invoke_dispatches_and_is_reentrant() {
+        // Register a connection by hand (no real socket) and drive the dispatch
+        // path directly, including a callback that re-enters the registry.
+        let id = 424242;
+        HANDLERS.with(|h| h.borrow_mut().insert(id, Handlers::default()));
+
+        let seen = std::rc::Rc::new(RefCell::new(Vec::<String>::new()));
+        let s = seen.clone();
+        HANDLERS.with(|h| {
+            h.borrow_mut().get_mut(&id).unwrap().on_message =
+                Some(Box::new(move |m| {
+                    if let WsMessage::Text(t) = m {
+                        s.borrow_mut().push(t);
+                    }
+                    // Re-enter the registry from inside the callback: must not
+                    // double-borrow.
+                    let present = HANDLERS.with(|h| h.borrow().contains_key(&id));
+                    assert!(present);
+                }));
+        });
+
+        dispatch(id, WsEvent::Message(WsMessage::Text("a".to_string())));
+        dispatch(id, WsEvent::Message(WsMessage::Text("b".to_string())));
+        assert_eq!(*seen.borrow(), vec!["a".to_string(), "b".to_string()]);
+
+        // Unknown ids are a silent no-op.
+        dispatch(999_999, WsEvent::Open);
+
+        HANDLERS.with(|h| {
+            h.borrow_mut().remove(&id);
+        });
+    }
+}

--- a/crates/rinch-ws/src/lib.rs
+++ b/crates/rinch-ws/src/lib.rs
@@ -297,7 +297,12 @@ mod tests {
 
     #[test]
     fn connect_rejects_non_ws_scheme() {
-        for url in ["http://example.com", "https://example.com/x", "example.com", ""] {
+        for url in [
+            "http://example.com",
+            "https://example.com/x",
+            "example.com",
+            "",
+        ] {
             match connect(url) {
                 Err(WsError::InvalidUrl(_)) => {}
                 Err(e) => panic!("expected InvalidUrl for {url:?}, got {e:?}"),
@@ -327,16 +332,15 @@ mod tests {
         let seen = std::rc::Rc::new(RefCell::new(Vec::<String>::new()));
         let s = seen.clone();
         HANDLERS.with(|h| {
-            h.borrow_mut().get_mut(&id).unwrap().on_message =
-                Some(Box::new(move |m| {
-                    if let WsMessage::Text(t) = m {
-                        s.borrow_mut().push(t);
-                    }
-                    // Re-enter the registry from inside the callback: must not
-                    // double-borrow.
-                    let present = HANDLERS.with(|h| h.borrow().contains_key(&id));
-                    assert!(present);
-                }));
+            h.borrow_mut().get_mut(&id).unwrap().on_message = Some(Box::new(move |m| {
+                if let WsMessage::Text(t) = m {
+                    s.borrow_mut().push(t);
+                }
+                // Re-enter the registry from inside the callback: must not
+                // double-borrow.
+                let present = HANDLERS.with(|h| h.borrow().contains_key(&id));
+                assert!(present);
+            }));
         });
 
         dispatch(id, WsEvent::Message(WsMessage::Text("a".to_string())));

--- a/crates/rinch-ws/src/native.rs
+++ b/crates/rinch-ws/src/native.rs
@@ -21,7 +21,7 @@
 use std::io;
 use std::net::TcpStream;
 use std::sync::mpsc::{self, Sender, TryRecvError};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tungstenite::stream::MaybeTlsStream;
 use tungstenite::{Error as TungError, Message, WebSocket};
@@ -36,6 +36,22 @@ const POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 /// Close code reported when the connection dropped without a close frame.
 const CLOSE_ABNORMAL: u16 = 1006;
+
+/// Close code reported when the closing handshake completed normally.
+const CLOSE_NORMAL: u16 = 1000;
+
+/// Reported when the peer's close frame carried no status code. RFC 6455 reserves
+/// 1005 ("no status received") for exactly this; 1006 means no close frame arrived
+/// at all, which is a different thing. Browsers surface 1005 here, so the web
+/// backend already reports it — native must match or the same server produces
+/// different close codes on desktop and web.
+const CLOSE_NO_STATUS: u16 = 1005;
+
+/// How long to keep reading after a local `close()` so the peer can complete the
+/// closing handshake. Without a grace period the first read timeout ends the
+/// connection, and every graceful close on a link slower than [`POLL_INTERVAL`]
+/// would be reported as abnormal.
+const CLOSE_GRACE: Duration = Duration::from_secs(1);
 
 /// A command from the main thread to the socket-owning worker thread.
 enum Cmd {
@@ -92,8 +108,19 @@ fn run(url: String, id: u64, cmd_rx: mpsc::Receiver<Cmd>) {
 
     let mut close_emitted = false;
     // Set once a close has been initiated locally; we then read only to drive the
-    // closing handshake to completion.
+    // closing handshake to completion. `closing_since` starts the grace period in
+    // which the peer may still send its half of the handshake.
     let mut closing = false;
+    let mut closing_since: Option<Instant> = None;
+    // A close we asked for that the peer completed is a *normal* closure; only a
+    // drop without a completed handshake is abnormal.
+    let local_close_code = |closing: bool| {
+        if closing {
+            CLOSE_NORMAL
+        } else {
+            CLOSE_ABNORMAL
+        }
+    };
 
     loop {
         // 1. Drain outgoing commands.
@@ -116,12 +143,14 @@ fn run(url: String, id: u64, cmd_rx: mpsc::Receiver<Cmd>) {
                 Ok(Cmd::Close) => {
                     let _ = socket.close(None);
                     closing = true;
+                    closing_since.get_or_insert_with(Instant::now);
                 }
                 Err(TryRecvError::Empty) => break,
                 // All senders dropped (handle dropped): close and finish.
                 Err(TryRecvError::Disconnected) => {
                     let _ = socket.close(None);
                     closing = true;
+                    closing_since.get_or_insert_with(Instant::now);
                     break;
                 }
             }
@@ -133,7 +162,12 @@ fn run(url: String, id: u64, cmd_rx: mpsc::Receiver<Cmd>) {
             Ok(()) => {}
             Err(TungError::Io(e)) if is_would_block(&e) => {}
             Err(TungError::ConnectionClosed | TungError::AlreadyClosed) => {
-                emit_close(id, CLOSE_ABNORMAL, String::new(), &mut close_emitted);
+                emit_close(
+                    id,
+                    local_close_code(closing),
+                    String::new(),
+                    &mut close_emitted,
+                );
                 return;
             }
             Err(e) => {
@@ -152,21 +186,27 @@ fn run(url: String, id: u64, cmd_rx: mpsc::Receiver<Cmd>) {
             Ok(Message::Close(frame)) => {
                 let (code, reason) = match frame {
                     Some(f) => (u16::from(f.code), f.reason.into_owned()),
-                    None => (CLOSE_ABNORMAL, String::new()),
+                    None => (CLOSE_NO_STATUS, String::new()),
                 };
                 emit_close(id, code, reason, &mut close_emitted);
                 return;
             }
             Err(TungError::Io(e)) if is_would_block(&e) => {
-                // Timed out with nothing to read. If we're closing and the peer
-                // hasn't acked, stop waiting rather than spin forever.
-                if closing {
+                // Timed out with nothing to read. While closing, keep reading for a
+                // bounded grace period so a peer slower than one poll interval can
+                // still complete the handshake; only then give up as abnormal.
+                if closing && closing_since.is_some_and(|t| t.elapsed() >= CLOSE_GRACE) {
                     emit_close(id, CLOSE_ABNORMAL, String::new(), &mut close_emitted);
                     return;
                 }
             }
             Err(TungError::ConnectionClosed | TungError::AlreadyClosed) => {
-                emit_close(id, CLOSE_ABNORMAL, String::new(), &mut close_emitted);
+                emit_close(
+                    id,
+                    local_close_code(closing),
+                    String::new(),
+                    &mut close_emitted,
+                );
                 return;
             }
             Err(e) => {

--- a/crates/rinch-ws/src/native.rs
+++ b/crates/rinch-ws/src/native.rs
@@ -1,0 +1,211 @@
+//! Native (non-wasm) WebSocket backend backed by synchronous `tungstenite`.
+//!
+//! [`connect`] spawns a `std::thread` that owns the socket and runs a single
+//! read/write loop. Outgoing frames are queued from the main thread over an
+//! `mpsc` channel; incoming frames and lifecycle events are hopped back to the
+//! main thread via [`rinch_core::run_on_main_thread`] and delivered to the
+//! callback registry by [`crate::dispatch`]. Only the connection id and the
+//! `Send` [`WsEvent`] cross the boundary, so the (`!Send`) callbacks never leave
+//! the main thread.
+//!
+//! `tungstenite` is synchronous and gives no way to split a socket into
+//! independent read/write halves, so the one owning thread interleaves both: it
+//! reads with a short timeout, and between reads drains the outgoing queue. The
+//! timeout (`POLL_INTERVAL`) bounds how long a queued send waits before it goes
+//! out — a small latency/wakeup trade-off, not a correctness issue.
+//!
+//! `wss://` is supported via `tungstenite`'s `rustls-tls-webpki-roots` feature,
+//! reusing the `rustls` stack already present in the tree (via `rinch-http`'s
+//! `ureq`).
+
+use std::io;
+use std::net::TcpStream;
+use std::sync::mpsc::{self, Sender, TryRecvError};
+use std::time::Duration;
+
+use tungstenite::stream::MaybeTlsStream;
+use tungstenite::{Error as TungError, Message, WebSocket};
+
+use rinch_core::run_on_main_thread;
+
+use crate::{WsClose, WsError, WsEvent, WsMessage};
+
+/// How long a read blocks before returning to drain the outgoing queue. Also the
+/// worst-case latency a queued `send` waits before being written.
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Close code reported when the connection dropped without a close frame.
+const CLOSE_ABNORMAL: u16 = 1006;
+
+/// A command from the main thread to the socket-owning worker thread.
+enum Cmd {
+    Text(String),
+    Binary(Vec<u8>),
+    Close,
+}
+
+/// The main-thread half of a native connection: a sender into the worker thread.
+pub(crate) struct Backend {
+    cmd_tx: Sender<Cmd>,
+}
+
+impl Backend {
+    pub(crate) fn send_text(&self, text: String) {
+        let _ = self.cmd_tx.send(Cmd::Text(text));
+    }
+
+    pub(crate) fn send_bytes(&self, bytes: Vec<u8>) {
+        let _ = self.cmd_tx.send(Cmd::Binary(bytes));
+    }
+
+    pub(crate) fn close(&self) {
+        let _ = self.cmd_tx.send(Cmd::Close);
+    }
+}
+
+pub(crate) fn connect(url: &str, id: u64) -> Result<Backend, WsError> {
+    let (cmd_tx, cmd_rx) = mpsc::channel();
+    let url = url.to_string();
+    // The blocking connect + read loop must not run on the main thread.
+    std::thread::spawn(move || run(url, id, cmd_rx));
+    Ok(Backend { cmd_tx })
+}
+
+/// Emit an event to the main-thread registry for connection `id`.
+fn emit(id: u64, event: WsEvent) {
+    run_on_main_thread(move || crate::dispatch(id, event));
+}
+
+fn run(url: String, id: u64, cmd_rx: mpsc::Receiver<Cmd>) {
+    let (mut socket, _resp) = match tungstenite::connect(&url) {
+        Ok(ok) => ok,
+        Err(e) => {
+            emit(id, WsEvent::Error(WsError::Connect(e.to_string())));
+            return;
+        }
+    };
+
+    // Bound how long `read()` blocks so the same thread can also service sends.
+    set_read_timeout(&mut socket, Some(POLL_INTERVAL));
+
+    emit(id, WsEvent::Open);
+
+    let mut close_emitted = false;
+    // Set once a close has been initiated locally; we then read only to drive the
+    // closing handshake to completion.
+    let mut closing = false;
+
+    loop {
+        // 1. Drain outgoing commands.
+        loop {
+            match cmd_rx.try_recv() {
+                Ok(Cmd::Text(t)) => {
+                    if let Err(e) = socket.send(Message::Text(t)) {
+                        emit(id, WsEvent::Error(WsError::Send(e.to_string())));
+                        emit_close(id, CLOSE_ABNORMAL, String::new(), &mut close_emitted);
+                        return;
+                    }
+                }
+                Ok(Cmd::Binary(b)) => {
+                    if let Err(e) = socket.send(Message::Binary(b)) {
+                        emit(id, WsEvent::Error(WsError::Send(e.to_string())));
+                        emit_close(id, CLOSE_ABNORMAL, String::new(), &mut close_emitted);
+                        return;
+                    }
+                }
+                Ok(Cmd::Close) => {
+                    let _ = socket.close(None);
+                    closing = true;
+                }
+                Err(TryRecvError::Empty) => break,
+                // All senders dropped (handle dropped): close and finish.
+                Err(TryRecvError::Disconnected) => {
+                    let _ = socket.close(None);
+                    closing = true;
+                    break;
+                }
+            }
+        }
+
+        // Flush any queued frames (pong replies, the close frame). A `WouldBlock`
+        // just means the write would block right now — retry next iteration.
+        match socket.flush() {
+            Ok(()) => {}
+            Err(TungError::Io(e)) if is_would_block(&e) => {}
+            Err(TungError::ConnectionClosed | TungError::AlreadyClosed) => {
+                emit_close(id, CLOSE_ABNORMAL, String::new(), &mut close_emitted);
+                return;
+            }
+            Err(e) => {
+                emit(id, WsEvent::Error(WsError::Send(e.to_string())));
+                emit_close(id, CLOSE_ABNORMAL, String::new(), &mut close_emitted);
+                return;
+            }
+        }
+
+        // 2. Read one frame (or time out).
+        match socket.read() {
+            Ok(Message::Text(t)) => emit(id, WsEvent::Message(WsMessage::Text(t))),
+            Ok(Message::Binary(b)) => emit(id, WsEvent::Message(WsMessage::Binary(b))),
+            // Control/continuation frames are handled internally by tungstenite.
+            Ok(Message::Ping(_) | Message::Pong(_) | Message::Frame(_)) => {}
+            Ok(Message::Close(frame)) => {
+                let (code, reason) = match frame {
+                    Some(f) => (u16::from(f.code), f.reason.into_owned()),
+                    None => (CLOSE_ABNORMAL, String::new()),
+                };
+                emit_close(id, code, reason, &mut close_emitted);
+                return;
+            }
+            Err(TungError::Io(e)) if is_would_block(&e) => {
+                // Timed out with nothing to read. If we're closing and the peer
+                // hasn't acked, stop waiting rather than spin forever.
+                if closing {
+                    emit_close(id, CLOSE_ABNORMAL, String::new(), &mut close_emitted);
+                    return;
+                }
+            }
+            Err(TungError::ConnectionClosed | TungError::AlreadyClosed) => {
+                emit_close(id, CLOSE_ABNORMAL, String::new(), &mut close_emitted);
+                return;
+            }
+            Err(e) => {
+                emit(id, WsEvent::Error(WsError::Protocol(e.to_string())));
+                emit_close(id, CLOSE_ABNORMAL, String::new(), &mut close_emitted);
+                return;
+            }
+        }
+    }
+}
+
+/// Emit a single `Close` event, at most once per connection.
+fn emit_close(id: u64, code: u16, reason: String, emitted: &mut bool) {
+    if *emitted {
+        return;
+    }
+    *emitted = true;
+    emit(id, WsEvent::Close(WsClose { code, reason }));
+}
+
+/// Whether an I/O error is a benign "no data yet" from the read timeout.
+fn is_would_block(e: &io::Error) -> bool {
+    matches!(
+        e.kind(),
+        io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+    )
+}
+
+/// Set the read timeout on the underlying `TcpStream`, reaching through TLS.
+fn set_read_timeout(socket: &mut WebSocket<MaybeTlsStream<TcpStream>>, dur: Option<Duration>) {
+    match socket.get_mut() {
+        MaybeTlsStream::Plain(s) => {
+            let _ = s.set_read_timeout(dur);
+        }
+        MaybeTlsStream::Rustls(s) => {
+            let _ = s.sock.set_read_timeout(dur);
+        }
+        // `MaybeTlsStream` is `#[non_exhaustive]`; other TLS backends are not
+        // compiled in for this crate.
+        _ => {}
+    }
+}

--- a/crates/rinch-ws/src/wasm.rs
+++ b/crates/rinch-ws/src/wasm.rs
@@ -1,0 +1,103 @@
+//! Web (wasm32) WebSocket backend backed by `web_sys::WebSocket`.
+//!
+//! Everything runs on the single web thread (the UI thread), so incoming events
+//! are dispatched to the callback registry directly — no
+//! `rinch_core::run_on_main_thread` hop (its `Send` bound a JS-capturing closure
+//! could not satisfy anyway).
+//!
+//! The JS event closures are kept alive by the [`Backend`] for as long as the
+//! connection is open; [`Backend::close`] detaches them from the socket before
+//! they are dropped so a late browser event can never invoke a freed closure.
+
+use wasm_bindgen::JsCast;
+use wasm_bindgen::prelude::*;
+use web_sys::{BinaryType, CloseEvent, MessageEvent, WebSocket};
+
+use crate::{WsClose, WsError, WsEvent, WsMessage};
+
+/// The web half of a connection: the socket plus its live event closures.
+pub(crate) struct Backend {
+    ws: WebSocket,
+    // Kept alive; dropped (after being detached in `close`) with the backend.
+    _on_open: Closure<dyn FnMut(JsValue)>,
+    _on_message: Closure<dyn FnMut(MessageEvent)>,
+    _on_close: Closure<dyn FnMut(CloseEvent)>,
+    _on_error: Closure<dyn FnMut(JsValue)>,
+}
+
+pub(crate) fn connect(url: &str, id: u64) -> Result<Backend, WsError> {
+    let ws = WebSocket::new(url).map_err(|e| WsError::InvalidUrl(js_err(&e)))?;
+    ws.set_binary_type(BinaryType::Arraybuffer);
+
+    let on_open = Closure::wrap(Box::new(move |_e: JsValue| {
+        crate::dispatch(id, WsEvent::Open);
+    }) as Box<dyn FnMut(JsValue)>);
+
+    let on_message = Closure::wrap(Box::new(move |e: MessageEvent| {
+        let data = e.data();
+        if let Some(text) = data.as_string() {
+            crate::dispatch(id, WsEvent::Message(WsMessage::Text(text)));
+        } else if data.is_instance_of::<js_sys::ArrayBuffer>() {
+            let bytes = js_sys::Uint8Array::new(&data).to_vec();
+            crate::dispatch(id, WsEvent::Message(WsMessage::Binary(bytes)));
+        }
+        // Blob is never produced: binary_type is forced to ArrayBuffer above.
+    }) as Box<dyn FnMut(MessageEvent)>);
+
+    let on_close = Closure::wrap(Box::new(move |e: CloseEvent| {
+        crate::dispatch(
+            id,
+            WsEvent::Close(WsClose {
+                code: e.code(),
+                reason: e.reason(),
+            }),
+        );
+    }) as Box<dyn FnMut(CloseEvent)>);
+
+    let on_error = Closure::wrap(Box::new(move |_e: JsValue| {
+        // The browser `error` event carries no useful detail; a `close` with the
+        // real code follows.
+        crate::dispatch(
+            id,
+            WsEvent::Error(WsError::Protocol("websocket error".to_string())),
+        );
+    }) as Box<dyn FnMut(JsValue)>);
+
+    ws.set_onopen(Some(on_open.as_ref().unchecked_ref()));
+    ws.set_onmessage(Some(on_message.as_ref().unchecked_ref()));
+    ws.set_onclose(Some(on_close.as_ref().unchecked_ref()));
+    ws.set_onerror(Some(on_error.as_ref().unchecked_ref()));
+
+    Ok(Backend {
+        ws,
+        _on_open: on_open,
+        _on_message: on_message,
+        _on_close: on_close,
+        _on_error: on_error,
+    })
+}
+
+impl Backend {
+    pub(crate) fn send_text(&self, text: String) {
+        let _ = self.ws.send_with_str(&text);
+    }
+
+    pub(crate) fn send_bytes(&self, bytes: Vec<u8>) {
+        let _ = self.ws.send_with_u8_array(&bytes);
+    }
+
+    pub(crate) fn close(&self) {
+        // Detach handlers first: the closures are about to be dropped with the
+        // backend, and a browser `close` event must not fire into a freed closure.
+        self.ws.set_onopen(None);
+        self.ws.set_onmessage(None);
+        self.ws.set_onclose(None);
+        self.ws.set_onerror(None);
+        let _ = self.ws.close();
+    }
+}
+
+/// Render a `JsValue` error into a debug string.
+fn js_err(e: &JsValue) -> String {
+    format!("{e:?}")
+}

--- a/crates/rinch-ws/tests/close.rs
+++ b/crates/rinch-ws/tests/close.rs
@@ -1,0 +1,138 @@
+//! Native close-semantics test, in its own binary so it gets its own process (and
+//! thus its own `register_main_thread`) — see `common`.
+//!
+//! All three scenarios share one test function on purpose: `register_main_thread`
+//! is per-process, so two `#[test]`s in one binary would race for the main-thread
+//! role and the loser would never see its events.
+#![cfg(not(target_arch = "wasm32"))]
+
+mod common;
+
+use std::cell::{Cell, RefCell};
+use std::net::TcpListener;
+use std::rc::Rc;
+use std::sync::Mutex;
+use std::thread;
+use std::time::Duration;
+
+use common::{PUMP, dispatcher, pump_until};
+use rinch_core::{register_main_thread, set_cross_thread_dispatcher};
+use rinch_ws::connect;
+use tungstenite::Message;
+use tungstenite::protocol::CloseFrame;
+use tungstenite::protocol::frame::coding::CloseCode;
+
+/// A peer that echoes until it sees a close, waits `ack_delay`, then completes the
+/// closing handshake with a **status-less** close frame (`ws.close(None)`).
+fn peer_acking_without_status(ack_delay: Duration) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    thread::spawn(move || {
+        let Ok((stream, _)) = listener.accept() else {
+            return;
+        };
+        let Ok(mut ws) = tungstenite::accept(stream) else {
+            return;
+        };
+        loop {
+            match ws.read() {
+                Ok(Message::Close(_)) => {
+                    thread::sleep(ack_delay);
+                    let _ = ws.close(None);
+                    let _ = ws.flush();
+                    break;
+                }
+                Ok(_) => {}
+                Err(_) => break,
+            }
+        }
+    });
+    format!("ws://{addr}/")
+}
+
+/// A peer that initiates the close itself, with an explicit code and reason.
+fn peer_closing_first() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    thread::spawn(move || {
+        let Ok((stream, _)) = listener.accept() else {
+            return;
+        };
+        let Ok(mut ws) = tungstenite::accept(stream) else {
+            return;
+        };
+        thread::sleep(Duration::from_millis(50));
+        let _ = ws.close(Some(CloseFrame {
+            code: CloseCode::Normal,
+            reason: "bye".into(),
+        }));
+        let _ = ws.flush();
+        for _ in 0..50 {
+            if ws.read().is_err() {
+                break;
+            }
+        }
+    });
+    format!("ws://{addr}/")
+}
+
+/// Connect, run `after_open`, and return the close `(code, reason)` reported.
+fn close_code_for(url: String, after_open: impl FnOnce(&rinch_ws::WsHandle)) -> (u16, String) {
+    let ws = connect(url).expect("connect starts");
+    let opened = Rc::new(Cell::new(false));
+    let closed: Rc<RefCell<Option<(u16, String)>>> = Rc::new(RefCell::new(None));
+
+    let o = opened.clone();
+    ws.on_open(move || o.set(true));
+    let c = closed.clone();
+    ws.on_close(move |cl| *c.borrow_mut() = Some((cl.code, cl.reason.clone())));
+
+    assert!(
+        pump_until(|| opened.get(), Duration::from_secs(10)),
+        "connection should open"
+    );
+    after_open(&ws);
+    assert!(
+        pump_until(|| closed.borrow().is_some(), Duration::from_secs(10)),
+        "on_close should fire"
+    );
+    closed.borrow().clone().unwrap()
+}
+
+#[test]
+fn close_codes_match_the_websocket_spec_and_the_web_backend() {
+    PUMP.set(Mutex::new(Vec::new())).ok();
+    register_main_thread();
+    set_cross_thread_dispatcher(dispatcher);
+
+    // 1. A local close(), acked promptly by a status-less close frame.
+    //
+    // RFC 6455 reserves **1005** for "close frame carried no status code"; 1006 means
+    // no close frame arrived at all. This previously reported 1006, so a clean
+    // shutdown was indistinguishable from a dropped connection — and it disagreed
+    // with the web backend, which passes through the browser's CloseEvent.code()
+    // (1005 in this case).
+    let (code, _) = close_code_for(peer_acking_without_status(Duration::ZERO), |ws| ws.close());
+    assert_eq!(
+        code, 1005,
+        "a completed close handshake is not 1006/abnormal"
+    );
+
+    // 2. The same, with a peer slower than one poll interval (50ms).
+    //
+    // The loop used to give up at the first read timeout after a local close, so any
+    // peer slower than a poll interval — i.e. anything off-localhost — reported an
+    // abnormal close. The close grace period keeps reading so the handshake lands.
+    let (code, _) = close_code_for(
+        peer_acking_without_status(Duration::from_millis(200)),
+        |ws| ws.close(),
+    );
+    assert_eq!(
+        code, 1005,
+        "a peer slower than POLL_INTERVAL must still complete the handshake"
+    );
+
+    // 3. A peer-initiated close carries its code and reason through untouched.
+    let (code, reason) = close_code_for(peer_closing_first(), |_ws| {});
+    assert_eq!((code, reason.as_str()), (1000, "bye"));
+}

--- a/crates/rinch-ws/tests/common/mod.rs
+++ b/crates/rinch-ws/tests/common/mod.rs
@@ -1,0 +1,100 @@
+//! Shared harness for the native integration tests.
+//!
+//! Outside a running rinch app there is no cross-thread dispatcher, so these tests
+//! stand one up: the test thread registers itself as the main thread, installs a
+//! dispatcher that parks main-thread work in a global queue, and pumps that queue
+//! — the role the winit event loop plays in the real app.
+//!
+//! `register_main_thread` is process-global, so each integration-test *file* gets
+//! its own process and registers exactly once. Two tests in one binary would race
+//! (cargo runs them on separate threads) and the loser would never see its events.
+#![allow(dead_code)]
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::net::TcpListener;
+use std::sync::{Mutex, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use tungstenite::Message;
+
+pub type MainJob = Box<dyn FnOnce() + Send>;
+
+/// Queue of closures dispatched to the "main" (test) thread by the rinch runtime
+/// stand-in. Drained by [`drain_pump`].
+pub static PUMP: OnceLock<Mutex<Vec<MainJob>>> = OnceLock::new();
+
+/// The cross-thread dispatcher installed into rinch-core: park work for the main
+/// thread. Must be a plain `fn` (no captures), hence the global queue.
+pub fn dispatcher(f: MainJob) {
+    PUMP.get()
+        .expect("pump initialized")
+        .lock()
+        .unwrap()
+        .push(f);
+}
+
+pub fn drain_pump() {
+    let jobs: Vec<_> = PUMP
+        .get()
+        .expect("pump initialized")
+        .lock()
+        .unwrap()
+        .drain(..)
+        .collect();
+    for job in jobs {
+        job();
+    }
+}
+
+/// Pump the main-thread queue until `cond` holds or `timeout` elapses.
+pub fn pump_until(mut cond: impl FnMut() -> bool, timeout: Duration) -> bool {
+    let start = Instant::now();
+    loop {
+        drain_pump();
+        if cond() {
+            return true;
+        }
+        if start.elapsed() >= timeout {
+            drain_pump();
+            return cond();
+        }
+        thread::sleep(Duration::from_millis(5));
+    }
+}
+
+/// Spawn a WebSocket echo server on an ephemeral port; returns its `ws://` URL.
+pub fn spawn_echo_server() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+    thread::spawn(move || {
+        let Ok((stream, _)) = listener.accept() else {
+            return;
+        };
+        let mut ws = match tungstenite::accept(stream) {
+            Ok(ws) => ws,
+            Err(_) => return,
+        };
+        loop {
+            match ws.read() {
+                Ok(Message::Text(t)) => {
+                    if ws.send(Message::Text(t)).is_err() {
+                        break;
+                    }
+                }
+                Ok(Message::Binary(b)) => {
+                    if ws.send(Message::Binary(b)).is_err() {
+                        break;
+                    }
+                }
+                Ok(Message::Close(_)) => {
+                    let _ = ws.close(None);
+                    break;
+                }
+                Ok(_) => {}
+                Err(_) => break,
+            }
+        }
+    });
+    format!("ws://{addr}/")
+}

--- a/crates/rinch-ws/tests/echo.rs
+++ b/crates/rinch-ws/tests/echo.rs
@@ -1,0 +1,160 @@
+//! Native end-to-end test: drive a real `rinch-ws` connection against an
+//! in-process tungstenite echo server, exercising the full wire path
+//! (connect → open → send → receive → close) and the worker→main-thread event
+//! dispatch.
+//!
+//! Outside a running rinch app there is no cross-thread dispatcher, so this test
+//! stands one up: it registers itself as the main thread, installs a dispatcher
+//! that parks main-thread work in a global queue, and pumps that queue from the
+//! test thread — the role the winit event loop plays in the real app.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::cell::{Cell, RefCell};
+use std::net::TcpListener;
+use std::rc::Rc;
+use std::sync::{Mutex, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use rinch_core::{register_main_thread, set_cross_thread_dispatcher};
+use rinch_ws::{WsMessage, connect};
+use tungstenite::Message;
+
+type MainJob = Box<dyn FnOnce() + Send>;
+
+/// Queue of closures dispatched to the "main" (test) thread by the rinch runtime
+/// stand-in. Drained by [`drain_pump`].
+static PUMP: OnceLock<Mutex<Vec<MainJob>>> = OnceLock::new();
+
+/// The cross-thread dispatcher installed into rinch-core: park work for the main
+/// thread. Must be a plain `fn` (no captures), hence the global queue.
+fn dispatcher(f: MainJob) {
+    PUMP.get()
+        .expect("pump initialized")
+        .lock()
+        .unwrap()
+        .push(f);
+}
+
+fn drain_pump() {
+    let jobs: Vec<_> = PUMP
+        .get()
+        .expect("pump initialized")
+        .lock()
+        .unwrap()
+        .drain(..)
+        .collect();
+    for job in jobs {
+        job();
+    }
+}
+
+/// Pump the main-thread queue until `cond` holds or `timeout` elapses.
+fn pump_until(mut cond: impl FnMut() -> bool, timeout: Duration) -> bool {
+    let start = Instant::now();
+    loop {
+        drain_pump();
+        if cond() {
+            return true;
+        }
+        if start.elapsed() >= timeout {
+            drain_pump();
+            return cond();
+        }
+        thread::sleep(Duration::from_millis(5));
+    }
+}
+
+/// Spawn a WebSocket echo server on an ephemeral port; returns its `ws://` URL.
+fn spawn_echo_server() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+    thread::spawn(move || {
+        let Ok((stream, _)) = listener.accept() else {
+            return;
+        };
+        let mut ws = match tungstenite::accept(stream) {
+            Ok(ws) => ws,
+            Err(_) => return,
+        };
+        loop {
+            match ws.read() {
+                Ok(Message::Text(t)) => {
+                    if ws.send(Message::Text(t)).is_err() {
+                        break;
+                    }
+                }
+                Ok(Message::Binary(b)) => {
+                    if ws.send(Message::Binary(b)).is_err() {
+                        break;
+                    }
+                }
+                Ok(Message::Close(_)) => {
+                    let _ = ws.close(None);
+                    break;
+                }
+                Ok(_) => {}
+                Err(_) => break,
+            }
+        }
+    });
+    format!("ws://{addr}/")
+}
+
+#[test]
+fn connect_send_receive_close() {
+    // Stand in for the rinch runtime: this thread is "main"; dispatched work is
+    // pumped by us.
+    PUMP.set(Mutex::new(Vec::new())).ok();
+    register_main_thread();
+    set_cross_thread_dispatcher(dispatcher);
+
+    let url = spawn_echo_server();
+
+    let opened = Rc::new(Cell::new(false));
+    let messages: Rc<RefCell<Vec<WsMessage>>> = Rc::new(RefCell::new(Vec::new()));
+    let closed = Rc::new(Cell::new(false));
+
+    let ws = connect(&url).expect("connect starts");
+
+    let o = opened.clone();
+    ws.on_open(move || o.set(true));
+    let m = messages.clone();
+    ws.on_message(move |msg| m.borrow_mut().push(msg));
+    let c = closed.clone();
+    ws.on_close(move |_| c.set(true));
+
+    assert!(
+        pump_until(|| opened.get(), Duration::from_secs(10)),
+        "connection should open"
+    );
+
+    // Text round-trip.
+    ws.send_text("hello");
+    assert!(
+        pump_until(|| messages.borrow().len() == 1, Duration::from_secs(10)),
+        "text frame should echo back"
+    );
+
+    // Binary round-trip.
+    ws.send_bytes(vec![1, 2, 3, 4]);
+    assert!(
+        pump_until(|| messages.borrow().len() == 2, Duration::from_secs(10)),
+        "binary frame should echo back"
+    );
+
+    assert_eq!(
+        *messages.borrow(),
+        vec![
+            WsMessage::Text("hello".to_string()),
+            WsMessage::Binary(vec![1, 2, 3, 4]),
+        ]
+    );
+
+    // Graceful close fires on_close.
+    ws.close();
+    assert!(
+        pump_until(|| closed.get(), Duration::from_secs(10)),
+        "on_close should fire after close()"
+    );
+}

--- a/crates/rinch-ws/tests/echo.rs
+++ b/crates/rinch-ws/tests/echo.rs
@@ -2,104 +2,18 @@
 //! in-process tungstenite echo server, exercising the full wire path
 //! (connect → open → send → receive → close) and the worker→main-thread event
 //! dispatch.
-//!
-//! Outside a running rinch app there is no cross-thread dispatcher, so this test
-//! stands one up: it registers itself as the main thread, installs a dispatcher
-//! that parks main-thread work in a global queue, and pumps that queue from the
-//! test thread — the role the winit event loop plays in the real app.
 #![cfg(not(target_arch = "wasm32"))]
 
-use std::cell::{Cell, RefCell};
-use std::net::TcpListener;
-use std::rc::Rc;
-use std::sync::{Mutex, OnceLock};
-use std::thread;
-use std::time::{Duration, Instant};
+mod common;
 
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use common::{PUMP, dispatcher, pump_until, spawn_echo_server};
 use rinch_core::{register_main_thread, set_cross_thread_dispatcher};
 use rinch_ws::{WsMessage, connect};
-use tungstenite::Message;
-
-type MainJob = Box<dyn FnOnce() + Send>;
-
-/// Queue of closures dispatched to the "main" (test) thread by the rinch runtime
-/// stand-in. Drained by [`drain_pump`].
-static PUMP: OnceLock<Mutex<Vec<MainJob>>> = OnceLock::new();
-
-/// The cross-thread dispatcher installed into rinch-core: park work for the main
-/// thread. Must be a plain `fn` (no captures), hence the global queue.
-fn dispatcher(f: MainJob) {
-    PUMP.get()
-        .expect("pump initialized")
-        .lock()
-        .unwrap()
-        .push(f);
-}
-
-fn drain_pump() {
-    let jobs: Vec<_> = PUMP
-        .get()
-        .expect("pump initialized")
-        .lock()
-        .unwrap()
-        .drain(..)
-        .collect();
-    for job in jobs {
-        job();
-    }
-}
-
-/// Pump the main-thread queue until `cond` holds or `timeout` elapses.
-fn pump_until(mut cond: impl FnMut() -> bool, timeout: Duration) -> bool {
-    let start = Instant::now();
-    loop {
-        drain_pump();
-        if cond() {
-            return true;
-        }
-        if start.elapsed() >= timeout {
-            drain_pump();
-            return cond();
-        }
-        thread::sleep(Duration::from_millis(5));
-    }
-}
-
-/// Spawn a WebSocket echo server on an ephemeral port; returns its `ws://` URL.
-fn spawn_echo_server() -> String {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
-    let addr = listener.local_addr().expect("local_addr");
-    thread::spawn(move || {
-        let Ok((stream, _)) = listener.accept() else {
-            return;
-        };
-        let mut ws = match tungstenite::accept(stream) {
-            Ok(ws) => ws,
-            Err(_) => return,
-        };
-        loop {
-            match ws.read() {
-                Ok(Message::Text(t)) => {
-                    if ws.send(Message::Text(t)).is_err() {
-                        break;
-                    }
-                }
-                Ok(Message::Binary(b)) => {
-                    if ws.send(Message::Binary(b)).is_err() {
-                        break;
-                    }
-                }
-                Ok(Message::Close(_)) => {
-                    let _ = ws.close(None);
-                    break;
-                }
-                Ok(_) => {}
-                Err(_) => break,
-            }
-        }
-    });
-    format!("ws://{addr}/")
-}
 
 #[test]
 fn connect_send_receive_close() {

--- a/crates/rinch-ws/tests/tls.rs
+++ b/crates/rinch-ws/tests/tls.rs
@@ -1,0 +1,77 @@
+//! Native TLS-path test, in its own binary so it gets its own process (and thus
+//! its own `register_main_thread`) — see `common`.
+#![cfg(not(target_arch = "wasm32"))]
+
+mod common;
+
+use std::cell::{Cell, RefCell};
+use std::net::TcpListener;
+use std::rc::Rc;
+use std::sync::Mutex;
+use std::thread;
+use std::time::Duration;
+
+use common::{PUMP, dispatcher, pump_until};
+use rinch_core::{register_main_thread, set_cross_thread_dispatcher};
+use rinch_ws::connect;
+
+/// The `wss://` path must reach a real TLS handshake and report failures through
+/// `on_error` — not panic.
+///
+/// Regression test for a missing rustls crypto provider. `tungstenite`'s
+/// `rustls-tls-webpki-roots` enables the `rustls` dependency but no provider
+/// feature, so rustls had no compiled-in default and panicked on the first
+/// handshake with "Could not automatically determine the process-level
+/// CryptoProvider". Because that panic happened on the connection's worker
+/// thread, it surfaced as a *silent hang*: no `on_error`, no `on_open`. It was
+/// masked whenever an app also linked `rinch-http` (ureq enables `rustls/ring`
+/// and cargo unifies features), so `wss://` worked only by accident of what else
+/// was in the dependency graph.
+///
+/// A full `wss://` round-trip isn't practical offline (webpki roots reject a
+/// self-signed cert by design), so this drives the handshake against a plain-TCP
+/// listener that answers with garbage: enough to prove rustls initialized and
+/// that the failure is reported rather than swallowed.
+#[test]
+fn wss_handshake_failure_is_reported_not_panicked() {
+    PUMP.set(Mutex::new(Vec::new())).ok();
+    register_main_thread();
+    set_cross_thread_dispatcher(dispatcher);
+
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let addr = listener.local_addr().unwrap();
+    thread::spawn(move || {
+        if let Ok((mut stream, _)) = listener.accept() {
+            use std::io::Write;
+            // Not a TLS ServerHello — the handshake must fail *after* rustls has
+            // successfully resolved its crypto provider.
+            let _ = stream.write_all(b"not a tls handshake\r\n\r\n");
+            thread::sleep(Duration::from_millis(300));
+        }
+    });
+
+    let ws = connect(format!("wss://127.0.0.1:{}/", addr.port())).expect("wss url is accepted");
+    let err: Rc<RefCell<Option<String>>> = Rc::new(RefCell::new(None));
+    let opened = Rc::new(Cell::new(false));
+
+    let e = err.clone();
+    ws.on_error(move |x| *e.borrow_mut() = Some(format!("{x:?}")));
+    let o = opened.clone();
+    ws.on_open(move || o.set(true));
+
+    assert!(
+        pump_until(
+            || err.borrow().is_some() || opened.get(),
+            Duration::from_secs(10)
+        ),
+        "a failed wss handshake must surface via on_error, not hang"
+    );
+    assert!(
+        !opened.get(),
+        "the handshake cannot succeed against garbage"
+    );
+    assert!(
+        err.borrow().is_some(),
+        "on_error must fire (a worker-thread panic would leave this None)"
+    );
+}


### PR DESCRIPTION
## What

New crate `rinch-ws`: a cross-platform WebSocket client with the same callback / `!Send`-friendly, push-based shape as `rinch-http`. Web uses the browser `WebSocket`; native uses `tungstenite`. Unblocks real-time features (e.g. PlotWeb's author↔beta feedback) on native desktop.

## Standalone, not built on `rinch-signaling`

`rinch-signaling` is the opposite architecture: blocking, `Send`-required, WebRTC-specific, `recv()`-pull. Mirroring `rinch-http`'s callback/`!Send`-push model meant a standalone crate. It did settle the native dep question though — `tungstenite 0.24` is already in the tree via signaling, so no new fundamental dependency (added the `rustls-tls-webpki-roots` feature, reusing the rustls 0.23 + webpki-roots stack `rinch-http`'s ureq already pulls).

## API

- `connect(url) -> Result<WsHandle, WsError>` (free fn, mirrors `fetch`). Absolute `ws://`/`wss://` only. Sync `Err` only for bad scheme / browser refusal; connect failures arrive via `on_error`.
- `WsHandle`: chainable `.on_open()/.on_message(WsMessage)/.on_close(WsClose)/.on_error(WsError)`; `.send_text()/.send_bytes()/.close()`. Drop closes + deregisters.
- `WsMessage::{Text,Binary}`, `WsClose{code,reason}`, `WsError`.

## Threading

Callbacks live in a main-thread-local registry keyed by connection id (a socket fires many events, so not the one-shot `park_main_callback`). Native worker hops each event to the main thread via `run_on_main_thread` — only the id + `Send` payload cross, callbacks stay `!Send`. `invoke()` removes the callback before calling, so a callback that drops the handle is double-borrow-safe.

Native backend: synchronous tungstenite on a spawned thread, one read/write loop with a 50 ms read timeout so a single thread interleaves reads and queued `mpsc` sends (tungstenite can't split a socket); timeout set on the underlying `TcpStream`, reaching through rustls `StreamOwned.sock` for TLS.

## Tested vs untested

- **Native integration test** (`tests/echo.rs`) — full real wire path against an in-process tungstenite echo server: connect → open → text round-trip → binary round-trip → graceful close firing `on_close`. Stands up a cross-thread dispatcher + main-thread pump to stand in for the winit loop. Passes.
- Unit: URL/scheme rejection, `WsMessage` accessors, re-entrant dispatch.
- **Untested in-harness**: the `wss://`/TLS path (compiled via the rustls feature, not exercised — no practical live TLS endpoint here; rustls' process-default crypto provider may need runtime selection since ureq also uses rustls).

## Verify

`cargo build -p rinch-ws` (native + wasm32) — clean. `cargo clippy` both targets — clean. `cargo test -p rinch-ws` — 3 unit + 1 real-wire integration pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dfj82yEkQviGePivgrBpUH