### PR TITLE
fix(rinch-debug,rinch-mcp-server): debug-channel input fidelity — punctuation keycodes + modifiers array (#151, #152)

### DIFF
--- a/crates/rinch-debug/src/lib.rs
+++ b/crates/rinch-debug/src/lib.rs
@@ -2,7 +2,7 @@ pub mod discovery;
 pub mod protocol;
 pub mod server;
 
-pub use protocol::{DebugCommand, DebugCommandKind, DebugResult};
+pub use protocol::{DebugCommand, DebugCommandKind, DebugResult, fold_modifier_names};
 pub use server::DebugServer;
 
 use std::sync::{Arc, mpsc};

--- a/crates/rinch-debug/src/protocol.rs
+++ b/crates/rinch-debug/src/protocol.rs
@@ -71,6 +71,12 @@ pub enum DebugCommandKind {
         ctrl: bool,
         #[serde(default)]
         alt: bool,
+        /// Modifier names OR'd into the flat booleans by the runtime via
+        /// [`fold_modifier_names`] — the natural array shape other automation
+        /// protocols use, and the only way to request `meta`. Unknown names
+        /// fail loud instead of silently altering the simulated input.
+        #[serde(default)]
+        modifiers: Vec<String>,
     },
     #[serde(rename = "ime")]
     Ime {
@@ -133,6 +139,30 @@ pub struct HandshakeResponse {
     pub pid: u32,
 }
 
+/// Fold a `key_press` `modifiers` name array into flat modifier booleans.
+///
+/// Recognized names (case-insensitive): `"ctrl"`/`"control"`, `"shift"`,
+/// `"alt"`/`"option"`, `"meta"`/`"cmd"`/`"super"`. Returns the offending name
+/// on failure so callers fail loud instead of silently dropping a modifier.
+pub fn fold_modifier_names(
+    names: &[String],
+    shift: &mut bool,
+    ctrl: &mut bool,
+    alt: &mut bool,
+    meta: &mut bool,
+) -> Result<(), String> {
+    for name in names {
+        match name.to_ascii_lowercase().as_str() {
+            "ctrl" | "control" => *ctrl = true,
+            "shift" => *shift = true,
+            "alt" | "option" => *alt = true,
+            "meta" | "cmd" | "super" => *meta = true,
+            _ => return Err(name.clone()),
+        }
+    }
+    Ok(())
+}
+
 /// Write a length-prefixed frame (4-byte big-endian length + JSON payload).
 pub fn write_frame(stream: &mut impl std::io::Write, data: &[u8]) -> std::io::Result<()> {
     let len = data.len() as u32;
@@ -156,4 +186,111 @@ pub fn read_frame(stream: &mut impl std::io::Read) -> std::io::Result<Vec<u8>> {
     let mut buf = vec![0u8; len];
     stream.read_exact(&mut buf)?;
     Ok(buf)
+}
+
+#[cfg(test)]
+mod key_press_modifiers_tests {
+    use super::*;
+
+    #[test]
+    fn modifiers_array_deserializes_and_folds_to_ctrl_true() {
+        // The array shape guessed from CDP/WebDriver/Playwright must not be
+        // silently dropped (issue #152): it deserializes into the variant and
+        // folds onto the flat booleans.
+        let req: Request = serde_json::from_str(
+            r#"{"id":1,"method":"key_press","params":{"key":"End","shift":false,"ctrl":false,"modifiers":["ctrl"]}}"#,
+        )
+        .unwrap();
+        let DebugCommandKind::KeyPress {
+            key,
+            mut shift,
+            mut ctrl,
+            mut alt,
+            modifiers,
+        } = req.command
+        else {
+            panic!("expected KeyPress");
+        };
+        assert_eq!(key, "End");
+        assert_eq!(modifiers, vec!["ctrl".to_string()]);
+        let mut meta = false;
+        fold_modifier_names(&modifiers, &mut shift, &mut ctrl, &mut alt, &mut meta).unwrap();
+        assert!(ctrl);
+        assert!(!shift && !alt && !meta);
+    }
+
+    #[test]
+    fn key_press_round_trips_with_modifiers() {
+        let original = Request {
+            id: 7,
+            command: DebugCommandKind::KeyPress {
+                key: "End".into(),
+                shift: false,
+                ctrl: false,
+                alt: false,
+                modifiers: vec!["ctrl".into(), "Shift".into()],
+            },
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let back: Request = serde_json::from_str(&json).unwrap();
+        let DebugCommandKind::KeyPress { key, modifiers, .. } = back.command else {
+            panic!("expected KeyPress");
+        };
+        assert_eq!(key, "End");
+        assert_eq!(modifiers, vec!["ctrl".to_string(), "Shift".to_string()]);
+    }
+
+    #[test]
+    fn omitting_the_modifiers_array_defaults_to_empty() {
+        // The stricter raw-TCP contract is preserved: shift/ctrl stay
+        // required, the new array is optional.
+        let req: Request = serde_json::from_str(
+            r#"{"id":2,"method":"key_press","params":{"key":"End","shift":true,"ctrl":true}}"#,
+        )
+        .unwrap();
+        let DebugCommandKind::KeyPress {
+            shift,
+            ctrl,
+            modifiers,
+            ..
+        } = req.command
+        else {
+            panic!("expected KeyPress");
+        };
+        assert!(shift && ctrl);
+        assert!(modifiers.is_empty());
+    }
+
+    #[test]
+    fn unknown_modifier_name_fails_loud() {
+        let (mut s, mut c, mut a, mut m) = (false, false, false, false);
+        let err = fold_modifier_names(
+            &["ctrl".into(), "hyper".into()],
+            &mut s,
+            &mut c,
+            &mut a,
+            &mut m,
+        )
+        .unwrap_err();
+        assert_eq!(err, "hyper");
+    }
+
+    #[test]
+    fn modifier_names_are_case_insensitive_with_aliases() {
+        let (mut s, mut c, mut a, mut m) = (false, false, false, false);
+        fold_modifier_names(
+            &[
+                "Control".into(),
+                "SHIFT".into(),
+                "option".into(),
+                "Cmd".into(),
+            ],
+            &mut s,
+            &mut c,
+            &mut a,
+            &mut m,
+        )
+        .unwrap();
+        assert!(s && c && a && m);
+    }
 }

--- a/crates/rinch-mcp-server/src/client.rs
+++ b/crates/rinch-mcp-server/src/client.rs
@@ -68,6 +68,10 @@ pub enum DebugCommandKind {
         ctrl: bool,
         #[serde(default)]
         alt: bool,
+        /// Modifier names OR'd into the flat booleans by the runtime (the only
+        /// way to request `meta`). Mirrored from rinch-debug in lockstep.
+        #[serde(default)]
+        modifiers: Vec<String>,
     },
     #[serde(rename = "get_caret_position")]
     GetCaretPosition { node_id: usize, byte_offset: usize },

--- a/crates/rinch-mcp-server/src/mcp_server.rs
+++ b/crates/rinch-mcp-server/src/mcp_server.rs
@@ -117,6 +117,12 @@ pub struct KeyPressParams {
     /// Alt modifier
     #[serde(default)]
     pub alt: bool,
+    /// Modifier names as an array, e.g. ["ctrl", "shift"]. Recognized
+    /// (case-insensitive): "ctrl"/"control", "shift", "alt"/"option",
+    /// "meta"/"cmd"/"super". Equivalent to the flat booleans (OR'd together);
+    /// the only way to request the meta modifier. Unknown names are an error.
+    #[serde(default)]
+    pub modifiers: Vec<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -422,11 +428,31 @@ impl RinchMcpServer {
         &self,
         params: Parameters<KeyPressParams>,
     ) -> Result<CallToolResult, McpError> {
+        // OR the `modifiers` array into the flat booleans (issue #152). Meta has
+        // no flat boolean on the wire — it travels via the forwarded array.
+        // Unknown names are rejected here, before anything reaches the app.
+        let mut shift = params.0.shift;
+        let mut ctrl = params.0.ctrl;
+        let mut alt = params.0.alt;
+        for name in &params.0.modifiers {
+            match name.to_ascii_lowercase().as_str() {
+                "ctrl" | "control" => ctrl = true,
+                "shift" => shift = true,
+                "alt" | "option" => alt = true,
+                "meta" | "cmd" | "super" => {}
+                _ => {
+                    return Ok(CallToolResult::error(vec![Content::text(format!(
+                        "Unknown modifier name: {name:?} (expected ctrl/control, shift, alt/option, meta/cmd/super)"
+                    ))]));
+                }
+            }
+        }
         self.forward_json_command(DebugCommandKind::KeyPress {
             key: params.0.key,
-            shift: params.0.shift,
-            ctrl: params.0.ctrl,
-            alt: params.0.alt,
+            shift,
+            ctrl,
+            alt,
+            modifiers: params.0.modifiers,
         })
         .await
     }
@@ -748,5 +774,31 @@ impl Drop for RinchMcpServer {
             let _ = child.kill();
             let _ = child.wait();
         }
+    }
+}
+
+#[cfg(test)]
+mod key_press_params_tests {
+    use super::KeyPressParams;
+
+    #[test]
+    fn modifiers_array_is_accepted_not_silently_dropped() {
+        // The natural array shape from other automation protocols (issue #152):
+        // it must land in `modifiers` for the tool to fold, not vanish into
+        // serde's unknown-field handling.
+        let p: KeyPressParams =
+            serde_json::from_str(r#"{"key":"End","modifiers":["ctrl"]}"#).unwrap();
+        assert_eq!(p.key, "End");
+        assert_eq!(p.modifiers, vec!["ctrl".to_string()]);
+        // Flat booleans stay defaulted; the key_press tool ORs the array in.
+        assert!(!p.shift && !p.ctrl && !p.alt);
+    }
+
+    #[test]
+    fn flat_booleans_still_work_without_the_array() {
+        let p: KeyPressParams =
+            serde_json::from_str(r#"{"key":"End","ctrl":true,"shift":true}"#).unwrap();
+        assert!(p.ctrl && p.shift && !p.alt);
+        assert!(p.modifiers.is_empty());
     }
 }

--- a/crates/rinch/src/app/debug_commands.rs
+++ b/crates/rinch/src/app/debug_commands.rs
@@ -9,10 +9,16 @@ fn parse_button(s: &Option<String>) -> MouseButton {
 }
 
 /// Map a printable character to a physical `KeyCode` for synthesizing keystrokes
-/// (the `text` field carries the actual character; the keycode only matters for
-/// shortcut/interceptor matching). Unknown characters fall back to `Space`.
+/// (the `text` field carries the actual character). Characters without a
+/// dedicated keycode map to `KeyCode::Other` — exactly how real hardware
+/// delivers punctuation (`shell/rinch_runtime.rs` translates unlisted winit
+/// keys to `Other`) — so the keyboard hook's key string falls through to the
+/// `text` field instead of masquerading as a named key. Space keeps its
+/// explicit arm: an injected `' '` must still read as `key = "Space"`, matching
+/// a physical spacebar press (issue #151).
 fn char_to_keycode(c: char) -> KeyCode {
     match c.to_ascii_lowercase() {
+        ' ' => KeyCode::Space,
         'a' => KeyCode::KeyA,
         'b' => KeyCode::KeyB,
         'c' => KeyCode::KeyC,
@@ -49,13 +55,17 @@ fn char_to_keycode(c: char) -> KeyCode {
         '7' => KeyCode::Digit7,
         '8' => KeyCode::Digit8,
         '9' => KeyCode::Digit9,
-        _ => KeyCode::Space,
+        _ => KeyCode::Other,
     }
 }
 
-/// Map a debug `key_press` key-name string to a `KeyCode`.
-fn keyname_to_keycode(key: &str) -> KeyCode {
-    match key {
+/// Map a debug `key_press` key-name string to a `KeyCode`. Single-character
+/// names go through [`char_to_keycode`] (punctuation → `KeyCode::Other`, with
+/// the character delivered via the event's `text` field); unknown multi-char
+/// names return `None` so the caller can fail loud instead of synthesizing a
+/// silent no-text `Other` press.
+fn keyname_to_keycode(key: &str) -> Option<KeyCode> {
+    Some(match key {
         "ArrowLeft" => KeyCode::ArrowLeft,
         "ArrowRight" => KeyCode::ArrowRight,
         "ArrowUp" => KeyCode::ArrowUp,
@@ -69,10 +79,11 @@ fn keyname_to_keycode(key: &str) -> KeyCode {
         "Delete" => KeyCode::Delete,
         "Tab" => KeyCode::Tab,
         "Escape" => KeyCode::Escape,
+        "Space" => KeyCode::Space,
         "F12" => KeyCode::F12,
         k if k.chars().count() == 1 => char_to_keycode(k.chars().next().unwrap()),
-        _ => KeyCode::Space,
-    }
+        _ => return None,
+    })
 }
 
 #[cfg(feature = "debug")]
@@ -377,14 +388,35 @@ impl RinchApp {
             }
             DebugCommandKind::KeyPress {
                 key,
-                shift,
-                ctrl,
-                alt,
+                mut shift,
+                mut ctrl,
+                mut alt,
+                modifiers,
             } => {
                 // Synthesize a real KeyDown and route through `handle_event` (which
                 // owns Escape/F12/inspect/editor/CE handling) so MCP `key_press`
                 // matches a physical keystroke.
-                let key_code = keyname_to_keycode(&key);
+                //
+                // Fold the optional `modifiers` name array into the flat booleans
+                // (issue #152) — the only path that can request `meta`. An unknown
+                // name fails loud instead of silently altering the simulated input.
+                let mut meta = false;
+                if let Err(name) = rinch_debug::fold_modifier_names(
+                    &modifiers, &mut shift, &mut ctrl, &mut alt, &mut meta,
+                ) {
+                    return DebugResult::Error {
+                        message: format!(
+                            "Unknown modifier name: {name:?} (expected ctrl/control, shift, alt/option, meta/cmd/super)"
+                        ),
+                    };
+                }
+                // Unknown multi-char key names fail loud too — a silent no-text
+                // `Other` press would be indistinguishable from a dead key (#151).
+                let Some(key_code) = keyname_to_keycode(&key) else {
+                    return DebugResult::Error {
+                        message: format!("Unknown key name: {key:?}"),
+                    };
+                };
                 let text = match key.as_str() {
                     "Enter" => Some("\n".to_string()),
                     k if k.chars().count() == 1 => Some(k.to_string()),
@@ -407,7 +439,7 @@ impl RinchApp {
                             shift,
                             ctrl,
                             alt,
-                            meta: false,
+                            meta,
                         },
                     },
                     window_size,
@@ -638,5 +670,42 @@ impl RinchApp {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod keycode_mapping_tests {
+    use super::{char_to_keycode, keyname_to_keycode};
+    use rinch_platform::KeyCode;
+
+    #[test]
+    fn punctuation_maps_to_other_not_space() {
+        // Punctuation must not masquerade as the spacebar (issue #151): with
+        // `Other`, the hook's key string falls through to the `text` field.
+        assert_eq!(char_to_keycode('.'), KeyCode::Other);
+    }
+
+    #[test]
+    fn space_char_keeps_its_named_keycode() {
+        // Space-parity gotcha: an injected ' ' must still read as
+        // `key = "Space"`, exactly like a physical spacebar press.
+        assert_eq!(char_to_keycode(' '), KeyCode::Space);
+    }
+
+    #[test]
+    fn keyname_space_maps_to_space() {
+        assert_eq!(keyname_to_keycode("Space"), Some(KeyCode::Space));
+    }
+
+    #[test]
+    fn keyname_single_char_punctuation_maps_to_other() {
+        assert_eq!(keyname_to_keycode("."), Some(KeyCode::Other));
+    }
+
+    #[test]
+    fn unknown_multi_char_keyname_is_rejected() {
+        // The KeyPress handler turns this into a DebugResult::Error rather
+        // than a silent no-text `Other` press.
+        assert_eq!(keyname_to_keycode("NoSuchKey"), None);
     }
 }

--- a/crates/rinch/src/app/event_dispatch.rs
+++ b/crates/rinch/src/app/event_dispatch.rs
@@ -831,51 +831,7 @@ impl RinchApp {
                 let alt = modifiers.alt;
 
                 // Build key string for the user keyboard hook + global fallback.
-                let key_str: Option<String> = match key {
-                    // Named keys
-                    KeyCode::ArrowLeft => Some("ArrowLeft".into()),
-                    KeyCode::ArrowRight => Some("ArrowRight".into()),
-                    KeyCode::ArrowUp => Some("ArrowUp".into()),
-                    KeyCode::ArrowDown => Some("ArrowDown".into()),
-                    KeyCode::Home => Some("Home".into()),
-                    KeyCode::End => Some("End".into()),
-                    KeyCode::Enter => Some("Enter".into()),
-                    KeyCode::Backspace => Some("Backspace".into()),
-                    KeyCode::Delete => Some("Delete".into()),
-                    KeyCode::Tab => Some("Tab".into()),
-                    KeyCode::Escape => Some("Escape".into()),
-                    KeyCode::PageUp => Some("PageUp".into()),
-                    KeyCode::PageDown => Some("PageDown".into()),
-                    KeyCode::Space => Some("Space".into()),
-                    // Modifier keys (as physical key presses)
-                    KeyCode::ShiftLeft => Some("Shift".into()),
-                    KeyCode::ShiftRight => Some("Shift".into()),
-                    KeyCode::ControlLeft => Some("Control".into()),
-                    KeyCode::ControlRight => Some("Control".into()),
-                    KeyCode::AltLeft => Some("Alt".into()),
-                    KeyCode::AltRight => Some("Alt".into()),
-                    // Ctrl+key combos: derive key letter from KeyCode
-                    KeyCode::KeyA if ctrl => Some("a".into()),
-                    KeyCode::KeyB if ctrl => Some("b".into()),
-                    KeyCode::KeyC if ctrl => Some("c".into()),
-                    KeyCode::KeyD if ctrl => Some("d".into()),
-                    KeyCode::KeyE if ctrl => Some("e".into()),
-                    KeyCode::KeyH if ctrl => Some("h".into()),
-                    KeyCode::KeyI if ctrl => Some("i".into()),
-                    KeyCode::KeyU if ctrl => Some("u".into()),
-                    KeyCode::KeyV if ctrl => Some("v".into()),
-                    KeyCode::KeyX if ctrl => Some("x".into()),
-                    KeyCode::KeyY if ctrl => Some("y".into()),
-                    KeyCode::KeyZ if ctrl => Some("z".into()),
-                    // Regular character input: use text field (filter control chars)
-                    _ => text.as_ref().and_then(|t| {
-                        if !t.is_empty() && t.chars().all(|c| !c.is_control()) {
-                            Some(t.clone())
-                        } else {
-                            None
-                        }
-                    }),
-                };
+                let key_str: Option<String> = hook_key_str(key, text.as_deref(), ctrl);
 
                 tracing::trace!(?key, ?text, ?key_str, shift, ctrl, alt, "KeyDown event");
 
@@ -1773,6 +1729,61 @@ pub(crate) enum Motion {
     LineEnd,
     DocStart,
     DocEnd,
+}
+
+/// Derive the key string handed to the user keyboard hook (and global
+/// fallback) from a `KeyDown`'s keycode + text. Named keys report their name
+/// (`"Space"`, `"Enter"`, …); Ctrl+letter combos report the letter; everything
+/// else — including `KeyCode::Other`, which is how both real hardware and the
+/// debug channel deliver punctuation — falls through to the event's `text`
+/// field, so a hook sees `key: "."` for a period but `key: "Space"` for a
+/// spacebar press.
+pub(crate) fn hook_key_str(key: KeyCode, text: Option<&str>, ctrl: bool) -> Option<String> {
+    match key {
+        // Named keys
+        KeyCode::ArrowLeft => Some("ArrowLeft".into()),
+        KeyCode::ArrowRight => Some("ArrowRight".into()),
+        KeyCode::ArrowUp => Some("ArrowUp".into()),
+        KeyCode::ArrowDown => Some("ArrowDown".into()),
+        KeyCode::Home => Some("Home".into()),
+        KeyCode::End => Some("End".into()),
+        KeyCode::Enter => Some("Enter".into()),
+        KeyCode::Backspace => Some("Backspace".into()),
+        KeyCode::Delete => Some("Delete".into()),
+        KeyCode::Tab => Some("Tab".into()),
+        KeyCode::Escape => Some("Escape".into()),
+        KeyCode::PageUp => Some("PageUp".into()),
+        KeyCode::PageDown => Some("PageDown".into()),
+        KeyCode::Space => Some("Space".into()),
+        // Modifier keys (as physical key presses)
+        KeyCode::ShiftLeft => Some("Shift".into()),
+        KeyCode::ShiftRight => Some("Shift".into()),
+        KeyCode::ControlLeft => Some("Control".into()),
+        KeyCode::ControlRight => Some("Control".into()),
+        KeyCode::AltLeft => Some("Alt".into()),
+        KeyCode::AltRight => Some("Alt".into()),
+        // Ctrl+key combos: derive key letter from KeyCode
+        KeyCode::KeyA if ctrl => Some("a".into()),
+        KeyCode::KeyB if ctrl => Some("b".into()),
+        KeyCode::KeyC if ctrl => Some("c".into()),
+        KeyCode::KeyD if ctrl => Some("d".into()),
+        KeyCode::KeyE if ctrl => Some("e".into()),
+        KeyCode::KeyH if ctrl => Some("h".into()),
+        KeyCode::KeyI if ctrl => Some("i".into()),
+        KeyCode::KeyU if ctrl => Some("u".into()),
+        KeyCode::KeyV if ctrl => Some("v".into()),
+        KeyCode::KeyX if ctrl => Some("x".into()),
+        KeyCode::KeyY if ctrl => Some("y".into()),
+        KeyCode::KeyZ if ctrl => Some("z".into()),
+        // Regular character input: use text field (filter control chars)
+        _ => text.and_then(|t| {
+            if !t.is_empty() && t.chars().all(|c| !c.is_control()) {
+                Some(t.to_string())
+            } else {
+                None
+            }
+        }),
+    }
 }
 
 /// Translate a platform key event into an editor-core `KeyBinding` for keymap lookup.
@@ -2849,6 +2860,33 @@ mod paste_image_tests {
         // 2×2 RGBA needs 16 bytes; give it 8 → None (not a panic).
         assert!(image_rgba_to_png_data_url(2, 2, &[0; 8]).is_none());
         assert!(image_rgba_to_png_data_url(0, 0, &[]).is_none());
+    }
+}
+
+#[cfg(test)]
+mod hook_key_str_tests {
+    use super::hook_key_str;
+    use rinch_platform::KeyCode;
+
+    #[test]
+    fn other_keycode_falls_through_to_the_text_field() {
+        // Punctuation — hardware and debug channel alike — arrives as
+        // `KeyCode::Other` with the character in `text`; the hook must see the
+        // character, not a named key (issue #151).
+        assert_eq!(
+            hook_key_str(KeyCode::Other, Some("."), false),
+            Some(".".to_string())
+        );
+    }
+
+    #[test]
+    fn spacebar_reports_the_named_key_not_its_text() {
+        // A real (or injected) spacebar press is `KeyCode::Space` with
+        // text=" " — the named-key arm must win so hooks see "Space".
+        assert_eq!(
+            hook_key_str(KeyCode::Space, Some(" "), false),
+            Some("Space".to_string())
+        );
     }
 }
 


### PR DESCRIPTION
Fixes #151. Fixes #152.

Two debug-channel input-fidelity bugs, one subsystem:

## #151 — punctuation arrived as the spacebar
`char_to_keycode` mapped only `a-z`/`0-9` with `_ => KeyCode::Space`, and the keyboard hook's `key_str` derivation matches `KeyCode::Space` on the named-key arm *before* the text-field fallback — so injected `.`, `(`, `;` etc. were indistinguishable from a real spacebar press. Real hardware punctuation goes through `KeyCode::Other` with the char in `text` (`rinch_runtime.rs:1335`), so the fix aligns the debug channel with hardware:

- `char_to_keycode`: explicit `' ' => KeyCode::Space` arm; fallback is now `KeyCode::Other` (space-parity preserved — injected spaces still arrive as `key="Space"`).
- `keyname_to_keycode`: explicit `"Space"` arm; now returns `Option<KeyCode>` — unknown multi-char key names produce `DebugResult::Error` instead of a silent fake Space press.
- Extracted the hook `key_str` derivation into a testable `pub(crate) fn hook_key_str` and pinned both contracts: `hook_key_str(Other, Some("."))==Some(".")`, `hook_key_str(Space, Some(" "))==Some("Space")`.
- Side benefit: injected punctuation no longer falsely activates a focused select widget (`Enter|Space` arm).

## #152 — `modifiers` array silently dropped
`{"key": "End", "modifiers": ["ctrl"]}` — the natural shape from CDP/WebDriver/Playwright habits — deserialized as a plain `End` press: serde ignores unknown fields and the MCP-side booleans are all `#[serde(default)]`. (`deny_unknown_fields` is not an option on the wire protocol: `Request` flattens the command enum and serde forbids combining them.)

- Both layers now accept `#[serde(default)] modifiers: Vec<String>`: protocol variant (`rinch-debug/src/protocol.rs`), mirrored in lockstep in `rinch-mcp-server/src/client.rs`, and `KeyPressParams` (doc comment feeds the advertised MCP JSON schema).
- Shared `fold_modifier_names` in rinch-debug maps `ctrl/control`, `shift`, `alt/option`, `meta/cmd/super` case-insensitively; **unknown names fail loud** at both the MCP tool and the runtime instead of being dropped.
- `meta` is now expressible (previously hardcoded `false` in `debug_commands.rs`) — delivered via the array; the flat `ctrl`/`shift`/`alt` booleans keep working unchanged, and raw-TCP keeps its stricter required-fields contract.

## Testing
12 new tests across three crates, all re-run independently by adversarial review:
- `cargo test -p rinch --features debug`: 18 passed (5 keycode-mapping pins + 2 hook_key_str pins new)
- `cargo test -p rinch-debug`: 5 passed (modifier fold: deserialize, round-trip, default-empty, unknown-name error, case-insensitive aliases)
- `cargo test -p rinch-mcp-server`: 2 passed (array accepted; flat booleans unchanged)
- clippy clean on all three; full-workspace pre-commit hook passed.

Pre-existing behavior noted but out of scope: `key_press("Space")` synthesizes `text=None` (hardware spacebar sends `Some(" ")`), so it won't type a space into inputs — unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)