### PR TITLE
fix(rinch-core,rinch): per-root store/context scoping with thread-global fallback (#136)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1342,7 +1342,7 @@ Your game owns the window and wgpu device. Rinch runs headless — you feed it e
 
 | Type | Purpose |
 |------|---------|
-| `RinchContext` | Main handle — `new()`, `update()`, `scene()`. Multiple contexts can coexist on one thread (#134): each holds its own `subscribe_signal_change` guard, and bounds signals / editor registrations / focus requests are scoped per document via `DomDocument::doc_key()`. Caveat: `create_store` is TypeId-keyed thread-wide — use distinct store types per context. |
+| `RinchContext` | Main handle — `new()`, `update()`, `scene()`. Multiple contexts can coexist on one thread (#134): each holds its own `subscribe_signal_change` guard, and bounds signals / editor registrations / focus requests are scoped per document via `DomDocument::doc_key()`. Stores/contexts are namespaced per context with a thread-global fallback (#136): `create_store` inside a context lands in that context's namespace (cleared on drop), its effects/handlers resolve it first, and lookups fall back to stores created outside any context. |
 | `RinchContextConfig` | Width, height, scale factor, optional theme |
 | `RinchOverlayRenderer` | Convenience Vello-to-texture renderer |
 | `GameViewport` | Component marking a transparent hole for game rendering |

--- a/crates/rinch-core/src/context.rs
+++ b/crates/rinch-core/src/context.rs
@@ -2,14 +2,61 @@
 //!
 //! Context provides a way to share values across your component tree without
 //! explicitly passing them through props.
+//!
+//! # Root scoping (issue #136)
+//!
+//! The store is keyed by `(root, TypeId)`. Root `0` is the **thread-global
+//! fallback root**: everything created with no root pushed — shell startups,
+//! menu/tray callbacks, timers, cross-thread-marshalled closures — lives
+//! there, so single-root apps behave exactly as before. A mounted embed root
+//! (`RinchContext`) pushes its own root key (its document's `doc_key`) around
+//! mount, and effects/event handlers capture the current root at creation
+//! time, so each context resolves its own namespace first and falls back to
+//! root `0` for anything it didn't create itself.
 
 use std::any::{Any, TypeId};
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 
-// Thread-local context store for sharing state across components
+/// The thread-global fallback root (see module docs).
+const GLOBAL_ROOT: u64 = 0;
+
+// Thread-local context store for sharing state across components, keyed by
+// (root, TypeId) — each mounted root gets its own namespace (issue #136).
 thread_local! {
-    static CONTEXT_STORE: RefCell<HashMap<TypeId, Box<dyn Any>>> = RefCell::new(HashMap::new());
+    static CONTEXT_STORE: RefCell<HashMap<(u64, TypeId), Box<dyn Any>>> =
+        RefCell::new(HashMap::new());
+    /// The root whose namespace create/use_context resolve right now.
+    static CURRENT_ROOT: Cell<u64> = const { Cell::new(GLOBAL_ROOT) };
+}
+
+/// The context root currently in effect on this thread (`0` = the
+/// thread-global fallback root).
+pub fn current_context_root() -> u64 {
+    CURRENT_ROOT.with(|r| r.get())
+}
+
+/// RAII guard returned by [`push_context_root`]; restores the previous root
+/// when dropped.
+pub struct ContextRootGuard {
+    prev: u64,
+}
+
+impl Drop for ContextRootGuard {
+    fn drop(&mut self) {
+        CURRENT_ROOT.with(|r| r.set(self.prev));
+    }
+}
+
+/// Make `root` the current context root until the returned guard drops.
+///
+/// Used by the framework around a mounted root's build (`RinchContext` mount),
+/// effect re-runs, and event-handler dispatch so `create_context`/`use_context`
+/// resolve that root's namespace. Closures that run with no root pushed
+/// resolve the thread-global root `0`.
+pub fn push_context_root(root: u64) -> ContextRootGuard {
+    let prev = CURRENT_ROOT.with(|r| r.replace(root));
+    ContextRootGuard { prev }
 }
 
 /// Create a context value accessible by any component.
@@ -17,6 +64,10 @@ thread_local! {
 /// Context provides a way to share values across your component tree without
 /// explicitly passing them through props. This is useful for global state like
 /// themes, user preferences, or authentication data.
+///
+/// The value is stored under the current context root — the mounted root being
+/// built, or the thread-global root when called outside any root (see module
+/// docs).
 ///
 /// # Example
 ///
@@ -57,10 +108,11 @@ thread_local! {
 /// }
 /// ```
 pub fn create_context<T: Clone + 'static>(value: T) -> T {
+    let root = current_context_root();
     CONTEXT_STORE.with(|store| {
         store
             .borrow_mut()
-            .insert(TypeId::of::<T>(), Box::new(value.clone()));
+            .insert((root, TypeId::of::<T>()), Box::new(value.clone()));
     });
     value
 }
@@ -103,6 +155,10 @@ pub fn use_context<T: Clone + 'static>() -> T {
 /// Returns `Some(value)` if a context of the given type has been created,
 /// or `None` if no such context exists.
 ///
+/// The current context root's namespace is checked first; when the value is
+/// not found there, the lookup falls back to the thread-global root `0` (see
+/// module docs).
+///
 /// Use this when the context may not be present and you want to handle
 /// the `None` case explicitly. For most uses, prefer [`use_context`] which
 /// panics with a helpful message if the context is missing.
@@ -120,10 +176,17 @@ pub fn use_context<T: Clone + 'static>() -> T {
 /// }
 /// ```
 pub fn try_use_context<T: Clone + 'static>() -> Option<T> {
+    let tid = TypeId::of::<T>();
+    let root = current_context_root();
     CONTEXT_STORE.with(|store| {
+        let store = store.borrow();
         store
-            .borrow()
-            .get(&TypeId::of::<T>())
+            .get(&(root, tid))
+            .or_else(|| {
+                (root != GLOBAL_ROOT)
+                    .then(|| store.get(&(GLOBAL_ROOT, tid)))
+                    .flatten()
+            })
             .and_then(|b| b.downcast_ref::<T>())
             .cloned()
     })
@@ -198,7 +261,18 @@ pub fn try_use_store<T: Clone + 'static>() -> Option<T> {
     try_use_context::<T>()
 }
 
-/// Clear all context (called during app reset).
+/// Clear the thread-global root's context (called during app reset).
+///
+/// Per-root namespaces are untouched — they are cleared by
+/// [`clear_context_for_root`] when their root is dropped.
 pub fn clear_context() {
-    CONTEXT_STORE.with(|store| store.borrow_mut().clear());
+    CONTEXT_STORE.with(|store| store.borrow_mut().retain(|(r, _), _| *r != GLOBAL_ROOT));
+}
+
+/// Clear one root's context namespace.
+///
+/// Called when a mounted root (e.g. an embed `RinchContext`) is dropped, so
+/// its stores/contexts do not outlive it (issue #136).
+pub fn clear_context_for_root(root: u64) {
+    CONTEXT_STORE.with(|store| store.borrow_mut().retain(|(r, _), _| *r != root));
 }

--- a/crates/rinch-core/src/events/handlers.rs
+++ b/crates/rinch-core/src/events/handlers.rs
@@ -276,6 +276,15 @@ impl ScrollRegistry {
 pub fn register_handler(callback: EventCallback) -> EventHandlerId {
     let id = next_handler_id();
     tracing::debug!("register_handler: Registered handler {:?}", id);
+    // Capture the context root current at registration time: dispatch happens
+    // from the event loop (no root pushed), so the wrapper re-enters the root
+    // the handler was built under — a handler inside a mounted root resolves
+    // that root's stores/contexts (issue #136).
+    let root = crate::context::current_context_root();
+    let callback: EventCallback = Rc::new(move || {
+        let _root = crate::context::push_context_root(root);
+        callback();
+    });
     EVENT_REGISTRY.with(|registry| {
         registry.borrow_mut().handlers.insert(id, callback);
     });
@@ -363,6 +372,12 @@ pub fn dispatch_event(id: EventHandlerId) -> bool {
 #[doc(hidden)]
 pub fn register_input_handler(callback: InputCallback) -> EventHandlerId {
     let id = next_handler_id();
+    // Re-enter the registration-time context root on dispatch (issue #136).
+    let root = crate::context::current_context_root();
+    let callback = InputCallback::new(move |value| {
+        let _root = crate::context::push_context_root(root);
+        callback.invoke(value);
+    });
     INPUT_REGISTRY.with(|registry| {
         registry.borrow_mut().handlers.insert(id, callback);
     });
@@ -406,6 +421,12 @@ pub fn dispatch_input_event(id: EventHandlerId, value: String) -> bool {
 #[doc(hidden)]
 pub fn register_file_drop_handler(callback: FileDropCallback) -> EventHandlerId {
     let id = next_handler_id();
+    // Re-enter the registration-time context root on dispatch (issue #136).
+    let root = crate::context::current_context_root();
+    let callback = FileDropCallback::new(move |paths| {
+        let _root = crate::context::push_context_root(root);
+        callback.invoke(paths);
+    });
     FILE_DROP_REGISTRY.with(|registry| {
         registry.borrow_mut().handlers.insert(id, callback);
     });
@@ -433,6 +454,12 @@ pub fn dispatch_file_drop_event(id: EventHandlerId, paths: Vec<PathBuf>) -> bool
 #[doc(hidden)]
 pub fn register_scroll_handler(callback: ScrollCallback) -> EventHandlerId {
     let id = next_handler_id();
+    // Re-enter the registration-time context root on dispatch (issue #136).
+    let root = crate::context::current_context_root();
+    let callback = ScrollCallback::new(move |scroll_top| {
+        let _root = crate::context::push_context_root(root);
+        callback.invoke(scroll_top);
+    });
     SCROLL_REGISTRY.with(|registry| {
         registry.borrow_mut().handlers.insert(id, callback);
     });

--- a/crates/rinch-core/src/lib.rs
+++ b/crates/rinch-core/src/lib.rs
@@ -55,7 +55,8 @@ pub use reactive::{
 
 // Re-export context for sharing state across components
 pub use context::{
-    clear_context, create_context, create_store, try_use_context, try_use_store, use_context,
+    ContextRootGuard, clear_context, clear_context_for_root, create_context, create_store,
+    current_context_root, push_context_root, try_use_context, try_use_store, use_context,
     use_store,
 };
 

--- a/crates/rinch-core/src/reactive/effect.rs
+++ b/crates/rinch-core/src/reactive/effect.rs
@@ -36,6 +36,10 @@ pub(super) struct EffectInner {
     pub(super) id: ObserverId,
     pub(super) f: RefCell<Box<dyn FnMut()>>,
     pub(super) disposed: Cell<bool>,
+    /// The context root current when this effect was created; re-entered on
+    /// every run so `use_context`/`use_store` resolve the same namespace as at
+    /// build time (issue #136). `0` = the thread-global fallback root.
+    pub(super) root: u64,
 }
 
 impl Effect {
@@ -50,6 +54,7 @@ impl Effect {
             id,
             f: RefCell::new(Box::new(f)),
             disposed: Cell::new(false),
+            root: crate::context::current_context_root(),
         });
 
         // Store the effect
@@ -79,6 +84,7 @@ impl Effect {
             id,
             f: RefCell::new(Box::new(f)),
             disposed: Cell::new(false),
+            root: crate::context::current_context_root(),
         });
 
         EFFECTS.with(|effects| {
@@ -134,6 +140,11 @@ pub(super) fn run_effect(id: ObserverId) {
         }
 
         tracing::debug!("run_effect({}): running", id.0);
+
+        // Re-enter the context root the effect was created under, so
+        // use_context/use_store resolve the same namespace as at build time
+        // (issue #136).
+        let _root_guard = crate::context::push_context_root(inner.root);
 
         // Push this effect as the current observer
         RUNTIME.with(|rt| {

--- a/crates/rinch-core/src/reactive/memo.rs
+++ b/crates/rinch-core/src/reactive/memo.rs
@@ -95,6 +95,7 @@ impl<T: Clone + 'static> Memo<T> {
                     });
                 })),
                 disposed: Cell::new(false),
+                root: crate::context::current_context_root(),
             }));
         });
 

--- a/crates/rinch/src/app/mod.rs
+++ b/crates/rinch/src/app/mod.rs
@@ -247,6 +247,10 @@ pub struct RinchApp {
     pub(crate) inspect_highlight: Option<(f32, f32, f32, f32)>,
     /// Font data to register on the document when it is created (for WASM).
     pub(crate) pending_fonts: Vec<&'static [u8]>,
+    /// When true, `mount_component` namespaces stores/contexts under the
+    /// document's `doc_key` (set by embed `RinchContext`s, issue #136). Shell
+    /// roots leave this false and keep writing to the thread-global root 0.
+    pub(crate) scope_context_to_doc: bool,
     /// Debug command receiver.
     #[cfg(feature = "debug")]
     pub(crate) debug_cmd_rx: Option<CommandReceiver>,
@@ -300,6 +304,7 @@ impl RinchApp {
             file_hover_target: None,
             inspect_highlight: None,
             pending_fonts: Vec::new(),
+            scope_context_to_doc: false,
             #[cfg(feature = "debug")]
             debug_cmd_rx: None,
             #[cfg(feature = "debug")]
@@ -443,6 +448,14 @@ impl RinchApp {
         {
             self.last_theme_css = Some(rinch_core::get_current_theme_css().unwrap_or_default());
         }
+
+        // An embed context namespaces its stores/contexts under the document's
+        // doc_key for the whole mount — the component run plus every effect it
+        // creates captures this root (issue #136). Shell roots don't push a
+        // root and keep writing to the thread-global root 0.
+        let _root_guard = self
+            .scope_context_to_doc
+            .then(|| rinch_core::push_context_root(doc.borrow().doc_key()));
 
         // Create RenderScope
         let doc_as_dom: Rc<RefCell<dyn DomDocument>> = doc.clone();

--- a/crates/rinch/src/embed.rs
+++ b/crates/rinch/src/embed.rs
@@ -143,6 +143,12 @@ impl RinchContext {
 
         let mut app = RinchApp::new(component);
 
+        // Namespace this context's stores/contexts under its document's
+        // doc_key: two contexts creating the same store type no longer
+        // overwrite each other, and lookups fall back to the thread-global
+        // root 0 for stores created outside any context (issue #136).
+        app.scope_context_to_doc = true;
+
         // Register any pre-mount fonts BEFORE mounting so the initial layout/paint
         // pass has glyphs (essential on wasm, which has no system fonts). These are
         // drained onto the document's render font context during mount_component.
@@ -330,6 +336,18 @@ impl RinchContext {
             self.size.0 as f32 / self.scale_factor as f32,
             self.size.1 as f32 / self.scale_factor as f32,
         )
+    }
+}
+
+impl Drop for RinchContext {
+    fn drop(&mut self) {
+        // Clear this context's store/context namespace so its stores don't
+        // outlive it (issue #136). The thread-global root 0 — and every other
+        // context's namespace — is untouched.
+        let key = self.app.doc_key();
+        if key != 0 {
+            rinch_core::clear_context_for_root(key);
+        }
     }
 }
 

--- a/crates/rinch/tests/multi_context.rs
+++ b/crates/rinch/tests/multi_context.rs
@@ -1,10 +1,10 @@
-//! Empirical pinning tests for issue #134: two `RinchContext`s on one thread.
+//! Empirical pinning tests for issues #134/#136: two `RinchContext`s on one
+//! thread.
 //!
 //! Each test constructs headless embed contexts (no window, no GPU — `scene()`
-//! is never called) and demonstrates the REAL current behavior of the shared
-//! thread-local state. Tests that document broken behavior assert the buggy
-//! outcome explicitly and are marked `BUG #134` — if such an assertion starts
-//! failing, the bug got fixed: flip the assertion to the correct behavior.
+//! is never called) and pins the behavior of the shared thread-local state:
+//! per-context signal subscriptions and bounds registries (#134) and per-root
+//! store/context namespacing with the thread-global root-0 fallback (#136).
 //!
 //! Requires the `embed` (or `gpu`) feature — with default features OFF (the
 //! `desktop` + `embed` combination does not compile; see #134's follow-ups):
@@ -213,18 +213,19 @@ fn contexts_keep_independent_dirty_flags() {
     });
 }
 
-// ── 3. CONTEXT_STORE (create_store/use_store) cross-talk ─────────────────────
+// ── 3. CONTEXT_STORE (create_store/use_store) per-root scoping ───────────────
 
 #[derive(Clone, Copy)]
 struct SharedStore {
     which: Signal<i32>,
 }
 
-/// CONTEXT_STORE is keyed by TypeId only — no per-context namespace. When both
-/// contexts `create_store` the same type, the second insert overwrites the
-/// first, and content A builds LATER (an `if` branch flipping) silently reads
-/// B's store. Dropping B does not remove its store, and dropping both contexts
-/// leaves the store behind entirely.
+/// FIXED (#136): CONTEXT_STORE is keyed by `(root, TypeId)`. Each mounted
+/// `RinchContext` namespaces its stores under its document's `doc_key`, so two
+/// contexts creating the same store type no longer overwrite each other:
+/// effects and handlers capture their root at creation time, so content A
+/// builds LATER (an `if` branch flipping after B mounted) still resolves A's
+/// OWN store. Dropping a context clears exactly its own namespace.
 #[test]
 fn store_crosstalk_between_contexts() {
     on_ui_thread(|| {
@@ -245,56 +246,109 @@ fn store_crosstalk_between_contexts() {
             }
         });
         a.update(&[]);
-        assert_eq!(
-            use_store::<SharedStore>().which.get(),
-            1,
-            "with only A mounted, use_store resolves A's store"
-        );
 
         let mut b = RinchContext::new(cfg(), move |__scope: &mut RenderScope| {
             create_store(SharedStore {
                 which: Signal::new(2),
             });
-            rsx! { div { "B" } }
+            rsx! {
+                div {
+                    p { {move || format!("store:{}", use_store::<SharedStore>().which.get())} }
+                }
+            }
         });
         b.update(&[]);
-
-        // BUG #134: this documents current-broken behavior. CORRECT behavior:
-        // each context should resolve its own store. B's create_store
-        // overwrote A's entry in the TypeId-keyed CONTEXT_STORE.
-        assert_eq!(
-            use_store::<SharedStore>().which.get(),
-            2,
-            "BUG #134 pinned: B's create_store overwrote A's store (TypeId-keyed, \
-             last write wins). If this fails with value 1, the bug was FIXED"
+        assert!(
+            doc_text(&b).contains("store:2"),
+            "B's content resolves B's own store; got: {}",
+            doc_text(&b)
         );
 
         // A's dynamically-built content — an `if` branch constructed AFTER B
-        // mounted — reads the store at build time and gets B's store, rendered
-        // into A's own document.
+        // mounted — resolves A's OWN store: the branch effect re-runs under
+        // A's captured root (#136).
         show_late.set(true);
         a.update(&[]);
         let text = doc_text(&a);
         assert!(
-            text.contains("store:2"),
-            "BUG #134 pinned: A's late-built UI silently received B's store \
-             (expected broken 'store:2', correct would be 'store:1'); got: {text}"
+            text.contains("store:1"),
+            "A's late-built UI must read A's own store, not B's (#136); got: {text}"
         );
 
-        // Dropping B does not remove its store — A keeps reading B's dead store.
+        // Remember A's root key so the post-drop check can look inside A's
+        // (former) namespace.
+        let a_root = a.app().doc().expect("A has a document").borrow().doc_key();
+
+        // Dropping B clears only B's namespace — A keeps resolving its own
+        // store when its branch rebuilds.
         drop(b);
-        assert_eq!(
-            use_store::<SharedStore>().which.get(),
-            2,
-            "BUG #134 pinned: B's store outlives B (RinchContext::drop never \
-             touches CONTEXT_STORE)"
+        show_late.set(false);
+        a.update(&[]);
+        show_late.set(true);
+        a.update(&[]);
+        assert!(
+            doc_text(&a).contains("store:1"),
+            "after dropping B, A still resolves its own store; got: {}",
+            doc_text(&a)
         );
 
-        // Even after BOTH contexts are gone the store persists on the thread.
+        // Dropping A clears A's namespace: nothing is left under A's root
+        // (the lookup below would fall back to root 0, where nothing ever
+        // landed in this test either).
         drop(a);
+        {
+            let _root = rinch_core::push_context_root(a_root);
+            assert!(
+                try_use_store::<SharedStore>().is_none(),
+                "A's namespaced store must be cleared when A drops (#136)"
+            );
+        }
         assert!(
-            try_use_store::<SharedStore>().is_some(),
-            "BUG #134 pinned: the store survives both contexts"
+            try_use_store::<SharedStore>().is_none(),
+            "no store leaked into the thread-global root 0"
+        );
+
+        // Leave the shared worker thread clean for the other tests.
+        rinch_core::clear_context();
+    });
+}
+
+#[derive(Clone, Copy)]
+struct GlobalStore {
+    value: Signal<i32>,
+}
+
+/// The thread-global fallback (#136): a store created at top level — no root
+/// pushed, exactly like shell-startup code — lands in root 0, and a mounted
+/// context that did NOT create that store type still finds it through the
+/// root-0 fallback. Dropping the context must not clear root-0 stores.
+#[test]
+fn store_root_zero_fallback() {
+    on_ui_thread(|| {
+        create_store(GlobalStore {
+            value: Signal::new(42),
+        });
+
+        let mut c = RinchContext::new(cfg(), move |__scope: &mut RenderScope| {
+            rsx! {
+                div {
+                    p { {move || format!("global:{}", use_store::<GlobalStore>().value.get())} }
+                }
+            }
+        });
+        c.update(&[]);
+        assert!(
+            doc_text(&c).contains("global:42"),
+            "a context that created no such store falls back to the \
+             thread-global root-0 store (#136); got: {}",
+            doc_text(&c)
+        );
+
+        // A root-0 store survives the context that merely read it.
+        drop(c);
+        assert!(
+            try_use_store::<GlobalStore>().is_some(),
+            "dropping a context must not clear thread-global (root 0) stores"
         );
 
         // Leave the shared worker thread clean for the other tests.

--- a/docs/src/guide/game-engine.md
+++ b/docs/src/guide/game-engine.md
@@ -304,12 +304,15 @@ fn main() {
 screen HUD plus N render-to-texture panels, say. Each context tracks signal
 changes through its own subscription (so creating or dropping one never
 silences another) and keeps its own document-scoped element-bounds signals,
-editor registrations, and focus requests. Two caveats remain, tracked in
-issue #134's follow-ups: `create_store`/`use_store` is keyed by **type** for
-the whole thread (two contexts creating the same store type share the last one
-— use distinct store types per context), and each context still processes the
-input events *you* feed it — route each window's events only to its own
-context.
+editor registrations, and focus requests. Stores/contexts are **namespaced
+per context** (#136): a `create_store` inside a context's component lands in
+that context's own namespace, its effects and event handlers resolve that
+namespace first, and lookups **fall back to the thread-global namespace** for
+stores created outside any context (e.g. before mounting). Two contexts can
+therefore create the *same* store type without overwriting each other, and
+dropping a context clears its namespace. One caveat remains: each context
+still processes the input events *you* feed it — route each window's events
+only to its own context.
 
 ### Input Routing
 


### PR DESCRIPTION
Fixes #136.

`CONTEXT_STORE` was a thread-wide `HashMap<TypeId, Box<dyn Any>>`: with two contexts, B's `create_store::<T>()` overwrote A's entry, A's dynamically-built branches silently rendered B's state, and both stores outlived both contexts. Design ratified by maintainer: **per-root maps with a thread-global fallback root** (option a of the three from triage).

## Changes
- `CONTEXT_STORE` re-keyed as `(root, TypeId)` with a thread-local `CURRENT_ROOT` marker (0 = the thread-global fallback). `create_context`/`create_store` write under the current root; `try_use_context` reads the current root then **falls back to root 0**. `clear_context` clears only root 0 (shell-startup semantics preserved); new `clear_context_for_root`.
- **Capture-at-creation coherence**: effects (including memo marker effects) capture the creation-time root and re-enter it via RAII guard on every run; all four event-handler registries capture the registration-time root and re-enter it around dispatch.
- `RinchApp` gains `scope_context_to_doc` (default **false** — shell paths bit-for-bit unchanged; shells call `clear_context`/`create_context` with no root pushed, verified). `RinchContext::new` sets it so mount pushes `doc_key` as root; new `RinchContext::Drop` clears its namespace.
- The deliberately-broken `store_crosstalk_between_contexts` test rewritten to assert the fixed behavior, plus a new `store_root_zero_fallback` test pinning the safety property (top-level stores remain reachable from inside contexts).
- Docs: `game-engine.md` multi-context paragraph (the "distinct store types per context" caveat is obsolete) and the CLAUDE.md embed-table caveat.

## Safety property (the reviewer's primary target)
Any closure running with **no root current** — menu/tray callbacks, timers, cross-thread-marshalled closures, every single-context shell path — resolves root 0, bit-identically to today. Adversarially traced and confirmed.

## Testing
All re-run independently by review: rinch-core 61 passed; `multi_context` suite 5 passed (`--no-default-features --features embed` — still the required invocation until #159/#140 merges); full default-feature rinch suite passed; rinch-web wasm32 check clean; clippy clean; full-workspace pre-commit hook passed.

## Reviewer-noted follow-ups (non-blocking)
- **Memo lazy recompute is not root-scoped**: the marker effect's captured root is inert; the user computation runs in `Memo::get()` under whatever root is current at the call site. A memo created in context A whose closure calls `use_store` resolves the wrong namespace if first read happens outside A. Not a regression (single-root apps always resolve 0); fix = capture creation root in `MemoInner` and push it around recompute — good #141 companion.
- A dropped context's still-alive effects fall back to root 0 on their next run (pre-existing effect-lifetime issue; #141 territory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)