### PR TITLE
fix(rinch,rinch-dom): notify on layout-time scroll clamp + refresh bounds signals on resize (#144, #145)

### DIFF
--- a/crates/rinch-core/src/dom/mod.rs
+++ b/crates/rinch-core/src/dom/mod.rs
@@ -615,12 +615,17 @@ impl NodeHandle {
     }
 
     /// Reactive bounds signal for this element, refreshed by the runtime after
-    /// each layout pass.
+    /// each layout pass — including pure window resizes (#145).
     ///
     /// The signal carries absolute viewport-relative pixel bounds — the same
     /// frame [`crate::events::ClickContext::element_x`] uses, not the
     /// parent-relative values from [`Self::get_layout_bounds`]. Subscribers
     /// only re-run when the rect changes (uses `set_if_changed` internally).
+    ///
+    /// There is no separate resize event: the root element's `bounds_signal()`
+    /// is the supported way to observe viewport size changes — a full-size
+    /// element's signal reports the new geometry as soon as the resize's
+    /// layout pass completes.
     ///
     /// Initial value is `ElementBounds::default()` (zero rect). The first real
     /// bounds arrive after the next layout pass.

--- a/crates/rinch-core/src/dom/traits.rs
+++ b/crates/rinch-core/src/dom/traits.rs
@@ -404,4 +404,16 @@ pub trait DomDocument {
     fn drain_scroll_into_view_requests(&mut self) -> Vec<NodeId> {
         Vec::new()
     }
+
+    /// Drain the scroll offsets clamped during layout, as (node, clamped
+    /// offset) pairs — coalesced to one entry per node (last value wins).
+    ///
+    /// Layout clamps a container's scroll offset when its content shrinks or
+    /// its viewport grows. Firing handlers mid-layout would re-enter user code
+    /// while the document is borrowed, so the engine queues the clamps and the
+    /// runtime drains them after `resolve_layout()` to dispatch the same
+    /// scroll events input-driven scrolling produces.
+    fn drain_scroll_clamps(&mut self) -> Vec<(NodeId, f64)> {
+        Vec::new()
+    }
 }

--- a/crates/rinch-core/src/reactive/bounds.rs
+++ b/crates/rinch-core/src/reactive/bounds.rs
@@ -5,6 +5,10 @@
 //! ultimately asking for: a way to read "how wide is this element right now,
 //! reactively?" Once available, app code can compose zoom + scroll + viewport
 //! signals to drive arbitrary domain-coordinate layouts in userland.
+//!
+//! The runtime refreshes these after *every* layout pass — including pure
+//! window resizes (#145) — so the root element's `bounds_signal()` doubles as
+//! the supported way to observe viewport size changes without polling.
 
 use std::cell::RefCell;
 

--- a/crates/rinch-dom/src/dom_impl/dom_document_impl.rs
+++ b/crates/rinch-dom/src/dom_impl/dom_document_impl.rs
@@ -1155,4 +1155,11 @@ impl DomDocument for RinchDocument {
             .map(NodeId)
             .collect()
     }
+
+    fn drain_scroll_clamps(&mut self) -> Vec<(NodeId, f64)> {
+        std::mem::take(&mut self.tree.pending_scroll_clamps)
+            .into_iter()
+            .map(|(id, offset)| (NodeId(id), offset))
+            .collect()
+    }
 }

--- a/crates/rinch-dom/src/layout_engine.rs
+++ b/crates/rinch-dom/src/layout_engine.rs
@@ -786,6 +786,20 @@ impl RinchDocument {
         }
         for (node_id, max_scroll) in clamps {
             self.tree.nodes[node_id].scroll_offset.1 = max_scroll;
+            // Queue a deferred scroll notification so the clamp isn't a silent
+            // mutation (#144). Coalesce per node (last value wins): layout can
+            // resolve more than once per frame, and a consumer must see one
+            // event per drain.
+            if let Some(pending) = self
+                .tree
+                .pending_scroll_clamps
+                .iter_mut()
+                .find(|(id, _)| *id == node_id)
+            {
+                pending.1 = max_scroll;
+            } else {
+                self.tree.pending_scroll_clamps.push((node_id, max_scroll));
+            }
         }
     }
 

