### PR TITLE
fix(rinch): per-document theme CSS — embed contexts own their theme, thread slot stays the shell default (#138)

### DIFF
--- a/crates/rinch/src/app/mod.rs
+++ b/crates/rinch/src/app/mod.rs
@@ -190,6 +190,11 @@ pub struct RinchApp {
     pub(crate) drag_over_surface: Option<(usize, usize)>,
     /// Last theme CSS loaded into the document (for change detection).
     pub(crate) last_theme_css: Option<String>,
+    /// Per-document theme CSS owned by this app (issue #138). `None` = follow
+    /// the thread-global theme slot (the single-root shell/web/android paths).
+    /// Embed contexts set this so creating another context on the same thread
+    /// never restyles this one.
+    pub(crate) owned_theme_css: Option<String>,
     /// Timestamp of last mouse click (for multi-click detection).
     pub(crate) last_click_time: Instant,
     /// Position of last mouse click.
@@ -284,6 +289,7 @@ impl RinchApp {
             active_dnd: None,
             drag_over_surface: None,
             last_theme_css: None,
+            owned_theme_css: None,
             last_click_time: Instant::now(),
             last_click_pos: (0.0, 0.0),
             click_count: 0,
@@ -410,6 +416,17 @@ impl RinchApp {
 
     // ── Component mounting ───────────────────────────────────────────────
 
+    /// The theme CSS this document should be using: the per-document owned CSS
+    /// when set (embed contexts, issue #138), otherwise the thread-global slot
+    /// (the single-root shell/web/android default).
+    #[cfg(feature = "theme")]
+    pub(crate) fn effective_theme_css(&self) -> String {
+        match &self.owned_theme_css {
+            Some(css) => css.clone(),
+            None => rinch_core::get_current_theme_css().unwrap_or_default(),
+        }
+    }
+
     /// Mount the component, building the initial DOM.
     ///
     /// Called once after the window and renderer are ready.
@@ -437,7 +454,7 @@ impl RinchApp {
             let mut d = doc.borrow_mut();
             #[cfg(feature = "theme")]
             {
-                let theme_css = rinch_core::get_current_theme_css().unwrap_or_default();
+                let theme_css = self.effective_theme_css();
                 if !theme_css.is_empty() {
                     // Must go through the theme slot (not load_css) so a later
                     // theme regeneration replaces this sheet instead of stacking
@@ -452,7 +469,7 @@ impl RinchApp {
         // Remember the initial theme CSS so we can detect changes later
         #[cfg(feature = "theme")]
         {
-            self.last_theme_css = Some(rinch_core::get_current_theme_css().unwrap_or_default());
+            self.last_theme_css = Some(self.effective_theme_css());
         }
 
         // An embed context namespaces its stores/contexts under the document's
@@ -558,7 +575,7 @@ impl RinchApp {
         let mut theme_changed = false;
         #[cfg(feature = "theme")]
         {
-            let current_theme = rinch_core::get_current_theme_css().unwrap_or_default();
+            let current_theme = self.effective_theme_css();
             theme_changed = self.last_theme_css.as_deref() != Some(current_theme.as_str());
 
             if theme_changed {

--- a/crates/rinch/src/embed.rs
+++ b/crates/rinch/src/embed.rs
@@ -130,18 +130,21 @@ impl RinchContext {
     where
         F: FnOnce(&mut RenderScope) -> NodeHandle + 'static,
     {
-        // Set up theme CSS before mounting the component
+        let mut app = RinchApp::new(component);
+
+        // Per-document theme (issue #138): generate this context's CSS from its
+        // own config and hand it to the app before mount. The thread-global
+        // theme slot is never touched — creating a second context can no longer
+        // restyle a concurrent one (or a mounted shell/web root).
         #[cfg(feature = "theme")]
         {
-            if let Some(ref theme) = config.theme {
-                crate::setup_theme_css(theme);
-            } else {
-                crate::setup_theme_css(&ThemeProviderProps::default());
-            }
+            let css = match config.theme {
+                Some(ref theme) => crate::generate_theme_css_string(theme),
+                None => crate::generate_theme_css_string(&ThemeProviderProps::default()),
+            };
+            app.owned_theme_css = Some(css);
         }
         let _ = &config.theme; // suppress unused warning when theme feature is off
-
-        let mut app = RinchApp::new(component);
 
         // Namespace this context's stores/contexts under its document's
         // doc_key: two contexts creating the same store type no longer
@@ -244,6 +247,30 @@ impl RinchContext {
     pub fn set_scale_factor(&mut self, scale: f64) {
         self.scale_factor = scale;
     }
+
+    /// Replace this context's theme at runtime.
+    ///
+    /// Regenerates the per-document theme CSS from `theme` and restyles this
+    /// context's document on its next [`update`](RinchContext::update). Other
+    /// concurrent contexts — and a mounted shell/web root following the
+    /// thread-global theme — are untouched (issue #138).
+    ///
+    /// **Caveat:** an embedded `ThemeProvider` component with a reactive
+    /// `dark_mode_fn`/`primary_color_fn` writes the *thread-global* theme slot,
+    /// which embed contexts deliberately ignore — this method is the supported
+    /// path for changing an embedded context's theme.
+    #[cfg(feature = "theme")]
+    pub fn set_theme(&mut self, theme: &ThemeProviderProps) {
+        self.app.owned_theme_css = Some(crate::generate_theme_css_string(theme));
+        // Wake the next update() — resolve_and_repaint detects the owned-CSS
+        // change against its cached last_theme_css and does the full restyle,
+        // exactly like the shell's thread-slot comparison path.
+        self.dirty.store(true, Ordering::Release);
+    }
+
+    /// No-op when the theme feature is disabled.
+    #[cfg(not(feature = "theme"))]
+    pub fn set_theme(&mut self, _theme: &ThemeProviderProps) {}
 
     /// Query the layout rect of a [`GameViewport`] component by name.
     ///

--- a/crates/rinch/src/lib.rs
+++ b/crates/rinch/src/lib.rs
@@ -247,9 +247,13 @@ pub use rinch_platform as platform;
 #[cfg(feature = "gpu")]
 pub use rinch_renderer as renderer;
 
-/// Dynamically update theme CSS at runtime.
+/// Generate the theme (+ component) CSS for the given props.
+///
+/// Pure: does **not** touch the thread-local theme slot. The shell paths use
+/// [`update_theme`] (which writes the slot); an embed `RinchContext` owns its
+/// CSS per document instead (issue #138).
 #[cfg(feature = "theme")]
-pub fn update_theme(props: &ThemeProviderProps) {
+pub fn generate_theme_css_string(props: &ThemeProviderProps) -> String {
     use rinch_theme::{ColorName, RadiusSize, Theme, generate_theme_css};
 
     let mut builder = Theme::builder();
@@ -290,7 +294,17 @@ pub fn update_theme(props: &ThemeProviderProps) {
         css.push_str(&rinch_components::generate_component_css());
     }
 
-    rinch_core::set_current_theme_css(Some(css));
+    css
+}
+
+/// Dynamically update theme CSS at runtime.
+///
+/// Writes the **thread-global** theme slot, which single-root shell/web/android
+/// apps follow. Embed contexts ignore the slot — use
+/// `embed::RinchContext::set_theme` there instead (issue #138).
+#[cfg(feature = "theme")]
+pub fn update_theme(props: &ThemeProviderProps) {
+    rinch_core::set_current_theme_css(Some(generate_theme_css_string(props)));
 }
 
 /// No-op when theme feature is disabled.

--- a/crates/rinch/tests/multi_context.rs
+++ b/crates/rinch/tests/multi_context.rs
@@ -9,6 +9,8 @@
 //! Requires the `embed` (or `gpu`) feature. Since #140 the painters are
 //! additive, so `desktop` + `embed` co-compiles and default features can stay on:
 //!     cargo test -p rinch --features embed --test multi_context
+//! The per-document theme tests (#138) additionally need the `theme` feature:
+//!     cargo test -p rinch --features embed,theme --test multi_context
 //!
 //! ## Why every test body runs on one shared worker thread
 //!
@@ -438,6 +440,142 @@ fn bounds_registry_crosstalk_across_documents() {
             bounds.get().width,
             100.0,
             "A's bounds signal keeps reporting A's document geometry"
+        );
+
+        drop(a);
+        drop(b);
+    });
+}
+
+// ── 5. per-document theme CSS (#138) ─────────────────────────────────────────
+
+/// Config with an explicit light/dark theme (requires the `theme` feature).
+#[cfg(feature = "theme")]
+fn themed_cfg(dark_mode: bool) -> RinchContextConfig {
+    RinchContextConfig {
+        theme: Some(rinch::core::element::ThemeProviderProps {
+            dark_mode,
+            ..Default::default()
+        }),
+        ..cfg()
+    }
+}
+
+/// The computed background color (Debug-formatted) of a context's `.probe`
+/// element. The probe paints `var(--rinch-color-body)`, which the light and
+/// dark themes resolve to different colors — an observable for which theme CSS
+/// the document actually holds.
+#[cfg(feature = "theme")]
+fn probe_bg(ctx: &RinchContext) -> String {
+    let doc = ctx.app().doc().expect("context has a document").clone();
+    let d = doc.borrow();
+    let id = *rinch_dom::testing::query_selector(&d.tree, ".probe")
+        .first()
+        .expect("probe element exists");
+    format!(
+        "{:?}",
+        d.tree
+            .get(id)
+            .expect("probe node")
+            .computed_style
+            .background_color()
+    )
+}
+
+/// FIXED (#138): each embed context owns its theme CSS per document. Creating
+/// context B (light) no longer overwrites the thread-global theme slot that A
+/// (dark) was compared against, so A's next resolve keeps A's own theme
+/// instead of silently adopting B's.
+#[cfg(feature = "theme")]
+#[test]
+fn creating_a_context_does_not_restyle_another() {
+    on_ui_thread(|| {
+        let sig_a = Signal::new(0i32);
+        let mut a = RinchContext::new(themed_cfg(true), move |__scope: &mut RenderScope| {
+            rsx! {
+                div { class: "probe", style: "background-color: var(--rinch-color-body);",
+                    p { {move || format!("A:{}", sig_a.get())} }
+                }
+            }
+        });
+        a.update(&[]);
+        let dark_bg = probe_bg(&a);
+
+        let mut b = RinchContext::new(themed_cfg(false), |__scope: &mut RenderScope| {
+            rsx! {
+                div { class: "probe", style: "background-color: var(--rinch-color-body);",
+                    "B"
+                }
+            }
+        });
+        b.update(&[]);
+        let light_bg = probe_bg(&b);
+        assert_ne!(
+            dark_bg, light_bg,
+            "sanity: light and dark themes must resolve --rinch-color-body differently"
+        );
+
+        // Drive A through a real update AFTER B was created — on the old
+        // thread-slot path this is where A compared the slot (holding B's
+        // light CSS) against its cached dark CSS and adopted B's theme.
+        sig_a.set(1);
+        a.update(&[]);
+        assert!(
+            doc_text(&a).contains("A:1"),
+            "A still renders: {}",
+            doc_text(&a)
+        );
+        assert_eq!(
+            probe_bg(&a),
+            dark_bg,
+            "creating context B must not restyle A's document (#138)"
+        );
+        assert_eq!(probe_bg(&b), light_bg, "B keeps its own light theme");
+
+        drop(a);
+        drop(b);
+    });
+}
+
+/// `RinchContext::set_theme` restyles only its own document (#138): A flips to
+/// dark on its next update; B — created with the same light theme — is
+/// untouched.
+#[cfg(feature = "theme")]
+#[test]
+fn set_theme_restyles_only_its_own_context() {
+    on_ui_thread(|| {
+        let mut a = RinchContext::new(themed_cfg(false), |__scope: &mut RenderScope| {
+            rsx! {
+                div { class: "probe", style: "background-color: var(--rinch-color-body);",
+                    "A"
+                }
+            }
+        });
+        let mut b = RinchContext::new(themed_cfg(false), |__scope: &mut RenderScope| {
+            rsx! {
+                div { class: "probe", style: "background-color: var(--rinch-color-body);",
+                    "B"
+                }
+            }
+        });
+        a.update(&[]);
+        b.update(&[]);
+        let light_bg = probe_bg(&a);
+        assert_eq!(probe_bg(&b), light_bg, "both start on the light theme");
+
+        a.set_theme(&rinch::core::element::ThemeProviderProps {
+            dark_mode: true,
+            ..Default::default()
+        });
+        a.update(&[]);
+        b.update(&[]);
+
+        let dark_bg = probe_bg(&a);
+        assert_ne!(dark_bg, light_bg, "set_theme must restyle A's document");
+        assert_eq!(
+            probe_bg(&b),
+            light_bg,
+            "set_theme on A must not touch B (#138)"
         );
 
         drop(a);

--- a/docs/src/guide/game-engine.md
+++ b/docs/src/guide/game-engine.md
@@ -401,6 +401,7 @@ PlatformEvent::Resized { width: 1920, height: 1080 }
 | `scene() -> &Scene` | Get the Vello scene (lazy rebuild) |
 | `resize(w, h)` | Notify of window resize (physical pixels) |
 | `set_scale_factor(scale)` | Update DPI scale factor |
+| `set_theme(&props)` | Replace this context's theme (restyles on the next `update()`) |
 | `viewport_rect(name) -> Option<LayoutRect>` | Query a GameViewport's computed rect |
 | `wants_mouse(x, y) -> bool` | True if point hits UI (not viewport hole) |
 | `wants_keyboard() -> bool` | True if a text input is focused |
@@ -425,6 +426,18 @@ PlatformEvent::Resized { width: 1920, height: 1080 }
 | `height` | `u32` | Initial viewport height (physical pixels) |
 | `scale_factor` | `f64` | Display scale factor |
 | `theme` | `Option<ThemeProviderProps>` | Theme configuration |
+
+**Theming is per-context.** Each `RinchContext` owns the theme CSS generated
+from its `config.theme` (or the default theme when `None`) — creating a second
+context, or a shell app changing the thread-global theme, never restyles an
+existing context (issue #138). To change an embedded context's theme at
+runtime, call `ctx.set_theme(&props)`; the document restyles on its next
+`update()`.
+
+> **Caveat:** an embedded `ThemeProvider` component with a reactive
+> `dark_mode_fn`/`primary_color_fn` writes the *thread-global* theme slot,
+> which embed contexts deliberately ignore — `RinchContext::set_theme` is the
+> supported path for runtime theme changes in the embed API.
 
 **LayoutRect:**
 


### PR DESCRIPTION
Fixes #138.

`CURRENT_THEME_CSS` is one slot per thread and `RinchContext::new` wrote it unconditionally — creating context B (light) overwrote A's (dark) theme; A's next `resolve_and_repaint` saw a "theme change" and silently adopted B's CSS with a full restyle. Design ratified by maintainer: **shell-global slot + explicit `RinchContext::set_theme`**.

## Changes
- `update_theme` split into pure `generate_theme_css_string(&ThemeProviderProps) -> String` + the existing slot write (`update_theme` stays shell-only; `setup_theme_css` unchanged for shell/web/android).
- `RinchApp.owned_theme_css: Option<String>` (None = follow the thread slot) with an `effective_theme_css()` helper replacing all three slot reads — **shell path byte-identical when owned is None**.
- `RinchContext::new` no longer touches the slot: it generates CSS from `config.theme` (or default) into `owned_theme_css` before mount. New `RinchContext::set_theme(&ThemeProviderProps)` regenerates the owned CSS and triggers the existing restyle path on the next `update()`.
- Ratified caveat documented (set_theme doc comment + `game-engine.md`): an embedded `ThemeProvider` with a reactive `dark_mode_fn` writes the thread slot, which embed contexts now ignore — `set_theme` is the supported path.

## Testing
- **Bug pinned counterfactually**: with main's source stashed back in, `creating_a_context_does_not_restyle_another` fails exactly as #138 describes (A's probe background flips from dark 0.141… to B's light 0.972…); passes with the fix. Second test: `set_theme` on A restyles A only, B unaffected.
- Theme tests run under `--no-default-features --features embed,theme` (embed does not imply theme); suite green there and under plain embed (theme tests cfg-gated out). Shell regression suite, clippy `-D warnings` workspace gate, and the full pre-commit hook all pass. All re-run independently by adversarial review.

Note (reviewer, pre-existing): neither CI nor the pre-commit hook runs the `embed,theme` invocation — same gap the whole `multi_context` suite has until #159 (#140) merges and the CI matrix can pick it up. Worth adding `embed,theme` to that matrix when #159 lands.

Expected trivial merge conflict with #164 (`fix/136-per-root-store-scoping`) at the `multi_context.rs` append point — whichever merges second needs a one-line rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)