### PR TITLE
feat: concurrent RinchContexts — signal subscriptions + per-document registries (#134)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1342,7 +1342,7 @@ Your game owns the window and wgpu device. Rinch runs headless — you feed it e
 
 | Type | Purpose |
 |------|---------|
-| `RinchContext` | Main handle — `new()`, `update()`, `scene()` |
+| `RinchContext` | Main handle — `new()`, `update()`, `scene()`. Multiple contexts can coexist on one thread (#134): each holds its own `subscribe_signal_change` guard, and bounds signals / editor registrations / focus requests are scoped per document via `DomDocument::doc_key()`. Caveat: `create_store` is TypeId-keyed thread-wide — use distinct store types per context. |
 | `RinchContextConfig` | Width, height, scale factor, optional theme |
 | `RinchOverlayRenderer` | Convenience Vello-to-texture renderer |
 | `GameViewport` | Component marking a transparent hole for game rendering |

--- a/crates/rinch-core/src/dom/mock.rs
+++ b/crates/rinch-core/src/dom/mock.rs
@@ -5,6 +5,7 @@ use super::traits::{DomDocument, GlyphBounds};
 
 /// A mock DOM document for testing.
 pub struct MockDomDocument {
+    doc_key: u64,
     next_id: usize,
     nodes: std::collections::HashMap<NodeId, MockNode>,
     dirty: Vec<NodeId>,
@@ -35,6 +36,7 @@ impl Default for MockDomDocument {
 impl MockDomDocument {
     pub fn new() -> Self {
         let mut doc = Self {
+            doc_key: crate::dom::next_doc_key(),
             next_id: 0,
             nodes: std::collections::HashMap::new(),
             dirty: Vec::new(),
@@ -58,6 +60,10 @@ impl MockDomDocument {
 }
 
 impl DomDocument for MockDomDocument {
+    fn doc_key(&self) -> u64 {
+        self.doc_key
+    }
+
     fn create_element(&mut self, tag: &str) -> NodeId {
         let id = self.next_id();
         self.nodes.insert(

--- a/crates/rinch-core/src/dom/mod.rs
+++ b/crates/rinch-core/src/dom/mod.rs
@@ -641,7 +641,16 @@ impl NodeHandle {
     /// }
     /// ```
     pub fn bounds_signal(&self) -> crate::reactive::Signal<crate::reactive::ElementBounds> {
-        crate::reactive::register_bounds_signal(self.node_id.0 as u64)
+        // Scope the registration to this node's document — node ids collide
+        // across documents (issue #134). A handle whose document is already
+        // gone registers under key 0 (matches no live document), yielding a
+        // signal that simply keeps its zero rect.
+        let doc_key = self
+            .doc
+            .upgrade()
+            .map(|doc| doc.borrow().doc_key())
+            .unwrap_or(0);
+        crate::reactive::register_bounds_signal(doc_key, self.node_id.0 as u64)
     }
 
     /// Get the tag name of this node (if it's an element).

--- a/crates/rinch-core/src/dom/traits.rs
+++ b/crates/rinch-core/src/dom/traits.rs
@@ -115,6 +115,16 @@ pub struct NodeFont {
     pub style: String,
 }
 
+/// Allocate a fresh process-unique document key for [`DomDocument::doc_key`].
+///
+/// Call once per document at construction and store the result. Monotonic and
+/// never reused, so it is immune to allocator address reuse (unlike keying by
+/// `Rc` pointer).
+pub fn next_doc_key() -> u64 {
+    static NEXT_DOC_KEY: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+    NEXT_DOC_KEY.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+}
+
 /// Trait for DOM documents that support mutation operations.
 ///
 /// This trait abstracts the DOM mutation API, allowing different
@@ -129,6 +139,19 @@ pub struct NodeFont {
 /// - Text mutation: [`set_text_content`](DomDocument::set_text_content)
 /// - Dirty tracking: [`mark_dirty`](DomDocument::mark_dirty), [`take_dirty_nodes`](DomDocument::take_dirty_nodes)
 pub trait DomDocument {
+    /// A process-unique identity for this document instance.
+    ///
+    /// Node ids are per-document slab indices, so two documents on one thread
+    /// (e.g. two embedded `RinchContext`s, issue #134) contain the same ids
+    /// `0, 1, 2, …`. Thread-local registries that key state by node id must
+    /// scope it with this key to avoid cross-document collisions (element
+    /// bounds signals, the editor registry, pending focus requests).
+    ///
+    /// Implementations should allocate it once at construction from
+    /// [`next_doc_key`] — never reuse a key, even for a document at the same
+    /// address (an `Rc` pointer is not a substitute: addresses can be reused).
+    fn doc_key(&self) -> u64;
+
     /// Create a new element node with the given tag name.
     fn create_element(&mut self, tag: &str) -> NodeId;
 

--- a/crates/rinch-core/src/events/selection.rs
+++ b/crates/rinch-core/src/events/selection.rs
@@ -173,17 +173,29 @@ pub fn take_pending_selection_clear() -> bool {
 // The runtime checks for and applies focus requests during event processing.
 
 thread_local! {
-    static PENDING_FOCUS_REQUEST: Cell<Option<usize>> = const { Cell::new(None) };
+    /// `(doc_key, node_id)` — the document key scopes the request so a runtime
+    /// driving one document never consumes (and misapplies) a focus request
+    /// posted by another document on the same thread (issue #134).
+    static PENDING_FOCUS_REQUEST: Cell<Option<(u64, usize)>> = const { Cell::new(None) };
 }
 
-/// Request that a specific element be focused.
+/// Request that a specific element be focused, identified by its document's
+/// [`doc_key`](crate::dom::DomDocument::doc_key) and node id.
 /// The runtime will apply this focus before the next event processing cycle.
-pub fn request_focus(node_id: usize) {
-    PENDING_FOCUS_REQUEST.with(|c| c.set(Some(node_id)));
+pub fn request_focus(doc_key: u64, node_id: usize) {
+    PENDING_FOCUS_REQUEST.with(|c| c.set(Some((doc_key, node_id))));
 }
 
-/// Check and consume the pending focus request.
-/// Called by the runtime during event processing.
-pub fn take_pending_focus_request() -> Option<usize> {
-    PENDING_FOCUS_REQUEST.with(|c| c.take())
+/// Consume the pending focus request **if it targets the given document**.
+/// Called by the runtime during event processing with its own document's key;
+/// a request posted by a different document is left in place for that
+/// document's runtime to pick up.
+pub fn take_pending_focus_request(doc_key: u64) -> Option<usize> {
+    PENDING_FOCUS_REQUEST.with(|c| match c.get() {
+        Some((key, node_id)) if key == doc_key => {
+            c.set(None);
+            Some(node_id)
+        }
+        _ => None,
+    })
 }

--- a/crates/rinch-core/src/lib.rs
+++ b/crates/rinch-core/src/lib.rs
@@ -46,10 +46,11 @@ pub use timer::{TimeoutHandle, clear_timeout, fire_timeout, set_timeout, set_tim
 
 // Re-export reactive types for convenience
 pub use reactive::{
-    Effect, ElementBounds, Memo, PollRate, Scope, Signal, batch, clear_on_signal_change,
-    clear_signals_changed, derived, drain_polls, poll_signal, register_bounds_signal,
-    register_main_thread, run_on_main_thread, set_cross_thread_dispatcher, set_on_signal_change,
-    signals_changed, untracked, update_bounds_signals,
+    Effect, ElementBounds, Memo, PollRate, Scope, Signal, SignalChangeSubscription, batch,
+    clear_on_signal_change, clear_signals_changed, derived, drain_polls, poll_signal,
+    register_bounds_signal, register_main_thread, run_on_main_thread, set_cross_thread_dispatcher,
+    set_on_signal_change, signals_changed, subscribe_signal_change, untracked,
+    update_bounds_signals,
 };
 
 // Re-export context for sharing state across components

--- a/crates/rinch-core/src/reactive/bounds.rs
+++ b/crates/rinch-core/src/reactive/bounds.rs
@@ -21,6 +21,11 @@ pub struct ElementBounds {
 }
 
 struct BoundsEntry {
+    /// The owning document's [`doc_key`](crate::dom::DomDocument::doc_key).
+    /// Node ids are per-document slab indices, so without this key two
+    /// documents on one thread (two embedded `RinchContext`s, issue #134) would
+    /// stomp each other's same-id entries on every layout pass.
+    doc_key: u64,
     node_id: u64,
     signal: Signal<ElementBounds>,
 }
@@ -29,7 +34,8 @@ thread_local! {
     static BOUNDS_REGISTRY: RefCell<Vec<BoundsEntry>> = const { RefCell::new(Vec::new()) };
 }
 
-/// Register a reactive `Signal<ElementBounds>` tracking the node's current rect.
+/// Register a reactive `Signal<ElementBounds>` tracking the node's current rect,
+/// scoped to the document identified by `doc_key`.
 ///
 /// The runtime calls [`update_bounds_signals`] after each layout pass to refresh
 /// the value. Subscribers only re-run when the bounds actually change
@@ -39,29 +45,35 @@ thread_local! {
 /// first real bounds arrive after the next layout pass.
 ///
 /// Most users should prefer [`NodeHandle::bounds_signal`](crate::dom::NodeHandle::bounds_signal),
-/// which calls this internally with the node's id.
-pub fn register_bounds_signal(node_id: u64) -> Signal<ElementBounds> {
+/// which calls this internally with the node's document key and id.
+pub fn register_bounds_signal(doc_key: u64, node_id: u64) -> Signal<ElementBounds> {
     let signal = Signal::new(ElementBounds::default());
     BOUNDS_REGISTRY.with(|reg| {
-        reg.borrow_mut().push(BoundsEntry { node_id, signal });
+        reg.borrow_mut().push(BoundsEntry {
+            doc_key,
+            node_id,
+            signal,
+        });
     });
     signal
 }
 
-/// Refresh all registered bounds signals from the supplied absolute-bounds
-/// lookup. Called by the rinch runtime after layout completes.
+/// Refresh the registered bounds signals belonging to the document identified
+/// by `doc_key` from the supplied absolute-bounds lookup. Called by the rinch
+/// runtime after that document's layout completes. Entries registered by other
+/// documents are left untouched — their own runtime pass updates them.
 ///
 /// The lookup returns `None` for nodes that no longer exist; their signals
 /// retain whatever value they last had (no panic, no removal — the registry
 /// currently never shrinks; callers must accept the memory cost as the price
 /// of the simple API).
-pub fn update_bounds_signals<F>(mut absolute_bounds: F)
+pub fn update_bounds_signals<F>(doc_key: u64, mut absolute_bounds: F)
 where
     F: FnMut(u64) -> Option<(f32, f32, f32, f32)>,
 {
     BOUNDS_REGISTRY.with(|reg| {
         let reg = reg.borrow();
-        for entry in reg.iter() {
+        for entry in reg.iter().filter(|e| e.doc_key == doc_key) {
             if let Some((x, y, width, height)) = absolute_bounds(entry.node_id) {
                 entry.signal.set_if_changed(ElementBounds {
                     x,
@@ -80,17 +92,17 @@ mod tests {
 
     #[test]
     fn register_returns_zero_initially() {
-        let signal = register_bounds_signal(99_001);
+        let signal = register_bounds_signal(1, 99_001);
         assert_eq!(signal.get(), ElementBounds::default());
     }
 
     #[test]
     fn update_propagates_when_changed() {
         let id = 99_002;
-        let signal = register_bounds_signal(id);
+        let signal = register_bounds_signal(1, id);
         assert_eq!(signal.get().width, 0.0);
 
-        update_bounds_signals(|qid| {
+        update_bounds_signals(1, |qid| {
             if qid == id {
                 Some((10.0, 20.0, 300.0, 50.0))
             } else {
@@ -108,7 +120,7 @@ mod tests {
         );
 
         // Same bounds → no change, no notify
-        update_bounds_signals(|qid| {
+        update_bounds_signals(1, |qid| {
             if qid == id {
                 Some((10.0, 20.0, 300.0, 50.0))
             } else {
@@ -118,7 +130,7 @@ mod tests {
         assert_eq!(signal.get().width, 300.0);
 
         // New bounds → updates
-        update_bounds_signals(|qid| {
+        update_bounds_signals(1, |qid| {
             if qid == id {
                 Some((10.0, 20.0, 400.0, 50.0))
             } else {
@@ -131,8 +143,8 @@ mod tests {
     #[test]
     fn missing_node_leaves_signal_alone() {
         let id = 99_003;
-        let signal = register_bounds_signal(id);
-        update_bounds_signals(|qid| {
+        let signal = register_bounds_signal(1, id);
+        update_bounds_signals(1, |qid| {
             if qid == id {
                 Some((1.0, 2.0, 3.0, 4.0))
             } else {
@@ -141,7 +153,7 @@ mod tests {
         });
         assert_eq!(signal.get().width, 3.0);
         // Node was removed mid-frame — return None, value persists.
-        update_bounds_signals(|_| None);
+        update_bounds_signals(1, |_| None);
         assert_eq!(signal.get().width, 3.0);
     }
 }

--- a/crates/rinch-core/src/reactive/mod.rs
+++ b/crates/rinch-core/src/reactive/mod.rs
@@ -75,8 +75,16 @@ pub(crate) struct Runtime {
     /// Counter for generating unique IDs
     next_id: usize,
 
-    /// Callback invoked when any signal changes (for UI re-render)
-    pub(crate) on_signal_change: Option<Rc<dyn Fn()>>,
+    /// Callbacks invoked when any signal changes (for UI re-render / dirty
+    /// tracking). Multi-subscriber: each entry is `(subscription id, callback)`;
+    /// a [`SignalChangeSubscription`] removes only its own entry on drop, so
+    /// several consumers (e.g. concurrent embed `RinchContext`s plus a mounted
+    /// shell/web root, issue #134) can each observe signal changes without
+    /// evicting one another.
+    pub(crate) on_signal_change: Vec<(u64, Rc<dyn Fn()>)>,
+
+    /// Counter for [`SignalChangeSubscription`] ids.
+    next_signal_change_sub: u64,
 
     /// Flag set when any signal changes (reset by `clear_signals_changed`)
     pub(crate) signals_changed: bool,
@@ -90,7 +98,8 @@ impl Runtime {
             pending_effects_set: HashSet::new(),
             batching: false,
             next_id: 0,
-            on_signal_change: None,
+            on_signal_change: Vec::new(),
+            next_signal_change_sub: 0,
             signals_changed: false,
         }
     }
@@ -102,10 +111,72 @@ impl Runtime {
     }
 }
 
-/// Register a callback to be invoked whenever any signal changes.
+/// A live signal-change subscription. Dropping it removes **only its own**
+/// callback, leaving every other subscriber attached.
 ///
-/// This is used by the UI runtime to automatically trigger re-renders
-/// when reactive state changes, without requiring manual `request_render()` calls.
+/// Returned by [`subscribe_signal_change`]. Hold it for as long as the callback
+/// should fire (typically as a field of the consumer, e.g. `RinchContext`).
+/// Thread-bound: the reactive runtime is thread-local, so the subscription must
+/// be dropped on the thread that created it.
+#[must_use = "dropping the subscription immediately detaches the callback"]
+pub struct SignalChangeSubscription {
+    id: u64,
+    /// The runtime is thread-local — keep the guard `!Send`/`!Sync`.
+    _not_send: std::marker::PhantomData<*const ()>,
+}
+
+impl Drop for SignalChangeSubscription {
+    fn drop(&mut self) {
+        // `try_with`: TLS may already be torn down at thread exit; `try_borrow_mut`
+        // guards a (pathological) drop from inside a signal-change callback.
+        let _ = RUNTIME.try_with(|rt| {
+            if let Ok(mut rt) = rt.try_borrow_mut() {
+                rt.on_signal_change.retain(|(id, _)| *id != self.id);
+            }
+        });
+    }
+}
+
+/// Register a callback invoked whenever any signal changes, alongside every
+/// other subscriber. Returns a guard that detaches **only this** callback on
+/// drop.
+///
+/// This is the multi-consumer form of [`set_on_signal_change`]: use it when the
+/// consumer has a bounded lifetime (an embedded `RinchContext`, a plugin, a
+/// debug overlay) so that creating or dropping one consumer never silences
+/// another (issue #134).
+///
+/// Callbacks run on the signal's thread, after that change's effects have
+/// flushed, in subscription order.
+pub fn subscribe_signal_change(callback: impl Fn() + 'static) -> SignalChangeSubscription {
+    let id = RUNTIME.with(|rt| {
+        let mut rt = rt.borrow_mut();
+        let id = rt.next_signal_change_sub;
+        rt.next_signal_change_sub += 1;
+        rt.on_signal_change.push((id, Rc::new(callback)));
+        id
+    });
+    SignalChangeSubscription {
+        id,
+        _not_send: std::marker::PhantomData,
+    }
+}
+
+thread_local! {
+    /// Backing subscription for the legacy [`set_on_signal_change`] /
+    /// [`clear_on_signal_change`] API, preserving its historical
+    /// single-occupancy (last-write-wins) semantics for the *legacy slot only* —
+    /// guard-based [`subscribe_signal_change`] subscribers are unaffected.
+    static LEGACY_SIGNAL_CHANGE_SUB: RefCell<Option<SignalChangeSubscription>> =
+        const { RefCell::new(None) };
+}
+
+/// Register the process-wide UI re-render callback (legacy single-slot API).
+///
+/// This replaces any callback previously installed **through this function**;
+/// subscribers registered with [`subscribe_signal_change`] are not affected.
+/// Long-lived runtimes (the desktop shell, `rinch-web`) use this; consumers
+/// with a bounded lifetime should prefer [`subscribe_signal_change`].
 ///
 /// # Example
 ///
@@ -116,16 +187,37 @@ impl Runtime {
 /// });
 /// ```
 pub fn set_on_signal_change(callback: impl Fn() + 'static) {
-    RUNTIME.with(|rt| {
-        rt.borrow_mut().on_signal_change = Some(Rc::new(callback));
+    let sub = subscribe_signal_change(callback);
+    LEGACY_SIGNAL_CHANGE_SUB.with(|slot| {
+        *slot.borrow_mut() = Some(sub);
     });
 }
 
-/// Clear the signal change callback.
+/// Clear the callback installed by [`set_on_signal_change`] (legacy API).
+///
+/// Subscribers registered with [`subscribe_signal_change`] are not affected.
 pub fn clear_on_signal_change() {
-    RUNTIME.with(|rt| {
-        rt.borrow_mut().on_signal_change = None;
+    LEGACY_SIGNAL_CHANGE_SUB.with(|slot| {
+        *slot.borrow_mut() = None;
     });
+}
+
+/// Invoke every live signal-change callback, with no runtime borrow held while
+/// each runs (a callback may itself touch signals). Iterates a snapshot, but
+/// re-checks membership before each invocation so a subscription dropped by an
+/// *earlier* callback in the same notification is honored immediately — keeping
+/// the [`SignalChangeSubscription`] "dropping detaches the callback" contract
+/// exact even mid-notification.
+pub(crate) fn notify_signal_change() {
+    let snapshot: Vec<(u64, Rc<dyn Fn()>)> =
+        RUNTIME.with(|rt| rt.borrow().on_signal_change.clone());
+    for (id, cb) in snapshot {
+        let still_subscribed =
+            RUNTIME.with(|rt| rt.borrow().on_signal_change.iter().any(|(i, _)| *i == id));
+        if still_subscribed {
+            cb();
+        }
+    }
 }
 
 /// Check if any signals have changed since the last call to `clear_signals_changed`.
@@ -393,14 +485,9 @@ pub fn batch<R>(f: impl FnOnce() -> R) -> R {
 
     flush_effects();
 
-    // Invoke the UI re-render callback AFTER Effects have run
-    // This allows fine-grained updates to be queued before the callback checks
-    // Clone the callback first and drop the borrow before calling it
-    // to avoid borrow conflicts if the callback accesses the runtime
-    let callback = RUNTIME.with(|rt| rt.borrow().on_signal_change.clone());
-    if let Some(callback) = callback {
-        callback();
-    }
+    // Invoke the UI re-render callbacks AFTER Effects have run
+    // This allows fine-grained updates to be queued before the callbacks check
+    notify_signal_change();
 
     result
 }
@@ -441,6 +528,92 @@ mod tests {
     use super::*;
     use std::cell::Cell;
     use std::rc::Rc;
+
+    #[test]
+    fn signal_change_subscriptions_are_independent() {
+        let a = Rc::new(Cell::new(0));
+        let b = Rc::new(Cell::new(0));
+
+        let a_hits = a.clone();
+        let sub_a = subscribe_signal_change(move || a_hits.set(a_hits.get() + 1));
+        let b_hits = b.clone();
+        let sub_b = subscribe_signal_change(move || b_hits.set(b_hits.get() + 1));
+
+        // Both subscribers see every change.
+        let sig = Signal::new(0);
+        sig.set(1);
+        assert_eq!(a.get(), 1, "first subscriber fires");
+        assert_eq!(b.get(), 1, "second subscriber fires alongside the first");
+
+        // Dropping one guard detaches only its own callback (#134).
+        drop(sub_b);
+        sig.set(2);
+        assert_eq!(a.get(), 2, "surviving subscriber still fires");
+        assert_eq!(b.get(), 1, "dropped subscriber no longer fires");
+
+        drop(sub_a);
+        sig.set(3);
+        assert_eq!(a.get(), 2, "dropped subscriber no longer fires");
+    }
+
+    #[test]
+    fn subscription_dropped_mid_notification_does_not_fire() {
+        // Subscriber A (registered first) drops B's guard from inside its own
+        // callback — B must NOT fire for that same notification: the guard's
+        // contract is that dropping detaches immediately.
+        let b_hits = Rc::new(Cell::new(0));
+        let b_guard: Rc<RefCell<Option<SignalChangeSubscription>>> = Rc::new(RefCell::new(None));
+
+        let b_guard_for_a = b_guard.clone();
+        let _sub_a = subscribe_signal_change(move || {
+            *b_guard_for_a.borrow_mut() = None; // drop B mid-notification
+        });
+        let b_hits_clone = b_hits.clone();
+        *b_guard.borrow_mut() = Some(subscribe_signal_change(move || {
+            b_hits_clone.set(b_hits_clone.get() + 1);
+        }));
+
+        let sig = Signal::new(0);
+        sig.set(1);
+        assert_eq!(
+            b_hits.get(),
+            0,
+            "a subscription dropped by an earlier callback in the same \
+             notification must not fire"
+        );
+    }
+
+    #[test]
+    fn legacy_slot_is_last_write_wins_but_spares_guard_subscribers() {
+        let legacy = Rc::new(Cell::new(0));
+        let guard = Rc::new(Cell::new(0));
+
+        let guard_hits = guard.clone();
+        let _sub = subscribe_signal_change(move || guard_hits.set(guard_hits.get() + 1));
+
+        // Legacy slot: second set_on_signal_change replaces the first…
+        let first = Rc::new(Cell::new(0));
+        let first_hits = first.clone();
+        set_on_signal_change(move || first_hits.set(first_hits.get() + 1));
+        let legacy_hits = legacy.clone();
+        set_on_signal_change(move || legacy_hits.set(legacy_hits.get() + 1));
+
+        let sig = Signal::new(0);
+        sig.set(1);
+        assert_eq!(first.get(), 0, "evicted legacy callback does not fire");
+        assert_eq!(legacy.get(), 1, "current legacy callback fires");
+        assert_eq!(
+            guard.get(),
+            1,
+            "guard-based subscriber unaffected by legacy churn"
+        );
+
+        // …and clear_on_signal_change removes only the legacy slot.
+        clear_on_signal_change();
+        sig.set(2);
+        assert_eq!(legacy.get(), 1, "cleared legacy callback does not fire");
+        assert_eq!(guard.get(), 2, "guard-based subscriber survives the clear");
+    }
 
     #[test]
     fn signal_basic() {

--- a/crates/rinch-core/src/reactive/signal.rs
+++ b/crates/rinch-core/src/reactive/signal.rs
@@ -130,11 +130,8 @@ impl<T: 'static> Signal<T> {
 
                 super::flush_effects();
 
-                // Invoke the UI re-render callback AFTER Effects have run
-                let callback = RUNTIME.with(|rt| rt.borrow().on_signal_change.clone());
-                if let Some(callback) = callback {
-                    callback();
-                }
+                // Invoke the UI re-render callbacks AFTER Effects have run
+                super::notify_signal_change();
             }
         });
     }

--- a/crates/rinch-dom/src/dom_impl/dom_document_impl.rs
+++ b/crates/rinch-dom/src/dom_impl/dom_document_impl.rs
@@ -14,6 +14,10 @@ use crate::node::{DirtyFlags, DisplayMode, Node, NodeContext, NodeKind, TextMeas
 use super::{RinchDocument, parse_style_string};
 
 impl DomDocument for RinchDocument {
+    fn doc_key(&self) -> u64 {
+        self.doc_key
+    }
+
     fn create_element(&mut self, tag: &str) -> NodeId {
         let id = self.tree.nodes.vacant_key();
         let mut node = Node::element(id, tag, self.tree.guard.clone());
@@ -997,8 +1001,10 @@ impl DomDocument for RinchDocument {
     }
 
     fn focus_element(&mut self, node_id: NodeId) {
-        // Request focus via the event system - the runtime will apply it
-        rinch_core::request_focus(node_id.0);
+        // Request focus via the event system - the runtime will apply it.
+        // Keyed by this document so another document's runtime on the same
+        // thread doesn't consume it (issue #134).
+        rinch_core::request_focus(self.doc_key, node_id.0);
     }
 
     fn resolve_layout(&mut self, width: f32, height: f32) {

--- a/crates/rinch-dom/src/dom_impl/mod.rs
+++ b/crates/rinch-dom/src/dom_impl/mod.rs
@@ -54,6 +54,10 @@ impl style::servo::media_queries::FontMetricsProvider for SimpleFontMetricsProvi
 /// In later phases, this will integrate Taffy for layout,
 /// Parley for text, and Vello for painting.
 pub struct RinchDocument {
+    /// Process-unique document identity (see [`DomDocument::doc_key`]) — scopes
+    /// per-node-id state in thread-local registries so two documents on one
+    /// thread never collide (issue #134).
+    pub(crate) doc_key: u64,
     /// The node tree.
     pub tree: NodeTree,
     /// Parley font context for text shaping.
@@ -76,6 +80,14 @@ impl Default for RinchDocument {
 }
 
 impl RinchDocument {
+    /// Process-unique document identity (see
+    /// [`DomDocument::doc_key`](rinch_core::dom::DomDocument::doc_key)) —
+    /// inherent accessor so callers holding a concrete `RinchDocument` don't
+    /// need the trait in scope.
+    pub fn doc_key(&self) -> u64 {
+        self.doc_key
+    }
+
     /// Create a new document with root and body nodes.
     pub fn new() -> Self {
         // Enable CSS Grid and text-overflow support in Stylo
@@ -104,6 +116,7 @@ impl RinchDocument {
         let stylist = Stylist::new(device, QuirksMode::NoQuirks);
 
         let mut doc = Self {
+            doc_key: rinch_core::dom::next_doc_key(),
             tree: NodeTree::new(),
             font_cx: parley::FontContext::new(),
             layout_cx: parley::LayoutContext::new(),

--- a/crates/rinch-editor-view/src/blink.rs
+++ b/crates/rinch-editor-view/src/blink.rs
@@ -23,10 +23,11 @@ thread_local! {
     /// The instant the caret phase last reset to "solid". `None` until the first
     /// [`tick`] anchors it.
     static ANCHOR: Cell<Option<Instant>> = const { Cell::new(None) };
-    /// The container id of the editor currently being blinked, so a focus change
-    /// can restore the previously-blinked caret to solid (never leave a blurred
-    /// editor frozen mid-blink with a hidden caret).
-    static TARGET: Cell<Option<usize>> = const { Cell::new(None) };
+    /// The `(doc_key, container id)` of the editor currently being blinked, so a
+    /// focus change can restore the previously-blinked caret to solid (never
+    /// leave a blurred editor frozen mid-blink with a hidden caret). Doc-scoped:
+    /// container ids collide across documents on one thread (issue #134).
+    static TARGET: Cell<Option<(u64, usize)>> = const { Cell::new(None) };
 }
 
 /// Reset the blink phase to "solid". Called whenever the caret moves or the
@@ -35,14 +36,14 @@ pub(crate) fn reset() {
     ANCHOR.with(|a| a.set(Some(Instant::now())));
 }
 
-/// The editor container currently being blinked, if any.
-pub(crate) fn target() -> Option<usize> {
+/// The `(doc_key, container id)` currently being blinked, if any.
+pub(crate) fn target() -> Option<(u64, usize)> {
     TARGET.with(|t| t.get())
 }
 
-/// Record which editor container is being blinked (`None` = none).
-pub(crate) fn set_target(id: Option<usize>) {
-    TARGET.with(|t| t.set(id));
+/// Record which editor is being blinked (`None` = none).
+pub(crate) fn set_target(key: Option<(u64, usize)>) {
+    TARGET.with(|t| t.set(key));
 }
 
 /// The current blink phase and the time until the next toggle. Lazily anchors

--- a/crates/rinch-editor-view/src/component.rs
+++ b/crates/rinch-editor-view/src/component.rs
@@ -55,7 +55,12 @@ impl Component for Editor {
         // Stop the runtime from driving this mount once the scope is disposed
         // (conditional hide, tab switch) — the handle itself may live on.
         let container_id = container.node_id().0;
-        scope.on_cleanup(move || super::registry::unregister_editor(container_id));
+        let doc_key = scope
+            .doc_weak()
+            .upgrade()
+            .map(|d| d.borrow().doc_key())
+            .unwrap_or(0);
+        scope.on_cleanup(move || super::registry::unregister_editor(doc_key, container_id));
         container
     }
 }

--- a/crates/rinch-editor-view/src/handle.rs
+++ b/crates/rinch-editor-view/src/handle.rs
@@ -210,7 +210,14 @@ impl EditorHandle {
         let container = scope.create_element("div");
         container.set_attribute("data-pm-editor", "true");
         self.attach(container.clone(), scope.doc_weak());
-        super::registry::register_editor(container.node_id().0, self.clone());
+        // Register scoped to this document — container ids collide across
+        // documents on one thread (issue #134).
+        let doc_key = scope
+            .doc_weak()
+            .upgrade()
+            .map(|d| d.borrow().doc_key())
+            .unwrap_or(0);
+        super::registry::register_editor(doc_key, container.node_id().0, self.clone());
         container
     }
 

--- a/crates/rinch-editor-view/src/lib.rs
+++ b/crates/rinch-editor-view/src/lib.rs
@@ -27,7 +27,8 @@ pub use handle::EditorHandle;
 #[cfg(feature = "collaboration")]
 pub use registry::collab_receive_for;
 pub use registry::{
-    begin_drag, drag_anchor, editor_for, end_drag, unregister_editor, update_all_carets,
+    begin_drag, drag_anchor, editor_for, editor_for_doc, end_drag, unregister_editor,
+    update_all_carets,
 };
 /// The collaboration error type (re-exported from `rinch-editor-collab`) returned by
 /// the [`EditorHandle`] collaboration methods.
@@ -90,20 +91,25 @@ pub struct CaretBlink {
 /// standalone animation tick). The clock uses `std::time::Instant`, so a web runtime
 /// drives blink with its own timer (`setInterval` → [`EditorHandle::set_caret_blink`])
 /// rather than calling this.
-pub fn caret_blink_tick(focused: Option<usize>) -> Option<CaretBlink> {
+/// `doc_key` is the calling runtime's document (see
+/// [`DomDocument::doc_key`](rinch_core::dom::DomDocument::doc_key)) — `focused`
+/// is a container id from that document's focus arbiter, and container ids
+/// collide across documents on one thread (issue #134).
+pub fn caret_blink_tick(doc_key: u64, focused: Option<usize>) -> Option<CaretBlink> {
+    let target = focused.map(|id| (doc_key, id));
     // On a focus change, restore the previously-blinked caret to solid so a
     // blurred editor never freezes mid-blink with a hidden caret.
     let prev = blink::target();
-    if prev != focused {
-        if let Some(prev_id) = prev
-            && let Some(h) = registry::editor_for(prev_id)
+    if prev != target {
+        if let Some((prev_dk, prev_id)) = prev
+            && let Some(h) = registry::editor_for_doc(prev_dk, prev_id)
         {
             h.set_caret_blink(true);
         }
-        blink::set_target(focused);
+        blink::set_target(target);
         blink::reset();
     }
-    let handle = registry::editor_for(focused?)?;
+    let handle = registry::editor_for_doc(doc_key, focused?)?;
     let (visible, next) = blink::tick();
     let redraw = handle.set_caret_blink(visible)?;
     Some(CaretBlink { redraw, next })

--- a/crates/rinch-editor-view/src/registry.rs
+++ b/crates/rinch-editor-view/src/registry.rs
@@ -16,8 +16,12 @@ use std::cell::RefCell;
 use crate::handle::EditorHandle;
 
 thread_local! {
-    /// `(container node id, handle)` for every mounted editor.
-    static EDITORS: RefCell<Vec<(usize, EditorHandle)>> = const { RefCell::new(Vec::new()) };
+    /// `(doc_key, container node id, handle)` for every mounted editor. The
+    /// [`doc_key`](rinch_core::dom::DomDocument::doc_key) scopes entries per
+    /// document: container node ids are per-document slab indices, so two
+    /// documents on one thread (two embedded `RinchContext`s, or two desktop
+    /// windows) can both hold an editor at the same container id (issue #134).
+    static EDITORS: RefCell<Vec<(u64, usize, EditorHandle)>> = const { RefCell::new(Vec::new()) };
     /// An in-progress pointer drag-select: `(container id, anchor position)`.
     static DRAG: RefCell<Option<(usize, usize)>> = const { RefCell::new(None) };
 }
@@ -38,12 +42,14 @@ pub fn end_drag() {
     DRAG.with(|d| *d.borrow_mut() = None);
 }
 
-/// Register `handle` under its `container_id` (replacing any prior registration).
-pub fn register_editor(container_id: usize, handle: EditorHandle) {
+/// Register `handle` under its document's `doc_key` and `container_id`
+/// (replacing any prior registration **for that same document + container** —
+/// another document's editor at a colliding container id is left registered).
+pub fn register_editor(doc_key: u64, container_id: usize, handle: EditorHandle) {
     EDITORS.with(|e| {
         let mut e = e.borrow_mut();
-        e.retain(|(id, _)| *id != container_id);
-        e.push((container_id, handle));
+        e.retain(|(dk, id, _)| !(*dk == doc_key && *id == container_id));
+        e.push((doc_key, container_id, handle));
     });
 }
 
@@ -53,24 +59,51 @@ pub fn register_editor(container_id: usize, handle: EditorHandle) {
 /// driver already drops windows for editors no longer in [`all_editors`] on its
 /// next sweep, and a stale window is never read in between (it is only consulted
 /// for currently-registered editors). So removal from the registry is sufficient.
-pub fn unregister_editor(container_id: usize) {
-    EDITORS.with(|e| e.borrow_mut().retain(|(id, _)| *id != container_id));
+pub fn unregister_editor(doc_key: u64, container_id: usize) {
+    EDITORS.with(|e| {
+        e.borrow_mut()
+            .retain(|(dk, id, _)| !(*dk == doc_key && *id == container_id))
+    });
 }
 
-/// Every mounted editor as `(container id, handle)`. The desktop virtualization
-/// driver sweeps these each layout to maintain a per-editor block window.
-pub fn all_editors() -> Vec<(usize, EditorHandle)> {
-    EDITORS.with(|e| e.borrow().iter().map(|(id, h)| (*id, h.clone())).collect())
+/// Every mounted editor as `(doc_key, container id, handle)`. The desktop
+/// virtualization driver sweeps these each layout — filtered to its own
+/// document — to maintain a per-editor block window.
+pub fn all_editors() -> Vec<(u64, usize, EditorHandle)> {
+    EDITORS.with(|e| {
+        e.borrow()
+            .iter()
+            .map(|(dk, id, h)| (*dk, *id, h.clone()))
+            .collect()
+    })
 }
 
-/// The handle registered for `container_id`, if any. The runtime resolves its
-/// `FocusTarget::Editor(container_id)` to a handle through this.
+/// The handle registered for `container_id` **in the document identified by
+/// `doc_key`**. Runtimes that resolved `container_id` from their own document
+/// (hit-testing, `FocusTarget::Editor`) must use this form — container ids
+/// collide across documents on one thread (issue #134).
+pub fn editor_for_doc(doc_key: u64, container_id: usize) -> Option<EditorHandle> {
+    EDITORS.with(|e| {
+        e.borrow()
+            .iter()
+            .find(|(dk, id, _)| *dk == doc_key && *id == container_id)
+            .map(|(_, _, h)| h.clone())
+    })
+}
+
+/// The first handle registered for `container_id` in **any** document.
+///
+/// For callers without a document in hand (the web input glue, collab routing,
+/// the caret blink tick). Exact when container ids are unique on the thread —
+/// the common single-document case; with several documents a collision resolves
+/// to the earliest registration. Prefer [`editor_for_doc`] where the document
+/// is known.
 pub fn editor_for(container_id: usize) -> Option<EditorHandle> {
     EDITORS.with(|e| {
         e.borrow()
             .iter()
-            .find(|(id, _)| *id == container_id)
-            .map(|(_, h)| h.clone())
+            .find(|(_, id, _)| *id == container_id)
+            .map(|(_, _, h)| h.clone())
     })
 }
 
@@ -82,11 +115,16 @@ pub fn editor_for(container_id: usize) -> Option<EditorHandle> {
 /// other mounted editor hides its overlays — so a blurred editor shows neither a
 /// caret nor a selection (and the caret blink, which only runs for the focused
 /// editor, idles for the rest).
-pub fn update_all_carets(focused: Option<usize>) -> bool {
-    let editors: Vec<(usize, EditorHandle)> =
-        EDITORS.with(|e| e.borrow().iter().map(|(id, h)| (*id, h.clone())).collect());
+/// `doc_key`: pass `Some(key)` to touch only that document's editors (a desktop
+/// or embed runtime driving its own post-layout pass); `None` sweeps every
+/// mounted editor (the web runtime, which drives all islands from one place).
+pub fn update_all_carets(doc_key: Option<u64>, focused: Option<usize>) -> bool {
+    let editors = all_editors();
     let mut moved = false;
-    for (id, handle) in editors {
+    for (dk, id, handle) in editors {
+        if doc_key.is_some_and(|k| k != dk) {
+            continue;
+        }
         if Some(id) == focused {
             moved |= handle.update_caret();
         } else {

--- a/crates/rinch-editor-view/src/styles.rs
+++ b/crates/rinch-editor-view/src/styles.rs
@@ -17,7 +17,6 @@
 //! flexbox (`table` = column, `row` = row, cells = equal-width flex items). This
 //! is why the default stylesheet is load-bearing for tables, not just cosmetic.
 
-use std::cell::Cell;
 use std::cell::RefCell;
 use std::rc::Weak;
 
@@ -185,24 +184,29 @@ pub(crate) const DEFAULT_EDITOR_CSS: &str = r#"
 "#;
 
 thread_local! {
-    /// Whether [`DEFAULT_EDITOR_CSS`] has already been injected on this thread.
-    /// The stylesheet is global and idempotent, so one injection per UI thread
-    /// (one document) suffices; the guard stops every mounted editor from adding
-    /// its own duplicate copy.
-    static INJECTED: Cell<bool> = const { Cell::new(false) };
+    /// The [`doc_key`](rinch_core::dom::DomDocument::doc_key)s of documents that
+    /// already carry [`DEFAULT_EDITOR_CSS`]. Keyed **per document**, not per
+    /// thread: two documents on one thread (e.g. two embedded `RinchContext`s,
+    /// issue #134) each need their own copy of the stylesheet — a thread-wide
+    /// flag left the second document's editor completely unstyled. The guard
+    /// still stops every mounted editor from adding a duplicate copy to *its*
+    /// document.
+    static INJECTED: RefCell<std::collections::HashSet<u64>> =
+        RefCell::new(std::collections::HashSet::new());
 }
 
 /// Inject [`DEFAULT_EDITOR_CSS`] into the document `<body>` as a `<style>` element,
-/// once per thread. A no-op if the document is gone or the styles are already
+/// once per document. A no-op if the document is gone or the styles are already
 /// present. Called by [`RinchDomEditorView`](super::view::RinchDomEditorView) on
 /// construction so consumers never have to wire the stylesheet by hand.
 pub(crate) fn ensure_default_styles(doc: &Weak<RefCell<dyn DomDocument>>) {
-    if INJECTED.with(|f| f.get()) {
-        return;
-    }
     let Some(doc) = doc.upgrade() else {
         return;
     };
+    let doc_key = doc.borrow().doc_key();
+    if INJECTED.with(|f| f.borrow().contains(&doc_key)) {
+        return;
+    }
     let mut d = doc.borrow_mut();
     let body = d.body();
     let style = d.create_element("style");
@@ -210,5 +214,5 @@ pub(crate) fn ensure_default_styles(doc: &Weak<RefCell<dyn DomDocument>>) {
     let text = d.create_text(DEFAULT_EDITOR_CSS);
     d.append_child(style, text);
     d.append_child(body, style);
-    INJECTED.with(|f| f.set(true));
+    INJECTED.with(|f| f.borrow_mut().insert(doc_key));
 }

--- a/crates/rinch-editor-view/src/view.rs
+++ b/crates/rinch-editor-view/src/view.rs
@@ -562,6 +562,16 @@ impl RinchDomEditorView {
         self.root.dom.node_id().0
     }
 
+    /// The host document's [`doc_key`](rinch_core::dom::DomDocument::doc_key),
+    /// or 0 if the document is gone. Scopes the blink target — container ids
+    /// collide across documents on one thread (issue #134).
+    pub(crate) fn doc_key(&self) -> u64 {
+        self.doc
+            .upgrade()
+            .map(|d| d.borrow().doc_key())
+            .unwrap_or(0)
+    }
+
     /// Switch the editor's color scheme by setting `data-pm-theme` on the container,
     /// which the default stylesheet's dark rules key off of (see
     /// [`styles`](super::styles)).
@@ -956,7 +966,7 @@ impl RinchDomEditorView {
         // `update_all_carets` sweeps every one, and a programmatic caret move in
         // an unfocused editor must not stomp the focused editor's global phase.
         // (A focus change resets the phase separately, in `caret_blink_tick`.)
-        if super::blink::target() == Some(self.container_id()) {
+        if super::blink::target() == Some((self.doc_key(), self.container_id())) {
             super::blink::reset();
         }
         // The `display: block` written below always puts this caret in the
@@ -1385,7 +1395,7 @@ mod tests {
         let mut view_b = RinchDomEditorView::new(container_b, doc_ref(&h), &st_b);
 
         // Editor A is the focused / blink-target editor.
-        crate::blink::set_target(Some(view_a.container_id()));
+        crate::blink::set_target(Some((view_a.doc_key(), view_a.container_id())));
         crate::blink::reset();
         let anchor0 = crate::blink::anchor_for_test();
 

--- a/crates/rinch-web/src/editor_input.rs
+++ b/crates/rinch-web/src/editor_input.rs
@@ -147,7 +147,7 @@ fn focused_handle() -> Option<(usize, EditorHandle)> {
 /// Resets the blink phase so the caret is solid immediately after an interaction.
 fn refresh_caret() {
     BLINK_ON.with(|c| c.set(true));
-    registry::update_all_carets(focused_editor());
+    registry::update_all_carets(None, focused_editor());
 }
 
 // ── Hidden capture target (clipboard + IME) ───────────────────────────────────

--- a/crates/rinch-web/src/web_document.rs
+++ b/crates/rinch-web/src/web_document.rs
@@ -23,6 +23,8 @@ static NEXT_NODE_ID: AtomicUsize = AtomicUsize::new(0);
 /// Reverse lookups (browser node -> NodeId) use a `__nid` JS property
 /// set on each node via `Reflect::set`.
 pub struct WebDocument {
+    /// Process-unique document identity (see [`DomDocument::doc_key`]).
+    doc_key: u64,
     /// The browser's document object.
     browser_doc: web_sys::Document,
     /// Map from rinch NodeId to browser DOM node.
@@ -236,6 +238,7 @@ impl WebDocument {
     /// as body, appending root to `document.body()`.
     pub fn new(browser_doc: web_sys::Document) -> Self {
         let mut doc = Self {
+            doc_key: rinch_core::dom::next_doc_key(),
             browser_doc,
             nodes: HashMap::new(),
             root_id: NodeId(0),
@@ -280,6 +283,7 @@ impl WebDocument {
     /// any number of islands can coexist on one page without id collisions.
     pub fn new_into(browser_doc: web_sys::Document, host: web_sys::Element) -> Self {
         let mut doc = Self {
+            doc_key: rinch_core::dom::next_doc_key(),
             browser_doc,
             nodes: HashMap::new(),
             root_id: NodeId(0),
@@ -398,6 +402,10 @@ fn utf8_byte_to_utf16_offset(text: &str, byte_offset: usize) -> usize {
 }
 
 impl DomDocument for WebDocument {
+    fn doc_key(&self) -> u64 {
+        self.doc_key
+    }
+
     fn create_element(&mut self, tag: &str) -> NodeId {
         let el = if is_svg_tag(tag) {
             self.browser_doc

--- a/crates/rinch/Cargo.toml
+++ b/crates/rinch/Cargo.toml
@@ -75,6 +75,8 @@ softbuffer = { git = "https://github.com/rust-windowing/softbuffer", rev = "672d
 [dev-dependencies]
 # Test-only: the headless DomDocument double, used by the new editor view's tests.
 rinch-core = { workspace = true, features = ["test-util"] }
+# Test-only: direct tree/text queries against RinchDocument (tests/multi_context.rs).
+rinch-dom = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gtk = { version = "0.18", optional = true }

--- a/crates/rinch/src/app/click_handling.rs
+++ b/crates/rinch/src/app/click_handling.rs
@@ -335,7 +335,9 @@ impl RinchApp {
                     events::dispatch_event(events::EventHandlerId(handler_id));
                     // Process any pending focus request from the event handler
                     // (e.g., a handler may call request_focus on an input element).
-                    if let Some(focus_node_id) = rinch_core::take_pending_focus_request() {
+                    if let Some(focus_node_id) =
+                        rinch_core::take_pending_focus_request(self.doc_key())
+                    {
                         self.try_focus_input(focus_node_id);
                     }
                     actions.push(AppAction::RequestRedraw);

--- a/crates/rinch/src/app/event_dispatch.rs
+++ b/crates/rinch/src/app/event_dispatch.rs
@@ -903,7 +903,9 @@ impl RinchApp {
                 match self.focus_target {
                     #[cfg(feature = "desktop")]
                     FocusTarget::Editor(container) => {
-                        if let Some(handle) = crate::editor::editor_for(container) {
+                        if let Some(handle) =
+                            crate::editor::editor_for_doc(self.doc_key(), container)
+                        {
                             self.dispatch_new_editor_key(
                                 &handle,
                                 key,
@@ -1031,7 +1033,9 @@ impl RinchApp {
                 match self.focus_target {
                     #[cfg(feature = "desktop")]
                     FocusTarget::Editor(container) => {
-                        if let Some(handle) = crate::editor::editor_for(container) {
+                        if let Some(handle) =
+                            crate::editor::editor_for_doc(self.doc_key(), container)
+                        {
                             self.dispatch_editor_ime(&handle, ime);
                             self.refresh_editor_overlays();
                             let (w, h) = (window_size.0 as f32, window_size.1 as f32);
@@ -1061,7 +1065,8 @@ impl RinchApp {
                 }
                 // Process any pending input focus request (e.g., from an Effect
                 // triggered by run_on_main_thread that called request_focus).
-                if let Some(focus_node_id) = rinch_core::take_pending_focus_request() {
+                if let Some(focus_node_id) = rinch_core::take_pending_focus_request(self.doc_key())
+                {
                     self.try_focus_input(focus_node_id);
                     actions.push(AppAction::RequestRedraw);
                 }
@@ -1174,7 +1179,8 @@ impl RinchApp {
                 }
 
                 // Process any pending input focus request from effects
-                if let Some(focus_node_id) = rinch_core::take_pending_focus_request() {
+                if let Some(focus_node_id) = rinch_core::take_pending_focus_request(self.doc_key())
+                {
                     self.try_focus_input(focus_node_id);
                     actions.push(AppAction::RequestRedraw);
                 }
@@ -2680,7 +2686,7 @@ impl RinchApp {
         let Some(container) = self.editor_container_at_physical(x, y, scale) else {
             return false;
         };
-        let Some(handle) = crate::editor::editor_for(container) else {
+        let Some(handle) = crate::editor::editor_for_doc(self.doc_key(), container) else {
             return false;
         };
         // Take keyboard focus through the arbiter (tears down a prior surface /
@@ -2765,7 +2771,7 @@ impl RinchApp {
         if c != container {
             return true;
         }
-        let Some(handle) = crate::editor::editor_for(container) else {
+        let Some(handle) = crate::editor::editor_for_doc(self.doc_key(), container) else {
             return false;
         };
         if let Some(head) = handle.pos_at(tb, ifc) {

--- a/crates/rinch/src/app/focus.rs
+++ b/crates/rinch/src/app/focus.rs
@@ -65,7 +65,7 @@ impl RinchApp {
                 // `EditorHandle` — this only clears the overlays.) A pure focus
                 // change doesn't dirty layout, so the post-layout caret pass may
                 // short-circuit; hide explicitly here at the focus choke-point.
-                if let Some(handle) = crate::editor::editor_for(prev) {
+                if let Some(handle) = crate::editor::editor_for_doc(self.doc_key(), prev) {
                     handle.hide_overlays();
                 }
             }
@@ -83,11 +83,12 @@ impl RinchApp {
         match self.focus_target {
             #[cfg(feature = "desktop")]
             FocusTarget::Editor(container) => {
-                let cursor_area = crate::editor::editor_for(container).and_then(|handle| {
-                    let head = handle.selection().head();
-                    self.editor_caret_point(&handle, head)
-                        .map(|(x, y, h)| (x, y, 1.0, h))
-                });
+                let cursor_area = crate::editor::editor_for_doc(self.doc_key(), container)
+                    .and_then(|handle| {
+                        let head = handle.selection().head();
+                        self.editor_caret_point(&handle, head)
+                            .map(|(x, y, h)| (x, y, 1.0, h))
+                    });
                 ImeState {
                     enabled: true,
                     cursor_area,

--- a/crates/rinch/src/app/mod.rs
+++ b/crates/rinch/src/app/mod.rs
@@ -494,8 +494,10 @@ impl RinchApp {
         // New-editor phase 2 (design A3): render mounted editors' carets against
         // the fresh initial layout (the steady-state pass in resolve_and_repaint
         // short-circuits when nothing is dirty, so the first caret renders here).
+        // Key off the local `doc` — `self.doc` is only assigned below, so
+        // `self.doc_key()` would still be 0 here and filter every editor out.
         #[cfg(feature = "desktop")]
-        crate::editor::update_all_carets(self.focused_editor_id());
+        crate::editor::update_all_carets(Some(doc.borrow().doc_key()), self.focused_editor_id());
 
         self.scene_dirty = true;
         self.doc = Some(doc.clone());
@@ -511,7 +513,7 @@ impl RinchApp {
     /// clear a moved absolute element's old rect — so without this they ghost.
     #[cfg(feature = "desktop")]
     pub(crate) fn refresh_editor_overlays(&mut self) {
-        if crate::editor::update_all_carets(self.focused_editor_id()) {
+        if crate::editor::update_all_carets(Some(self.doc_key()), self.focused_editor_id()) {
             self.scene_dirty = true;
             #[cfg(not(feature = "gpu"))]
             {
@@ -621,7 +623,7 @@ impl RinchApp {
         // dirty-region cache can't clear a moved absolute element's *old* rect, so
         // the overlay would otherwise ghost.
         #[cfg(feature = "desktop")]
-        if crate::editor::update_all_carets(self.focused_editor_id()) {
+        if crate::editor::update_all_carets(Some(self.doc_key()), self.focused_editor_id()) {
             {
                 let mut d = doc.borrow_mut();
                 let _ = d.take_dirty_nodes();
@@ -640,7 +642,7 @@ impl RinchApp {
         // borrowed read-only just for the lookup.
         {
             let d = doc.borrow();
-            rinch_core::reactive::update_bounds_signals(|node_id| {
+            rinch_core::reactive::update_bounds_signals(d.doc_key(), |node_id| {
                 let nid = node_id as usize;
                 let n = d.tree.nodes.get(nid)?;
                 // Walk to root accumulating parent-relative offsets — same
@@ -1483,6 +1485,13 @@ impl RinchApp {
         }
 
         self.scene_dirty = true;
+    }
+
+    /// This app's document identity (see `DomDocument::doc_key`), or 0 before
+    /// mount. Used to scope thread-local registries (bounds signals, pending
+    /// focus requests) to this document (issue #134).
+    pub(crate) fn doc_key(&self) -> u64 {
+        self.doc.as_ref().map(|d| d.borrow().doc_key()).unwrap_or(0)
     }
 
     /// Programmatically focus an input element by node ID.

--- a/crates/rinch/src/editor/virtualization.rs
+++ b/crates/rinch/src/editor/virtualization.rs
@@ -24,8 +24,12 @@ use rinch_editor_view::registry;
 use super::virtual_window::CeVirtualWindow;
 
 thread_local! {
-    /// `(container id, window)` for each scroll-container editor being virtualized.
-    static WINDOWS: RefCell<Vec<(usize, CeVirtualWindow)>> = const { RefCell::new(Vec::new()) };
+    /// `((doc_key, container id), window)` for each scroll-container editor being
+    /// virtualized. Keyed per document: container ids are per-document slab
+    /// indices, so two documents on one thread would otherwise share (and stomp)
+    /// a window at a colliding id (issue #134).
+    static WINDOWS: RefCell<Vec<((u64, usize), CeVirtualWindow)>> =
+        const { RefCell::new(Vec::new()) };
 }
 
 /// Phase 1 (before layout): for every mounted editor that is a scroll container,
@@ -34,24 +38,33 @@ thread_local! {
 /// document's style/layout dirty flags, so the caller's short-circuit will not fire
 /// and the upcoming resolve applies the collapse.
 pub(crate) fn pre_layout(doc: &mut RinchDocument, focused: Option<usize>) {
-    let editors = registry::all_editors();
+    let doc_key = doc.doc_key();
+    // Only this document's editors: another document's editors are driven by its
+    // own runtime pass, against its own tree (issue #134).
+    let editors: Vec<(usize, EditorHandle)> = registry::all_editors()
+        .into_iter()
+        .filter(|(dk, _, _)| *dk == doc_key)
+        .map(|(_, id, h)| (id, h))
+        .collect();
     WINDOWS.with(|w| {
         let mut windows = w.borrow_mut();
-        // Drop windows whose editor unmounted.
-        windows.retain(|(id, _)| editors.iter().any(|(eid, _)| eid == id));
+        // Drop THIS document's windows whose editor unmounted; other documents'
+        // windows are managed by their own pass.
+        windows.retain(|((dk, id), _)| *dk != doc_key || editors.iter().any(|(eid, _)| eid == id));
         for (container, handle) in &editors {
             let container = *container;
             if container == 0 {
                 continue;
             }
-            let idx = match windows.iter().position(|(id, _)| *id == container) {
+            let key = (doc_key, container);
+            let idx = match windows.iter().position(|(k, _)| *k == key) {
                 Some(i) => i,
                 None => {
                     if !is_scroll_container(doc, container) {
                         continue;
                     }
                     let vw = CeVirtualWindow::new_filtered(container, doc, true);
-                    windows.push((container, vw));
+                    windows.push((key, vw));
                     windows.len() - 1
                 }
             };
@@ -73,12 +86,18 @@ pub(crate) fn pre_layout(doc: &mut RinchDocument, focused: Option<usize>) {
 /// Phase 2 (after layout): cache measured heights, then re-verify the materialized
 /// range with fresh positions; if it changed (a big scroll jump), re-layout once.
 pub(crate) fn post_layout(doc: &mut RinchDocument, focused: Option<usize>, vw_w: f32, vw_h: f32) {
-    let editors = registry::all_editors();
+    let doc_key = doc.doc_key();
+    let editors: Vec<(usize, EditorHandle)> = registry::all_editors()
+        .into_iter()
+        .filter(|(dk, _, _)| *dk == doc_key)
+        .map(|(_, id, h)| (id, h))
+        .collect();
     WINDOWS.with(|w| {
         let mut windows = w.borrow_mut();
         for (container, handle) in &editors {
             let container = *container;
-            let Some(idx) = windows.iter().position(|(id, _)| *id == container) else {
+            let key = (doc_key, container);
+            let Some(idx) = windows.iter().position(|(k, _)| *k == key) else {
                 continue;
             };
             let vw = &mut windows[idx].1;

--- a/crates/rinch/src/embed.rs
+++ b/crates/rinch/src/embed.rs
@@ -114,6 +114,11 @@ pub struct RinchContext {
     size: (u32, u32),
     scale_factor: f64,
     dirty: Arc<AtomicBool>,
+    /// This context's signal-change subscription. Multi-subscriber: several
+    /// concurrent contexts (plus a mounted shell/web root) each hold their own,
+    /// and dropping this context detaches only its own callback — creating or
+    /// dropping context B never silences context A (issue #134).
+    _signal_change_sub: rinch_core::SignalChangeSubscription,
 }
 
 impl RinchContext {
@@ -157,10 +162,12 @@ impl RinchContext {
         // Register main thread for cross-thread signal dispatch
         rinch_core::register_main_thread();
 
-        // Set up signal-change callback so the game loop can detect dirty state
+        // Subscribe to signal changes so the game loop can detect dirty state.
+        // A guard-based subscription (not the legacy single slot): each context
+        // observes independently, so N contexts can coexist (issue #134).
         let dirty = Arc::new(AtomicBool::new(false));
         let dirty_clone = dirty.clone();
-        rinch_core::set_on_signal_change(move || {
+        let signal_change_sub = rinch_core::subscribe_signal_change(move || {
             dirty_clone.store(true, Ordering::Release);
         });
 
@@ -169,6 +176,7 @@ impl RinchContext {
             size: (width, height),
             scale_factor,
             dirty,
+            _signal_change_sub: signal_change_sub,
         }
     }
 
@@ -322,12 +330,6 @@ impl RinchContext {
             self.size.0 as f32 / self.scale_factor as f32,
             self.size.1 as f32 / self.scale_factor as f32,
         )
-    }
-}
-
-impl Drop for RinchContext {
-    fn drop(&mut self) {
-        rinch_core::clear_on_signal_change();
     }
 }
 

--- a/crates/rinch/src/shell/rinch_runtime.rs
+++ b/crates/rinch/src/shell/rinch_runtime.rs
@@ -1842,7 +1842,7 @@ impl RinchRuntime {
     #[cfg(feature = "desktop")]
     fn tick_caret_blink(&mut self, event_loop: &dyn ActiveEventLoop) {
         let focused = self.app.focused_editor_id();
-        match crate::editor::caret_blink_tick(focused) {
+        match crate::editor::caret_blink_tick(self.app.doc_key(), focused) {
             Some(blink) => {
                 if blink.redraw
                     && let Some(w) = &self.window
@@ -1912,7 +1912,7 @@ impl RinchRuntime {
         let Some(handle) = self
             .app
             .focused_editor_id()
-            .and_then(crate::editor::editor_for)
+            .and_then(|id| crate::editor::editor_for_doc(self.app.doc_key(), id))
         else {
             return;
         };
@@ -1941,7 +1941,7 @@ impl RinchRuntime {
         let Some(handle) = self
             .app
             .focused_editor_id()
-            .and_then(crate::editor::editor_for)
+            .and_then(|id| crate::editor::editor_for_doc(self.app.doc_key(), id))
         else {
             return;
         };

--- a/crates/rinch/tests/multi_context.rs
+++ b/crates/rinch/tests/multi_context.rs
@@ -1,0 +1,392 @@
+//! Empirical pinning tests for issue #134: two `RinchContext`s on one thread.
+//!
+//! Each test constructs headless embed contexts (no window, no GPU — `scene()`
+//! is never called) and demonstrates the REAL current behavior of the shared
+//! thread-local state. Tests that document broken behavior assert the buggy
+//! outcome explicitly and are marked `BUG #134` — if such an assertion starts
+//! failing, the bug got fixed: flip the assertion to the correct behavior.
+//!
+//! Requires the `embed` (or `gpu`) feature — with default features OFF (the
+//! `desktop` + `embed` combination does not compile; see #134's follow-ups):
+//!     cargo test -p rinch --no-default-features --features embed --test multi_context
+//!
+//! ## Why every test body runs on one shared worker thread
+//!
+//! `RinchContext::new` calls `rinch_core::register_main_thread()`, a
+//! process-wide `OnceLock` — the FIRST test thread to create a context becomes
+//! "the main thread" forever, and `Signal::set` panics on every other thread.
+//! The libtest harness runs each `#[test]` on its own thread, so all bodies are
+//! marshalled onto a single long-lived worker thread (`on_ui_thread`), which
+//! also serializes them. Consequence: thread-local reactive state leaks from
+//! one test to the next, so each test cleans up what it can (contexts dropped,
+//! `clear_context()` where stores are used).
+
+#![cfg(any(feature = "gpu", feature = "embed"))]
+
+use std::cell::Cell;
+use std::rc::Rc;
+use std::sync::mpsc;
+use std::sync::{Mutex, OnceLock};
+
+use rinch::embed::{RinchContext, RinchContextConfig};
+use rinch::prelude::*;
+
+// ── harness ──────────────────────────────────────────────────────────────────
+
+type Job = Box<dyn FnOnce() + Send>;
+
+/// Run `f` on the single shared "UI" worker thread and propagate its panic (if
+/// any) back to the calling test thread.
+fn on_ui_thread<T: Send + 'static>(f: impl FnOnce() -> T + Send + 'static) -> T {
+    static SENDER: OnceLock<Mutex<mpsc::Sender<Job>>> = OnceLock::new();
+    let sender = SENDER.get_or_init(|| {
+        let (tx, rx) = mpsc::channel::<Job>();
+        std::thread::Builder::new()
+            .name("rinch-test-ui".into())
+            .spawn(move || {
+                for job in rx {
+                    job();
+                }
+            })
+            .expect("spawn ui worker");
+        Mutex::new(tx)
+    });
+
+    let (result_tx, result_rx) = mpsc::channel();
+    let job: Job = Box::new(move || {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+        let _ = result_tx.send(result);
+    });
+    sender
+        .lock()
+        .expect("ui sender lock")
+        .send(job)
+        .expect("ui worker alive");
+    match result_rx.recv().expect("ui worker responded") {
+        Ok(v) => v,
+        Err(panic) => std::panic::resume_unwind(panic),
+    }
+}
+
+fn cfg() -> RinchContextConfig {
+    RinchContextConfig {
+        width: 800,
+        height: 600,
+        scale_factor: 1.0,
+        theme: None,
+        fonts: Vec::new(),
+    }
+}
+
+/// All text content in a context's document, in tree order.
+fn doc_text(ctx: &RinchContext) -> String {
+    let doc = ctx.app().doc().expect("context has a document").clone();
+    let d = doc.borrow();
+    rinch_dom::testing::get_text_content(&d.tree, d.tree.root_id)
+}
+
+// ── 1. independent rendering ─────────────────────────────────────────────────
+
+/// Two contexts, each with its own Signal + reactive text. Driving one signal
+/// updates only that context's document. This is the part of the shared
+/// reactive graph that WORKS: signals/effects live in unique slots, and
+/// `Signal::notify` is subscriber-precise, so cross-context effects never
+/// misfire.
+#[test]
+fn two_contexts_render_independently() {
+    on_ui_thread(|| {
+        let sig_a = Signal::new(0i32);
+        let sig_b = Signal::new(0i32);
+
+        let mut a = RinchContext::new(cfg(), move |__scope: &mut RenderScope| {
+            rsx! {
+                div {
+                    p { {move || format!("A:{}", sig_a.get())} }
+                }
+            }
+        });
+        let mut b = RinchContext::new(cfg(), move |__scope: &mut RenderScope| {
+            rsx! {
+                div {
+                    p { {move || format!("B:{}", sig_b.get())} }
+                }
+            }
+        });
+        a.update(&[]);
+        b.update(&[]);
+
+        assert!(doc_text(&a).contains("A:0"), "A initial: {}", doc_text(&a));
+        assert!(doc_text(&b).contains("B:0"), "B initial: {}", doc_text(&b));
+
+        // Drive A's signal — only A's document changes.
+        sig_a.set(1);
+        a.update(&[]);
+        b.update(&[]);
+        assert!(
+            doc_text(&a).contains("A:1"),
+            "A must update after its own signal changed, got: {}",
+            doc_text(&a)
+        );
+        assert!(
+            doc_text(&b).contains("B:0") && !doc_text(&b).contains("A:"),
+            "B must be untouched by A's signal, got: {}",
+            doc_text(&b)
+        );
+
+        // Drive B's signal — only B's document changes.
+        sig_b.set(7);
+        a.update(&[]);
+        b.update(&[]);
+        assert!(
+            doc_text(&b).contains("B:7"),
+            "B must update after its own signal changed, got: {}",
+            doc_text(&b)
+        );
+        assert!(
+            doc_text(&a).contains("A:1"),
+            "A must be untouched by B's signal, got: {}",
+            doc_text(&a)
+        );
+    });
+}
+
+// ── 2. per-context signal-change subscriptions ───────────────────────────────
+
+/// FIXED (#134): each `RinchContext` holds its own guard-based
+/// `subscribe_signal_change` subscription instead of fighting over the legacy
+/// single slot. Creating a second context leaves the first connected, every
+/// live context sees every signal change, and dropping a context detaches only
+/// its own callback — the survivor keeps working.
+#[test]
+fn contexts_keep_independent_dirty_flags() {
+    on_ui_thread(|| {
+        // A "bare" signal: no effect subscribes to it, so it never dirties any
+        // DOM node — isolating the signal-change dirty flag from the
+        // has_dirty_nodes() fallback inside needs_update().
+        let bare = Signal::new(0i32);
+
+        let mut a = RinchContext::new(cfg(), |__scope: &mut RenderScope| {
+            rsx! { div { "A static" } }
+        });
+        a.update(&[]);
+        assert!(
+            !a.needs_update(),
+            "A must be settled after update() with no pending changes"
+        );
+
+        // Baseline (single context): any signal change sets A's dirty flag.
+        bare.set(1);
+        assert!(
+            a.needs_update(),
+            "baseline: a signal change must set the sole context's dirty flag"
+        );
+        a.update(&[]);
+        assert!(!a.needs_update(), "update() must consume the dirty flag");
+
+        // Create B: both contexts now subscribe independently.
+        let mut b = RinchContext::new(cfg(), |__scope: &mut RenderScope| {
+            rsx! { div { "B static" } }
+        });
+        b.update(&[]);
+
+        bare.set(2);
+        assert!(
+            a.needs_update(),
+            "creating context B must not disconnect A's dirty flag (#134)"
+        );
+        assert!(
+            b.needs_update(),
+            "B sees the same signal change through its own subscription"
+        );
+        a.update(&[]);
+        b.update(&[]);
+
+        // Drop B: its subscription guard detaches only B's callback.
+        drop(b);
+        bare.set(3);
+        assert!(
+            a.needs_update(),
+            "after dropping B the survivor A must still see signal changes (#134)"
+        );
+        a.update(&[]);
+        drop(a);
+    });
+}
+
+// ── 3. CONTEXT_STORE (create_store/use_store) cross-talk ─────────────────────
+
+#[derive(Clone, Copy)]
+struct SharedStore {
+    which: Signal<i32>,
+}
+
+/// CONTEXT_STORE is keyed by TypeId only — no per-context namespace. When both
+/// contexts `create_store` the same type, the second insert overwrites the
+/// first, and content A builds LATER (an `if` branch flipping) silently reads
+/// B's store. Dropping B does not remove its store, and dropping both contexts
+/// leaves the store behind entirely.
+#[test]
+fn store_crosstalk_between_contexts() {
+    on_ui_thread(|| {
+        let show_late = Signal::new(false);
+
+        let mut a = RinchContext::new(cfg(), move |__scope: &mut RenderScope| {
+            create_store(SharedStore {
+                which: Signal::new(1),
+            });
+            rsx! {
+                div {
+                    if show_late.get() {
+                        p { {move || format!("store:{}", use_store::<SharedStore>().which.get())} }
+                    } else {
+                        p { "waiting" }
+                    }
+                }
+            }
+        });
+        a.update(&[]);
+        assert_eq!(
+            use_store::<SharedStore>().which.get(),
+            1,
+            "with only A mounted, use_store resolves A's store"
+        );
+
+        let mut b = RinchContext::new(cfg(), move |__scope: &mut RenderScope| {
+            create_store(SharedStore {
+                which: Signal::new(2),
+            });
+            rsx! { div { "B" } }
+        });
+        b.update(&[]);
+
+        // BUG #134: this documents current-broken behavior. CORRECT behavior:
+        // each context should resolve its own store. B's create_store
+        // overwrote A's entry in the TypeId-keyed CONTEXT_STORE.
+        assert_eq!(
+            use_store::<SharedStore>().which.get(),
+            2,
+            "BUG #134 pinned: B's create_store overwrote A's store (TypeId-keyed, \
+             last write wins). If this fails with value 1, the bug was FIXED"
+        );
+
+        // A's dynamically-built content — an `if` branch constructed AFTER B
+        // mounted — reads the store at build time and gets B's store, rendered
+        // into A's own document.
+        show_late.set(true);
+        a.update(&[]);
+        let text = doc_text(&a);
+        assert!(
+            text.contains("store:2"),
+            "BUG #134 pinned: A's late-built UI silently received B's store \
+             (expected broken 'store:2', correct would be 'store:1'); got: {text}"
+        );
+
+        // Dropping B does not remove its store — A keeps reading B's dead store.
+        drop(b);
+        assert_eq!(
+            use_store::<SharedStore>().which.get(),
+            2,
+            "BUG #134 pinned: B's store outlives B (RinchContext::drop never \
+             touches CONTEXT_STORE)"
+        );
+
+        // Even after BOTH contexts are gone the store persists on the thread.
+        drop(a);
+        assert!(
+            try_use_store::<SharedStore>().is_some(),
+            "BUG #134 pinned: the store survives both contexts"
+        );
+
+        // Leave the shared worker thread clean for the other tests.
+        rinch_core::clear_context();
+    });
+}
+
+// ── 4. BOUNDS_REGISTRY per-document scoping ──────────────────────────────────
+
+/// FIXED (#134): bounds-signal registry entries carry their document's
+/// `doc_key`, and each context's `resolve_and_repaint` refreshes only its own
+/// document's entries. Two documents with colliding node ids (both slabs start
+/// at 0) no longer stomp each other's bounds signals.
+#[test]
+fn bounds_registry_crosstalk_across_documents() {
+    on_ui_thread(|| {
+        // Both components build the identical node structure (root div → inner
+        // div → text), so the inner div gets the SAME raw node id in both
+        // documents. A registers a bounds signal on ITS inner div (100px wide);
+        // B's inner div is 200px wide and registers nothing.
+        let a_bounds: Rc<Cell<Option<Signal<rinch_core::ElementBounds>>>> =
+            Rc::new(Cell::new(None));
+        let a_bounds_setter = a_bounds.clone();
+
+        let dirty_a = Signal::new(0i32);
+        let dirty_b = Signal::new(0i32);
+
+        let mut a = RinchContext::new(cfg(), move |__scope: &mut RenderScope| {
+            let root = __scope.create_element("div");
+            let inner = __scope.create_element("div");
+            inner.set_attribute("style", "width: 100px; height: 50px;");
+            root.append_child(&inner);
+            // Reactive text gives the test a deterministic way to dirty A's
+            // DOM so a layout pass definitely runs. (Since the #134 fix, A's
+            // dirty flag also stays connected while B exists — see test 2.)
+            let text = __scope.create_text("0");
+            root.append_child(&text);
+            let text_handle = text.clone();
+            __scope.create_effect(move || {
+                text_handle.set_text(&dirty_a.get().to_string());
+            });
+            a_bounds_setter.set(Some(inner.bounds_signal()));
+            root
+        });
+
+        let mut b = RinchContext::new(cfg(), move |__scope: &mut RenderScope| {
+            let root = __scope.create_element("div");
+            let inner = __scope.create_element("div");
+            inner.set_attribute("style", "width: 200px; height: 50px;");
+            root.append_child(&inner);
+            let text = __scope.create_text("0");
+            root.append_child(&text);
+            let text_handle = text.clone();
+            __scope.create_effect(move || {
+                text_handle.set_text(&dirty_b.get().to_string());
+            });
+            root
+        });
+
+        let bounds = a_bounds.get().expect("A registered its bounds signal");
+
+        // A resolves: its inner div is 100px wide.
+        dirty_a.set(1);
+        a.update(&[]);
+        assert_eq!(
+            bounds.get().width,
+            100.0,
+            "after A's layout, A's bounds signal reports A's geometry"
+        );
+
+        // B resolves: its layout pass refreshes only B's registry entries, so
+        // A's bounds signal — registered under A's doc_key — is untouched even
+        // though B's document contains the same raw node id.
+        dirty_b.set(1);
+        b.update(&[]);
+        assert_eq!(
+            bounds.get().width,
+            100.0,
+            "B's layout pass must not touch A's bounds signal (#134: entries \
+             are scoped by doc_key)"
+        );
+
+        // A's own next resolve still refreshes it normally — no flapping.
+        dirty_a.set(2);
+        a.update(&[]);
+        assert_eq!(
+            bounds.get().width,
+            100.0,
+            "A's bounds signal keeps reporting A's document geometry"
+        );
+
+        drop(a);
+        drop(b);
+    });
+}

--- a/docs/src/guide/game-engine.md
+++ b/docs/src/guide/game-engine.md
@@ -297,7 +297,19 @@ fn main() {
 
 ### RinchContext
 
-`RinchContext` is the main handle. Create it once, call `update()` each frame.
+`RinchContext` is the main handle. Create it during initialization, call
+`update()` each frame.
+
+**Multiple contexts.** Several `RinchContext`s can coexist on one thread — a
+screen HUD plus N render-to-texture panels, say. Each context tracks signal
+changes through its own subscription (so creating or dropping one never
+silences another) and keeps its own document-scoped element-bounds signals,
+editor registrations, and focus requests. Two caveats remain, tracked in
+issue #134's follow-ups: `create_store`/`use_store` is keyed by **type** for
+the whole thread (two contexts creating the same store type share the last one
+— use distinct store types per context), and each context still processes the
+input events *you* feed it — route each window's events only to its own
+context.
 
 ### Input Routing
 


### PR DESCRIPTION
## Summary

Implements #134's core ask — N concurrent `RinchContext`s (plus a mounted shell/web root) with correct per-context dirty tracking — and the mechanical half of its cross-talk findings.

### 1. Multi-subscriber signal-change notification

`Runtime.on_signal_change` was a single-occupancy slot: `RinchContext::new` overwrote it (creating B silenced A's dirty flag) and `Drop` cleared it globally (dropping either context silenced the survivor). Now:

- **`subscribe_signal_change(cb) -> SignalChangeSubscription`** — subscriber list + RAII guard; dropping a guard detaches only its own callback. The detach is exact even mid-notification (a guard dropped by an earlier callback in the same notification never fires — pinned by a unit test).
- **`set_on_signal_change` / `clear_on_signal_change`** remain as shims over a dedicated legacy slot with their historical last-write-wins semantics — the desktop shell, `rinch-web`, and android runtimes are behaviorally unchanged.
- `RinchContext` holds a guard; its global-clearing `Drop` impl is deleted.

### 2. Per-document registry keying (`DomDocument::doc_key()`)

Node ids are per-document slab indices, so thread-local registries keyed by bare node id collide across documents. A new required trait method `doc_key()` (process-unique `u64` via `next_doc_key()`; implemented by `RinchDocument`, `WebDocument`, `MockDomDocument`) now scopes:

| Registry | Two-context failure it fixes |
|---|---|
| Element-bounds signals | A's layout pass rewrote B's same-id entries **every frame** (flapping geometry) |
| Pending focus requests | Whichever context processed events next consumed (and misapplied) the other document's focus request |
| Editor registry | Mounting B's editor **evicted** A's editor at a colliding container id (caret/input/collab died); `editor_for_doc` for runtimes that know their document, `editor_for` kept as a documented any-match (web glue, collab routing) |
| Caret blink target | The blink tick could toggle a phantom caret in the wrong document's editor |
| Virtualization windows | Cross-document window stomping; dead documents' windows are now also reclaimed |
| Editor default CSS | The **second** document's editor rendered completely unstyled (thread-wide injection flag) |

### Testing

- New rinch-core unit tests: subscriber independence, legacy-slot isolation from guard subscribers, mid-notification drop.
- New headless two-context integration suite (`crates/rinch/tests/multi_context.rs`, runs via `--no-default-features --features embed`): independent rendering, independent dirty flags across create/drop, per-document bounds signals — plus a deliberately still-pinned test documenting the `create_store` TypeId cross-talk left for a follow-up.
- Full suites green: rinch-core, rinch-dom, rinch-editor-view (57), rinch (default + embed feature sets); wasm checks green for `rinch-web` and `ui-zoo-web`.
- Diff was multi-agent adversarially reviewed pre-commit; all 7 confirmed findings (incl. an unscoped blink-tick path and a mount-order bug where the first caret pass keyed off a not-yet-assigned doc) are fixed in this PR.

### Not in this PR (follow-ups, to be filed on #134)

Design-heavy remainder from the audit: `create_store`/`CONTEXT_STORE` TypeId-only keying, `PENDING_IMAGES` decode-queue routing, per-context theme CSS, multi-context input routing (`ACTIVE_DRAG` etc.), the `desktop`+`embed` feature co-compilation conflict, and reactive resource leaks on context drop.

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)