--- a/crates/rinch-dom/src/node.rs
+++ b/crates/rinch-dom/src/node.rs
@@ -662,6 +662,13 @@ pub struct NodeTree {
     pub ifc_measure_cache: HashMap<(RawNodeId, u32), (f32, f32)>,
     /// Nodes that have requested scroll-into-view (deferred until after layout).
     pub scroll_into_view_requests: Vec<RawNodeId>,
+    /// Scroll offsets clamped by the layout engine, pending event dispatch.
+    /// Layout must not mutate observable scroll state silently (#144), but it
+    /// also can't fire handlers mid-resolve (the facade holds the document
+    /// borrow), so `clamp_scroll_offsets` queues (node, clamped offset) pairs
+    /// here — coalesced per node, last value wins, since layout may resolve
+    /// more than once per frame — for the facade to drain after layout.
+    pub pending_scroll_clamps: Vec<(RawNodeId, f64)>,
     /// Scale factor for text rendering (1.0 on desktop, >1.0 on HiDPI/mobile).
     /// Applied to Parley font sizes so glyphs rasterize at physical pixel resolution.
     pub text_scale: f32,
@@ -775,6 +782,7 @@ impl NodeTree {
             dirty_ifc_text_roots: HashSet::new(),
             ifc_measure_cache: HashMap::new(),
             scroll_into_view_requests: Vec::new(),
+            pending_scroll_clamps: Vec::new(),
             text_scale: 1.0,
         }
     }

--- a/crates/rinch-dom/tests/layout_tests.rs
+++ b/crates/rinch-dom/tests/layout_tests.rs
@@ -1617,3 +1617,46 @@ fn test_inline_block_percent_width_is_stable_across_relayouts() {
         "width must settle at 700 on every layout, got {widths:?}"
     );
 }
+
+/// #144: layout-time scroll clamping must not be a silent mutation. When a
+/// scroll container's content shrinks, `resolve_layout` clamps the stale
+/// offset AND queues a (node, clamped offset) pair for the runtime to drain
+/// and dispatch as a scroll event — coalesced to one entry per node with the
+/// final value, even when layout resolves more than once before the drain.
+#[test]
+fn test_scroll_clamp_is_queued_for_notification() {
+    let mut doc = RinchDocument::new();
+    let body = doc.body();
+    let container = doc.create_element("div");
+    doc.set_attribute(container, "style", "height: 100px; overflow-y: auto");
+    doc.append_child(body, container);
+    let content = doc.create_element("div");
+    doc.set_attribute(content, "style", "height: 500px");
+    doc.append_child(container, content);
+
+    doc.resolve_layout(800.0, 600.0);
+
+    // Scroll to max (500 content - 100 visible = 400). A valid offset is
+    // never clamped, so nothing is queued.
+    doc.set_scroll_top(container, 400.0);
+    doc.resolve_layout(800.0, 600.0);
+    assert_eq!(doc.scroll_top(container), 400.0);
+    assert!(
+        doc.drain_scroll_clamps().is_empty(),
+        "a valid offset must not queue a clamp event"
+    );
+
+    // Shrink the content twice before the runtime drains — the queue must
+    // coalesce to a single entry carrying the final clamped value.
+    doc.set_attribute(content, "style", "height: 250px");
+    doc.resolve_layout(800.0, 600.0);
+    doc.set_attribute(content, "style", "height: 180px");
+    doc.resolve_layout(800.0, 600.0);
+
+    // Offset clamped to the final max (180 - 100 = 80)...
+    assert_eq!(doc.scroll_top(container), 80.0);
+    // ...and the clamp was queued exactly once, not applied silently.
+    assert_eq!(doc.drain_scroll_clamps(), vec![(container, 80.0)]);
+    // Drained — a second drain yields nothing.
+    assert!(doc.drain_scroll_clamps().is_empty());
+}

--- a/crates/rinch/src/app/mod.rs
+++ b/crates/rinch/src/app/mod.rs
@@ -502,6 +502,10 @@ impl RinchApp {
         self.scene_dirty = true;
         self.doc = Some(doc.clone());
         self._render_scope = Some(scope);
+
+        // The initial layout can clamp a scroll offset a component set during
+        // construction (via set_scroll_top) — drain + notify (#144).
+        self.dispatch_scroll_clamp_events();
     }
 
     // ── Layout / repaint ─────────────────────────────────────────────────
@@ -636,34 +640,12 @@ impl RinchApp {
             }
         }
 
+        // Dispatch deferred scroll events for offsets the layout clamped, now
+        // that the last resolve of the frame has run (#144).
+        self.dispatch_scroll_clamp_events();
+
         // Refresh element-bounds signals against the freshly-computed layout.
