### PR TITLE
fix(rinch-clipboard): enable arboard wayland-data-control for native Wayland paste (#148)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,6 +299,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "windows-sys 0.60.2",
+ "wl-clipboard-rs",
  "x11rb",
 ]
 
@@ -903,7 +904,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -1769,6 +1770,12 @@ name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -3033,7 +3040,7 @@ dependencies = [
  "libc",
  "libspa-sys",
  "nix",
- "nom",
+ "nom 7.1.3",
  "system-deps",
 ]
 
@@ -3535,6 +3542,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3980,6 +3996,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "overflow-test"
 version = "0.1.0"
 dependencies = [
@@ -4115,6 +4141,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap",
+]
 
 [[package]]
 name = "phf"
@@ -6414,6 +6451,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
+]
+
+[[package]]
 name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7921,6 +7969,24 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix 1.1.3",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
 
 [[package]]
 name = "writeable"

--- a/crates/rinch-clipboard/Cargo.toml
+++ b/crates/rinch-clipboard/Cargo.toml
@@ -6,8 +6,14 @@ description = "Cross-platform clipboard abstraction for rinch (native + WASM)"
 
 [dependencies]
 # Native clipboard (not available on WASM)
+# wayland-data-control: without it arboard talks X11-only on Linux, and its X11
+# backend serves its own cached copy while it owns the selection — a compositor
+# that doesn't sync Wayland→X11 never revokes that ownership, so paste goes
+# stale (#148). arboard target-gates wl-clipboard-rs itself and only prefers
+# the Wayland backend at runtime when WAYLAND_DISPLAY is set (X11 fallback
+# otherwise), so enabling it unconditionally here is safe on all platforms.
 [target.'cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))'.dependencies]
-arboard = "3"
+arboard = { workspace = true, features = ["wayland-data-control"] }
 
 # Android clipboard via rinch-android JNI bridge
 [target.'cfg(target_os = "android")'.dependencies]

--- a/crates/rinch-clipboard/tests/wayland_feature.rs
+++ b/crates/rinch-clipboard/tests/wayland_feature.rs
@@ -1,0 +1,43 @@
+//! Pins arboard's `wayland-data-control` feature into the build graph (#148).
+//!
+//! Without it, all Linux clipboard traffic goes through X11/XWayland, and
+//! arboard's X11 backend serves its own cached copy for as long as it owns the
+//! X11 selection — a compositor that doesn't sync Wayland→X11 (observed on KDE
+//! Plasma Wayland) never revokes that ownership, so `paste_text()` silently
+//! returns stale data. This test fails if a future dependency cleanup drops the
+//! feature again.
+
+#![cfg(target_os = "linux")]
+
+use std::process::Command;
+
+/// Asserts via `cargo tree -e features` that this crate enables arboard's
+/// `wayland-data-control` feature and that `wl-clipboard-rs` (the native
+/// Wayland backend it gates) is actually in the dependency graph.
+#[test]
+fn arboard_wayland_data_control_is_enabled() {
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+    let output = Command::new(cargo)
+        .args(["tree", "-p", "rinch-clipboard", "-e", "features"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .expect("failed to run `cargo tree`");
+    assert!(
+        output.status.success(),
+        "`cargo tree` failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let tree = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        tree.contains("arboard feature \"wayland-data-control\""),
+        "arboard's wayland-data-control feature is no longer enabled — \
+         Linux clipboard would silently fall back to X11-only and serve \
+         stale pastes on Wayland (#148)"
+    );
+    assert!(
+        tree.contains("wl-clipboard-rs"),
+        "wl-clipboard-rs (arboard's native Wayland backend) missing from \
+         the dependency graph (#148)"
+    );
+}


### PR DESCRIPTION
Fixes #148.

On Wayland sessions, all clipboard traffic went through X11/XWayland because arboard was built without its `wayland-data-control` feature. arboard's X11 backend serves its own cached copy while it owns the X11 selection (`x11.rs` `read()` short-circuits on `is_owner`), which a compositor that doesn't sync Wayland→X11 never revokes — so `paste_text()` silently returned stale, previously-copied text instead of the current system clipboard.

## Changes
- `crates/rinch-clipboard/Cargo.toml`: switch to the (previously orphaned) workspace `arboard` dep with `features = ["wayland-data-control"]`. Enabling it unconditionally in the existing non-wasm/non-android target table is safe: arboard target-gates `wl-clipboard-rs` itself, prefers the Wayland data-control backend only when `WAYLAND_DISPLAY` is set, and warns + falls back to X11 when the compositor lacks the protocol (older GNOME/Mutter) — worst case is status quo.
- `Cargo.lock`: lands `wl-clipboard-rs` 0.9.3 + transitives (pure Rust, no new system libs).
- `crates/rinch-clipboard/tests/wayland_feature.rs` (linux-gated): regression pin via `cargo tree -p rinch-clipboard -e features` asserting the feature and the `wl-clipboard-rs` subtree stay in the graph, so a future dep cleanup can't silently drop the fix.

## Testing
- `cargo test -p rinch-clipboard`: 1 passed (new pin test); clippy clean; full-workspace pre-commit hook passed.
- Independently re-verified by adversarial review: test re-run, `cargo check -p rinch --features clipboard`, lockfile diff audited (additive only), confirmed rinch-clipboard is the workspace's only arboard consumer.
- Manual verification on a live Wayland session (`wl-copy sentinel` → `paste_text()`) still worth doing before merge — CI has no compositor.

Note for #149: land this before any clipboard-timeout work is measured — the Wayland backend has different blocking characteristics than the X11 4s-timeout path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)