### PR TITLE
fix(rinch): drain native events before paint + post-paint self-wake so debug commands aren't serialized behind paints (#153)

### DIFF
--- a/crates/rinch/Cargo.toml
+++ b/crates/rinch/Cargo.toml
@@ -185,3 +185,8 @@ serde = ["rinch-editor-core/serde"]
 # wasm-compatible, so the web view reuses the SAME adapter (the web app supplies a wasm
 # randomness source for automerge→uuid).
 collaboration = ["desktop", "rinch-editor-view/collaboration"]
+
+# Probe app for the ignored e2e test tests/debug_event_latency.rs (issue #153).
+[[example]]
+name = "debug_click_latency"
+required-features = ["desktop", "debug"]

--- a/crates/rinch/examples/debug_click_latency.rs
+++ b/crates/rinch/examples/debug_click_latency.rs
@@ -1,0 +1,58 @@
+//! Probe app for `tests/debug_event_latency.rs` (issue #153).
+//!
+//! Renders a full-window click target that records the interval between
+//! consecutive clicks into a `.click-delta` text node. The companion ignored
+//! test drives two back-to-back `click` commands through the raw rinch-debug
+//! TCP protocol and asserts the app-observed delta stays far below one paint.
+//!
+//! Every click toggles the root background color, dirtying the whole window —
+//! otherwise dirty-region caching would repaint only the tiny changed text and
+//! the paint the second click stalls behind would be too cheap to observe. The
+//! text-heavy filler rows make that full-window paint genuinely expensive in a
+//! debug software build.
+//!
+//! Build with: `cargo build -p rinch --example debug_click_latency --features debug`
+
+use rinch::prelude::*;
+use std::time::Instant;
+
+#[component]
+fn app() -> NodeHandle {
+    let last_click = Signal::new(None::<Instant>);
+    let delta_ms = Signal::new(String::from("none"));
+    let count = Signal::new(0u32);
+
+    rsx! {
+        div {
+            style: {move || format!(
+                "display: flex; flex-direction: column; width: 900px; height: 600px; \
+                 padding: 20px; gap: 2px; background-color: {}",
+                if count.get().is_multiple_of(2) { "#e3f2fd" } else { "#fff3e0" }
+            )},
+            onclick: move || {
+                let now = Instant::now();
+                if let Some(prev) = last_click.get() {
+                    delta_ms.set(format!(
+                        "{:.1}",
+                        now.duration_since(prev).as_secs_f64() * 1000.0
+                    ));
+                }
+                last_click.set(Some(now));
+                count.update(|n| *n += 1);
+            },
+            div { class: "click-count", "Clicks: " {|| count.get().to_string()} }
+            div { class: "click-delta", {|| delta_ms.get()} }
+            for i in (0..40u32).collect::<Vec<_>>() {
+                div { key: i, style: "font-size: 12px",
+                    "Filler row " {i.to_string()} " with enough text to make a \
+                     full-window software paint expensive in a debug build, so a \
+                     debug command serialized behind one is clearly observable (#153)."
+                }
+            }
+        }
+    }
+}
+
+fn main() {
+    rinch::run("debug-click-latency-probe", 900, 600, app);
+}