-        // Subscribers (e.g. timeline-style widgets reading a strip's measured
-        // width) re-run inside this borrow, so the document RefCell must be
-        // borrowed read-only just for the lookup.
-        {
-            let d = doc.borrow();
-            rinch_core::reactive::update_bounds_signals(d.doc_key(), |node_id| {
-                let nid = node_id as usize;
-                let n = d.tree.nodes.get(nid)?;
-                // Walk to root accumulating parent-relative offsets — same
-                // convention as `dispatch_oncontextmenu` / `click_handling`.
-                let mut ax = n.layout.x;
-                let mut ay = n.layout.y;
-                let mut pid = n.parent;
-                while let Some(p) = pid {
-                    if let Some(pn) = d.tree.nodes.get(p) {
-                        ax += pn.layout.x;
-                        ay += pn.layout.y;
-                        ax -= pn.scroll_offset.0 as f32;
-                        ay -= pn.scroll_offset.1 as f32;
-                        pid = pn.parent;
-                    } else {
-                        break;
-                    }
-                }
-                Some((ax, ay, n.layout.width, n.layout.height))
-            });
-        }
+        self.refresh_bounds_signals();
 
         self.scene_dirty = true;
 
@@ -679,6 +661,78 @@ impl RinchApp {
         }
 
         true
+    }
+
+    /// Refresh element-bounds signals against the freshly-computed layout.
+    /// Subscribers (e.g. timeline-style widgets reading a strip's measured
+    /// width) re-run inside this borrow, so the document RefCell must be
+    /// borrowed read-only just for the lookup.
+    ///
+    /// Called from `resolve_and_repaint` and from `resize_layout` — the resize
+    /// path drains the dirty set, so the subsequent paint skips
+    /// `resolve_and_repaint` and this is the only refresh a pure resize gets
+    /// (#145).
+    fn refresh_bounds_signals(&self) {
+        let Some(doc) = &self.doc else { return };
+        let d = doc.borrow();
+        rinch_core::reactive::update_bounds_signals(d.doc_key(), |node_id| {
+            let nid = node_id as usize;
+            let n = d.tree.nodes.get(nid)?;
+            // Walk to root accumulating parent-relative offsets — same
+            // convention as `dispatch_oncontextmenu` / `click_handling`.
+            let mut ax = n.layout.x;
+            let mut ay = n.layout.y;
+            let mut pid = n.parent;
+            while let Some(p) = pid {
+                if let Some(pn) = d.tree.nodes.get(p) {
+                    ax += pn.layout.x;
+                    ay += pn.layout.y;
+                    ax -= pn.scroll_offset.0 as f32;
+                    ay -= pn.scroll_offset.1 as f32;
+                    pid = pn.parent;
+                } else {
+                    break;
+                }
+            }
+            Some((ax, ay, n.layout.width, n.layout.height))
+        });
+    }
+
+    /// Dispatch deferred scroll events for offsets the layout engine clamped.
+    ///
+    /// `resolve_layout` clamps a scroll container's offset when its content
+    /// shrinks or its viewport grows (#144). The clamp runs while this app
+    /// holds the document borrow, so the engine queues the (node, offset)
+    /// pairs; this drains them once the borrow is released and fires the same
+    /// `data-onscroll` handlers input-driven scrolling does.
+    fn dispatch_scroll_clamp_events(&mut self) {
+        let Some(doc) = self.doc.clone() else { return };
+        let clamps = doc.borrow_mut().drain_scroll_clamps();
+        if clamps.is_empty() {
+            return;
+        }
+        // Resolve handler ids under a read borrow, then drop it before
+        // dispatching — handlers are user code and may call back into the
+        // document.
+        let mut to_fire: Vec<(usize, f64)> = Vec::new();
+        {
+            let d = doc.borrow();
+            for (node, scroll_top) in clamps {
+                if let Some(handler_id) = d
+                    .tree
+                    .nodes
+                    .get(node.0)
+                    .and_then(|n| n.attributes.get("data-onscroll"))
+                    .and_then(|s| s.parse::<usize>().ok())
+                {
+                    to_fire.push((handler_id, scroll_top));
+                }
+            }
+        }
+        for (handler_id, scroll_top) in to_fire {
+            use rinch_core::events::{EventHandlerId, dispatch_scroll_event};
+            dispatch_scroll_event(EventHandlerId(handler_id), scroll_top);
+        }
     }
 
     /// Apply deferred scroll-into-view requests.
