### PR TITLE
feat(rinch): native <select> combobox widget (#121, part 2/2)

### DIFF
--- a/crates/rinch-dom/src/dom_impl/dom_document_impl.rs
+++ b/crates/rinch-dom/src/dom_impl/dom_document_impl.rs
@@ -480,23 +480,35 @@ impl DomDocument for RinchDocument {
 
     fn remove_attribute(&mut self, node: NodeId, name: &str) {
         self.tree.nodes[node.0].attributes.remove(name);
-        if name == "class" || name == "style" {
-            self.push_dirty_flags(
-                node.0,
-                DirtyFlags::STYLE | DirtyFlags::LAYOUT | DirtyFlags::PAINT,
-            );
-            // Invalidate Stylo element data so styles are recomputed
-            *self.tree.nodes[node.0].stylo_element_data.borrow_mut() = None;
+        if name == "style" {
             self.tree.nodes[node.0].style_attribute_cache = None;
-            self.tree.style_roots.push(node.0);
-            self.tree.styles_dirty = true;
-            // Class removal affects descendant selectors
-            if name == "class" {
-                self.invalidate_descendant_styles(node.0);
-            }
-        } else {
-            self.push_dirty(node.0);
         }
+        // Invalidate IFC for style/class changes on inline-participating nodes,
+        // mirroring set_attribute.
+        if (name == "style" || name == "class")
+            && (self.tree.nodes[node.0].ifc_root.is_some()
+                || self.tree.nodes[node.0].is_inline()
+                || self.tree.nodes[node.0].text_layout.is_some())
+        {
+            self.invalidate_ifc_for_node(node.0);
+            if let Some(parent_id) = self.tree.nodes[node.0].parent {
+                self.invalidate_parent_ifc(parent_id);
+            }
+        }
+        // Symmetric with set_attribute: any attribute can participate in a
+        // selector (`[data-highlighted]`, `[aria-selected]`, …), so *removing*
+        // one must re-resolve this node and its subtree too — otherwise a style
+        // that matched only while the attribute was present stays applied (e.g. a
+        // popup option keeps its highlight background after the attribute is
+        // cleared).
+        *self.tree.nodes[node.0].stylo_element_data.borrow_mut() = None;
+        self.tree.style_roots.push(node.0);
+        self.tree.styles_dirty = true;
+        self.push_dirty_flags(
+            node.0,
+            DirtyFlags::STYLE | DirtyFlags::LAYOUT | DirtyFlags::PAINT,
+        );
+        self.invalidate_descendant_styles(node.0);
     }
 
     fn get_attribute(&self, node: NodeId, name: &str) -> Option<String> {

--- a/crates/rinch-dom/src/layout_engine.rs
+++ b/crates/rinch-dom/src/layout_engine.rs
@@ -910,7 +910,14 @@ impl RinchDocument {
         let border_top = node.computed_style.border_top_width.to_px();
         let border_bottom = node.computed_style.border_bottom_width.to_px();
         let gap = node.computed_style.gap_row.to_px();
+        // Children stack vertically (heights sum) when the container is a block
+        // box or a flex column; a flex row lays them side by side (take the max).
+        // Without the `Block` case a `position: fixed` block with auto height —
+        // e.g. a popup/menu appended to <body> — collapses to one child's height.
         let is_column = matches!(
+            node.computed_style.display,
+            crate::computed_style::DisplayValue::Block
+        ) || matches!(
             node.computed_style.flex_direction,
             crate::computed_style::FlexDirectionValue::Column
                 | crate::computed_style::FlexDirectionValue::ColumnReverse
@@ -935,7 +942,27 @@ impl RinchDocument {
             }
         }
 
-        content_h + pad_top + pad_bottom + border_top + border_bottom
+        let mut h = content_h + pad_top + pad_bottom + border_top + border_bottom;
+
+        // Respect the element's own min/max-height (border-box, like the rest of
+        // the box model here) so a fixed scroll container clamps and scrolls its
+        // overflow instead of growing past its cap.
+        use crate::computed_style::DimensionValue;
+        let vh = self.tree.viewport.height;
+        let resolve = |d: &DimensionValue| -> Option<f32> {
+            match d {
+                DimensionValue::Length(v) => Some(*v),
+                DimensionValue::Percent(p) => Some(p * vh),
+                DimensionValue::Auto => None,
+            }
+        };
+        if let Some(max_h) = resolve(&node.computed_style.max_height) {
+            h = h.min(max_h);
+        }
+        if let Some(min_h) = resolve(&node.computed_style.min_height) {
+            h = h.max(min_h);
+        }
+        h
     }
 
     /// Handle display:contents nodes by reparenting their taffy children

--- a/crates/rinch-dom/tests/computed_style_tests.rs
+++ b/crates/rinch-dom/tests/computed_style_tests.rs
@@ -823,3 +823,35 @@ fn tag_selector_matches_table_cells_and_custom_tags() {
         "an unlisted custom-element tag selector matches via dynamic interning"
     );
 }
+
+/// Removing a selector-affecting attribute must re-resolve styles (symmetric with
+/// setting one — issue #67). A `[data-x]` rule must stop applying once the
+/// attribute is gone (e.g. a popup option losing its highlight).
+#[test]
+fn removing_attribute_restyles_the_node() {
+    let blue = |bg: &BackgroundValue| {
+        matches!(bg, BackgroundValue::Color(c)
+            if c.components[2] > 0.9 && c.components[0] < 0.1)
+    };
+    let mut doc = RinchDocument::new();
+    doc.load_css(
+        "div { background-color: rgb(255, 255, 255); } \
+         div[data-hl] { background-color: rgb(0, 0, 255); }",
+    );
+    let body = doc.body();
+    let el = doc.create_element("div");
+    doc.set_attribute(el, "data-hl", "");
+    doc.append_child(body, el);
+    doc.resolve_layout(400.0, 300.0);
+    assert!(
+        blue(&doc.tree.get(el.0).unwrap().computed_style.background),
+        "with [data-hl] the option is blue"
+    );
+
+    doc.remove_attribute(el, "data-hl");
+    doc.resolve_layout(400.0, 300.0);
+    assert!(
+        !blue(&doc.tree.get(el.0).unwrap().computed_style.background),
+        "removing [data-hl] must drop the highlight background"
+    );
+}

--- a/crates/rinch-dom/tests/layout_tests.rs
+++ b/crates/rinch-dom/tests/layout_tests.rs
@@ -1376,3 +1376,57 @@ fn test_inline_block_percent_width_fills_containing_block() {
         "inline-block width:100% should fill its 700px containing block, got {ib_w}"
     );
 }
+
+/// A `position: fixed` block box with `height: auto` must size to the sum of its
+/// stacked block children — not collapse to one child's height. Regression for a
+/// bug that made a fixed popup/menu appended to <body> show only its first row.
+#[test]
+fn test_fixed_block_auto_height_sums_children() {
+    let mut doc = RinchDocument::new();
+    let body = doc.body();
+    let panel = doc.create_element("div");
+    doc.set_attribute(
+        panel,
+        "style",
+        "position: fixed; left: 10px; top: 10px; padding: 4px;",
+    );
+    doc.append_child(body, panel);
+    for _ in 0..8 {
+        let row = doc.create_element("div");
+        doc.set_attribute(row, "style", "height: 30px;");
+        doc.append_child(panel, row);
+    }
+    doc.resolve_layout(1000.0, 800.0);
+    let h = doc.tree.get(panel.0).unwrap().layout.height;
+    // 8 * 30 + 4 + 4 padding = 248.
+    assert!(
+        (h - 248.0).abs() < 2.0,
+        "fixed auto-height should sum children (expected ~248), got {h}"
+    );
+}
+
+/// The same fixed box clamps to its `max-height` (and scrolls the overflow)
+/// rather than growing past the cap.
+#[test]
+fn test_fixed_block_auto_height_clamps_to_max_height() {
+    let mut doc = RinchDocument::new();
+    let body = doc.body();
+    let panel = doc.create_element("div");
+    doc.set_attribute(
+        panel,
+        "style",
+        "position: fixed; left: 10px; top: 10px; max-height: 120px; overflow-y: auto; padding: 4px;",
+    );
+    doc.append_child(body, panel);
+    for _ in 0..8 {
+        let row = doc.create_element("div");
+        doc.set_attribute(row, "style", "height: 30px;");
+        doc.append_child(panel, row);
+    }
+    doc.resolve_layout(1000.0, 800.0);
+    let h = doc.tree.get(panel.0).unwrap().layout.height;
+    assert!(
+        (h - 120.0).abs() < 1.0,
+        "fixed auto-height must clamp to max-height 120, got {h}"
+    );
+}

--- a/crates/rinch/src/app/click_handling.rs
+++ b/crates/rinch/src/app/click_handling.rs
@@ -38,6 +38,16 @@ impl RinchApp {
         };
         let doc = &doc;
 
+        // ── Phase -1: open native <select> popup is modal ────────────
+        // While a popup is open its backdrop covers the window: the click either
+        // commits an option, no-ops on the panel, or dismisses. Handled here so it
+        // pre-empts every other phase.
+        if self.is_select_open() {
+            self.handle_open_select_click(x, y, viewport_width, viewport_height);
+            actions.push(AppAction::RequestRedraw);
+            return actions;
+        }
+
         // ── Phase 0: render surface detection ────────────────────────
         // Check if the click lands on a render surface. If so, dispatch
         // the event, set focus, and return early.
@@ -81,6 +91,22 @@ impl RinchApp {
             // teardown dispatches FocusLost). Other targets are taken below.
             if matches!(self.focus_target, FocusTarget::Surface(_)) {
                 self.set_focus_target(FocusTarget::None);
+            }
+        }
+
+        // ── Phase 0.5: open a native <select> popup ──────────────────
+        // A click on a closed `<select>` (its options are display:none, so the hit
+        // lands on the control itself) opens the combobox popup and consumes the
+        // click.
+        {
+            let select_hit = {
+                let d = doc.borrow();
+                hit_test(&d.tree, x, y).and_then(|hid| Self::select_ancestor(&d.tree, hid))
+            };
+            if let Some(select_id) = select_hit {
+                self.open_select_popup(select_id, viewport_width, viewport_height);
+                actions.push(AppAction::RequestRedraw);
+                return actions;
             }
         }
 

--- a/crates/rinch/src/app/event_dispatch.rs
+++ b/crates/rinch/src/app/event_dispatch.rs
@@ -953,6 +953,14 @@ impl RinchApp {
                         }
                         actions.push(AppAction::RequestRedraw);
                     }
+                    // A native <select> popup owns the keyboard while open:
+                    // navigate / commit / dismiss / type-ahead.
+                    FocusTarget::Select(_) => {
+                        if self.handle_select_key(key, text.as_deref(), vp_w, vp_h) {
+                            actions.push(AppAction::RequestRedraw);
+                            return actions;
+                        }
+                    }
                     // No widget owns the key, or a plain `<input>` does (its editing
                     // commands live in the global handlers, gated internally on
                     // `focused_input_state`). Falls through to DevTools / inspect /

--- a/crates/rinch/src/app/focus.rs
+++ b/crates/rinch/src/app/focus.rs
@@ -53,6 +53,11 @@ impl RinchApp {
                 self.focused_input_node_id = None;
                 self.focused_input_preedit = None;
             }
+            FocusTarget::Select(_) => {
+                // Tearing down select focus dismisses its popup: remove the
+                // app-created backdrop + panel nodes.
+                self.remove_select_popup_nodes();
+            }
             #[cfg(feature = "desktop")]
             FocusTarget::Editor(prev) => {
                 // Hide the blurred editor's caret and selection highlight so an

--- a/crates/rinch/src/app/mod.rs
+++ b/crates/rinch/src/app/mod.rs
@@ -12,6 +12,7 @@ mod debug_commands;
 mod event_dispatch;
 mod focus;
 pub(crate) mod hit_testing;
+mod select_widget;
 mod text_selection;
 
 pub(crate) use hit_testing::*;
@@ -133,6 +134,9 @@ pub(crate) enum FocusTarget {
     Surface(usize),
     /// An `<input>`/`<textarea>` (the rinch-editable engine), by DOM node id.
     Input(usize),
+    /// A native `<select>` whose popup is open, by the select's DOM node id. The
+    /// popup nodes and highlight live in [`RinchApp::open_select`] (issue #121).
+    Select(usize),
     /// A rich-text editor (`rinch-editor-core`) instance, by container node id.
     #[cfg(feature = "desktop")]
     Editor(usize),
@@ -217,6 +221,12 @@ pub struct RinchApp {
     /// (`focused_input_*`, the surface/editor registries) via
     /// [`Self::set_focus_target`].
     pub(crate) focus_target: FocusTarget,
+    /// The open native-`<select>` popup, if any. Present exactly when
+    /// `focus_target == FocusTarget::Select(_)`. Holds the app-created popup DOM
+    /// node ids and the keyboard highlight state (issue #121).
+    pub(crate) open_select: Option<select_widget::OpenSelect>,
+    /// Whether the native-select popup stylesheet has been injected (once).
+    pub(crate) select_css_injected: bool,
     /// The "goal column" (a window-space x) preserved across consecutive vertical
     /// cursor moves (Up/Down) in the focused new editor, so the caret keeps its
     /// horizontal position through short lines instead of drifting to line ends.
@@ -280,6 +290,8 @@ impl RinchApp {
             focused_input_node_id: None,
             focused_input_preedit: None,
             focus_target: FocusTarget::None,
+            open_select: None,
+            select_css_injected: false,
             #[cfg(feature = "desktop")]
             editor_goal_x: None,
             hovered_surface: None,

--- a/crates/rinch/src/app/select_widget.rs
+++ b/crates/rinch/src/app/select_widget.rs
@@ -1,0 +1,552 @@
+//! Native `<select>` combobox behaviour (issue #121, PR2).
+//!
+//! rinch-dom renders the *closed* control (the selected label + arrow — PR1);
+//! this drives the *interaction*: click to open a popup, navigate/commit with the
+//! keyboard, dismiss on Escape or an outside click, and report the chosen value.
+//!
+//! The split mirrors native `<input>`: rinch-dom paints the box, the app owns the
+//! interaction. The popup is **DOM-synthesized** — a backdrop and an option list
+//! are appended to `<body>` so they reuse layout, paint, theming, scrolling and
+//! hit-testing rather than being hand-painted. They live outside any reactive
+//! scope (trailing `<body>` children the reconciler never touches) and are torn
+//! down through the [focus arbiter](super::RinchApp::set_focus_target): the popup
+//! is open exactly when `focus_target == FocusTarget::Select(_)`.
+
+use super::*;
+use rinch_core::dom::NodeId;
+use rinch_dom::select::resolve_select_model;
+
+/// Approximate popup row height (used only to estimate popup height for the
+/// up/down flip decision before layout runs).
+const ROW_HEIGHT_ESTIMATE: f32 = 30.0;
+/// Cap on popup height; longer lists scroll.
+const MAX_POPUP_HEIGHT: f32 = 260.0;
+/// Type-ahead buffer resets after this idle gap.
+const TYPEAHEAD_RESET_MS: u128 = 900;
+
+/// The open native-`<select>` popup: the app-created DOM nodes plus keyboard
+/// highlight/type-ahead state. Index-aligned vectors mirror the resolved options.
+pub(crate) struct OpenSelect {
+    /// The `<select>` element the popup belongs to.
+    pub select_id: usize,
+    /// Full-window click-catcher behind the panel.
+    pub backdrop_id: usize,
+    /// The option-list panel.
+    pub panel_id: usize,
+    /// Option row node ids, aligned to the option list.
+    pub option_ids: Vec<usize>,
+    /// Option submit values, aligned.
+    pub values: Vec<String>,
+    /// Option display labels, aligned (for type-ahead).
+    pub labels: Vec<String>,
+    /// Whether each option is disabled, aligned.
+    pub disabled: Vec<bool>,
+    /// Currently highlighted option index.
+    pub highlighted: usize,
+    /// Accumulated type-ahead buffer.
+    pub typeahead: String,
+    /// When the last type-ahead key landed (buffer resets after a gap).
+    pub typeahead_at: Option<Instant>,
+}
+
+/// Popup stylesheet, injected once. Uses theme variables with light fallbacks so
+/// it looks right with or without the theme feature.
+const NATIVE_SELECT_CSS: &str = r#"
+.rinch-nsel-backdrop {
+    position: fixed;
+    left: 0; top: 0; right: 0; bottom: 0;
+    z-index: 9998;
+}
+.rinch-nsel-panel {
+    position: fixed;
+    z-index: 9999;
+    box-sizing: border-box;
+    padding: 4px;
+    background: var(--rinch-color-body, #ffffff);
+    border: 1px solid var(--rinch-color-gray-3, #dee2e6);
+    border-radius: 6px;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.15);
+    overflow-y: auto;
+}
+.rinch-nsel-option {
+    padding: 6px 10px;
+    border-radius: 4px;
+    font-size: 14px;
+    line-height: 1.4;
+    color: var(--rinch-color-text, #212529);
+    white-space: nowrap;
+    cursor: pointer;
+}
+.rinch-nsel-option[data-selected]:not([data-highlighted]) {
+    background: var(--rinch-color-gray-1, #f1f3f5);
+}
+.rinch-nsel-option[data-highlighted] {
+    background: var(--rinch-primary-color, #228be6);
+    color: #ffffff;
+}
+.rinch-nsel-option[data-disabled] {
+    color: var(--rinch-color-gray-5, #adb5bd);
+    cursor: default;
+}
+"#;
+
+impl RinchApp {
+    /// Whether a native-select popup is currently open.
+    pub(crate) fn is_select_open(&self) -> bool {
+        self.open_select.is_some()
+    }
+
+    /// Walk up from a hit node to the enclosing `<select>` element, if any.
+    pub(super) fn select_ancestor(tree: &rinch_dom::NodeTree, hit_id: usize) -> Option<usize> {
+        let mut cur = Some(hit_id);
+        while let Some(nid) = cur {
+            let node = tree.get(nid)?;
+            if node.tag() == Some("select") {
+                return Some(nid);
+            }
+            cur = node.parent;
+        }
+        None
+    }
+
+    /// Absolute on-screen rect `(x, y, w, h)` of a node, summing ancestor offsets
+    /// and scroll (the same walk click dispatch uses).
+    fn absolute_rect(tree: &rinch_dom::NodeTree, node_id: usize) -> (f32, f32, f32, f32) {
+        let Some(node) = tree.get(node_id) else {
+            return (0.0, 0.0, 0.0, 0.0);
+        };
+        let (w, h) = (node.layout.width, node.layout.height);
+        let mut x = node.layout.x;
+        let mut y = node.layout.y;
+        let mut pid = node.parent;
+        while let Some(p) = pid {
+            let Some(pn) = tree.get(p) else { break };
+            x += pn.layout.x - pn.scroll_offset.0 as f32;
+            y += pn.layout.y - pn.scroll_offset.1 as f32;
+            pid = pn.parent;
+        }
+        (x, y, w, h)
+    }
+
+    /// Open the popup for `select_id`, anchored to the control.
+    pub(super) fn open_select_popup(&mut self, select_id: usize, vp_w: f32, vp_h: f32) {
+        // Start from a clean slate (also tears down any prior popup / focus).
+        self.close_select_popup();
+
+        let Some(doc) = self.doc.clone() else { return };
+
+        let (rect, model) = {
+            let d = doc.borrow();
+            (
+                Self::absolute_rect(&d.tree, select_id),
+                resolve_select_model(&d.tree, select_id),
+            )
+        };
+        if model.options.is_empty() {
+            return;
+        }
+        let (sx, sy, sw, sh) = rect;
+
+        if !self.select_css_injected {
+            doc.borrow_mut().load_css(NATIVE_SELECT_CSS);
+            self.select_css_injected = true;
+        }
+
+        // Up/down flip: prefer opening below, flip above when the popup wouldn't
+        // fit below but would above. Panel geometry is a fixed on-screen rect, so
+        // it needs no `--rinch-window-top-inset` (unlike a declarative top: 0).
+        let count = model.options.len() as f32;
+        let popup_h = (count * ROW_HEIGHT_ESTIMATE + 8.0).min(MAX_POPUP_HEIGHT);
+        let space_below = vp_h - (sy + sh);
+        let flip_above = space_below < popup_h && sy > space_below;
+        let (top, max_h) = if flip_above {
+            let mh = popup_h.min(sy - 4.0).max(60.0);
+            ((sy - mh).max(0.0), mh)
+        } else {
+            (sy + sh, popup_h.min((space_below - 4.0).max(60.0)))
+        };
+
+        let selected = model.selected_index.unwrap_or(0);
+
+        let mut d = doc.borrow_mut();
+        let body = d.body();
+
+        let backdrop = d.create_element("div");
+        d.set_attribute(backdrop, "class", "rinch-nsel-backdrop");
+        d.append_child(body, backdrop);
+
+        let panel = d.create_element("div");
+        d.set_attribute(panel, "class", "rinch-nsel-panel");
+        d.set_style(panel, "left", &format!("{sx}px"));
+        d.set_style(panel, "top", &format!("{top}px"));
+        // Match the control's width. A `width: auto` fixed block fills the
+        // viewport, and the closed control is already sized to its widest option
+        // (PR1), so the control width is the right popup width. Long labels clip
+        // (option is white-space: nowrap), as a browser's popup does.
+        d.set_style(panel, "width", &format!("{sw}px"));
+        d.set_style(panel, "max-height", &format!("{max_h}px"));
+
+        let mut option_ids = Vec::with_capacity(model.options.len());
+        let mut values = Vec::with_capacity(model.options.len());
+        let mut labels = Vec::with_capacity(model.options.len());
+        let mut disabled = Vec::with_capacity(model.options.len());
+        for (i, opt) in model.options.iter().enumerate() {
+            let o = d.create_element("div");
+            d.set_attribute(o, "class", "rinch-nsel-option");
+            d.set_attribute(o, "data-nsel-opt", &i.to_string());
+            if i == selected {
+                d.set_attribute(o, "data-selected", "");
+                d.set_attribute(o, "data-highlighted", "");
+            }
+            if opt.disabled {
+                d.set_attribute(o, "data-disabled", "");
+            }
+            let t = d.create_text(&opt.label);
+            d.append_child(o, t);
+            d.append_child(panel, o);
+            option_ids.push(o.0);
+            values.push(opt.value.clone());
+            labels.push(opt.label.clone());
+            disabled.push(opt.disabled);
+        }
+        d.append_child(body, panel);
+        drop(d);
+
+        self.open_select = Some(OpenSelect {
+            select_id,
+            backdrop_id: backdrop.0,
+            panel_id: panel.0,
+            option_ids,
+            values,
+            labels,
+            disabled,
+            highlighted: selected,
+            typeahead: String::new(),
+            typeahead_at: None,
+        });
+        // Route keyboard to the popup. Teardown of the previous focus already ran
+        // via close_select_popup above, so this just installs Select focus.
+        self.set_focus_target(FocusTarget::Select(select_id));
+        self.scene_dirty = true;
+        self.resolve_and_repaint(vp_w, vp_h);
+        self.scroll_highlight_into_view(vp_w, vp_h);
+    }
+
+    /// Remove the popup DOM nodes (idempotent). Called from the focus arbiter's
+    /// teardown; does not touch `focus_target`.
+    pub(crate) fn remove_select_popup_nodes(&mut self) {
+        let Some(open) = self.open_select.take() else {
+            return;
+        };
+        if let Some(doc) = self.doc.clone() {
+            let mut d = doc.borrow_mut();
+            d.remove_node(NodeId(open.panel_id));
+            d.remove_node(NodeId(open.backdrop_id));
+        }
+        self.scene_dirty = true;
+    }
+
+    /// Close the popup (via the focus arbiter, so teardown removes the nodes).
+    pub(super) fn close_select_popup(&mut self) {
+        if matches!(self.focus_target, FocusTarget::Select(_)) {
+            self.set_focus_target(FocusTarget::None);
+        } else {
+            // Defensive: nodes without matching focus (shouldn't happen).
+            self.remove_select_popup_nodes();
+        }
+    }
+
+    /// Handle a click while a popup is open. Returns `true` (the click is always
+    /// consumed while open — the backdrop is modal).
+    pub(super) fn handle_open_select_click(
+        &mut self,
+        x: f32,
+        y: f32,
+        vp_w: f32,
+        vp_h: f32,
+    ) -> bool {
+        let Some(open) = self.open_select.as_ref() else {
+            return false;
+        };
+        let panel_id = open.panel_id;
+        let Some(doc) = self.doc.clone() else {
+            return false;
+        };
+
+        enum Hit {
+            Option(usize),
+            InsidePanel,
+            Outside,
+        }
+        let hit = {
+            let d = doc.borrow();
+            match hit_test(&d.tree, x, y) {
+                Some(hid) => {
+                    let mut cur = Some(hid);
+                    let mut result = Hit::Outside;
+                    while let Some(nid) = cur {
+                        let Some(node) = d.tree.get(nid) else { break };
+                        if let Some(idx) = node
+                            .attributes
+                            .get("data-nsel-opt")
+                            .and_then(|s| s.parse::<usize>().ok())
+                        {
+                            result = Hit::Option(idx);
+                            break;
+                        }
+                        if nid == panel_id {
+                            result = Hit::InsidePanel;
+                            break;
+                        }
+                        cur = node.parent;
+                    }
+                    result
+                }
+                None => Hit::Outside,
+            }
+        };
+
+        match hit {
+            Hit::Option(idx) => {
+                if !open.disabled.get(idx).copied().unwrap_or(true) {
+                    self.commit_select(idx, vp_w, vp_h);
+                }
+            }
+            Hit::InsidePanel => {} // click on the panel's own padding — keep open
+            Hit::Outside => {
+                self.close_select_popup();
+                self.resolve_and_repaint(vp_w, vp_h);
+            }
+        }
+        true
+    }
+
+    /// Commit option `index`: write the value back to the `<select>`, dispatch the
+    /// change handler, and close the popup.
+    fn commit_select(&mut self, index: usize, vp_w: f32, vp_h: f32) {
+        let Some(open) = self.open_select.as_ref() else {
+            return;
+        };
+        let select_id = open.select_id;
+        let Some(value) = open.values.get(index).cloned() else {
+            return;
+        };
+        let Some(doc) = self.doc.clone() else {
+            return;
+        };
+
+        let handler_id = {
+            let mut d = doc.borrow_mut();
+            // The resolver reads `value` back, so the closed control repaints with
+            // the new label; mark the control dirty so paint re-runs.
+            d.set_attribute(NodeId(select_id), "value", &value);
+            d.mark_dirty(NodeId(select_id));
+            d.tree
+                .get(select_id)
+                .and_then(|n| n.attributes.get("data-oninput"))
+                .and_then(|s| s.parse::<usize>().ok())
+        };
+
+        self.close_select_popup();
+
+        // Report the chosen value to the app's onchange/oninput handler. Native
+        // `<select onchange>`/`oninput` both register as `data-oninput` (a
+        // `Fn(String)`), exactly like `<input>`. Dispatched with no doc borrow
+        // held, since the handler may mutate the DOM.
+        if let Some(hid) = handler_id {
+            events::dispatch_input_event(events::EventHandlerId(hid), value);
+        }
+        self.scene_dirty = true;
+        self.resolve_and_repaint(vp_w, vp_h);
+    }
+
+    /// Route a key to the open popup. Returns `true` if the key was consumed
+    /// (every key is consumed while the popup is open, so typing doesn't leak to
+    /// the global handlers).
+    pub(super) fn handle_select_key(
+        &mut self,
+        key: KeyCode,
+        text: Option<&str>,
+        vp_w: f32,
+        vp_h: f32,
+    ) -> bool {
+        if self.open_select.is_none() {
+            return false;
+        }
+        match key {
+            KeyCode::Escape => {
+                self.close_select_popup();
+                self.resolve_and_repaint(vp_w, vp_h);
+            }
+            KeyCode::Enter | KeyCode::Space => {
+                if let Some(open) = self.open_select.as_ref() {
+                    let idx = open.highlighted;
+                    if !open.disabled.get(idx).copied().unwrap_or(true) {
+                        self.commit_select(idx, vp_w, vp_h);
+                    }
+                }
+            }
+            KeyCode::ArrowDown => self.step_select_highlight(1, vp_w, vp_h),
+            KeyCode::ArrowUp => self.step_select_highlight(-1, vp_w, vp_h),
+            KeyCode::Home => self.jump_select_highlight(true, vp_w, vp_h),
+            KeyCode::End => self.jump_select_highlight(false, vp_w, vp_h),
+            _ => {
+                if let Some(t) = text
+                    && !t.is_empty()
+                    && t.chars().all(|c| !c.is_control())
+                {
+                    self.select_typeahead(t, vp_w, vp_h);
+                }
+                // Consume all other keys while open.
+            }
+        }
+        true
+    }
+
+    /// Move the highlight by `dir` (+1 down / -1 up) to the next enabled option.
+    fn step_select_highlight(&mut self, dir: isize, vp_w: f32, vp_h: f32) {
+        let Some(open) = self.open_select.as_ref() else {
+            return;
+        };
+        let n = open.option_ids.len() as isize;
+        let mut i = open.highlighted as isize;
+        loop {
+            let next = i + dir;
+            if next < 0 || next >= n {
+                return; // no wrap — stay put at the ends
+            }
+            i = next;
+            if !open.disabled.get(i as usize).copied().unwrap_or(false) {
+                break;
+            }
+        }
+        self.set_select_highlight(i as usize, vp_w, vp_h);
+    }
+
+    /// Highlight the first (`home`) or last enabled option.
+    fn jump_select_highlight(&mut self, home: bool, vp_w: f32, vp_h: f32) {
+        let Some(open) = self.open_select.as_ref() else {
+            return;
+        };
+        let n = open.option_ids.len();
+        let target = if home {
+            (0..n).find(|&i| !open.disabled[i])
+        } else {
+            (0..n).rev().find(|&i| !open.disabled[i])
+        };
+        if let Some(i) = target {
+            self.set_select_highlight(i, vp_w, vp_h);
+        }
+    }
+
+    /// Type-ahead: extend the buffer and jump to the first enabled option whose
+    /// label starts with it (case-insensitive). A single repeated letter cycles
+    /// through the options that start with that letter.
+    fn select_typeahead(&mut self, ch: &str, vp_w: f32, vp_h: f32) {
+        let now = Instant::now();
+        let Some(open) = self.open_select.as_mut() else {
+            return;
+        };
+        let expired = open
+            .typeahead_at
+            .map(|t| now.duration_since(t).as_millis() > TYPEAHEAD_RESET_MS)
+            .unwrap_or(true);
+        if expired {
+            open.typeahead.clear();
+        }
+        open.typeahead.push_str(&ch.to_lowercase());
+        open.typeahead_at = Some(now);
+
+        let query = open.typeahead.clone();
+        let start = open.highlighted;
+        let n = open.labels.len();
+
+        // If the buffer is a single repeated char, advance to the next match;
+        // otherwise match from the current position.
+        let single_repeat =
+            query.len() >= 2 && query.chars().all(|c| c == query.chars().next().unwrap());
+        let (needle, from) = if single_repeat {
+            (query[..1].to_string(), (start + 1) % n)
+        } else {
+            (query.clone(), start)
+        };
+
+        let mut found = None;
+        for k in 0..n {
+            let i = (from + k) % n;
+            if open.disabled[i] {
+                continue;
+            }
+            if open.labels[i].to_lowercase().starts_with(&needle) {
+                found = Some(i);
+                break;
+            }
+        }
+        if let Some(i) = found {
+            self.set_select_highlight(i, vp_w, vp_h);
+        }
+    }
+
+    /// Move the highlight to option `index`, swapping the `data-highlighted`
+    /// attribute and scrolling it into view.
+    fn set_select_highlight(&mut self, index: usize, vp_w: f32, vp_h: f32) {
+        let Some(open) = self.open_select.as_mut() else {
+            return;
+        };
+        if index == open.highlighted || index >= open.option_ids.len() {
+            return;
+        }
+        let prev = open.option_ids[open.highlighted];
+        let next = open.option_ids[index];
+        open.highlighted = index;
+
+        if let Some(doc) = self.doc.clone() {
+            let mut d = doc.borrow_mut();
+            d.remove_attribute(NodeId(prev), "data-highlighted");
+            d.set_attribute(NodeId(next), "data-highlighted", "");
+        }
+        self.scene_dirty = true;
+        self.resolve_and_repaint(vp_w, vp_h);
+        self.scroll_highlight_into_view(vp_w, vp_h);
+    }
+
+    /// Scroll the panel so the highlighted option is visible.
+    fn scroll_highlight_into_view(&mut self, vp_w: f32, vp_h: f32) {
+        let Some(open) = self.open_select.as_ref() else {
+            return;
+        };
+        let (panel_id, opt_id) = (open.panel_id, open.option_ids[open.highlighted]);
+        let Some(doc) = self.doc.clone() else {
+            return;
+        };
+
+        let new_scroll = {
+            let d = doc.borrow();
+            let (Some(panel), Some(opt)) = (d.tree.get(panel_id), d.tree.get(opt_id)) else {
+                return;
+            };
+            // Option y is relative to the panel's content box; the panel clips to
+            // its own height minus padding.
+            let pad_top = panel.computed_style.padding_top.to_px();
+            let pad_bottom = panel.computed_style.padding_bottom.to_px();
+            let visible = panel.layout.height - pad_top - pad_bottom;
+            let scroll = panel.scroll_offset.1 as f32;
+            let opt_top = opt.layout.y;
+            let opt_bottom = opt_top + opt.layout.height;
+            if opt_top < scroll {
+                Some(opt_top)
+            } else if opt_bottom > scroll + visible {
+                Some(opt_bottom - visible)
+            } else {
+                None
+            }
+        };
+
+        if let Some(s) = new_scroll {
+            doc.borrow_mut()
+                .set_scroll_top(NodeId(panel_id), s.max(0.0) as f64);
+            self.scene_dirty = true;
+            self.resolve_and_repaint(vp_w, vp_h);
+        }
+    }
+}


### PR DESCRIPTION
Part 2 of #121 — the interactive combobox. **Stacked on #128** (part 1, the closed-control render); review/merge that first. This PR's base is the part-1 branch, so the diff below is part 2 only.

Closes #121.

## What this adds

A native `<select>` is now a real combobox on the desktop backend. It mirrors native `<input>` — rinch-dom paints the box, the app owns interaction:

- **Click** the control → popup listing the options, anchored to the control (fixed at its measured on-screen rect, flips above when it won't fit below), width matching the control.
- **Click an option** → commit; **outside click** (a modal backdrop) → dismiss.
- **Keyboard while open:** ↑/↓ move the highlight over enabled options, Home/End jump to the ends, Enter/Space commit, Escape dismisses, and typing does **type-ahead** (first option whose label starts with the buffer; a repeated letter cycles). All keys are consumed so nothing leaks to the page.
- **Commit** writes the chosen value to the `<select>`'s `value` attribute (so the closed control repaints via the shared resolver from part 1) and **dispatches the change** — a native `<select onchange>`/`oninput` registers as `data-oninput` (a `Fn(String)`), exactly like `<input>`.

## How

- New `FocusTarget::Select(node_id)` arbiter variant holds keyboard focus while open; the focus choke-point's teardown removes the popup, so the popup is open exactly when `Select` is focused.
- The popup is **DOM-synthesized** — backdrop + option list appended to `<body>` — reusing layout/paint/theming/scroll/hit-testing instead of hand-painting. Those nodes are trailing `<body>` children outside any reactive scope, so the reconciler never touches them.
- Keyboard routes through a new `Select` arm in the focus-arbiter `match` (no single-slot interceptor).

## Two rinch-dom fixes it surfaced (separate commits)

Both are independent correctness bugs the popup exposed, each with its own regression test:

1. **`fix(rinch-dom): size fixed-position blocks with auto height from content`** — a `position: fixed` block with `height: auto` collapsed to one child's height (`compute_content_height` only summed for a flex *column*, not for a block box), so the popup showed one row. Now sums for vertically-stacking containers and clamps to min/max-height. Drawer/Modal set both insets and don't hit this path.
2. **`fix(rinch-dom): restyle on attribute removal, symmetric with set_attribute`** — `remove_attribute` only re-resolved styles for `class`/`style`, so clearing `data-highlighted` left the old highlight painted. Now symmetric with `set_attribute` (#67).

## Verification

Verified end-to-end in a running app via the debug bridge: open, click-commit, arrow navigation (highlight clears correctly), Enter-commit, type-ahead, Escape, outside-click, and preselected-value initial highlight. Screenshots in the thread. rinch-dom test count 254 → 267 (new fixed-height, max-height-clamp, and remove-attribute-restyle tests). Full pre-commit gate (fmt, clippy, WASM, workspace tests) green on all three commits.

## Follow-ups (not in this PR)

- Tab-to-focus a closed `<select>` then open with the keyboard (needs a focus-ring on the closed control). This PR opens via click; full in-popup keyboard is covered.
- A native-`<select>` showcase in ui-zoo (deferred from part 1 so it isn't a dead control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)