### PR TITLE
fix(ci): scope the docs concurrency group per ref

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,9 +12,15 @@ permissions:
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment
+# One concurrent run per ref, not one globally. A single shared "pages" group made
+# every docs run cancel every other one regardless of branch — merging to main would
+# kill an in-flight PR's build, and PRs opened close together cancelled each other,
+# so a green-looking queue was really a queue of cancellations. Keying on the ref
+# still supersedes older runs of the *same* branch (the useful behaviour) while
+# letting main and each PR build independently. Only `deploy` touches Pages, and it
+# runs on main pushes alone, so per-ref groups cannot produce concurrent deploys.
 concurrency:
-  group: "pages"
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
The Documentation workflow used a single **global** concurrency group with `cancel-in-progress`:

```yaml
concurrency:
  group: "pages"          # global — every ref shares it
  cancel-in-progress: true
```

So *any* docs run cancelled *any* other, regardless of branch.

## Observed impact

- Merging #116 to `main` cancelled #118's in-flight build. #118 then showed a **red `build` check** for a PR that was completely fine — the step log reads `Install trunk: cancelled`, not failed.
- The five PRs opened within ~20 minutes on 2026-07-16 (#113–#118) cancelled each other. Four still show `cancelled` docs runs from that batch.

The practical cost is that the docs check stops carrying information: a red or cancelled result says nothing about the PR, which defeats the point of running it on PRs at all.

## Fix

`group: pages-${{ github.ref }}`. This keeps the behaviour you actually want — a new push to a branch supersedes that branch's older run — while letting `main` and each PR build independently.

**This cannot cause concurrent Pages deploys.** The `deploy` job is gated on `if: github.ref == 'refs/heads/main'` (docs.yml:98), so every deploy shares the single `pages-refs/heads/main` group and still serialises. PR runs build but never deploy.

Verified the YAML parses and the group renders as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)