### PR TITLE
fix(editor-core): stop materializing attribute defaults into the document

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,15 @@ jobs:
       - name: Run tests
         run: cargo test --workspace
 
+      # The `serde` feature gates the durable DocNode wire format, and
+      # `cargo test --workspace` never enables it — so that surface went unrun
+      # until #123, where a lossless-round-trip test had been failing on main
+      # unnoticed. Same for `collaboration`, which gates the CRDT adapter wiring.
+      - name: Run feature-gated tests
+        run: |
+          cargo test -p rinch-editor-core --features serde
+          cargo test -p rinch-editor-view --features collaboration
+
   clippy:
     runs-on: ubuntu-latest
     steps:

--- a/crates/rinch-editor-core/src/model/types.rs
+++ b/crates/rinch-editor-core/src/model/types.rs
@@ -20,20 +20,36 @@ use std::collections::BTreeMap;
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
 
-/// Compute the full, typed attribute set for a node/mark of the given spec from a
-/// (possibly partial) set of `provided` attributes — the port of ProseMirror's
-/// `computeAttrs`. For each attribute the type *declares*:
+/// Validate and normalize the attribute set for a node/mark of the given spec from
+/// a (possibly partial) set of `provided` attributes. For each attribute the type
+/// *declares*:
 ///
 /// - if `provided` carries it, keep that value;
-/// - else if the spec has a default, fill the default;
+/// - else if the spec has a default, **leave it absent**;
 /// - else (a required attribute with no default) return
 ///   [`EditorError::SchemaValidation`].
 ///
 /// Attributes present in `provided` but **not declared** by the spec are dropped
 /// (PM behavior) — a node never carries undeclared attrs, which keeps the model,