@@ -783,12 +837,19 @@ impl RinchApp {
     pub fn resize_layout(&mut self, width: u32, height: u32) {
         let width = width.max(1);
         let height = height.max(1);
-        if let Some(doc) = &self.doc {
+        let Some(doc) = self.doc.clone() else { return };
+        {
             let mut d = doc.borrow_mut();
             d.resolve_layout(width as f32, height as f32);
             let _ = d.take_dirty_nodes();
-            self.scene_dirty = true;
         }
+        self.scene_dirty = true;
+        // Layout at the new size may have clamped scroll offsets — notify (#144).
+        self.dispatch_scroll_clamp_events();
+        // The drain above emptied the dirty set, so the subsequent paint skips
+        // `resolve_and_repaint`; without this a pure resize leaves bounds
+        // signals reporting the pre-resize geometry (#145).
+        self.refresh_bounds_signals();
     }
 
     /// Build the Vello scene from the current document state.
@@ -1856,5 +1917,99 @@ impl RinchApp {
                 d.tree.dirty_nodes.insert(node_id);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod layout_notification_tests {
+    use super::*;
+    use std::cell::Cell;
+
+    /// #145: a pure window resize must refresh bounds signals. `resize_layout`
+    /// drains the dirty set, so the subsequent paint never reaches
+    /// `resolve_and_repaint` — the resize path has to refresh the signals
+    /// itself or a full-size element keeps reporting pre-resize geometry.
+    #[test]
+    fn resize_layout_refreshes_bounds_signals() {
+        use rinch_core::reactive::{ElementBounds, Signal};
+
+        let captured: Rc<Cell<Option<Signal<ElementBounds>>>> = Rc::new(Cell::new(None));
+        let captured_in = captured.clone();
+        let mut app = RinchApp::new(move |scope: &mut RenderScope| {
+            let root = scope.create_element("div");
+            root.set_attribute("style", "width: 100%; height: 100%");
+            captured_in.set(Some(root.bounds_signal()));
+            root
+        });
+        app.mount_component(800.0, 600.0);
+        let bounds = captured.get().expect("bounds signal captured at mount");
+
+        // Pure resize, no other interaction: the signal must report the new
+        // viewport size.
+        app.resize_layout(400, 300);
+        let b = bounds.get();
+        assert_eq!(
+            (b.width, b.height),
+            (400.0, 300.0),
+            "bounds signal must track the resized viewport, got {b:?}"
+        );
+
+        // And again — a second resize keeps tracking.
+        app.resize_layout(640, 480);
+        let b = bounds.get();
+        assert_eq!((b.width, b.height), (640.0, 480.0));
+    }
+
+    /// #144: a layout-time scroll clamp must fire the container's
+    /// `data-onscroll` handler — exactly once, with the clamped offset —
+    /// through the deferred queue drained after layout.
+    #[test]
+    fn layout_scroll_clamp_fires_onscroll_handler() {
+        use rinch_core::events::{ScrollCallback, register_scroll_handler};
+
+        let fired: Rc<RefCell<Vec<f64>>> = Rc::new(RefCell::new(Vec::new()));
+        let fired_in = fired.clone();
+        let handler_id = register_scroll_handler(ScrollCallback::from(move |top: f64| {
+            fired_in.borrow_mut().push(top);
+        }));
+
+        let nodes: Rc<RefCell<Option<(NodeHandle, NodeHandle)>>> = Rc::new(RefCell::new(None));
+        let nodes_in = nodes.clone();
+        let mut app = RinchApp::new(move |scope: &mut RenderScope| {
+            let container = scope.create_element("div");
+            container.set_attribute("style", "height: 100px; overflow-y: auto");
+            container.set_attribute("data-onscroll", &handler_id.0.to_string());
+            let content = scope.create_element("div");
+            content.set_attribute("style", "height: 500px");
+            container.append_child(&content);
+            *nodes_in.borrow_mut() = Some((container.clone(), content));
+            container
+        });
+        app.mount_component(800.0, 600.0);
+        let (container, content) = nodes.borrow().clone().expect("nodes captured at mount");
+
+        // Scroll to max (500 content - 100 visible = 400) — a valid offset,
+        // so no clamp event fires.
+        if let Some(doc) = &app.doc {
+            doc.borrow_mut().set_scroll_top(container.node_id(), 400.0);
+        }
+        app.resolve_and_repaint(800.0, 600.0);
+        assert!(
+            fired.borrow().is_empty(),
+            "no clamp event while the offset is valid"
+        );
+
+        // Shrink the content: layout clamps 400 → 150 and must notify once.
+        content.set_attribute("style", "height: 250px");
+        app.resolve_and_repaint(800.0, 600.0);
+        assert_eq!(*fired.borrow(), vec![150.0]);
+
+        // Settled — a further frame must not re-fire.
+        app.resolve_and_repaint(800.0, 600.0);
+        assert_eq!(
+            fired.borrow().len(),
+            1,
+            "clamp event must fire exactly once"
+        );
     }
 }

--- a/docs/src/guide/windows.md
+++ b/docs/src/guide/windows.md
@@ -309,6 +309,24 @@ fn main() {
 }
 ```
 
+## Observing Window Resizes
+
+There is no separate resize event. The supported way to observe viewport size
+changes is a root element's `bounds_signal()`, which the runtime refreshes after
+every layout pass — including pure window resizes:
+
+```rust
+#[component]
+fn app() -> NodeHandle {
+    let root = __scope.create_element("div");
+    root.set_attribute("style", "width: 100%; height: 100%");
+    let bounds = root.bounds_signal(); // Signal<ElementBounds>
+
+    // bounds.get().width / bounds.get().height track the viewport reactively.
+    root
+}
+```
+
 ## Programmatic Window Management
 
 Open and close windows programmatically at runtime using the `windows` module.


### PR DESCRIPTION
Fixes #144. Fixes #145.

Two instances of the same defect class — layout silently mutating observable state:

## #145 — bounds signals stale after window resize
`resize_layout` drained dirty nodes, so the subsequent paint skipped `resolve_and_repaint` — the sole caller of `update_bounds_signals`. Consumers mirroring viewport geometry (the rinch-ce virtualized editor's 500ms-poll workaround) went stale, contradicting the documented contract in `bounds.rs`.

- Extracted the bounds-refresh block into `refresh_bounds_signals`, called from both `resolve_and_repaint` and the end of `resize_layout` — one move fixes desktop, embed (`RinchContext::resize`), and the DevTools window.
- **No new resize API** (deliberate scope call): the root element's `bounds_signal()` *is* the resize observer now that it refreshes on resize — documented on `NodeHandle::bounds_signal`, the `bounds.rs` module header, and a new "Observing Window Resizes" section in `docs/src/guide/windows.md`.

## #144 — layout-time scroll clamp fires no scroll event
`clamp_scroll_offsets` assigned clamped offsets directly with no dispatch, while every input-driven scroll path fires `data-onscroll`. Synchronous dispatch mid-layout would `BorrowMutError` (the facade holds `borrow_mut` across `resolve_layout`), so this follows the existing `scroll_into_view_requests` deferred-queue precedent:

- `pending_scroll_clamps` queue on the tree, populated in the clamp apply loop with **keep-last per-node coalescing** (`resolve_and_repaint` can resolve layout twice per frame via the caret pass — consumers see exactly one event per drain; coalescing is provably correct since clamps only shrink).
- `drain_scroll_clamps()` added as a `DomDocument` trait method with a default impl — rinch-web and test doubles need no changes.
- `dispatch_scroll_clamp_events` on the facade: drains, resolves `data-onscroll` handler ids, drops the borrow, then dispatches via the same path as input-driven scrolls. Called after resolve in `resolve_and_repaint`, at the end of mount, and in `resize_layout`. The two undrained `resolve_layout` sites (editor virtualization, shell) are followed by a same-frame facade drain.

Out of scope, listed for follow-up (found in triage): `apply_scroll_into_view` and programmatic `set_scroll_top` dispatch no event (browsers fire for both); horizontal offsets are never layout-clamped; `dispatch_scroll_event` carries only `scroll_top`.

## Testing
- New rinch-dom test pins clamp + queue + keep-last coalescing across two resolves (shrink 500→250→180 → drain yields exactly one entry at 80.0).
- Two new facade tests: `resize_layout_refreshes_bounds_signals` (exact bounds asserted post-resize, no interaction needed) and `layout_scroll_clamp_fires_onscroll_handler` (handler fires exactly once with the clamped value).
- Full suites re-run twice (implementer + adversarial review): rinch-dom 58-in-suite/all pass, rinch 13-in-suite/all pass, rinch-core pass, `--no-default-features --features embed` and rinch-web compile clean, clippy `-D warnings` clean, full-workspace pre-commit hook passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)