### PR TITLE
feat(editor-collab): project bullet/ordered lists onto Automerge

### DIFF
--- a/crates/rinch-editor-collab/src/project.rs
+++ b/crates/rinch-editor-collab/src/project.rs
@@ -7,20 +7,22 @@
 //! 1. The unchanged leading/trailing blocks are skipped by **`Rc` identity**
 //!    ([`Node::same_ref`]) — the persistent model shares every untouched block, so
 //!    typing one character reads and re-splices exactly one block.
-//! 2. Each changed block is reconciled in place ([`CollabDoc::reconcile_block`]) with a
+//! 2. Each changed block is reconciled in place ([`CollabDoc::reconcile_node`]) with a
 //!    minimal common-prefix/suffix text splice, so the per-character CRDT identity of
 //!    unchanged text survives and concurrent edits merge.
 //! 3. The net block-count difference is inserted/deleted at the boundary, preserving
 //!    the identity of the leading reconciled blocks (so a split keeps block N's text
 //!    object and only *adds* the tail block).
 //!
-//! Any non-flat node anywhere in `before` or `after` fails loud
-//! ([`CollabError::Unsupported`], design A22).
+//! A changed top-level *list* reconciles recursively (same diff, one level down), so a
+//! keystroke inside one list item re-splices only that item's text object. Any node
+//! outside the supported scope (a non-list nested block, an inline atom) anywhere in
+//! `before` or `after` fails loud ([`CollabError::Unsupported`], design A22).
 
 use rinch_editor_core::{Node, Transaction};
 
 use crate::error::Result;
