### PR TITLE
fix(ci): install mdbook and trunk with --locked

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,11 +33,15 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
+      # `--locked` builds these tools from their own published lockfiles. Without it
+      # cargo re-resolves their transitive deps to latest-semver-compatible, which is
+      # what broke this job: trunk pulled cssparser 0.33 and 0.37 into one graph and
+      # lightningcss failed to compile against the mismatched types.
       - name: Install mdbook
-        run: cargo install mdbook --no-default-features
+        run: cargo install mdbook --locked --no-default-features
 
       - name: Install trunk
-        run: cargo install trunk
+        run: cargo install trunk --locked
 
       - name: Cache cargo registry
         uses: actions/cache@v4


### PR DESCRIPTION
The Documentation job has failed at **Install trunk** since 2026-07-20 ([run 29779803264](https://github.com/joeleaver/rinch/actions/runs/29779803264) on `main`), taking the Pages deploy with it. Every PR opened since inherits the same red check — including #116, which is what surfaced this.

## Cause

`cargo install trunk` re-resolves trunk's transitive deps to latest-semver-compatible instead of using its published lockfile. That pulled **cssparser 0.33.0 and 0.37.0 into one graph**, and `lightningcss` — written against 0.33 — failed with 61 type errors against 0.37's `Parser`/`ParseError`:

```
expected `cssparser::parser::Parser<'_, '_>`, found `cssparser::Parser<'i, 't>`
note: there are multiple different versions of crate `cssparser` in the dependency graph
error: could not compile `lightningcss` (lib) due to 61 previous errors
```

Nothing in this repo changed to cause it — an upstream release drifted into an incompatible combination.

## Fix

`--locked` builds each tool from its own `Cargo.lock`. Verified that trunk's lockfile resolves cssparser to 0.27.2/0.33.0, so lightningcss gets the 0.33.0 it expects and the clash never forms. Applied to `mdbook` too, which is exposed to the same drift.

## Verification

Both installs run clean locally, into a temp `--root` so nothing on the machine was disturbed:

- `cargo install trunk --locked --version 0.21.14` → exit 0, built in 2m35s, **0 errors**
- `cargo install mdbook --locked --no-default-features` → exit 0, installed mdbook 0.5.4

## Worth knowing

While this job was broken it never reached **Build UI Zoo (WASM)** — that step was *skipped*, not run. So the WASM build has had **no CI coverage since 2026-07-20**. This PR restores it, and the first green run here is also the first real CI check of the wasm target in that window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)