### PR TITLE
fix(rinch): desktop + embed features co-compile — additive painter selection (#140)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,16 @@ jobs:
       - name: Run clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+      # Feature combinations the workspace-wide default build never exercises.
+      # desktop + embed carries BOTH painters since #140 (the winit shell drives
+      # TinySkia while embed RinchContexts drive Vello) and broke silently before
+      # anything checked it. Plain `cargo check` — compile-only, cheap.
+      - name: Check rinch feature combinations
+        run: |
+          cargo check -p rinch --features embed
+          cargo check -p rinch --no-default-features --features embed
+          cargo check -p rinch --features gpu,embed
+
   # Lint the wasm target too. `clippy --workspace` above only ever sees the native
   # cfg, so anything behind `cfg(target_arch = "wasm32")` — the whole rinch-web
   # backend, the render-surface canvas path, the wasm halves of rinch-ws/http —

--- a/crates/rinch/build.rs
+++ b/crates/rinch/build.rs
@@ -1,0 +1,21 @@
+//! Emits the `software_shell` cfg alias (issue #140).
+//!
+//! `software_shell` is set when a native shell (`desktop` or `android`)
+//! presents via the TinySkia software painter — i.e. no GPU shell feature
+//! (`gpu` / `android-gpu`) replaced it. Painter selection is **additive**:
+//! the Vello painter is gated on `any(gpu, android-gpu, embed)` and the
+//! software painter on `software_shell`, so `desktop` (software) + `embed`
+//! carries BOTH painters — the winit shell drives `build_pixels`/TinySkia
+//! while embed `RinchContext`s drive `build_scene`/Vello. One alias here
+//! instead of repeating the compound condition at every gate in `app/`.
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(software_shell)");
+
+    let feature = |name: &str| std::env::var(format!("CARGO_FEATURE_{name}")).is_ok();
+    let native_shell = feature("DESKTOP") || feature("ANDROID");
+    let gpu_shell = feature("GPU") || feature("ANDROID_GPU");
+    if native_shell && !gpu_shell {
+        println!("cargo::rustc-cfg=software_shell");
+    }
+}