-use crate::projection::{CollabDoc, read_block};
+use crate::projection::{CollabDoc, read_node};
 
 impl CollabDoc {
     /// Project a freshly-applied local transaction onto the CRDT. A no-op for a
@@ -71,23 +73,25 @@ impl CollabDoc {
         // wedging the session in a half-projected state.
         let mut targets = Vec::with_capacity(post_mid);
         for k in 0..post_mid {
-            targets.push(read_block(after.child(prefix + k))?);
+            targets.push(read_node(after.child(prefix + k))?);
         }
         for idx in prefix + common..prefix + pre_mid {
             // Validate (and discard) each block being deleted — fail loud if non-flat.
-            read_block(before.child(idx))?;
+            read_node(before.child(idx))?;
         }
 
         // Writes — past here only an automerge I/O error can fail, not a content one.
-        // Reconcile the overlapping changed blocks in place (keeps identity).
+        // Reconcile the overlapping changed blocks in place (keeps identity). A changed
+        // top-level list reconciles recursively, touching only the edited descendant.
+        let content = self.content.clone();
         for (k, target) in targets.iter().take(common).enumerate() {
-            self.reconcile_block(prefix + k, target)?;
+            self.reconcile_node(&content, prefix + k, target)?;
         }
         // Insert the extra post blocks (e.g. the tail of a split). `targets` has
         // exactly `post_mid` entries, so skipping `common` yields indices
         // `common..post_mid`.
         for (k, target) in targets.iter().enumerate().skip(common) {
-            self.insert_block(prefix + k, target)?;
+            self.insert_node(&content, prefix + k, target)?;
         }
         // Delete the extra pre blocks (e.g. a join, or a block deletion). `common` is
         // the min, so at most one of insert/delete runs; when this runs the CRDT

--- a/crates/rinch-editor-collab/src/projection.rs
+++ b/crates/rinch-editor-collab/src/projection.rs
@@ -9,30 +9,42 @@
 //!
 //! ## Wire shape (rich-text projection)
 //!
+//! Every model node — at any depth — projects onto the **same** Automerge `Map` shape;
+//! nesting is just recursion on it. A node is *either* a textblock (carries a `text`)
+//! *or* a container (carries a `content` list of child nodes):
+//!
 //! ```text
 //! ROOT (Map)
-//!   "content" -> List<Block>
-//!     Block (Map):
-//!       "type"  -> Str            // "paragraph" | "heading" | "code_block"
-//!       "attrs" -> Map<Str,scalar>// e.g. heading {"level": 2}
-//!       "text"  -> Text           // the block's plain text, codepoint-indexed
-//!         (marks applied to "text" via doc.mark(): name = mark type;
-//!          value = Bool(true) for an attr-less mark, or Str(json) carrying its attrs)
+//!   "content" -> List<Node>
+//!     Node (Map):
+//!       "type"  -> Str             // "paragraph" | "heading" | "bullet_list" | …
+//!       "attrs" -> Map<Str,scalar> // e.g. heading {"level": 2}, ordered_list {"start": 3}
+//!       and then EXACTLY ONE of:
+//!         "text"    -> Text        // a textblock's plain text, codepoint-indexed
+//!           (marks applied to "text" via doc.mark(): name = mark type;
+//!            value = Bool(true) for an attr-less mark, or Str(json) carrying its attrs)
+//!         "content" -> List<Node>  // a container block's child nodes, recursively
 //! ```
 //!
-//! One `Text` per block with Automerge marks over it is the *rich-text* model — text
+//! One `Text` per textblock with Automerge marks over it is the *rich-text* model — text
 //! and formatting merge independently, which is exactly the "concurrent insert/format"
 //! convergence the milestone requires. Automerge `Text` is **codepoint-indexed**, which
-//! matches `rinch-editor-core`'s char-based positions exactly — no UTF conversion.
+//! matches `rinch-editor-core`'s char-based positions exactly — no UTF conversion. A
+//! textblock keeps its own `Text` object however deeply it is nested, so concurrent edits
+//! to *different* list items are edits to *different* `Text` objects and merge without
+//! loss.
 //!
-//! ## Staged scope (design A22)
+//! ## Scope (design A22)
 //!
-//! The first milestone covers **flat text-blocks + marks**: a `doc` whose children are
-//! all [textblocks](rinch_editor_core::Node::is_textblock) (`paragraph`/`heading`/
-//! `code_block`) whose own children are all text nodes. Anything else — a nested block
-//! (blockquote, list, table), an inline atom (`hard_break`, `image`) — is
-//! [`CollabError::Unsupported`](crate::CollabError::Unsupported): **fail loud, never a
-//! silent drop**.
+//! Supported: **flat text-blocks + marks** (`paragraph`/`heading`/`code_block` whose own
+//! children are text nodes), and the **list containers** `bullet_list` / `ordered_list` /
+//! `list_item`, nested into each other and around text-blocks to any depth.
+//!
+//! Everything else still **fails loud** with
+//! [`CollabError::Unsupported`](crate::CollabError::Unsupported) — **never a silent
+//! drop**: any other nested block (`blockquote`, `table`/`table_row`/cells,
+//! `task_list`/`task_item`) and every inline atom (`hard_break`, `image`,
+//! `horizontal_rule`).
 
 use automerge::marks::{ExpandMark, Mark as AmMark};
 use automerge::transaction::Transactable;
@@ -66,6 +78,50 @@ pub(crate) struct BlockData {
     pub marks: Vec<SpanMark>,
 }
 
+/// One projectable model node: either a flat text-block ([`BlockData`]) or a container
+/// block (a list / list item) holding child nodes recursively. Structural equality is
+/// canonical (marks are sorted in [`read_block`] / [`CollabDoc::read_text_marks`]), so
+/// comparing two `NodeData` trees is the same as comparing the model nodes they came
+/// from — the child-list diff in [`CollabDoc::reconcile_child_list`] relies on that.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum NodeData {
+    /// A flat text-block (`paragraph`/`heading`/`code_block`): its `text` + marks.
+    Block(BlockData),
+    /// A container block (`bullet_list`/`ordered_list`/`list_item`): its child nodes.
+    Container {
+        type_name: String,
+        attrs: Attrs,
+        children: Vec<NodeData>,
+    },
+}
+
+impl NodeData {
+    /// The node's type name.
+    fn type_name(&self) -> &str {
+        match self {
+            NodeData::Block(b) => &b.type_name,
+            NodeData::Container { type_name, .. } => type_name,
+        }
+    }
+
+    /// The node's attributes.
+    fn attrs(&self) -> &Attrs {
+        match self {
+            NodeData::Block(b) => &b.attrs,
+            NodeData::Container { attrs, .. } => attrs,
+        }
+    }
+}
+
+/// The container block types the projection nests (design A22). A container carries a
+/// `content` list of child nodes instead of a `text`. Deliberately a whitelist: every
+/// other non-text-block node (`blockquote`, tables, `task_list`/`task_item`, atoms)
+/// stays [`CollabError::Unsupported`] so an unsupported shape fails loud rather than
+/// being silently mangled.
+fn is_supported_container(type_name: &str) -> bool {
+    matches!(type_name, "bullet_list" | "ordered_list" | "list_item")
+}
+
 /// An Automerge document projecting a flat editor document.
 #[derive(Debug)]
 pub struct CollabDoc {
@@ -81,10 +137,13 @@ impl CollabDoc {
     pub fn from_doc(doc: &Node) -> Result<CollabDoc> {
         let mut am = AutoCommit::new();
         let content = am.put_object(automerge::ROOT, CONTENT, ObjType::List)?;
-        let mut cdoc = CollabDoc { doc: am, content };
+        let mut cdoc = CollabDoc {
+            doc: am,
+            content: content.clone(),
+        };
         for i in 0..doc.child_count() {
-            let block = read_block(doc.child(i))?;
-            cdoc.insert_block(i, &block)?;
+            let node = read_node(doc.child(i))?;
+            cdoc.insert_node(&content, i, &node)?;
         }
         Ok(cdoc)
     }
@@ -113,15 +172,21 @@ impl CollabDoc {
         self.doc.length(&self.content)
     }
 
-    /// The object id of the block at `index`.
-    pub(crate) fn block_obj(&self, index: usize) -> Option<ObjId> {
-        match self.doc.get(&self.content, index) {
+    /// The map object of the child at `index` of a content list (top-level `content` or
+    /// a container's nested `content`).
+    pub(crate) fn child_map(&self, list: &ObjId, index: usize) -> Option<ObjId> {
+        match self.doc.get(list, index) {
             Ok(Some((Value::Object(ObjType::Map), id))) => Some(id),
             _ => None,
         }
     }
 
-    /// The `text` Text object of a block.
+    /// The object id of the top-level block at `index`.
+    pub(crate) fn block_obj(&self, index: usize) -> Option<ObjId> {
+        self.child_map(&self.content, index)
+    }
+
+    /// The `text` Text object of a text-block node.
     pub(crate) fn block_text_obj(&self, block: &ObjId) -> Option<ObjId> {
         match self.doc.get(block, TEXT) {
             Ok(Some((Value::Object(ObjType::Text), id))) => Some(id),
@@ -129,68 +194,170 @@ impl CollabDoc {
         }
     }
 
-    /// Insert a new block (type + attrs + text + marks) at `index`.
-    pub(crate) fn insert_block(&mut self, index: usize, b: &BlockData) -> Result<()> {
-        let block = self.doc.insert_object(&self.content, index, ObjType::Map)?;
-        self.doc.put(&block, TYPE, b.type_name.as_str())?;
-        let attrs_obj = self.doc.put_object(&block, ATTRS, ObjType::Map)?;
-        write_attrs(&mut self.doc, &attrs_obj, &b.attrs)?;
-        let text = self.doc.put_object(&block, TEXT, ObjType::Text)?;
-        if !b.text.is_empty() {
-            self.doc.splice_text(&text, 0, 0, &b.text)?;
+    /// The `content` List object of a container node.
+    pub(crate) fn node_content_obj(&self, node: &ObjId) -> Option<ObjId> {
+        match self.doc.get(node, CONTENT) {
+            Ok(Some((Value::Object(ObjType::List), id))) => Some(id),
+            _ => None,
         }
-        for m in &b.marks {
-            self.apply_mark(&text, m)?;
+    }
+
+    /// Insert a new node (text-block or container) at `index` of `list`.
+    pub(crate) fn insert_node(&mut self, list: &ObjId, index: usize, nd: &NodeData) -> Result<()> {
+        let node = self.doc.insert_object(list, index, ObjType::Map)?;
+        self.write_node(&node, nd)
+    }
+
+    /// Write a node's contents into its (already-inserted) map object. Recurses into a
+    /// container's children.
+    fn write_node(&mut self, node: &ObjId, nd: &NodeData) -> Result<()> {
+        self.doc.put(node, TYPE, nd.type_name())?;
+        let attrs_obj = self.doc.put_object(node, ATTRS, ObjType::Map)?;
+        write_attrs(&mut self.doc, &attrs_obj, nd.attrs())?;
+        match nd {
+            NodeData::Block(b) => {
+                let text = self.doc.put_object(node, TEXT, ObjType::Text)?;
+                if !b.text.is_empty() {
+                    self.doc.splice_text(&text, 0, 0, &b.text)?;
+                }
+                for m in &b.marks {
+                    self.apply_mark(&text, m)?;
+                }
+            }
+            NodeData::Container { children, .. } => {
+                let content = self.doc.put_object(node, CONTENT, ObjType::List)?;
+                for (i, child) in children.iter().enumerate() {
+                    self.insert_node(&content, i, child)?;
+                }
+            }
         }
         Ok(())
     }
 
-    /// Delete the block at `index`.
+    /// Delete the top-level block at `index`.
     pub(crate) fn delete_block(&mut self, index: usize) -> Result<()> {
         self.doc.delete(&self.content, index)?;
         Ok(())
     }
 
-    /// Reconcile the block at `index` to `target`: update type/attrs if they changed,
-    /// splice the text to match (minimal common-prefix/suffix splice so the per-char
-    /// CRDT identity of unchanged text survives), and resync its marks.
-    pub(crate) fn reconcile_block(&mut self, index: usize, target: &BlockData) -> Result<()> {
-        let block = self
-            .block_obj(index)
-            .ok_or_else(|| CollabError::schema("reconcile_block: missing block"))?;
+    /// Reconcile the node at `index` of `list` to `target`: update type/attrs if they
+    /// changed, then reconcile its body — a text-block's text + marks, or a container's
+    /// child list — recursively. Unchanged descendants keep their CRDT identity, so a
+    /// concurrent edit to a *different* text-block (even in a different list item) merges.
+    pub(crate) fn reconcile_node(
+        &mut self,
+        list: &ObjId,
+        index: usize,
+        target: &NodeData,
+    ) -> Result<()> {
+        let node = self
+            .child_map(list, index)
+            .ok_or_else(|| CollabError::schema("reconcile_node: missing node"))?;
+
+        // A node changing *kind* (text-block <-> container — e.g. a paragraph wrapped
+        // into a list) can't be reconciled in place; replace it wholesale. Rare, so the
+        // coarse-grained replace is fine.
+        let crdt_is_block = self.block_text_obj(&node).is_some();
+        let target_is_block = matches!(target, NodeData::Block(_));
+        if crdt_is_block != target_is_block {
+            self.doc.delete(list, index)?;
+            self.insert_node(list, index, target)?;
+            return Ok(());
+        }
 
         // type — only write when it changed
-        if self.scalar_str(&block, TYPE).as_deref() != Some(target.type_name.as_str()) {
-            self.doc.put(&block, TYPE, target.type_name.as_str())?;
+        if self.scalar_str(&node, TYPE).as_deref() != Some(target.type_name()) {
+            self.doc.put(&node, TYPE, target.type_name())?;
         }
         // attrs — only rebuild when they changed. Replacing the attrs object on every
         // keystroke would churn the CRDT and clobber a concurrent remote attr edit on
-        // the same block.
-        let current_attrs = match self.doc.get(&block, ATTRS) {
+        // the same node.
+        let current_attrs = match self.doc.get(&node, ATTRS) {
             Ok(Some((Value::Object(ObjType::Map), id))) => read_attrs(&self.doc, &id),
             _ => Attrs::new(),
         };
-        if current_attrs != target.attrs {
-            let attrs_obj = self.doc.put_object(&block, ATTRS, ObjType::Map)?;
-            write_attrs(&mut self.doc, &attrs_obj, &target.attrs)?;
+        if current_attrs != *target.attrs() {
+            let attrs_obj = self.doc.put_object(&node, ATTRS, ObjType::Map)?;
+            write_attrs(&mut self.doc, &attrs_obj, target.attrs())?;
         }
 
-        // text — minimal splice
-        let text = self
-            .block_text_obj(&block)
-            .ok_or_else(|| CollabError::schema("reconcile_block: missing text"))?;
-        let old = self.doc.text(&text)?;
-        if old != target.text {
-            splice_min(&mut self.doc, &text, &old, &target.text)?;
+        match target {
+            NodeData::Block(b) => {
+                let text = self
+                    .block_text_obj(&node)
+                    .ok_or_else(|| CollabError::schema("reconcile_node: missing text"))?;
+                self.reconcile_text(&text, b)?;
+            }
+            NodeData::Container { children, .. } => {
+                let content = self
+                    .node_content_obj(&node)
+                    .ok_or_else(|| CollabError::schema("reconcile_node: missing content"))?;
+                self.reconcile_child_list(&content, children)?;
+            }
         }
+        Ok(())
+    }
 
+    /// Reconcile a text-block's `text` Text object to `b`: a minimal common-prefix/suffix
+    /// splice (so the per-char CRDT identity of unchanged text survives) plus a mark
+    /// resync only when the marks actually changed.
+    fn reconcile_text(&mut self, text: &ObjId, b: &BlockData) -> Result<()> {
+        let old = self.doc.text(text)?;
+        if old != b.text {
+            splice_min(&mut self.doc, text, &old, &b.text)?;
+        }
         // marks — only clear-and-reapply when they actually changed (after the splice,
         // Automerge has already shifted existing mark ranges with the text). Skipping
         // the resync on a pure text edit avoids clobbering a concurrent remote mark.
-        let mut target_marks = target.marks.clone();
+        let mut target_marks = b.marks.clone();
         target_marks.sort_by(|a, b| (a.start, a.end, &a.name).cmp(&(b.start, b.end, &b.name)));
-        if self.read_text_marks(&text)? != target_marks {
-            self.resync_marks(&text, &target.marks)?;
+        if self.read_text_marks(text)? != target_marks {
+            self.resync_marks(text, &b.marks)?;
+        }
+        Ok(())
+    }
+
+    /// Reconcile a container's `content` list to `target`. Diffs the CRDT's current
+    /// children against `target` by *structural* equality (a common leading/trailing run
+    /// is left untouched, keeping the CRDT identity — and merge behaviour — of every
+    /// node in it), reconciles the overlapping middle in place, and inserts/deletes the
+    /// count difference. This is the same block-list diff as [`Self::project_change`],
+    /// one level down; recursion carries it to any depth.
+    fn reconcile_child_list(&mut self, content: &ObjId, target: &[NodeData]) -> Result<()> {
+        let cn = self.doc.length(content);
+        let mut cur = Vec::with_capacity(cn);
+        for i in 0..cn {
+            cur.push(self.read_node_data(content, i)?);
+        }
+        let tn = target.len();
+
+        let mut prefix = 0;
+        while prefix < cn && prefix < tn && cur[prefix] == target[prefix] {
+            prefix += 1;
+        }
+        let mut suffix = 0;
+        while suffix < cn - prefix
+            && suffix < tn - prefix
+            && cur[cn - 1 - suffix] == target[tn - 1 - suffix]
+        {
+            suffix += 1;
+        }
+
+        let cur_mid = cn - prefix - suffix;
+        let tgt_mid = tn - prefix - suffix;
+        let common = cur_mid.min(tgt_mid);
+
+        // Reconcile the overlapping changed children in place (keeps identity).
+        for k in 0..common {
+            self.reconcile_node(content, prefix + k, &target[prefix + k])?;
+        }
+        // Insert the extra target children.
+        for k in common..tgt_mid {
+            self.insert_node(content, prefix + k, &target[prefix + k])?;
+        }
+        // Delete the extra current children (from the end so earlier indices stay valid).
+        for idx in (prefix + common..prefix + cur_mid).rev() {
+            self.doc.delete(content, idx)?;
         }
         Ok(())
     }
@@ -264,29 +431,46 @@ impl CollabDoc {
         }
     }
 
-    /// Read the block at `index` back out of the CRDT as [`BlockData`].
-    pub(crate) fn read_block_data(&self, index: usize) -> Result<BlockData> {
-        let block = self
-            .block_obj(index)
-            .ok_or_else(|| CollabError::schema("read_block_data: missing block"))?;
+    /// Read the node at `index` of `list` back out of the CRDT as [`NodeData`]. A node
+    /// carrying a `text` Text is a text-block; a node carrying a `content` List is a
+    /// container, read recursively. Fails loud on a node that is neither (a corrupt
+    /// projection), rather than materializing a broken shape.
+    pub(crate) fn read_node_data(&self, list: &ObjId, index: usize) -> Result<NodeData> {
+        let node = self
+            .child_map(list, index)
+            .ok_or_else(|| CollabError::schema("read_node_data: missing node"))?;
         let type_name = self
-            .scalar_str(&block, TYPE)
-            .ok_or_else(|| CollabError::schema("block has no type"))?;
-        let attrs = match self.doc.get(&block, ATTRS) {
+            .scalar_str(&node, TYPE)
+            .ok_or_else(|| CollabError::schema("node has no type"))?;
+        let attrs = match self.doc.get(&node, ATTRS) {
             Ok(Some((Value::Object(ObjType::Map), id))) => read_attrs(&self.doc, &id),
             _ => Attrs::new(),
         };
-        let text_obj = self
-            .block_text_obj(&block)
-            .ok_or_else(|| CollabError::schema("block has no text"))?;
-        let text = self.doc.text(&text_obj)?;
-        let marks = self.read_text_marks(&text_obj)?;
-        Ok(BlockData {
-            type_name,
-            attrs,
-            text,
-            marks,
-        })
+        if let Some(text_obj) = self.block_text_obj(&node) {
+            let text = self.doc.text(&text_obj)?;
+            let marks = self.read_text_marks(&text_obj)?;
+            Ok(NodeData::Block(BlockData {
+                type_name,
+                attrs,
+                text,
+                marks,
+            }))
+        } else if let Some(content) = self.node_content_obj(&node) {
+            let len = self.doc.length(&content);
+            let mut children = Vec::with_capacity(len);
+            for i in 0..len {
+                children.push(self.read_node_data(&content, i)?);
+            }
+            Ok(NodeData::Container {
+                type_name,
+                attrs,
+                children,
+            })
+        } else {
+            Err(CollabError::schema(format!(
+                "node `{type_name}` has neither a `text` nor a `content` object"
+            )))
+        }
     }
 
     /// Rebuild the whole model document from the projection (the canonical, total
@@ -295,8 +479,8 @@ impl CollabDoc {
         let n = self.block_count();
         let mut blocks = Vec::with_capacity(n);
         for i in 0..n {
-            let b = self.read_block_data(i)?;
-            blocks.push(build_block(schema, &b)?);
+            let nd = self.read_node_data(&self.content, i)?;
+            blocks.push(build_node(schema, &nd)?);
         }
         if blocks.is_empty() {
             // An editor doc is never empty; mirror the starter empty paragraph.
@@ -311,7 +495,38 @@ impl CollabDoc {
     }
 }
 
-/// Validate a model block is a flat textblock and extract its projectable data.
+/// Validate a model node is projectable and extract its [`NodeData`], recursing into
+/// list containers. A flat text-block becomes [`NodeData::Block`]; a supported list
+/// container ([`is_supported_container`]) becomes [`NodeData::Container`] over its
+/// recursively-read children. Anything else — an unsupported nested block (`blockquote`,
+/// table, task list) or an inline atom — fails loud (design A22).
+pub(crate) fn read_node(node: &Node) -> Result<NodeData> {
+    if node.is_textblock() {
+        return Ok(NodeData::Block(read_block(node)?));
+    }
+    if is_supported_container(node.type_name()) {
+        let mut children = Vec::with_capacity(node.child_count());
+        for i in 0..node.child_count() {
+            children.push(read_node(node.child(i))?);
+        }
+        return Ok(NodeData::Container {
+            type_name: node.type_name().to_string(),
+            attrs: node.attrs().clone(),
+            children,
+        });
+    }
+    Err(CollabError::unsupported(format!(
+        "node `{}` is not a flat text-block or a supported list container \
+         (bullet_list/ordered_list/list_item); other nested blocks, tables and inline \
+         atoms are not yet supported",
+        node.type_name()
+    )))
+}
+
+/// Validate a model block is a flat textblock and extract its projectable data. Marks
+/// are returned in canonical `(start, end, name)` order — matching
+/// [`CollabDoc::read_text_marks`] — so a [`NodeData`] read from the model compares equal
+/// to the same node read back from the CRDT.
 pub(crate) fn read_block(block: &Node) -> Result<BlockData> {
     if !block.is_textblock() {
         return Err(CollabError::unsupported(format!(
@@ -336,6 +551,7 @@ pub(crate) fn read_block(block: &Node) -> Result<BlockData> {
             push_span(&mut marks, m, start, end);
         }
     }
+    marks.sort_by(|a, b| (a.start, a.end, &a.name).cmp(&(b.start, b.end, &b.name)));
     Ok(BlockData {
         type_name: block.type_name().to_string(),
         attrs: block.attrs().clone(),
@@ -361,6 +577,35 @@ fn push_span(marks: &mut Vec<SpanMark>, m: &Mark, start: usize, end: usize) {
         start,
         end,
     });
+}
+
+/// Rebuild a model node from projected [`NodeData`], recursing into list containers.
+/// The inbound scope guard (A22) is shared with the outbound [`read_node`]: a container
+/// type must be one [`is_supported_container`] permits, so a peer CRDT can never
+/// materialize an out-of-scope shape here even though [`Schema::create_node`] would
+/// happily build one.
+fn build_node(schema: &Schema, nd: &NodeData) -> Result<Node> {
+    match nd {
+        NodeData::Block(b) => build_block(schema, b),
+        NodeData::Container {
+            type_name,
+            attrs,
+            children,
+        } => {
+            if !is_supported_container(type_name) {
+                return Err(CollabError::unsupported(format!(
+                    "container `{type_name}` is not a supported list type in the CRDT"
+                )));
+            }
+            let mut kids = Vec::with_capacity(children.len());
+            for c in children {
+                kids.push(build_node(schema, c)?);
+            }
+            schema
+                .create_node(type_name, attrs.clone(), Fragment::from_children(kids))
+                .map_err(CollabError::from)
+        }
+    }
 }
 
 /// Rebuild a model textblock node from projected block data: split the text into runs

--- a/crates/rinch-editor-collab/tests/collab.rs
+++ b/crates/rinch-editor-collab/tests/collab.rs
@@ -10,8 +10,8 @@ use std::rc::Rc;
 
 use rinch_editor_collab::{CollabPlugin, CollabSession, RemoteOp, rebase_steps};
 use rinch_editor_core::{
-    AttrValue, Attrs, EditorState, Fragment, Mark, Node, Plugin, Pos, Schema, Selection, Step,
-    Transaction, default_plugins,
+    AttrValue, Attrs, EditorState, Fragment, Mark, Node, Plugin, Pos, Schema, Selection, Slice,
+    Step, Transaction, default_plugins,
 };
 
 // --- harness -------------------------------------------------------------------
@@ -35,6 +35,44 @@ fn doc_of(schema: &Schema, blocks: Vec<Node>) -> Node {
     schema
         .branch("doc", Fragment::from_children(blocks))
         .unwrap()
+}
+
+fn list_item(schema: &Schema, blocks: Vec<Node>) -> Node {
+    schema
+        .branch("list_item", Fragment::from_children(blocks))
+        .unwrap()
+}
+
+fn bullet_list(schema: &Schema, items: Vec<Node>) -> Node {
+    schema
+        .branch("bullet_list", Fragment::from_children(items))
+        .unwrap()
+}
+
+fn ordered_list(schema: &Schema, start: i64, items: Vec<Node>) -> Node {
+    schema
+        .create_node(
+            "ordered_list",
+            Attrs::new().with("start", start),
+            Fragment::from_children(items),
+        )
+        .unwrap()
+}
+
+/// A fully recursive canonical string form of a document (nesting-aware), so two
+/// structurally-equal trees — however deeply nested — compare equal regardless of how
+/// text/marks/children were assembled. `norm` above is the flat-only sibling the
+/// original tests use.
+fn tree(n: &Node) -> String {
+    if let Some(t) = n.text() {
+        return format!("«{}|{}»", t, canon_marks(n).join("+"));
+    }
+    let mut s = format!("<{} {}>", n.type_name(), norm_attrs(n));
+    for i in 0..n.child_count() {
+        s.push_str(&tree(n.child(i)));
+    }
+    s.push_str("</>");
+    s
 }
 
 /// One collaborating editor: its model state plus its CRDT session.
@@ -505,6 +543,176 @@ fn unsupported_change_does_not_partially_mutate() {
         original,
         norm(&cdoc.to_doc(&schema).unwrap()),
         "an unsupported change must not partially mutate the CRDT (block 0 stays \"alpha\")"
+    );
+}
+
+// --- lists (bullet / ordered / nested list items) ------------------------------
+
+#[test]
+fn projection_round_trips_bullet_and_ordered_lists_with_nesting_and_marks() {
+    // The headline list test: a document whose content is a bullet list (with a
+    // bold+italic run and a nested bullet list inside a list item) and an ordered list
+    // (start=3) survives the CRDT round-trip byte-for-byte — structure, order, nesting
+    // depth, list attrs, and inline marks all preserved.
+    let schema = Rc::new(Schema::starter_kit());
+    let bold = Mark::simple(schema.mark_type("bold").unwrap().clone());
+    let italic = Mark::simple(schema.mark_type("italic").unwrap().clone());
+
+    // Item 1: a paragraph with a plain run + a bold+italic run.
+    let item1 = list_item(
+        &schema,
+        vec![
+            schema
+                .create_node(
+                    "paragraph",
+                    Default::default(),
+                    Fragment::from_children(vec![
+                        schema.text("plain ").unwrap(),
+                        schema
+                            .text_with_marks("strong", vec![bold.clone(), italic.clone()])
+                            .unwrap(),
+                    ]),
+                )
+                .unwrap(),
+        ],
+    );
+    // Item 2: a paragraph plus a *nested* bullet list (depth 2).
+    let nested = bullet_list(
+        &schema,
+        vec![list_item(&schema, vec![para(&schema, "nested item")])],
+    );
+    let item2 = list_item(&schema, vec![para(&schema, "outer"), nested]);
+    let bullet = bullet_list(&schema, vec![item1, item2]);
+
+    let ordered = ordered_list(
+        &schema,
+        3,
+        vec![
+            list_item(&schema, vec![para(&schema, "first")]),
+            list_item(&schema, vec![para(&schema, "second")]),
+        ],
+    );
+
+    let doc = doc_of(&schema, vec![para(&schema, "intro"), bullet, ordered]);
+
+    let cdoc = rinch_editor_collab::CollabDoc::from_doc(&doc).unwrap();
+    let back = cdoc.to_doc(&schema).unwrap();
+    assert_eq!(tree(&doc), tree(&back), "list round-trip must be lossless");
+    // Structural equality is the strongest form of the same claim.
+    assert_eq!(doc, back);
+}
+
+#[test]
+fn concurrent_edits_in_different_list_items_converge() {
+    // Two peers edit *different* items of the same bullet list. Because every text-block
+    // keeps its own Text object however deeply nested, the two edits touch different
+    // CRDT objects and must merge without loss.
+    let schema = Rc::new(Schema::starter_kit());
+    let list = bullet_list(
+        &schema,
+        vec![
+            list_item(&schema, vec![para(&schema, "one")]),
+            list_item(&schema, vec![para(&schema, "two")]),
+        ],
+    );
+    let (schema, mut a, mut b) = {
+        let _ = &schema;
+        two_peers(vec![list])
+    };
+    // Positions: doc>ul>li>p>text. "one" ends at model pos 6; "two" ends at pos 13.
+    a.type_at(6, "A"); // item 0 -> "oneA"
+    b.type_at(13, "B"); // item 1 -> "twoB"
+    sync(&mut a, &mut b);
+
+    let pa = a.session.projected_doc(&schema).unwrap();
+    let pb = b.session.projected_doc(&schema).unwrap();
+    assert_eq!(tree(&pa), tree(&pb), "list projections must converge");
+    assert_eq!(tree(&a.state.doc), tree(&pa), "peer A model ≡ projection");
+    assert_eq!(tree(&b.state.doc), tree(&pb), "peer B model ≡ projection");
+    let t = tree(&pa);
+    assert!(
+        t.contains("oneA") && t.contains("twoB"),
+        "both list-item edits kept: {t}"
+    );
+}
+
+#[test]
+fn concurrent_list_item_edit_and_appended_item_converge() {
+    // One peer edits an existing item's text; the other appends a whole new list item.
+    // Both the text edit and the structural insert must survive the merge.
+    let schema = Rc::new(Schema::starter_kit());
+    let list = bullet_list(
+        &schema,
+        vec![
+            list_item(&schema, vec![para(&schema, "alpha")]),
+            list_item(&schema, vec![para(&schema, "beta")]),
+        ],
+    );
+    let (schema, mut a, mut b) = {
+        let _ = &schema;
+        two_peers(vec![list])
+    };
+    // A edits item 0: "alpha" content is pos 3..8, so type at pos 8 -> "alphaX".
+    a.type_at(8, "X");
+    // B appends a third list item at the end of the bullet list. The list content ends
+    // just before the bullet_list close token; a block-level replace inserts a new item.
+    let li = list_item(b.state.schema(), vec![para(b.state.schema(), "gamma")]);
+    let insert_at = b.state.doc.child(0).node_size() - 1; // just inside the ul close token
+    b.local(|tr| {
+        tr.replace(
+            insert_at,
+            insert_at,
+            Slice::new(Fragment::from_node(li), 0, 0),
+        )
+        .unwrap();
+    });
+    sync(&mut a, &mut b);
+
+    let pa = a.session.projected_doc(&schema).unwrap();
+    let pb = b.session.projected_doc(&schema).unwrap();
+    assert_eq!(tree(&pa), tree(&pb), "must converge");
+    assert_eq!(tree(&a.state.doc), tree(&pa), "peer A model ≡ projection");
+    assert_eq!(tree(&b.state.doc), tree(&pb), "peer B model ≡ projection");
+    let t = tree(&pa);
+    assert!(t.contains("alphaX"), "text edit kept: {t}");
+    assert!(t.contains("gamma"), "appended item kept: {t}");
+}
+
+#[test]
+fn table_still_fails_loud() {
+    // The scope is narrowed, not removed: lists project, but a table (and its rows/cells)
+    // is still out of scope and must fail loud rather than be silently mangled.
+    let schema = Rc::new(Schema::starter_kit());
+    let cell = schema
+        .branch("table_cell", Fragment::from_node(para(&schema, "x")))
+        .unwrap();
+    let row = schema
+        .branch("table_row", Fragment::from_node(cell))
+        .unwrap();
+    let table = schema.branch("table", Fragment::from_node(row)).unwrap();
+    let doc = doc_of(&schema, vec![table]);
+    let err = rinch_editor_collab::CollabDoc::from_doc(&doc).unwrap_err();
+    assert!(
+        matches!(err, rinch_editor_collab::CollabError::Unsupported(_)),
+        "a table must still fail loud, got {err:?}"
+    );
+}
+
+#[test]
+fn unsupported_block_inside_a_list_item_fails_loud() {
+    // A supported container (list_item) holding an *unsupported* child (blockquote) must
+    // fail loud on the descendant — the recursion doesn't relax the scope for children.
+    let schema = Rc::new(Schema::starter_kit());
+    let bq = schema
+        .branch("blockquote", Fragment::from_node(para(&schema, "q")))
+        .unwrap();
+    let item = list_item(&schema, vec![bq]);
+    let list = bullet_list(&schema, vec![item]);
+    let doc = doc_of(&schema, vec![list]);
+    let err = rinch_editor_collab::CollabDoc::from_doc(&doc).unwrap_err();
+    assert!(
+        matches!(err, rinch_editor_collab::CollabError::Unsupported(_)),
+        "an unsupported block nested in a list item must fail loud, got {err:?}"
     );
 }
 

--- a/crates/rinch-editor-collab/tests/fuzz.rs
+++ b/crates/rinch-editor-collab/tests/fuzz.rs
@@ -1,6 +1,7 @@
 //! Seeded, deterministic fuzz/property tests for the collab adapter.
 //!
-//! Two invariants are stress-tested over thousands of random flat-text edits:
+//! Two invariants are stress-tested over thousands of random edits, spanning both
+//! flat text-blocks and list containers (nested to depth 3 in practice):
 //!
 //! 1. **`model ≡ project(model)`** — after EVERY local edit, the CRDT must read
 //!    back (`projected_doc`) as *exactly* the editor model that produced it. This is
@@ -84,12 +85,14 @@ fn random_text(rng: &mut Rng) -> String {
         .collect()
 }
 
-/// Apply one random *flat-scope* edit (insert / delete / mark / split / block-type)
-/// to `state`. Returns `None` (skip) when the random selection makes the op invalid
-/// — the fuzz tolerates skips. Never produces non-flat content, so `record_local`
-/// never hits the A22 `Unsupported` boundary.
+/// Apply one random *projectable* edit to `state` — insert / delete / mark / split /
+/// block-type, plus the list container ops (wrap, unwrap, indent, outdent). Returns
+/// `None` (skip) when the random selection makes the op invalid; the fuzz tolerates
+/// skips. Stays inside the projected scope (no task lists, blockquotes, tables, or
+/// inline atoms), so `record_local` never hits the A22 `Unsupported` boundary — a
+/// failure here is a real projection bug, not an out-of-scope node.
 fn random_edit(rng: &mut Rng, state: &EditorState) -> Option<EditorState> {
-    match rng.below(9) {
+    match rng.below(11) {
         // Insert text (weighted — the common case).
         0..=3 => {
             let p = random_pos(rng, state);
@@ -133,6 +136,29 @@ fn random_edit(rng: &mut Rng, state: &EditorState) -> Option<EditorState> {
             let mut tr = state.tr();
             tr.set_selection(Selection::cursor(p));
             state.apply(tr).run("splitBlock")
+        }
+        // Wrap/unwrap the block in a list, and nest/un-nest list items. These are the
+        // container operations — they are what makes the projection recursive, so the
+        // fuzz has to produce them or list convergence goes untested. Only the
+        // projectable containers appear here: task lists and blockquotes are still
+        // `Unsupported`, and generating one would (correctly) fail the projection
+        // assertion below rather than find a real bug.
+        9 => {
+            let p = random_pos(rng, state);
+            let mut tr = state.tr();
+            tr.set_selection(Selection::cursor(p));
+            let placed = state.apply(tr);
+            let cmd = ["toggleBulletList", "toggleOrderedList"][rng.below(2)];
+            placed.run(cmd)
+        }
+        // Indent / outdent a list item (creates and collapses nesting depth).
+        10 => {
+            let p = random_pos(rng, state);
+            let mut tr = state.tr();
+            tr.set_selection(Selection::cursor(p));
+            let placed = state.apply(tr);
+            let cmd = ["sinkListItem", "liftListItem"][rng.below(2)];
+            placed.run(cmd)
         }
         // Set the block type (paragraph / heading / code_block — all flat).
         _ => {

--- a/crates/rinch-editor-view/src/handle.rs
+++ b/crates/rinch-editor-view/src/handle.rs
@@ -1920,8 +1920,9 @@ mod tests {
             loopback(&host, &guest);
             assert_eq!(doc_text(&guest), "ok");
 
-            // A bullet list is a nested block — outside the staged flat-text scope.
-            assert!(host.load_html("<ul><li><p>item</p></li></ul>"));
+            // A blockquote is still outside the projected scope (lists are supported
+            // now; blockquote / tables / task lists / inline atoms are not).
+            assert!(host.load_html("<blockquote><p>quoted</p></blockquote>"));
 
             // The host's model changed locally, but the projection failed loud (the
             // CRDT was left untouched, all-or-nothing) so the peer received nothing.
@@ -1933,6 +1934,37 @@ mod tests {
                 doc_text(&guest),
                 "ok",
                 "the peer is untouched by an unsupported local edit (no partial sync)"
+            );
+        }
+
+        #[test]
+        fn list_edits_sync_to_the_peer() {
+            let s = schema();
+            let host = mount(doc_node(&s, vec![para(&s, "ok")])).handle;
+            let guest = mount(doc_node(&s, vec![para(&s, "")])).handle;
+            loopback(&host, &guest);
+            assert_eq!(doc_text(&guest), "ok");
+
+            // Lists are inside the projected scope, so this must sync rather than
+            // fail loud (the counterpart to the blockquote case above).
+            assert!(host.load_html("<ul><li><p>item</p></li></ul>"));
+            assert!(
+                host.collab_take_error().is_none(),
+                "a bullet list is supported and must not fail loud"
+            );
+            assert_eq!(
+                doc_text(&guest),
+                "item",
+                "the peer receives the list content"
+            );
+
+            // A nested list survives the round-trip too.
+            assert!(host.load_html("<ol><li><p>a</p><ul><li><p>b</p></li></ul></li></ol>"));
+            assert!(host.collab_take_error().is_none());
+            assert_eq!(
+                doc_text(&guest),
+                "ab",
+                "nested list content reaches the peer"
             );
         }
 


### PR DESCRIPTION
## What

Extends `rinch-editor-collab`'s Automerge projection to cover **bullet lists, ordered lists, and list items** (nested to any depth), while keeping existing flat-block behavior byte-for-byte identical. Previously lists returned `CollabError::Unsupported`.

## The data-model choice (the crux)

The old wire shape was a flat `content: List<Block>`, each Block a Map with `type` + `attrs` + a `text` Text object. Rather than restructure the projection, I generalized the *node* Map so every model node — at any depth — projects onto the **same** shape carrying **exactly one of**:

- `text` → a `Text` object (a text-block: paragraph/heading/code_block — unchanged), or
- `content` → a `List<Node>` of child node Maps (a container: bullet_list/ordered_list/list_item).

Nesting is then pure recursion on that one shape. **Why it's the right call:** every text-block keeps its own `Text` CRDT object however deeply nested — so two edits to different list items are edits to *different* `Text` objects and merge natively, no special-casing.

Each flat helper gained a recursive sibling dispatching on `NodeData { Block | Container }`:
- `read_node`/`build_node` — outbound/inbound, recursive, sharing the existing scope guard.
- `reconcile_node` + `reconcile_child_list` — a container reconciles its child list with the **same** structural prefix/suffix diff `project_change` uses, one level down, so a keystroke in one list item re-splices only that item's text and siblings keep CRDT identity.
- `read_block` now returns marks in canonical `(start,end,name)` order so a node read from the model compares equal to one read back from the CRDT (the child-list diff relies on it).

`project_change`'s top level is unchanged (Rc-identity prefix/suffix); a changed top-level list recurses into `reconcile_node`. The fail-loud validation pre-pass recurses too, so an unsupported descendant aborts before any CRDT write.

## Supported vs still Unsupported

- **Now:** paragraph/heading/code_block + inline marks (as before), plus `bullet_list`, `ordered_list` (incl. `start`), `list_item`, nested arbitrarily.
- **Still `Unsupported` (deliberate tight whitelist):** blockquote, tables, task lists, inline atoms (hard_break/image/hr). Kept tight partly because existing tests pin blockquote as Unsupported.

`remote.rs` (the surgical op translator) is untouched and stays flat-top-level by its documented scope; the convergence path uses converged rebuild, which handles nesting.

## Tests

Proved the 3 new list tests **fail with `Unsupported` against pre-change code** (git-stashed), then pass. Full suite green: **5 unit + 18 integration (5 new) + 4 fuzz + 1 doctest**. New coverage: lossless round-trip of nested bullet list (plain + bold+italic) and ordered list (start=3); **two peers editing different list items converge**; text-edit + appended-item converge; table/blockquote-in-list-item still fail loud. Fuzz convergence (2/3/4/many peers) stays green. `clippy` clean.

## Known coarser-grained bits (correct, just not optimal)

- Nested reconcile has no "before" model (only top-level `project_change` has Rc identity), so containers diff the CRDT's current children against the target by **structural** equality — mirrors what `reconcile_text` already does. Cost: reading a container's children on each edit into it (same O(N) as the converged-rebuild path).
- A kind change (paragraph → wrapped in a list) can't reconcile in place, so the node is replaced wholesale. Rare, lossless, coarser for that one step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dfj82yEkQviGePivgrBpUH