-/// equality, and serialization clean. The result is total (every declared attr is
-/// present) and deterministic (keys are ordered by [`Attrs`]'s `BTreeMap`), and
-/// the function is idempotent: `compute(compute(x)) == compute(x)`.
+/// equality, and serialization clean. The result is deterministic (keys ordered by
+/// [`Attrs`]'s `BTreeMap`) and idempotent: `compute(compute(x)) == compute(x)`.
+///
+/// # Absent means unspecified
+///
+/// An optional attribute that was never set stays **absent** rather than being
+/// materialized to its default. The default belongs to the presentation layer, not
+/// to the stored document: the view resolves a missing `text_align` to left-aligned
+/// and the HTML serializer omits it, exactly as CSS supplies an initial value
+/// without writing it onto the element. Recording it in the data would assert an
+/// intent the user never expressed, and would freeze today's default into documents
+/// that outlive it.
+///
+/// This is also what makes the wire round-trip faithful. Filling here meant a
+/// freshly built paragraph (`{}`) came back as `{indent: 0}` — equal in meaning,
+/// unequal as a value, and identical under `Debug`, which made the mismatch
+/// baffling to read. Adding nothing and removing nothing, `to_doc` → `node_from_doc`
+/// is now lossless for both an unset attribute and one explicitly set to its
+/// default value.
 fn compute_attrs(
     specs: &BTreeMap<String, AttrSpec>,
     provided: &Attrs,
@@ -47,8 +63,10 @@ fn compute_attrs(
     for (name, spec) in specs {
         if let Some(v) = provided.get(name) {
             pairs.push((name.as_str().into(), v.clone()));
-        } else if let Some(default) = &spec.default {
-            pairs.push((name.as_str().into(), default.clone()));
+        } else if spec.default.is_some() {
+            // Optional and unset: leave it absent. Readers resolve the default at
+            // the point of use, so storing it here would only add a second
+            // representation of the same document.
         } else {
             return Err(EditorError::SchemaValidation(format!(
                 "missing required attribute '{name}' on {kind} '{type_name}'"
@@ -235,21 +253,27 @@ mod tests {
     use crate::Schema;
     use crate::model::{AttrValue, Attrs};
 
+    /// An optional attribute that was never set stays **absent** — the default is
+    /// resolved by whoever reads it (the view, the serializers), not baked into the
+    /// stored document. Keeping one representation is what makes the DocNode wire
+    /// round-trip faithful.
     #[test]
-    fn compute_attrs_fills_defaults() {
+    fn compute_attrs_leaves_unset_optionals_absent() {
         let s = Schema::starter_kit();
-        // heading.level defaults to Int(1)
+        // heading.level, task_item.checked and ordered_list.start all declare
+        // defaults; none of them materialize when unset.
         let heading = s.node_type("heading").unwrap();
         let computed = heading.compute_attrs(&Attrs::new()).unwrap();
-        assert_eq!(computed.get_int("level"), Some(1));
-        // task_item.checked defaults to Bool(false), ordered_list.start to Int(1)
+        assert_eq!(computed.get_int("level"), None);
+        assert!(computed.is_empty(), "no optional default is materialized");
+
         assert_eq!(
             s.node_type("task_item")
                 .unwrap()
                 .compute_attrs(&Attrs::new())
                 .unwrap()
                 .get_bool("checked"),
-            Some(false)
+            None
         );
         assert_eq!(
             s.node_type("ordered_list")
@@ -257,8 +281,23 @@ mod tests {
                 .compute_attrs(&Attrs::new())
                 .unwrap()
                 .get_int("start"),
-            Some(1)
+            None
         );
+    }
+
+    /// A value equal to the default is still a value: if a caller sets it, it is
+    /// kept, so "explicitly default" and "unspecified" both survive a round-trip as
+    /// themselves rather than collapsing together.
+    #[test]
+    fn compute_attrs_keeps_an_explicitly_default_value() {
+        let s = Schema::starter_kit();
+        let provided = Attrs::from_iter([("level", AttrValue::Int(1))]); // == the default
+        let computed = s
+            .node_type("heading")
+            .unwrap()
+            .compute_attrs(&provided)
+            .unwrap();
+        assert_eq!(computed.get_int("level"), Some(1));
     }
 
     #[test]

--- a/crates/rinch-editor-core/src/serialize/doc_json.rs
+++ b/crates/rinch-editor-core/src/serialize/doc_json.rs
@@ -5,9 +5,10 @@
 //! marks — #59). The shape is **recursive** (nesting works), **typed**
 //! (attributes carry their `AttrValue` kind, not stringly values), and **total**:
 //!
-//! - **Serialize** ([`Node::to_doc`]) walks the schema, applies attribute
-//!   defaults, and would fail (not silently emit garbage) on a node missing a
-//!   required attribute.
+//! - **Serialize** ([`Node::to_doc`]) walks the schema and would fail (not
+//!   silently emit garbage) on a node missing a required attribute. It adds
+//!   nothing: an optional attribute the node does not carry stays off the wire,
+//!   because its default belongs to the presentation layer, not the document.
 //! - **Deserialize** ([`Schema::node_from_doc`]) consults the schema: an unknown
 //!   node or mark type is a hard [`EditorError::SchemaValidation`], never a silent
 //!   drop, and a missing required attribute is an error. The boundary either
@@ -113,14 +114,15 @@ impl<'de> Deserialize<'de> for JsonAttr {
 }
 
 /// The durable wire shape for a document node. Recursive, so nesting (lists,
-/// blockquotes, tables) is expressible; total, so every node carries its schema
-/// type name and (defaults-applied) typed attributes.
+/// blockquotes, tables) is expressible, and every node carries its schema type
+/// name and typed attributes.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct DocNode {
     /// The schema node-type name (`paragraph`, `heading`, `text`, …). Always present.
     #[serde(rename = "type")]
     pub node_type: String,
-    /// Typed attributes, defaults applied. Omitted from JSON when empty.
+    /// Typed attributes, exactly those the node carries — an unset optional is
+    /// absent rather than written at its default. Omitted from JSON when empty.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub attrs: BTreeMap<String, JsonAttr>,
     /// Child nodes (recursive). Omitted from JSON when empty.
@@ -140,7 +142,7 @@ pub struct DocMark {
     /// The schema mark-type name (`bold`, `link`, …).
     #[serde(rename = "type")]
     pub mark_type: String,
-    /// Typed mark attributes, defaults applied. Omitted from JSON when empty.
+    /// Typed mark attributes, exactly those the mark carries. Omitted when empty.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub attrs: BTreeMap<String, JsonAttr>,
 }
@@ -148,7 +150,8 @@ pub struct DocMark {
 impl Node {
     /// Serialize this node (and its subtree) to the durable [`DocNode`] wire shape.
     ///
-    /// Attribute defaults are applied so the wire is total. Returns
+    /// Faithful in both directions: nothing is added and nothing is dropped, so
+    /// `to_doc` → [`Schema::node_from_doc`] returns an equal node. Returns
     /// [`EditorError::SchemaValidation`] if any node is missing a required
     /// attribute (such a node was never a valid document and must not be silently
     /// persisted).
@@ -496,10 +499,13 @@ mod tests {
         assert!(s.node_from_doc(&wire).is_err());
     }
 
+    /// Deserializing adds nothing. An optional attribute absent from the wire stays
+    /// absent on the node; its default is resolved by whoever reads it, so the
+    /// document carries one representation rather than two.
     #[test]
-    fn deserialize_fills_optional_defaults() {
+    fn deserialize_leaves_unset_optionals_absent() {
         let s = Schema::starter_kit();
-        // heading with no `level` on the wire → default Int(1) on the node
+        // heading with no `level` on the wire → still no `level` on the node
         let wire = DocNode {
             node_type: "heading".to_string(),
             attrs: BTreeMap::new(),
@@ -508,7 +514,41 @@ mod tests {
             marks: vec![],
         };
         let node = s.node_from_doc(&wire).unwrap();
-        assert_eq!(node.attrs().get_int("level"), Some(1));
+        assert_eq!(node.attrs().get_int("level"), None);
+        // Readers supply the default at the point of use, which is how the level
+        // still renders as 1.
+        assert_eq!(node.attrs().get_int("level").unwrap_or(1), 1);
+    }
+
+    /// The wire round-trip adds and removes nothing, for either representation.
+    ///
+    /// Filling defaults on the way through used to make these differ: a node built
+    /// with no attrs came back carrying its defaults — equal in meaning, unequal as
+    /// a value, and identical under `Debug`.
+    #[test]
+    fn round_trip_is_faithful_for_unset_and_explicit_defaults() {
+        let s = Schema::starter_kit();
+        let para = s.node_type("paragraph").unwrap().clone();
+
+        // (a) nothing set.
+        let bare = Node::new_branch(para.clone(), Attrs::new(), Fragment::empty());
+        let back = s.node_from_doc(&bare.to_doc().unwrap()).unwrap();
+        assert_eq!(back, bare, "an attrless node must round-trip unchanged");
+        assert!(back.attrs().is_empty());
+
+        // (b) an attribute explicitly set to its own default value is a real value
+        //     and must survive as one, not collapse into (a).
+        let explicit = Node::new_branch(
+            para,
+            Attrs::from_iter([("indent", AttrValue::Int(0))]),
+            Fragment::empty(),
+        );
+        let back = s.node_from_doc(&explicit.to_doc().unwrap()).unwrap();
+        assert_eq!(
+            back, explicit,
+            "an explicit default must round-trip unchanged"
+        );
+        assert_eq!(back.attrs().get_int("indent"), Some(0));
     }
 
     #[test]

--- a/crates/rinch-editor-core/src/serialize/html.rs
+++ b/crates/rinch-editor-core/src/serialize/html.rs
@@ -1534,9 +1534,10 @@ mod tests {
             align_of(r#"<p style="color:red; text-align:right">x</p>"#).as_deref(),
             Some("right")
         );
-        // Everything else reads back as the schema's `left` default — the parser
-        // attaches no `text_align`, so `make_node` fills the default in. That is the
-        // safe fallback: a value outside the whitelist is dropped, never trusted.
+        // Everything else leaves `text_align` **absent**. A value outside the
+        // whitelist is dropped rather than trusted, and an unset optional attribute
+        // is not materialized to its default — the view and the serializer resolve a
+        // missing alignment to left-aligned at the point of use.
         for html in [
             r#"<p style="text-align:left">x</p>"#, // the default, stated explicitly
             r#"<p style="text-align:end">x</p>"#,  // valid CSS, outside the whitelist
@@ -1544,9 +1545,9 @@ mod tests {
             r#"<p>x</p>"#, // no style at all
         ] {
             assert_eq!(
-                align_of(html).as_deref(),
-                Some("left"),
-                "unrecognized alignment must fall back to the default: {html}"
+                align_of(html),
+                None,
+                "an unrecognized alignment must be dropped, not stored: {html}"
             );
         }
         // A rejected alignment must also not leak into the re-serialized markup.


### PR DESCRIPTION
Fixes #123.

An optional attribute that was never set now stays **absent** instead of being written at its default. The default belongs to the presentation layer, not to the stored document.

## Why this way

Everything that *consumes* these attributes already worked this way:

- the view resolves a missing `text_align` to left-aligned
- the HTML serializer omits `text-align` when it is absent or `left`
- every attribute read in the codebase is `unwrap_or` / `filter` / `match` — there are no bare `.unwrap()`s on attrs in production code

Only `compute_attrs` disagreed, filling defaults at every boundary. That is what created a second representation of the same document.

Storing the default also asserts an intent the user never expressed, and freezes today's default into documents that outlive it — a doc written now would claim `text_align: "left"` even if the app later defaults to right for RTL. It is the same reason CSS supplies an initial value without writing it onto the element.

## What #123 actually was

The DocNode round-trip was not lossless: a paragraph built by the editor carried `{}` and came back carrying `{indent: 0}` — equal in meaning, unequal as a value, and **identical under `Debug`**, which is why the assertion output read as nonsense:

```
assertion `left == right` failed: DocNode round-trip is lossless
  left:  doc([paragraph([text("x", marks=["bold"])])])
  right: doc([paragraph([text("x", marks=["bold"])])])
```

Adding nothing and removing nothing on the way through, `to_doc` → `node_from_doc` is now faithful for **both** an unset attribute and one explicitly set to its default value. Both cases matter: `setParagraph` explicitly writes `indent = 0` and `text_align = "left"`, so nodes carrying an explicit default really do occur in a running editor.

## Smaller than expected

This needed **no change to `Node::new_branch`**. My earlier analysis on the issue assumed the fix had to be enforced centrally at construction — but the asymmetry was created by *filling*, not by construction. Removing the fill was sufficient, and the 31 direct `new_branch` call sites keep working unchanged.

## Tests

Three tests encoded the old behavior and were rewritten to the new contract:

- `compute_attrs_leaves_unset_optionals_absent` (was `compute_attrs_fills_defaults`)
- `deserialize_leaves_unset_optionals_absent` (was `deserialize_fills_optional_defaults`)
- the text-align parse test from #113, which asserted the materialized `Some("left")`

Plus a new `round_trip_is_faithful_for_unset_and_explicit_defaults` covering both representations explicitly. The wire-format module docs said "defaults applied" throughout and are now accurate.

## CI

Now runs the feature-gated suites (`serde`, `collaboration`). The serde surface had **never** run in CI, which is how a failing round-trip test sat on `main` unnoticed. That was the last of the coverage gaps from this review batch — disk exhaustion and wasm linting landed in #124, browser-backed IndexedDB tests in #115.

## Verification

- workspace: **900 passed, 0 failed**
- `--features serde`: 338 passed
- `--features collaboration`: 65 passed
- fmt clean; clippy clean on native and on all seven wasm crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
