### PR TITLE
fix(rinch-dom): re-wrap clamped inline-block text at paint time (#127)

### DIFF
--- a/crates/rinch-dom/src/paint/mod.rs
+++ b/crates/rinch-dom/src/paint/mod.rs
@@ -1311,10 +1311,8 @@ fn paint_node(
             }
 
             // Fallback: build layout on demand (should not happen with caching)
-            let parent_computed = node
-                .parent
-                .and_then(|p| tree.get(p))
-                .map(|p| &p.computed_style);
+            let parent_node = node.parent.and_then(|p| tree.get(p));
+            let parent_computed = parent_node.map(|p| &p.computed_style);
 
             let font_size = parent_computed.map(|s| s.font_size).unwrap_or(16.0);
             let font_weight = parent_computed.map(|s| s.font_weight).unwrap_or(400.0);
@@ -1332,10 +1330,16 @@ fn paint_node(
                 .and_then(|s| s.color)
                 .unwrap_or_else(|| AlphaColor::<Srgb>::from_rgba8(0, 0, 0, 255));
 
-            // Build Parley layout with identical parameters to measurement
-            let scaled_font_size = font_size * scale as f32;
+            // Build the Parley layout at the *logical* font size (scale 1.0) — the
+            // same space `measure_inline_blocks` sized the box in and the same space
+            // the cached IFC path (`build_inline_layout(..., 1.0, ...)`) uses. The
+            // painter re-applies `scale` in `render_text`. (Building at `font_size *
+            // scale` here would both double-scale the glyphs at render *and*, because
+            // glyph advances don't scale perfectly linearly, make this layout's width
+            // diverge from the width the box was measured at — breaking the wrap
+            // constraint below at fractional scale factors.)
             let mut builder = layout_cx.ranged_builder(font_cx, &text_data.content, 1.0, true);
-            builder.push_default(parley::style::StyleProperty::FontSize(scaled_font_size));
+            builder.push_default(parley::style::StyleProperty::FontSize(font_size));
             builder.push_default(parley::style::StyleProperty::Brush(Brush::Solid(color)));
             builder.push_default(parley::style::StyleProperty::FontStack(
                 parley::style::FontStack::Source(std::borrow::Cow::Owned(font_family)),
@@ -1351,10 +1355,42 @@ fn paint_node(
 
             let mut text_layout = builder.build(&text_data.content);
 
-            // Text was measured without width constraint to get natural width.
-            // Paint should use the same (no constraint) to avoid re-wrapping.
-            // The parent element's width constrains positioning, not text wrapping.
+            // Lay out unwrapped first to get the natural (single-line) width & height.
             text_layout.break_all_lines(None);
+
+            // This fallback fires for text that is not part of a cached IFC layout —
+            // notably the sole text child of an `inline-block`, which is not an IFC
+            // root (so it never gets a `cached_text_parley`). Such text was measured
+            // at the parent's max-content width, so for an *auto*-width box painting
+            // it unwrapped is correct. But once the box is clamped
+            // (`width`/`max-width`/`min-width` narrower than the content) layout wraps
+            // the text and sizes the box for the *wrapped* height, while these glyphs
+            // would still paint one overflowing line (#127).
+            //
+            // We can't decide "is it clamped?" by comparing this layout's width to the
+            // box: this on-demand layout's width drifts a pixel or two from the width
+            // the box was measured at (a different Parley build path), so a width test
+            // spuriously wraps auto-width boxes. Instead compare *heights*: layout
+            // records this text node's wrapped height, and line counts are discrete —
+            // if the node is more than ~1.5 single lines tall, layout wrapped it, so
+            // the box is clamped and paint must wrap to the content box too.
+            let one_line_h = text_layout.height();
+            let clamped = one_line_h > 0.0 && node.layout.height > one_line_h * 1.5;
+            if clamped && let Some(p) = parent_node {
+                let cs = &p.computed_style;
+                let padding_h = cs.padding_left.to_px() + cs.padding_right.to_px();
+                let border_h = cs.border_left_width.to_px() + cs.border_right_width.to_px();
+                let content_width = p.layout.width - padding_h - border_h;
+                if content_width > 0.0 {
+                    // Wrap to the content box, but 2% wider. This on-demand layout is a
+                    // hair wider per glyph run than the one layout wrapped the box with,
+                    // so breaking at exactly `content_width` fits fewer words per line
+                    // and can spill one extra line past the box's reserved height. The
+                    // small proportional slack reproduces layout's line breaks; any
+                    // residual right overflow stays within the element's padding.
+                    text_layout.break_all_lines(Some(content_width * 1.02));
+                }
+            }
 
             // Read text-align from parent's computed style
             let alignment = parent_computed


### PR DESCRIPTION
## Summary

Text that is the direct child of an `inline-block` painted as a single unwrapped line, overflowing its box, whenever the box was clamped narrower than the text's max-content width (`width`, `max-width`, or a percentage clamp). Layout had already wrapped the text and reserved the wrapped height — only paint disagreed.

**Cause:** such text has `ifc_root == None` and never gets a `cached_text_parley`, so paint falls to the on-demand fallback in `paint/mod.rs`, which hard-coded `break_all_lines(None)` — correct for an *auto*-width inline-block (measured at MaxContent), wrong once the box is clamped.

## The fix (two parts, both needed)

1. **Build the fallback layout at the logical font size** (scale 1.0) — the same space `measure_inline_blocks` sized the box in and the same space the cached IFC path uses — and let `render_text` apply `scale`. The old `font_size * scale` build both double-scaled glyphs at render *and* made the layout's width diverge from the measured width at fractional DPI (glyph advances don't scale linearly).

2. **Decide "is the box clamped?" by height, not width.** This on-demand layout is a *different* Parley build than the one the box was measured with — its width drifts a pixel or two even with identical font parameters, so any width comparison (including the `content_width + 1px` tolerance `build_ifc_layouts` uses within a single layout) spuriously wraps auto-width boxes. Line counts are discrete: lay out unwrapped, and if the text node's laid-out height exceeds ~1.5 single lines, layout wrapped it → the box is clamped → re-break at the parent's content box. The wrap width gets 2% slack so paint reproduces layout's line breaks despite the width drift (breaking at exactly `content_width` fit fewer words per line and spilled an extra, clipped line); residual overflow stays within the element's padding.

## Testing

Verified visually via the rinch MCP tools with a 5-case repro:
- definite `max-width: 175px` (the issue's repro), definite `width: 160px`, and percentage `max-width: 25%` — all now wrap inside their boxes, box height matches, **no bottom clipping**;
- two auto-width inline-blocks (short and long text) — still a single unwrapped line (no spurious re-wrap);
- the existing `hello_rinch_dom` inline-block buttons ("OK"/"Cancel"/"BTN") — unaffected.

Full `rinch-dom` test suite passes; workspace pre-commit gate passes.

Fixes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)