### PR TITLE
fix(ci): lint the wasm target, and stop the test job running out of disk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,29 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # This workspace links wgpu, stylo, vello and parley; a full debug build with
+  # symbols overruns a runner's ~14 GB of free disk, which surfaces as a linker
+  # "Bus error" or `rustc-LLVM ERROR: IO failure ... No space left on device`
+  # rather than as a test failure (it took down the `test` job on #114). Debug
+  # info is the bulk of that and is useless in CI, where nothing runs a debugger.
+  CARGO_PROFILE_DEV_DEBUG: "0"
+  CARGO_PROFILE_TEST_DEBUG: "0"
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      # Reclaim disk before building. The runner image ships several GB of
+      # toolchains this workspace never uses, and the build needs the headroom
+      # (see the debug-info note in `env` above).
+      - name: Free disk space
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
+          df -h /
 
       - name: Install system dependencies
         run: |
@@ -65,6 +82,49 @@ jobs:
 
       - name: Run clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
+
+  # Lint the wasm target too. `clippy --workspace` above only ever sees the native
+  # cfg, so anything behind `cfg(target_arch = "wasm32")` — the whole rinch-web
+  # backend, the render-surface canvas path, the wasm halves of rinch-ws/http —
+  # was never linted. Two real lints and a batch of `unexpected_cfgs` warnings hid
+  # there; a green clippy meant less than it looked.
+  #
+  # Per-crate, not `--workspace`: a workspace-wide wasm build pulls
+  # rinch-editor-collab -> automerge -> uuid -> getrandom, which refuses to build
+  # for wasm32 unless a *consuming app* enables its `js` feature. That layering is
+  # deliberate (see the collaboration notes in CLAUDE.md), so the crates that are
+  # meant to stand alone on wasm are listed explicitly instead.
+  clippy-wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-clippy-wasm-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-clippy-wasm-
+
+      - name: Run clippy (wasm32)
+        run: |
+          for crate in rinch-core rinch-editor-core rinch-editor-view \
+                       rinch-http rinch-ws rinch-web; do
+            echo "::group::clippy $crate (wasm32)"
+            cargo clippy -p "$crate" --target wasm32-unknown-unknown \
+              --all-targets -- -D warnings
+            echo "::endgroup::"
+          done
 
   fmt:
     runs-on: ubuntu-latest

--- a/crates/rinch/src/render_surface.rs
+++ b/crates/rinch/src/render_surface.rs
@@ -685,6 +685,10 @@ pub fn any_surface_dirty() -> bool {
 /// Surfaces created by `create_render_surface()` have auto-generated names
 /// starting with `__render_surface_` and paint inline. Surfaces created by
 /// `create_render_surface_with_name()` have custom names and use the compositor.
+///
+/// Every caller is behind `desktop` or `gpu` (which implies `desktop`), so this is
+/// dead code on a wasm build — gate it the same way rather than warn there.
+#[cfg(feature = "desktop")]
 fn is_inline_surface(surface: &RenderSurfaceHandle) -> bool {
     surface.viewport_name.starts_with("__render_surface_")
 }
@@ -1205,6 +1209,11 @@ fn teardown_web_surface(surface: &RenderSurfaceHandle) {
 /// call this safely and only one loop exists at a time. After an unmount stops
 /// the loop, a remount (via [`schedule_canvas_init`]) restarts it — otherwise a
 /// render-callback surface would stay blank after a hide→show cycle.
+/// A `requestAnimationFrame` callback that has to reference itself in order to
+/// re-schedule, so it can only be built as a cell filled in after construction.
+#[cfg(target_arch = "wasm32")]
+type RafClosure = std::rc::Rc<RefCell<Option<wasm_bindgen::prelude::Closure<dyn FnMut()>>>>;
+
 #[cfg(target_arch = "wasm32")]
 fn start_raf_loop(surface_id: usize, running: std::rc::Rc<Cell<bool>>) {
     use std::rc::Rc;
@@ -1215,7 +1224,7 @@ fn start_raf_loop(surface_id: usize, running: std::rc::Rc<Cell<bool>>) {
     }
     running.set(true);
 
-    let closure: Rc<RefCell<Option<Closure<dyn FnMut()>>>> = Rc::new(RefCell::new(None));
+    let closure: RafClosure = Rc::new(RefCell::new(None));
     let closure_clone = closure.clone();
 
     *closure.borrow_mut() = Some(Closure::wrap(Box::new(move || {


### PR DESCRIPTION
Two gaps that made green checks mean less than they looked, both surfaced while reviewing the #113–#118 batch.

## The `test` job was running out of disk, not failing

#114's red `test` check was never a test failure:

```
rustc-LLVM ERROR: IO failure on output stream: No space left on device
collect2: fatal error: ld terminated with signal 7 [Bus error], core dumped
```

This workspace links wgpu, stylo, vello and parley; a full debug build with symbols overruns a runner's ~14 GB of free disk (locally `target/` is **58 GB**). Debug info is the bulk of that and is useless in CI, where nothing attaches a debugger — so the profile overrides drop it, and a cleanup step reclaims the unused toolchains in the runner image.

This is the "known-flaky test job". It was not flaky; it was out of space.

## The wasm target was never linted

`cargo clippy --workspace` only ever sees the native cfg. Everything behind `cfg(target_arch = "wasm32")` — the whole `rinch-web` backend, the render-surface canvas path, the wasm halves of `rinch-ws`/`rinch-http` — has never been linted. That is how #116's `unexpected_cfgs` warnings hid, and it was **still** hiding two real lints in `render_surface.rs`, both fixed here:

- `is_inline_surface` is dead code on wasm — all four callers are behind `desktop`/`gpu` (and `gpu` implies `desktop`), so it now carries the matching cfg.
- The self-referencing `requestAnimationFrame` closure tripped `type_complexity`; it is now a named `RafClosure` alias.

**Why per-crate and not `--workspace`:** a workspace-wide wasm build pulls `rinch-editor-collab → automerge → uuid → getrandom`, which refuses to build for wasm32 unless a *consuming app* enables its `js` feature. That layering is deliberate (see the collaboration notes in CLAUDE.md), so the crates meant to stand alone on wasm are listed explicitly.

## Not fixed here: `--features serde`

CI still does not run it, because that suite **fails on main today** (#123) — adding the step would just make main red. I diagnosed the exact mechanism and [wrote it up on the issue](https://github.com/joeleaver/rinch/issues/123): `node_from_doc_node` fills schema defaults via `compute_attrs` while normal construction does not, so a wire round-trip changes a node's attr map. Choosing between the three available fixes changes what node equality means, so it wants a deliberate call rather than being folded into a CI change. Once decided, adding the job is one line.

## Verification

- wasm clippy clean for all six listed crates (it was **not** before this PR)
- native clippy and fmt unaffected
- the profile overrides build the workspace clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)