--- a/crates/rinch/src/app/event_dispatch.rs
+++ b/crates/rinch/src/app/event_dispatch.rs
@@ -1680,20 +1680,23 @@ impl RinchApp {
     ) {
         let Some(doc) = &self.doc else { return };
 
-        let anchor;
+        // Computed up-front, once: both snapshot blocks below may be compiled
+        // in the same build (desktop software + embed carries both painters).
+        let anchor = {
+            let d = doc.borrow();
+            let (abs_x, abs_y) =
+                rinch_dom::paint::compute_absolute_position(&d.tree, node_id, scale_factor);
+            (
+                mousedown_pos.0 - abs_x as f32,
+                mousedown_pos.1 - abs_y as f32,
+            )
+        };
 
         #[cfg(any(feature = "gpu", feature = "android-gpu", feature = "embed"))]
         let snapshot = {
             let mut painter = VelloPainter::new();
             let mut d = doc.borrow_mut();
             let d = &mut *d;
-
-            let (abs_x, abs_y) =
-                rinch_dom::paint::compute_absolute_position(&d.tree, node_id, scale_factor);
-            anchor = (
-                mousedown_pos.0 - abs_x as f32,
-                mousedown_pos.1 - abs_y as f32,
-            );
 
             rinch_dom::paint::paint_subtree(
                 &d.tree,
@@ -1706,17 +1709,10 @@ impl RinchApp {
             painter
         };
 
-        #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
+        #[cfg(software_shell)]
         let (snapshot_pixels, snapshot_width, snapshot_height) = {
             let mut d = doc.borrow_mut();
             let d = &mut *d;
-
-            let (abs_x, abs_y) =
-                rinch_dom::paint::compute_absolute_position(&d.tree, node_id, scale_factor);
-            anchor = (
-                mousedown_pos.0 - abs_x as f32,
-                mousedown_pos.1 - abs_y as f32,
-            );
 
             // Compute the element's size in physical pixels for the snapshot pixmap
             let node = d.tree.get(node_id);
@@ -1746,11 +1742,11 @@ impl RinchApp {
             node_id,
             #[cfg(any(feature = "gpu", feature = "android-gpu", feature = "embed"))]
             snapshot,
-            #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
+            #[cfg(software_shell)]
             snapshot_pixels,
-            #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
+            #[cfg(software_shell)]
             snapshot_width,
-            #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
+            #[cfg(software_shell)]
             snapshot_height,
             anchor,
             cursor,

--- a/crates/rinch/src/app/mod.rs
+++ b/crates/rinch/src/app/mod.rs
@@ -24,7 +24,13 @@ use rinch_core::dom::{DomDocument, NodeHandle, RenderScope, clear_render_scope, 
 use rinch_core::events;
 use rinch_dom::RinchDocument;
 use rinch_dom::paint::painter::Painter;
-#[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
+// Painter selection is ADDITIVE (issue #140): the software painter is compiled
+// whenever a native shell presents via TinySkia (`software_shell`, emitted by
+// build.rs = desktop/android without gpu/android-gpu), and the Vello painter
+// whenever anything drives `build_scene` (gpu/android-gpu/embed). Under
+// desktop(software) + embed BOTH are present: the winit shell uses
+// `build_pixels` while embed `RinchContext`s use `build_scene`.
+#[cfg(software_shell)]
 use rinch_dom::paint::skia_painter::TinySkiaPainter;
 #[cfg(any(feature = "gpu", feature = "android-gpu", feature = "embed"))]
 use rinch_dom::paint::vello_painter::VelloPainter;
@@ -69,13 +75,13 @@ pub(crate) struct ActiveDrag {
     #[cfg(any(feature = "gpu", feature = "android-gpu", feature = "embed"))]
     pub snapshot: VelloPainter,
     /// Captured RGBA pixels of the source element's subtree (software backend).
-    #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
+    #[cfg(software_shell)]
     pub snapshot_pixels: Vec<u8>,
     /// Width of the snapshot pixmap in physical pixels.
-    #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
+    #[cfg(software_shell)]
     pub snapshot_width: u32,
     /// Height of the snapshot pixmap in physical pixels.
-    #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
+    #[cfg(software_shell)]
     pub snapshot_height: u32,
     /// Offset within element where the grab happened (physical px, relative to element top-left).
     pub anchor: (f32, f32),
@@ -166,7 +172,7 @@ pub struct RinchApp {
     #[cfg(any(feature = "gpu", feature = "android-gpu", feature = "embed"))]
     pub(crate) painter: VelloPainter,
     /// Software painter (reused across frames). Uses tiny-skia for CPU rendering.
-    #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
+    #[cfg(software_shell)]
     pub(crate) skia_painter: Option<TinySkiaPainter>,
     /// Parley layout context for paint-time text layout (debug screenshots).
     #[cfg(feature = "debug")]
@@ -201,7 +207,7 @@ pub struct RinchApp {
     /// Text rendering scale for HiDPI/mobile (applied to Parley font sizes).
     pub(crate) text_scale: f32,
     /// Whether we have a previous frame's pixels for dirty region caching.
-    #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
+    #[cfg(software_shell)]
     pub(crate) has_previous_frame: bool,
     /// The data-oninput handler ID for the currently focused text input.
     pub(crate) focused_input_handler_id: Option<usize>,
@@ -264,7 +270,7 @@ impl RinchApp {
             doc: None,
             #[cfg(any(feature = "gpu", feature = "android-gpu", feature = "embed"))]
             painter: VelloPainter::new(),
-            #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
+            #[cfg(software_shell)]
             skia_painter: None,
             #[cfg(feature = "debug")]
             paint_layout_cx: parley::LayoutContext::new(),
@@ -282,7 +288,7 @@ impl RinchApp {
             modifiers: Modifiers::default(),
             scene_dirty: true,
             text_scale: 1.0,
-            #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
+            #[cfg(software_shell)]
             has_previous_frame: false,
             focused_input_handler_id: None,
             focused_input_value: String::new(),
@@ -515,7 +521,7 @@ impl RinchApp {
     pub(crate) fn refresh_editor_overlays(&mut self) {
         if crate::editor::update_all_carets(Some(self.doc_key()), self.focused_editor_id()) {
             self.scene_dirty = true;
-            #[cfg(not(feature = "gpu"))]
+            #[cfg(software_shell)]
             {
                 self.has_previous_frame = false;
             }
@@ -548,7 +554,7 @@ impl RinchApp {
                 // Force full repaint — recompute_all_styles_full() updates computed
                 // styles but doesn't populate paint_dirty_nodes, so the software
                 // renderer's dirty region optimization would skip most of the screen.
-                #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
+                #[cfg(software_shell)]
                 {
                     self.has_previous_frame = false;
                 }
@@ -590,7 +596,7 @@ impl RinchApp {
             if d.tree.full_repaint_needed {
                 d.tree.full_repaint_needed = false;
                 self.scene_dirty = true;
-                #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
+                #[cfg(software_shell)]
                 {
                     self.has_previous_frame = false;
                 }
@@ -630,7 +636,7 @@ impl RinchApp {
                 d.resolve_layout(viewport_width, viewport_height);
             }
             self.scene_dirty = true;
-            #[cfg(not(feature = "gpu"))]
+            #[cfg(software_shell)]
             {
                 self.has_previous_frame = false;
             }
@@ -846,7 +852,7 @@ impl RinchApp {
     ///
     /// Returns (pixels, width, height) in RGBA8 format. The painter is lazily
     /// created on first call and resized as needed.
-    #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
+    #[cfg(software_shell)]
     pub fn build_pixels(
         &mut self,
         scale: f64,
@@ -1049,7 +1055,7 @@ impl RinchApp {
     /// Blit premultiplied RGBA source pixels onto a destination buffer with
     /// alpha compositing (source-over). `dx`/`dy` can be negative for partially
     /// off-screen overlays.
-    #[cfg(not(any(feature = "gpu", feature = "android-gpu", feature = "embed")))]
+    #[cfg(software_shell)]
     #[allow(clippy::too_many_arguments)]
     fn blit_drag_overlay(
         dst: &mut [u8],

--- a/crates/rinch/tests/multi_context.rs
+++ b/crates/rinch/tests/multi_context.rs
@@ -6,9 +6,9 @@
 //! outcome explicitly and are marked `BUG #134` — if such an assertion starts
 //! failing, the bug got fixed: flip the assertion to the correct behavior.
 //!
-//! Requires the `embed` (or `gpu`) feature — with default features OFF (the
-//! `desktop` + `embed` combination does not compile; see #134's follow-ups):
-//!     cargo test -p rinch --no-default-features --features embed --test multi_context
+//! Requires the `embed` (or `gpu`) feature. Since #140 the painters are
+//! additive, so `desktop` + `embed` co-compiles and default features can stay on:
+//!     cargo test -p rinch --features embed --test multi_context
 //!
 //! ## Why every test body runs on one shared worker thread
 //!


### PR DESCRIPTION
Fixes #140.

`cargo check -p rinch --features embed` (desktop default + embed) failed with 7 errors: enabling `embed` switched the painter cfg exclusively to Vello, removing `build_pixels`/`skia_painter`/`has_previous_frame` that the software desktop shell requires. The break was crate-internal (2 of the 7 errors were inside `app/mod.rs` itself), and `gpu,embed` already compiled — proving the combination was meant to work.

## Changes
- New minimal `crates/rinch/build.rs` emitting a `software_shell` cfg alias (`any(desktop, android) && !gpu && !android-gpu`, with `rustc-check-cfg` so `unexpected_cfgs` stays quiet) — one alias replaces ~12 repetitions of the compound cfg.
- All software-path gates in `app/mod.rs` / `app/event_dispatch.rs` moved to `#[cfg(software_shell)]`; Vello gates (`any(gpu, android-gpu, embed)`) unchanged. Under software-desktop + embed the struct carries **both** painters: the shell drives TinySkia, embed contexts drive Vello. No shell changes needed.
- `activate_drag` had a deferred `let anchor;` assigned in both cfg blocks (legal when exclusive, E0384 once both compile) — anchor computation hoisted out; under the combo both drag-ghost snapshots are captured once per drag start (negligible, reviewer-acknowledged).
- The two `has_previous_frame` resets in desktop editor code also moved to `software_shell`, incidentally fixing the latent desktop+android-gpu sibling of this break.
- `multi_context.rs` doc header updated — the suite now runs under default features (`cargo test -p rinch --features embed --test multi_context`).
- CI: cheap 3-combination `cargo check` step added to the existing clippy job (shares its cache).

## Testing
Full feature-matrix verified twice (implementer + independent adversarial review): `--features embed` (was 7 errors → 0 warnings), `--no-default-features --features embed` (warning set byte-identical to main), `--features gpu`, `--features gpu,embed`, default, and bare `--no-default-features`. `multi_context` suite: 4/4 under default features. Clippy clean including on the newly co-compiled combination. Full-workspace pre-commit hook passed.

This unblocks the test harness for the multi-context batches (#136/#138 and later) — their tests pin in `multi_context.rs`, which now runs in the normal CI configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)