### PR TITLE
fix(rinch-dom): tag PENDING_IMAGES with doc_key so each document drains only its own decodes (#137)

### DIFF
--- a/crates/rinch-dom/src/dom_impl/mod.rs
+++ b/crates/rinch-dom/src/dom_impl/mod.rs
@@ -79,6 +79,15 @@ impl Default for RinchDocument {
     }
 }
 
+impl Drop for RinchDocument {
+    fn drop(&mut self) {
+        // A torn-down document can never drain its queued image decodes —
+        // purge them so they don't strand in the process-global pending
+        // queue forever (issue #137).
+        crate::image_cache::purge_pending(self.doc_key);
+    }
+}
+
 impl RinchDocument {
     /// Process-unique document identity (see
     /// [`DomDocument::doc_key`](rinch_core::dom::DomDocument::doc_key)) —
@@ -558,8 +567,9 @@ impl RinchDocument {
             );
         }
 
-        // Kick off async load — result goes to PENDING_IMAGES static queue
-        crate::image_cache::request_image_load(src.to_string(), loader);
+        // Kick off async load — result goes to PENDING_IMAGES static queue,
+        // tagged with this document's identity (#137)
+        crate::image_cache::request_image_load(self.doc_key, src.to_string(), loader);
     }
 
     /// Scan for background-image URLs that need loading and trigger async loads.
@@ -586,7 +596,7 @@ impl RinchDocument {
 
         for url in urls_to_load {
             self.tree.image_cache.mark_loading(url.clone());
-            crate::image_cache::request_image_load(url, loader.clone());
+            crate::image_cache::request_image_load(self.doc_key, url, loader.clone());
         }
     }
 