--- a/crates/rinch/src/shell/rinch_runtime.rs
+++ b/crates/rinch/src/shell/rinch_runtime.rs
@@ -209,6 +209,10 @@ pub struct RinchRuntime {
     modifiers: winit::keyboard::ModifiersState,
     /// Native menu bar (attached to the window).
     native_menu: Option<muda::Menu>,
+    /// True while [`Self::drain_native_events`] is running. Prevents re-entrant
+    /// drains: `DebugCommandKind::Screenshot` calls [`Self::paint`] from inside
+    /// the drain, and the `RedrawRequested` arm drains before painting (#153).
+    draining_native_events: bool,
 
     // ── DevTools ─────────────────────────────────────────────────
     /// Shared DevTools store (persists across open/close cycles).
@@ -272,6 +276,7 @@ impl RinchRuntime {
             height,
             modifiers: winit::keyboard::ModifiersState::empty(),
             native_menu: None,
+            draining_native_events: false,
             devtools_store: None,
             devtools_app: None,
             devtools_window: None,
@@ -1390,15 +1395,18 @@ impl RinchRuntime {
             return false;
         };
 
-        // Collect commands that need renderer access
-        let mut pending = Vec::new();
-        while let Ok(cmd) = rx.0.try_recv() {
-            pending.push(cmd);
-        }
-
         let mut should_exit = false;
 
-        for cmd in pending {
+        // Process commands as they arrive. After answering command N, wait a
+        // short beat for a pipelined follow-up — a fast client sends command
+        // N+1 the moment it reads response N, but by then the paint N induced
+        // is usually already dispatched, so without this window N+1 would
+        // stall behind that full paint (#153). Batching here lets the whole
+        // burst ride a single paint. The window is bounded so a spamming
+        // client cannot starve painting.
+        let batch_start = std::time::Instant::now();
+        let mut next = rx.0.try_recv().ok();
+        while let Some(cmd) = next {
             let response = match &cmd.kind {
                 rinch_debug::DebugCommandKind::Screenshot => {
                     // Screenshot needs the renderer -- handle it here in the shell
@@ -1443,6 +1451,12 @@ impl RinchRuntime {
                 }
             };
             let _ = cmd.response_tx.send(response);
+
+            next = if batch_start.elapsed() < std::time::Duration::from_millis(25) {
+                rx.0.recv_timeout(std::time::Duration::from_millis(2)).ok()
+            } else {
+                rx.0.try_recv().ok()
+            };
         }
 
         self.app.debug_cmd_rx = Some(rx);
@@ -1476,10 +1490,7 @@ impl ApplicationHandler for RinchRuntime {
         drain_main_queue();
 
         // Drain queued native events.
-        let events: Vec<_> = NATIVE_EVENT_QUEUE.lock().unwrap().drain(..).collect();
-        for event in events {
-            self.handle_native_event(event, event_loop);
-        }
+        self.drain_native_events(event_loop);
 
         // A cross-thread Signal::send()/update_send() drained above runs its
         // effects on this thread, but the ReRender handler's resolve_and_repaint
@@ -1527,9 +1538,25 @@ impl ApplicationHandler for RinchRuntime {
                 }
             }
             WindowEvent::RedrawRequested => {
+                // Drain queued native events (debug commands, injected input)
+                // before painting so a command that arrived while the loop was
+                // busy isn't serialized behind a full paint (#153). Pre-paint
+                // is safe: the paint preamble re-resolves layout when
+                // has_pending_layout(), so the paint sees the drained state.
+                self.drain_native_events(event_loop);
                 // Paint directly -- this is shell-level, not delegated
                 if let Err(e) = self.paint() {
                     eprintln!("Paint error: {}", e);
+                }
+                // winit coalesces wake_up() calls arbitrarily, so a wake that
+                // landed mid-paint may already have been consumed. If events
+                // queued while we painted, self-wake so they're delivered
+                // immediately instead of waiting for the next external event
+                // (#153).
+                if !NATIVE_EVENT_QUEUE.lock().unwrap().is_empty() {
+                    if let Some(proxy) = GLOBAL_PROXY.get() {
+                        proxy.wake_up();
+                    }
                 }
                 return;
             }
@@ -1953,6 +1980,26 @@ impl RinchRuntime {
             handle.set_selection(sel);
             send_native_event(RinchNativeEvent::ReRender);
         }
+    }
+
+    /// Drain queued native events (debug commands, window controls, injected
+    /// platform events) and dispatch each through [`Self::handle_native_event`].
+    ///
+    /// Called from `proxy_wake_up` and from the top of the `RedrawRequested`
+    /// arm — the latter so a command that arrived while the loop was busy is
+    /// processed *before* the paint instead of stalling a full paint behind it
+    /// (#153). Guarded against re-entry: `DebugCommandKind::Screenshot` calls
+    /// [`Self::paint`] from inside the drain, so a nested drain must no-op.
+    fn drain_native_events(&mut self, event_loop: &dyn ActiveEventLoop) {
+        if self.draining_native_events {
+            return;
+        }
+        self.draining_native_events = true;
+        let events: Vec<_> = NATIVE_EVENT_QUEUE.lock().unwrap().drain(..).collect();
+        for event in events {
+            self.handle_native_event(event, event_loop);
+        }
+        self.draining_native_events = false;
     }
 
     /// Handle a single native event from the queue.

--- a/crates/rinch/tests/debug_event_latency.rs
+++ b/crates/rinch/tests/debug_event_latency.rs
@@ -1,0 +1,240 @@
+//! E2E pin for issue #153: debug-channel commands must not be serialized
+//! behind full paints.
+//!
+//! Drives pairs of back-to-back `click` commands through the raw rinch-debug
+//! TCP protocol (length-prefixed JSON, see `rinch-debug/src/protocol.rs`)
+//! against the `debug_click_latency` probe example at 900x600, then reads the
+//! app-observed inter-click delta back out of the DOM via `get_text_content`.
+//! Before the #153 fix the second click of a pair stalled behind a full
+//! software paint (350ms-2s in a debug build at this size, depending on
+//! content), so no pair could land inside a double-click threshold; with the
+//! fix (pre-paint drain + post-paint self-wake + pipelined command batching)
+//! every pair lands within a few milliseconds.
+//!
+//! Needs a display (X11/Wayland), so it is `#[ignore]`d for CI. Run manually:
+//!
+//! ```sh
+//! cargo build -p rinch --example debug_click_latency --features debug
+//! cargo test -p rinch --test debug_event_latency -- --ignored
+//! ```
+//!
+//! Headless: start `Xvfb :99 -screen 0 1280x720x24 &` and run both commands
+//! with `DISPLAY=:99` (or wrap them in `xvfb-run -a`).
+#![cfg(feature = "desktop")] // serde_json comes in via the desktop feature
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::process::{Child, Command};
+use std::time::{Duration, Instant};
+
+/// Write a length-prefixed frame (4-byte big-endian length + JSON payload).
+fn write_frame(stream: &mut TcpStream, data: &[u8]) {
+    let len = data.len() as u32;
+    stream
+        .write_all(&len.to_be_bytes())
+        .expect("write frame len");
+    stream.write_all(data).expect("write frame body");
+    stream.flush().expect("flush frame");
+}
+
+/// Read a length-prefixed frame (4-byte big-endian length + JSON payload).
+fn read_frame(stream: &mut TcpStream) -> Vec<u8> {
+    let mut len_buf = [0u8; 4];
+    stream.read_exact(&mut len_buf).expect("read frame len");
+    let len = u32::from_be_bytes(len_buf) as usize;
+    let mut buf = vec![0u8; len];
+    stream.read_exact(&mut buf).expect("read frame body");
+    buf
+}
+
+/// Send one request and wait for its response.
+fn request(stream: &mut TcpStream, req: &serde_json::Value) -> serde_json::Value {
+    write_frame(stream, req.to_string().as_bytes());
+    serde_json::from_slice(&read_frame(stream)).expect("parse response")
+}
+
+/// Kill the probe app when the test exits (pass or panic).
+struct ChildGuard(Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Build (no-op when fresh) and locate the probe example binary.
+fn build_probe_binary() -> PathBuf {
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".into());
+    let status = Command::new(cargo)
+        .args([
+            "build",
+            "-p",
+            "rinch",
+            "--example",
+            "debug_click_latency",
+            "--features",
+            "debug",
+        ])
+        .current_dir(&workspace_root)
+        .status()
+        .expect("run cargo build for probe example");
+    assert!(status.success(), "probe example build failed");
+
+    let target_dir = std::env::var("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| workspace_root.join("target"));
+    target_dir.join("debug/examples/debug_click_latency")
+}
+
+#[test]
+#[ignore = "needs a display (X11/Wayland or Xvfb); see module docs"]
+fn back_to_back_debug_clicks_are_not_serialized_behind_paints() {
+    let binary = build_probe_binary();
+
+    // Reserve a free port for the probe's debug server.
+    let port = {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        listener.local_addr().unwrap().port()
+    };
+
+    let child = Command::new(&binary)
+        .env("RINCH_DEBUG", "1")
+        .env("RINCH_DEBUG_PORT", port.to_string())
+        .spawn()
+        .expect("spawn probe app");
+    let mut guard = ChildGuard(child);
+
+    // Connect (the debug server starts before the event loop, so this is quick).
+    let mut stream = {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            match TcpStream::connect(("127.0.0.1", port)) {
+                Ok(s) => break s,
+                Err(_) if Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(200));
+                }
+                Err(e) => panic!("could not connect to probe debug server: {e}"),
+            }
+        }
+    };
+    stream.set_nodelay(true).ok();
+    stream.set_read_timeout(Some(Duration::from_secs(30))).ok();
+
+    // Handshake.
+    write_frame(&mut stream, br#"{"protocol":"rinch-debug","version":1}"#);
+    let handshake: serde_json::Value =
+        serde_json::from_slice(&read_frame(&mut stream)).expect("parse handshake");
+    assert_eq!(handshake["protocol"], "rinch-debug");
+
+    // Wait for the DOM to exist (window creation + first paint in a debug
+    // build can take a while), polling for the delta node.
+    let mut next_id: u64 = 1;
+    let delta_node_id = {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            let resp = request(
+                &mut stream,
+                &serde_json::json!({
+                    "id": next_id,
+                    "method": "query_selector",
+                    "params": { "selector": ".click-delta" },
+                }),
+            );
+            next_id += 1;
+            if let Some(id) = resp["data"].get(0).and_then(|n| n["id"].as_u64()) {
+                break id;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "probe app never exposed .click-delta: {resp}"
+            );
+            std::thread::sleep(Duration::from_millis(500));
+        }
+    };
+    // Let startup paints settle so the first pair starts from an idle loop.
+    std::thread::sleep(Duration::from_secs(2));
+
+    // Drive pairs of back-to-back clicks. Both request frames are written
+    // before reading responses, so the server dispatches click N+1 the moment
+    // it has answered click N — no client round trip in the critical path.
+    // Click N's response is sent before its induced paint, so without the
+    // fix click N+1 stalls a full paint; with the pipelined batching window
+    // it is processed within a couple of milliseconds. Several pairs absorb
+    // scheduling jitter; assert on the best pair.
+    let mut deltas = Vec::new();
+    for _ in 0..5 {
+        let click = |id: u64| {
+            serde_json::json!({
+                "id": id,
+                "method": "click",
+                "params": { "x": 450.0, "y": 300.0 },
+            })
+        };
+        write_frame(&mut stream, click(next_id).to_string().as_bytes());
+        write_frame(&mut stream, click(next_id + 1).to_string().as_bytes());
+        next_id += 2;
+        let _resp1: serde_json::Value =
+            serde_json::from_slice(&read_frame(&mut stream)).expect("parse click 1");
+        let _resp2: serde_json::Value =
+            serde_json::from_slice(&read_frame(&mut stream)).expect("parse click 2");
+
+        // The handler recorded the intra-pair delta while processing click 2,
+        // before its response was sent — read it back out of the DOM.
+        let resp = request(
+            &mut stream,
+            &serde_json::json!({
+                "id": next_id,
+                "method": "get_text_content",
+                "params": { "id": delta_node_id },
+            }),
+        );
+        next_id += 1;
+        let text = resp["data"]
+            .as_str()
+            .expect("delta text")
+            .trim()
+            .to_string();
+        let delta: f64 = text
+            .parse()
+            .unwrap_or_else(|_| panic!("unexpected .click-delta content: {text:?}"));
+        deltas.push(delta);
+
+        // Let the pair's paints finish so the next pair starts from idle.
+        std::thread::sleep(Duration::from_millis(800));
+    }
+
+    let best = deltas.iter().cloned().fold(f64::INFINITY, f64::min);
+    println!("intra-pair click deltas (ms): {deltas:?}; best: {best:.1}");
+
+    // Shut the probe down gracefully and verify the drained exit behaves
+    // (winit's exit is deferred; the app must still terminate cleanly). The
+    // guard kills the process if it doesn't.
+    write_frame(
+        &mut stream,
+        serde_json::json!({ "id": next_id, "method": "close_app" })
+            .to_string()
+            .as_bytes(),
+    );
+    let exited = {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            match guard.0.try_wait().expect("poll probe app") {
+                Some(_) => break true,
+                None if Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(200));
+                }
+                None => break false,
+            }
+        }
+    };
+    assert!(exited, "probe app did not exit after close_app");
+
+    assert!(
+        best < 100.0,
+        "no click pair landed inside 100ms (deltas: {deltas:?}); \
+         debug commands are being serialized behind paints (#153)"
+    );
+}


