### PR TITLE
feat(rinch-dom): render native <select> as a closed control (#121, part 1/2)

### DIFF
--- a/crates/rinch-dom/src/dom_impl/mod.rs
+++ b/crates/rinch-dom/src/dom_impl/mod.rs
@@ -172,6 +172,22 @@ impl RinchDocument {
                 display: inline-block;
             }
 
+            /* A closed <select> shows the selected option's label (painted by the
+               backend) plus a dropdown arrow — its <option>/<optgroup> children are
+               not laid out. Reserve room on the right for the arrow, and a
+               min-width so an unstyled control doesn't collapse to its padding.
+               The interactive popup is drawn by the app/shell layer (issue #121). */
+            option, optgroup {
+                display: none;
+            }
+
+            select {
+                padding: 4px 24px 4px 8px;
+                min-width: 60px;
+                white-space: nowrap;
+                overflow: hidden;
+            }
+
             /* Default list indentation (matches browser default) */
             ul, ol {
                 padding-left: 40px;

--- a/crates/rinch-dom/src/lib.rs
+++ b/crates/rinch-dom/src/lib.rs
@@ -15,6 +15,7 @@ pub mod layout;
 mod layout_engine;
 pub mod node;
 pub mod paint;
+pub mod select;
 mod style_resolution;
 pub mod stylesheet;
 pub mod stylo_impl;

--- a/crates/rinch-dom/src/paint/mod.rs
+++ b/crates/rinch-dom/src/paint/mod.rs
@@ -7,6 +7,7 @@ mod borders;
 mod contenteditable;
 pub mod image;
 pub mod painter;
+mod select;
 mod svg;
 mod text;
 pub mod vello_painter;
@@ -1005,6 +1006,22 @@ fn paint_node(
                 if matches!(node.tag(), Some("input" | "textarea")) {
                     paint_input_value(
                         node,
+                        painter,
+                        scale,
+                        x,
+                        y,
+                        w,
+                        h,
+                        font_cx,
+                        layout_cx,
+                        node_transform,
+                    );
+                } else if node.tag() == Some("select") {
+                    // The closed control's label + arrow. Options are display:none
+                    // (they don't lay out); the selected label is painted here.
+                    select::paint_select_value(
+                        tree,
+                        node_id,
                         painter,
                         scale,
                         x,

--- a/crates/rinch-dom/src/paint/select.rs
+++ b/crates/rinch-dom/src/paint/select.rs
@@ -1,0 +1,147 @@
+//! Closed `<select>` control rendering: the selected option's label plus a
+//! dropdown arrow. The interactive popup lives in the app/shell layer (issue
+//! #121); this only draws the resting, closed control so a `<select>` looks like
+//! a real form control instead of a run of stacked option text.
+
+use peniko::color::{AlphaColor, Srgb};
+use peniko::kurbo::{Affine, BezPath, Point};
+use peniko::{Brush, Fill};
+
+use super::painter::Painter;
+use super::text::render_text_with_shadow;
+use crate::node::{NodeTree, RawNodeId};
+use crate::select::resolve_select_model;
+
+/// Width reserved on the right of the control for the dropdown arrow. Matches the
+/// `24px` right padding the UA stylesheet gives `<select>`.
+const ARROW_BOX: f64 = 24.0;
+
+/// Paint the closed `<select>`: the selected option's label, clipped to the
+/// content box, plus a chevron arrow on the right.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn paint_select_value(
+    tree: &NodeTree,
+    node_id: RawNodeId,
+    painter: &mut dyn Painter,
+    scale: f64,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+    font_cx: &mut parley::FontContext,
+    layout_cx: &mut parley::LayoutContext<Brush>,
+    transform: Affine,
+) {
+    let Some(node) = tree.get(node_id) else {
+        return;
+    };
+
+    let model = resolve_select_model(tree, node_id);
+
+    let padding_left = node.computed_style.padding_left.to_px() as f64 * scale;
+    let padding_right = node.computed_style.padding_right.to_px() as f64 * scale;
+
+    let base_color = node
+        .computed_style
+        .color
+        .unwrap_or_else(|| AlphaColor::<Srgb>::from_rgba8(33, 37, 41, 255)); // #212529
+
+    // Draw the arrow first so it always shows, even for an empty <select>.
+    paint_arrow(
+        painter,
+        scale,
+        x,
+        y,
+        w,
+        h,
+        padding_right,
+        base_color,
+        transform,
+    );
+
+    // A single <select> with options always has a selected label; an empty
+    // <select> has nothing to show.
+    let Some(label) = model.selected_label().filter(|s| !s.is_empty()) else {
+        return;
+    };
+
+    let font_size = node.computed_style.font_size;
+    let font_weight = node.computed_style.font_weight;
+    let font_family = if node.computed_style.font_family.is_empty() {
+        "sans-serif".to_string()
+    } else {
+        node.computed_style.font_family.clone()
+    };
+
+    let scaled_font_size = font_size * scale as f32;
+    let mut builder = layout_cx.ranged_builder(font_cx, label, 1.0, true);
+    builder.push_default(parley::style::StyleProperty::FontSize(scaled_font_size));
+    builder.push_default(parley::style::StyleProperty::Brush(Brush::Solid(
+        base_color,
+    )));
+    builder.push_default(parley::style::StyleProperty::FontStack(
+        parley::style::FontStack::Source(std::borrow::Cow::Owned(font_family)),
+    ));
+    if (font_weight - 400.0).abs() > 1.0 {
+        builder.push_default(parley::style::StyleProperty::FontWeight(
+            parley::style::FontWeight::new(font_weight),
+        ));
+    }
+
+    let mut text_layout = builder.build(label);
+    // Single line, clipped: never wrap the closed control's label.
+    text_layout.break_all_lines(None);
+
+    let text_height = text_layout.height() as f64;
+    let text_x = x + padding_left;
+    let text_y = y + (h - text_height) / 2.0;
+
+    // Clip the label to the content box (control width minus the arrow area) so a
+    // long option ellipsis-style clips instead of running under the arrow.
+    let arrow_w = padding_right.max(ARROW_BOX * scale);
+    let content_right = (x + w - arrow_w).max(text_x);
+    let clip_rect = peniko::kurbo::Rect::new(text_x, y, content_right, y + h);
+    painter.push_clip(Fill::NonZero, transform, &clip_rect.into());
+
+    let text_shadows = node.computed_style.text_shadow.as_slice();
+    render_text_with_shadow(
+        painter,
+        &text_layout,
+        text_x,
+        text_y,
+        text_shadows,
+        transform,
+        1.0,
+    );
+
+    painter.pop_layer();
+}
+
+/// Draw the downward chevron in the arrow box on the right of the control.
+#[allow(clippy::too_many_arguments)]
+fn paint_arrow(
+    painter: &mut dyn Painter,
+    scale: f64,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+    padding_right: f64,
+    color: AlphaColor<Srgb>,
+    transform: Affine,
+) {
+    let arrow_w = padding_right.max(ARROW_BOX * scale);
+    // Center the chevron within the arrow box on the right edge.
+    let cx = x + w - arrow_w / 2.0;
+    let cy = y + h / 2.0;
+    let half = 4.0 * scale; // half-width of the chevron
+    let drop = 3.0 * scale; // vertical extent
+
+    let mut path = BezPath::new();
+    path.move_to(Point::new(cx - half, cy - drop / 2.0));
+    path.line_to(Point::new(cx + half, cy - drop / 2.0));
+    path.line_to(Point::new(cx, cy + drop / 2.0 + drop / 2.0));
+    path.close_path();
+
+    painter.fill(Fill::NonZero, transform, &Brush::Solid(color), &path.into());
+}

--- a/crates/rinch-dom/src/select.rs
+++ b/crates/rinch-dom/src/select.rs
@@ -1,0 +1,160 @@
+//! Shared model for the native `<select>` form control.
+//!
+//! `<select>` on the desktop backend is rendered by rinch-dom (the closed
+//! control — the selected option's label plus a dropdown arrow) while the
+//! interactive popup, focus and keyboard handling live in the app/shell layer
+//! (issue #121), mirroring how native `<input>` is split. Both layers need the
+//! same answer to "what are the options and which one is selected", so that
+//! resolution lives here, once.
+//!
+//! Selection follows HTML semantics, resolved in this order:
+//! 1. the option whose value equals the select's own `value` attribute, if the
+//!    select has one (this is what the app writes back when the user picks an
+//!    option, and what the `value:` rsx prop sets);
+//! 2. otherwise the last option carrying a `selected` attribute;
+//! 3. otherwise the first non-disabled option — a single `<select>` always has a
+//!    selected option in a browser, defaulting to the first.
+//!
+//! `<optgroup>`s are flattened: their `<option>` children are collected in
+//! document order as if the group weren't there. (Rendering the group *labels*
+//! in the popup is an app-layer concern; the model only needs the options.)
+
+use crate::node::{NodeKind, NodeTree, RawNodeId};
+
+/// One resolved `<option>` of a `<select>`.
+#[derive(Debug, Clone)]
+pub struct SelectOption {
+    /// DOM node id of the `<option>` element.
+    pub node_id: RawNodeId,
+    /// Submit value: the `value` attribute, or the label if there is no `value`
+    /// attribute (HTML falls back to the text content).
+    pub value: String,
+    /// Display label: the `label` attribute if present, else the trimmed text
+    /// content.
+    pub label: String,
+    /// Whether the option carries a `selected` attribute.
+    pub selected_attr: bool,
+    /// Whether the option is `disabled`.
+    pub disabled: bool,
+}
+
+/// The resolved options of a `<select>` plus which one is currently selected.
+#[derive(Debug, Clone, Default)]
+pub struct SelectModel {
+    pub options: Vec<SelectOption>,
+    /// Index into `options` of the selected option, or `None` when the select
+    /// has no (enabled) options at all.
+    pub selected_index: Option<usize>,
+}
+
+impl SelectModel {
+    /// The currently selected option, if any.
+    pub fn selected(&self) -> Option<&SelectOption> {
+        self.selected_index.and_then(|i| self.options.get(i))
+    }
+
+    /// The label to show in the closed control, if an option is selected.
+    pub fn selected_label(&self) -> Option<&str> {
+        self.selected().map(|o| o.label.as_str())
+    }
+}
+
+/// Resolve a `<select>`'s options and current selection from the DOM.
+///
+/// Returns an empty model (no options, `selected_index == None`) if `select_id`
+/// is not a `<select>` element.
+pub fn resolve_select_model(tree: &NodeTree, select_id: RawNodeId) -> SelectModel {
+    let mut options = Vec::new();
+    let Some(select) = tree.get(select_id) else {
+        return SelectModel::default();
+    };
+    if select.tag() != Some("select") {
+        return SelectModel::default();
+    }
+
+    collect_options(tree, select_id, &mut options);
+
+    // The select's own `value` attribute is authoritative when present.
+    let select_value = select.attributes.get("value").map(|s| s.as_str());
+
+    let selected_index = resolve_selected_index(&options, select_value);
+
+    SelectModel {
+        options,
+        selected_index,
+    }
+}
+
+/// Walk `<option>` children in document order, descending into `<optgroup>`.
+fn collect_options(tree: &NodeTree, parent_id: RawNodeId, out: &mut Vec<SelectOption>) {
+    let Some(parent) = tree.get(parent_id) else {
+        return;
+    };
+    for &child_id in &parent.children {
+        let Some(child) = tree.get(child_id) else {
+            continue;
+        };
+        match child.tag() {
+            Some("option") => {
+                let label_text = element_text(tree, child_id);
+                let label = child
+                    .attributes
+                    .get("label")
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or_else(|| label_text.trim().to_string());
+                // HTML: an option's value defaults to its text content when the
+                // `value` attribute is absent.
+                let value = child
+                    .attributes
+                    .get("value")
+                    .cloned()
+                    .unwrap_or_else(|| label_text.trim().to_string());
+                out.push(SelectOption {
+                    node_id: child_id,
+                    value,
+                    label,
+                    selected_attr: child.attributes.contains_key("selected"),
+                    disabled: child.attributes.contains_key("disabled"),
+                });
+            }
+            Some("optgroup") => collect_options(tree, child_id, out),
+            _ => {}
+        }
+    }
+}
+
+/// Concatenate the text of a subtree (an option's visible label).
+fn element_text(tree: &NodeTree, id: RawNodeId) -> String {
+    let mut buf = String::new();
+    fn walk(tree: &NodeTree, id: RawNodeId, buf: &mut String) {
+        let Some(node) = tree.get(id) else { return };
+        if let NodeKind::Text(t) = &node.kind {
+            buf.push_str(&t.content);
+        }
+        for &child in &node.children {
+            walk(tree, child, buf);
+        }
+    }
+    walk(tree, id, &mut buf);
+    buf
+}
+
+fn resolve_selected_index(options: &[SelectOption], select_value: Option<&str>) -> Option<usize> {
+    if options.is_empty() {
+        return None;
+    }
+    // 1. Match the select's `value` attribute.
+    if let Some(val) = select_value
+        && let Some(i) = options.iter().position(|o| o.value == val)
+    {
+        return Some(i);
+    }
+    // 2. Last option with a `selected` attribute (a single select keeps the last
+    //    one when markup mistakenly marks several).
+    if let Some(i) = options.iter().rposition(|o| o.selected_attr) {
+        return Some(i);
+    }
+    // 3. First non-disabled option, else the first option.
+    options.iter().position(|o| !o.disabled).or(Some(0))
+}

--- a/crates/rinch-dom/src/style_resolution/mod.rs
+++ b/crates/rinch-dom/src/style_resolution/mod.rs
@@ -471,6 +471,40 @@ impl RinchDocument {
                     crate::computed_style::DimensionValue::Length(intrinsic.max(author_min));
             }
 
+            // A closed `<select>` shows one option's label, so browsers size it to
+            // fit the *widest* option — the width stays stable when the selection
+            // changes. Its `<option>` children are `display:none` and give it no
+            // content, so without this the control collapses to its padding and
+            // clips the label. Only applied when the author left `width: auto`; an
+            // explicit width is respected and the label clips (the painter clips
+            // too). The text width is estimated from the label length rather than
+            // measured with Parley (not available at style-resolution time) —
+            // erring wide is harmless since the painter clips to the content box.
+            if node.tag() == Some("select") && new_style.width.is_auto() {
+                let model = crate::select::resolve_select_model(&self.tree, node_id);
+                let widest = model
+                    .options
+                    .iter()
+                    .map(|o| o.label.chars().count())
+                    .max()
+                    .unwrap_or(0);
+                if widest > 0 {
+                    let text_w = widest as f32 * new_style.font_size * 0.62;
+                    // border-box, and padding_right already reserves the arrow box.
+                    let intrinsic = text_w
+                        + new_style.padding_left.to_px()
+                        + new_style.padding_right.to_px()
+                        + new_style.border_left_width.to_px()
+                        + new_style.border_right_width.to_px();
+                    let author_min = match new_style.min_width {
+                        crate::computed_style::DimensionValue::Length(px) => px,
+                        _ => 0.0,
+                    };
+                    new_style.min_width =
+                        crate::computed_style::DimensionValue::Length(intrinsic.max(author_min));
+                }
+            }
+
             // Check inline style for user-select override (Stylo servo build
             // doesn't handle this property).
             if let Some(style_str) = node.attributes.get("style") {

--- a/crates/rinch-dom/tests/select_tests.rs
+++ b/crates/rinch-dom/tests/select_tests.rs
@@ -1,0 +1,262 @@
+//! Native `<select>` closed-control model + layout (issue #121, PR1).
+
+use rinch_core::dom::DomDocument;
+use rinch_dom::RinchDocument;
+use rinch_dom::select::resolve_select_model;
+
+/// One option spec: `(value_attr, label, extra_attrs)`.
+type OptSpec<'a> = (Option<&'a str>, &'a str, &'a [(&'a str, &'a str)]);
+
+/// Build a `<select>` with the given options and an optional `value` attribute on
+/// the select itself. Returns (doc, select_id).
+fn build_select(select_value: Option<&str>, options: &[OptSpec]) -> (RinchDocument, usize) {
+    let mut doc = RinchDocument::new();
+    let body = doc.body();
+    let sel = doc.create_element("select");
+    if let Some(v) = select_value {
+        doc.set_attribute(sel, "value", v);
+    }
+    doc.append_child(body, sel);
+    for (value, label, extra) in options {
+        let o = doc.create_element("option");
+        if let Some(v) = value {
+            doc.set_attribute(o, "value", v);
+        }
+        for (k, val) in *extra {
+            doc.set_attribute(o, k, val);
+        }
+        doc.append_child(sel, o);
+        let t = doc.create_text(label);
+        doc.append_child(o, t);
+    }
+    (doc, sel.0)
+}
+
+#[test]
+fn model_collects_options_with_value_and_label() {
+    let (doc, sel) = build_select(
+        None,
+        &[
+            (Some("a"), "Apple", &[]),
+            (Some("b"), "Banana", &[]),
+            (None, "Cherry", &[]), // no value attr → value falls back to label
+        ],
+    );
+    let m = resolve_select_model(&doc.tree, sel);
+    assert_eq!(m.options.len(), 3);
+    assert_eq!(m.options[0].value, "a");
+    assert_eq!(m.options[0].label, "Apple");
+    assert_eq!(
+        m.options[2].value, "Cherry",
+        "value defaults to text content"
+    );
+    assert_eq!(m.options[2].label, "Cherry");
+}
+
+#[test]
+fn first_option_is_selected_by_default() {
+    let (doc, sel) = build_select(
+        None,
+        &[(Some("a"), "Apple", &[]), (Some("b"), "Banana", &[])],
+    );
+    let m = resolve_select_model(&doc.tree, sel);
+    assert_eq!(m.selected_index, Some(0));
+    assert_eq!(m.selected_label(), Some("Apple"));
+}
+
+#[test]
+fn selected_attribute_wins_over_default() {
+    let (doc, sel) = build_select(
+        None,
+        &[
+            (Some("a"), "Apple", &[]),
+            (Some("b"), "Banana", &[("selected", "")]),
+            (Some("c"), "Cherry", &[]),
+        ],
+    );
+    let m = resolve_select_model(&doc.tree, sel);
+    assert_eq!(m.selected_index, Some(1));
+    assert_eq!(m.selected_label(), Some("Banana"));
+}
+
+#[test]
+fn select_value_attribute_wins_over_selected_attribute() {
+    // The app writes the chosen value to the select's `value` attribute; it must
+    // take precedence over any stale `selected` attribute in the markup.
+    let (doc, sel) = build_select(
+        Some("c"),
+        &[
+            (Some("a"), "Apple", &[]),
+            (Some("b"), "Banana", &[("selected", "")]),
+            (Some("c"), "Cherry", &[]),
+        ],
+    );
+    let m = resolve_select_model(&doc.tree, sel);
+    assert_eq!(m.selected_index, Some(2));
+    assert_eq!(m.selected_label(), Some("Cherry"));
+}
+
+#[test]
+fn last_selected_attribute_wins_when_several() {
+    let (doc, sel) = build_select(
+        None,
+        &[
+            (Some("a"), "Apple", &[("selected", "")]),
+            (Some("b"), "Banana", &[("selected", "")]),
+        ],
+    );
+    let m = resolve_select_model(&doc.tree, sel);
+    assert_eq!(m.selected_index, Some(1));
+}
+
+#[test]
+fn label_attribute_overrides_text_content() {
+    let (doc, sel) = build_select(
+        None,
+        &[(Some("a"), "Apple text", &[("label", "Apple label")])],
+    );
+    let m = resolve_select_model(&doc.tree, sel);
+    assert_eq!(m.options[0].label, "Apple label");
+    // value still comes from the value attr (or text) — not the label attr.
+    assert_eq!(m.options[0].value, "a");
+}
+
+#[test]
+fn optgroup_options_are_flattened() {
+    let mut doc = RinchDocument::new();
+    let body = doc.body();
+    let sel = doc.create_element("select");
+    doc.append_child(body, sel);
+
+    let group = doc.create_element("optgroup");
+    doc.set_attribute(group, "label", "Fruit");
+    doc.append_child(sel, group);
+    for (v, l) in [("a", "Apple"), ("b", "Banana")] {
+        let o = doc.create_element("option");
+        doc.set_attribute(o, "value", v);
+        doc.append_child(group, o);
+        let t = doc.create_text(l);
+        doc.append_child(o, t);
+    }
+    // a loose option after the group
+    let o = doc.create_element("option");
+    doc.set_attribute(o, "value", "c");
+    doc.append_child(sel, o);
+    let t = doc.create_text("Cherry");
+    doc.append_child(o, t);
+
+    let m = resolve_select_model(&doc.tree, sel.0);
+    assert_eq!(m.options.len(), 3, "optgroup children flattened in order");
+    assert_eq!(m.options[0].value, "a");
+    assert_eq!(m.options[2].value, "c");
+}
+
+#[test]
+fn empty_select_has_no_selection() {
+    let (doc, sel) = build_select(None, &[]);
+    let m = resolve_select_model(&doc.tree, sel);
+    assert_eq!(m.selected_index, None);
+    assert_eq!(m.selected_label(), None);
+}
+
+#[test]
+fn disabled_first_option_is_skipped_for_default() {
+    let (doc, sel) = build_select(
+        None,
+        &[
+            (Some("a"), "Pick one", &[("disabled", "")]),
+            (Some("b"), "Banana", &[]),
+        ],
+    );
+    let m = resolve_select_model(&doc.tree, sel);
+    assert_eq!(m.selected_index, Some(1), "skip the disabled first option");
+}
+
+#[test]
+fn options_do_not_lay_out_as_stacked_text() {
+    // The core bug: option children must not render as visible stacked/inline
+    // text. With `option { display: none }` they contribute no layout box.
+    let (mut doc, sel) = build_select(
+        None,
+        &[
+            (Some("a"), "Apple", &[]),
+            (Some("b"), "Banana Longname", &[]),
+            (Some("c"), "Cherry", &[]),
+        ],
+    );
+    doc.resolve_layout(1000.0, 800.0);
+
+    let sel_layout = doc.tree.get(sel).unwrap().layout;
+    // The control is a single row tall — not three options stacked.
+    assert!(
+        sel_layout.height < 40.0,
+        "closed select should be one control-height row, got {}",
+        sel_layout.height
+    );
+    for &opt_id in &doc.tree.get(sel).unwrap().children.clone() {
+        let o = doc.tree.get(opt_id).unwrap();
+        assert_eq!(
+            (o.layout.width, o.layout.height),
+            (0.0, 0.0),
+            "option must not lay out (display:none)"
+        );
+    }
+}
+
+#[test]
+fn unstyled_select_does_not_collapse() {
+    // A raw <select> with no CSS must still be a visible control (min-width +
+    // padding), not collapse the way a raw <input> does.
+    let (mut doc, sel) = build_select(None, &[(Some("a"), "Apple", &[])]);
+    doc.resolve_layout(1000.0, 800.0);
+    let l = doc.tree.get(sel).unwrap().layout;
+    assert!(
+        l.width >= 60.0,
+        "min-width keeps the control visible, got {}",
+        l.width
+    );
+    assert!(l.height > 0.0, "control has height, got {}", l.height);
+}
+
+#[test]
+fn unstyled_select_width_tracks_widest_option() {
+    // The closed control sizes to the widest option (browser behaviour), so a
+    // longer set of options yields a wider control — and the width does not
+    // depend on which option is selected.
+    let (mut narrow, n_sel) = build_select(None, &[(Some("a"), "Hi", &[])]);
+    narrow.resolve_layout(1000.0, 800.0);
+    let narrow_w = narrow.tree.get(n_sel).unwrap().layout.width;
+
+    let (mut wide, w_sel) = build_select(
+        None,
+        &[
+            (Some("a"), "Hi", &[]),
+            (Some("b"), "A much longer option label", &[]),
+        ],
+    );
+    wide.resolve_layout(1000.0, 800.0);
+    let wide_w = wide.tree.get(w_sel).unwrap().layout.width;
+
+    assert!(
+        wide_w > narrow_w + 50.0,
+        "wider options → wider control: narrow={narrow_w}, wide={wide_w}"
+    );
+}
+
+#[test]
+fn explicit_width_is_respected_over_intrinsic() {
+    // An author width wins — the label clips rather than forcing the control wide.
+    let mut doc = RinchDocument::new();
+    let body = doc.body();
+    let sel = doc.create_element("select");
+    doc.set_attribute(sel, "style", "width: 90px;");
+    doc.append_child(body, sel);
+    let o = doc.create_element("option");
+    doc.append_child(sel, o);
+    let t = doc.create_text("An option label far wider than ninety pixels");
+    doc.append_child(o, t);
+
+    doc.resolve_layout(1000.0, 800.0);
+    let w = doc.tree.get(sel.0).unwrap().layout.width;
+    assert!((w - 90.0).abs() < 1.0, "explicit width respected, got {w}");
+}


### PR DESCRIPTION
First of two PRs for #121. This one is **rinch-dom only** — it fixes the *rendering* of a native `<select>`. The interactive popup, focus and keyboard handling follow in part 2 (the app/shell layer), so **#121 stays open** until then.

## The bug

On the desktop backend `<select>` mapped to `inline-block` and its `<option>` children resolved to `display: inline`, so every option's text rendered as one visible run — `AppleBananaCherry` — with no control and no notion of selection.

## What this does

Renders the **closed** control the way a browser does: the selected option's label plus a dropdown arrow.

- **`select::resolve_select_model`** — a shared resolver for "what are the options and which is selected", reused by paint here and by the app layer in part 2. HTML selection order: the select's own `value` attribute → last option with `selected` → first non-disabled option. `<optgroup>`s are flattened; an option's value falls back to its text content, its label to the `label` attribute or text.
- **UA stylesheet** hides `option, optgroup` and gives `select` padding (arrow room on the right), `min-width`, and clip.
- **Intrinsic width** in style resolution: the control sizes to its **widest** option (browser behaviour — stable width across selection changes), only when the author left `width: auto`; an explicit width is respected and the label clips. Width is estimated from label length (Parley isn't available at style-resolution time) and erring wide is harmless because the painter clips. Mirrors the existing `<textarea rows>` intrinsic-height path.
- **`paint::select::paint_select_value`** paints the selected label (clipped to the content box) + a chevron, mirroring `paint_input_value`.

## Design notes

- The split mirrors native `<input>`: rinch-dom renders the box, the app owns interaction.
- No default border/background is imposed — a raw `<input>` is itself `0×0` without styling, so this stays consistent with the other form controls. Styled selects look like real controls (see screenshot).
- Intrinsic width is estimated, not Parley-measured — a possible follow-up if exactness ever matters.

## Verification

Screenshot of four cases (unstyled, styled+selected, explicit-width clipping, optgroup) — all render as real closed controls:

- Unstyled sizes to its widest option and shows the first option selected.
- `value: "banana"` selects Banana.
- `width: 180px` clips a long label under the arrow.
- optgroup options are flattened; first is selected by default.

13 tests in `select_tests.rs` cover model resolution (value / selected / first-option / optgroup / label / disabled), that options no longer lay out, and that the control sizes to its widest option while respecting an explicit width. Full workspace (fmt, clippy, WASM build, tests) green via the pre-commit gate.

## Next (part 2)

App-layer combobox: `FocusTarget::Select`, click-to-open DOM-synthesized popup, full keyboard (open/navigate/commit/dismiss/type-ahead), outside-click/Escape dismissal, and writing the chosen value back to the `value` attribute + change dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)