@@ -595,7 +605,7 @@ impl RinchDocument {
     /// Called before layout to pick up newly decoded images.
     /// Returns true if any images were newly decoded (needs re-layout).
     pub fn drain_pending_images(&mut self) -> bool {
-        let newly_decoded = self.tree.image_cache.drain_pending();
+        let newly_decoded = self.tree.image_cache.drain_pending(self.doc_key);
         if newly_decoded.is_empty() {
             return false;
         }

--- a/crates/rinch-dom/src/image_cache.rs
+++ b/crates/rinch-dom/src/image_cache.rs
@@ -32,6 +32,10 @@ enum ImageState {
 
 /// A completed image load result, pending insertion into the main cache.
 pub struct PendingImage {
+    /// Identity of the requesting document ([`RinchDocument::doc_key`]) — the
+    /// queue is process-global, so entries must be tagged so each document
+    /// drains only its own decodes (issue #137).
+    pub doc_key: u64,
     pub src: String,
     pub result: Result<DecodedImage, String>,
 }
@@ -39,6 +43,8 @@ pub struct PendingImage {
 /// Thread-safe queue for completed image loads from background threads.
 ///
 /// Background threads push into this; the main thread drains it during layout.
+/// Entries are tagged with the requesting document's `doc_key` — each
+/// document's [`ImageCache::drain_pending`] removes only its own entries.
 static PENDING_IMAGES: Mutex<Vec<PendingImage>> = Mutex::new(Vec::new());
 
 /// Cache of loaded images, keyed by source string (file path or URL).
@@ -88,14 +94,16 @@ impl ImageCache {
         self.entries.insert(src, ImageState::Failed(error));
     }
 
-    /// Drain the pending images queue and insert into this cache.
+    /// Drain this document's entries from the pending images queue and insert
+    /// them into this cache. Entries tagged with a different `doc_key` are left
+    /// queued for their own document (issue #137).
     ///
     /// Returns the list of source strings that were newly decoded (for re-layout).
-    pub fn drain_pending(&mut self) -> Vec<String> {
+    pub fn drain_pending(&mut self, doc_key: u64) -> Vec<String> {
         let pending: Vec<PendingImage> = PENDING_IMAGES
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .drain(..)
+            .extract_if(.., |item| item.doc_key == doc_key)
             .collect();
         let mut newly_decoded = Vec::new();
         for item in pending {
@@ -137,11 +145,14 @@ impl ImageLoader for FileImageLoader {
 /// reach this path — they are decoded inline via [`decode_data_uri`] — so embedded
 /// (base64) images still render on the web. (issue #97)
 #[cfg(target_arch = "wasm32")]
-pub fn request_image_load(_src: String, _loader: Arc<dyn ImageLoader>) {}
+pub fn request_image_load(_doc_key: u64, _src: String, _loader: Arc<dyn ImageLoader>) {}
 
 /// Spawn a background thread to load and decode an image (native).
+///
+/// The result lands in the pending queue tagged with `doc_key` so only the
+/// requesting document's [`ImageCache::drain_pending`] picks it up.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn request_image_load(src: String, loader: Arc<dyn ImageLoader>) {
+pub fn request_image_load(doc_key: u64, src: String, loader: Arc<dyn ImageLoader>) {
     std::thread::spawn(move || {
         let result = loader.load(&src);
         let pending = match result {
@@ -150,6 +161,7 @@ pub fn request_image_load(src: String, loader: Arc<dyn ImageLoader>) {
                     let rgba = img.to_rgba8();
                     let (w, h) = (rgba.width(), rgba.height());
                     PendingImage {
+                        doc_key,
                         src,
                         result: Ok(DecodedImage {
                             data: rgba.into_raw(),
@@ -159,11 +171,13 @@ pub fn request_image_load(src: String, loader: Arc<dyn ImageLoader>) {
                     }
                 }
                 Err(e) => PendingImage {
+                    doc_key,
                     src,
                     result: Err(format!("Failed to decode image: {}", e)),
                 },
             },
             ImageLoadResult::Failed(e) => PendingImage {
+                doc_key,
                 src,
                 result: Err(e),
             },
@@ -173,6 +187,18 @@ pub fn request_image_load(src: String, loader: Arc<dyn ImageLoader>) {
             .unwrap_or_else(|e| e.into_inner())
             .push(pending);
     });
+}
+
+/// Remove all queued entries for a document that is being torn down.
+///
+/// Without this, decodes that land after a document is dropped would strand in
+/// the process-global queue forever (nothing drains a dead doc_key). Called
+/// from `RinchDocument::drop` (issue #137).
+pub fn purge_pending(doc_key: u64) {
+    PENDING_IMAGES
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .retain(|item| item.doc_key != doc_key);
 }
 
 /// Decode a `data:` URI into raw bytes.
@@ -188,5 +214,86 @@ pub fn decode_data_uri(src: &str) -> Option<Vec<u8>> {
         base64::engine::general_purpose::STANDARD.decode(data).ok()
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Push an entry directly onto the process-global pending queue,
+    /// bypassing the background-thread decode pipeline.
+    fn push_pending(doc_key: u64, src: &str) {
+        PENDING_IMAGES
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .push(PendingImage {
+                doc_key,
+                src: src.to_string(),
+                result: Ok(DecodedImage {
+                    data: vec![0; 4],
+                    width: 1,
+                    height: 1,
+                }),
+            });
+    }
+
+    /// Count queued entries for a doc_key. Scoped per-key (not a global count)
+    /// so parallel tests sharing the static queue don't interfere.
+    fn pending_count_for(doc_key: u64) -> usize {
+        PENDING_IMAGES
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .iter()
+            .filter(|item| item.doc_key == doc_key)
+            .count()
+    }
+
+    #[test]
+    fn drain_pending_takes_only_own_documents_entries() {
+        let doc1 = rinch_core::dom::next_doc_key();
+        let doc2 = rinch_core::dom::next_doc_key();
+        let mut cache1 = ImageCache::new();
+        let mut cache2 = ImageCache::new();
+
+        // A decode lands for doc2, then doc1 lays out first (the #137 race).
+        push_pending(doc2, "doc2.png");
+        assert!(
+            cache1.drain_pending(doc1).is_empty(),
+            "doc1 must not absorb doc2's decode"
+        );
+        assert!(cache1.get("doc2.png").is_none());
+        assert_eq!(
+            pending_count_for(doc2),
+            1,
+            "doc2's entry must survive doc1's drain"
+        );
+
+        // doc2's own drain picks it up.
+        assert_eq!(cache2.drain_pending(doc2), vec!["doc2.png".to_string()]);
+        assert!(cache2.get("doc2.png").is_some());
+        assert_eq!(pending_count_for(doc2), 0);
+    }
+
+    #[test]
+    fn purge_pending_removes_only_own_entries() {
+        let doc1 = rinch_core::dom::next_doc_key();
+        let doc2 = rinch_core::dom::next_doc_key();
+
+        push_pending(doc1, "doc1.png");
+        push_pending(doc2, "doc2.png");
+        purge_pending(doc1);
+        assert_eq!(pending_count_for(doc1), 0, "doc1's entry must be purged");
+        assert_eq!(
+            pending_count_for(doc2),
+            1,
+            "doc2's entry must survive doc1's purge"
+        );
+
+        // Nothing left for doc1 to drain; doc2 still gets its image.
+        let mut cache1 = ImageCache::new();
+        let mut cache2 = ImageCache::new();
+        assert!(cache1.drain_pending(doc1).is_empty());
+        assert_eq!(cache2.drain_pending(doc2), vec!["doc2.png".to_string()]);
     }
 }


### PR DESCRIPTION
Fixes #137.

`PENDING_IMAGES` is a process-global decode queue, but each per-document `ImageCache` drained the *entire* queue during its own layout pass. With two documents — not just embed: **the DevTools window is a second `RinchApp` on the same thread**, so F12 + an async image decode reproduces this in a plain desktop app — whichever document laid out first absorbed the other's decoded image. The loser's cache entry stayed `Loading` forever (`contains()` gates re-requests), so its image silently never rendered.

## Changes
- `PendingImage` gains `doc_key: u64`; `request_image_load` takes the requesting document's key (native fn + wasm stub) and the decode thread stamps it into every queue entry.
- `ImageCache::drain_pending(doc_key)` removes only matching entries under the lock (`Vec::extract_if`) — non-matching entries stay queued for their own document. Single-document behavior is bit-identical (every entry matches).
- Both call sites (`request_image_load_for_node`, `request_background_image_loads`) and `drain_pending_images` pass `self.doc_key`. Workspace-wide scan confirmed no other callers of the changed `pub` signatures.
- Drop-purge hygiene: new narrow `impl Drop for RinchDocument` calls `purge_pending(doc_key)` so a dead document's entries don't strand in the static (pre-fix they were stolen; without the purge they'd strand).

## Testing
- `cargo test -p rinch-dom`: 277 passed, 0 failed — including two new pins: `drain_pending_takes_only_own_documents_entries` (doc1's drain leaves doc2's entry queued; doc2's drain claims it) and `purge_pending_removes_only_own_entries`. Tests use `next_doc_key()` + per-key counts so they're robust to parallel test processes sharing the global static.
- `cargo check -p rinch` and `cargo check --target wasm32-unknown-unknown -p rinch-dom`: pass.
- Full-workspace pre-commit hook passed; all results independently re-verified by adversarial review.

Known bounded limitation (reviewer-noted, strictly better than pre-fix): a decode thread still in flight when its document drops pushes its entry *after* the Drop purge, stranding at most one entry per in-flight load at teardown. Proper lifecycle for that belongs with #141's scope-ownership work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)