### PR DESCRIPTION
Fixes #153.

Debug-channel commands were serialized one-per-paint: `NATIVE_EVENT_QUEUE` was drained only in `proxy_wake_up`, winit coalesces wakes arbitrarily (the vendored fork's docs say delivery can slip past *multiple* redraws), and each click command requests a redraw with its response sent before the paint — so command N+1 always waited a full paint (~2.1s measured in a software debug build at 900×600, not the issue's estimated 350–400ms). Double-click testing through the debug channel was impossible.

## Changes (all in `shell/rinch_runtime.rs`)
1. **Pre-paint drain**: queue drain factored into `drain_native_events()`, called at the top of the `RedrawRequested` arm before `paint()` (never inside the paint fns after layout resolution — the paint preamble re-resolves on `has_pending_layout()`, which is what makes pre-paint safe). Re-entrancy guard field included: `Screenshot` paints from inside the drain.
2. **Post-paint self-wake**: if the queue is non-empty after `paint()` returns, self-wake via `GLOBAL_PROXY` so a wake coalesced mid-paint delivers immediately instead of "eventually".
3. **⚠️ Deviation from the pre-ratified design — bounded pipelined batching**: measured counterfactually, (1)+(2) alone still left deltas at exactly one full paint — the pre-paint drain only helps if N+1 is already queued when the redraw dispatches, and the main thread wins that µs race essentially always. The debug command handler now waits up to 2ms after answering a command for a pipelined follow-up (batch capped at 25ms so a spamming client can't starve painting), letting a burst ride a single paint. Confined to the debug feature path; reviewer accepted with a noted minor (a 2ms `recv_timeout` stall per drain even when no follow-up comes).

`event_loop.exit()` from a drained command on the redraw path verified safe (winit exit is deferred; the e2e asserts clean termination after `close_app`).

## Testing
- New e2e pin: `crates/rinch/tests/debug_event_latency.rs` (+ probe example `debug_click_latency.rs`), `#[ignore]`-gated (needs a display; Xvfb `:99` pattern documented). Drives 5 click pairs over the raw length-prefixed-JSON TCP protocol and reads app-observed deltas from the DOM. **Counterfactual verified by both implementer and reviewer independently**: with fix, deltas 0.7–1.5ms; with `rinch_runtime.rs` reverted to main, 2.1–8.4s (one-to-multiple paints). The probe toggles the root background per click to defeat dirty-region caching — without that, repaints were too cheap for the pin to discriminate.
- `cargo test -p rinch` (11 unit + 2 integration, 0 failed), checks on default/`gpu`/`debug` features, clippy clean on all three, full-workspace pre-commit hook passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)