### PR TITLE
fix(rinch-web): inject_style no longer stamps the theme marker (#155)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,9 @@ jobs:
       - name: Run wasm tests (headless Chrome)
         env:
           CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER: wasm-bindgen-test-runner
-        run: cargo test -p rinch-storage --target wasm32-unknown-unknown
+        run: |
+          cargo test -p rinch-storage --target wasm32-unknown-unknown
+          cargo test -p rinch-web --target wasm32-unknown-unknown
 
   fmt:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5090,6 +5090,7 @@ dependencies = [
  "rinch-editor-core",
  "rinch-editor-view",
  "wasm-bindgen",
+ "wasm-bindgen-test",
  "web-sys",
 ]
 

--- a/crates/rinch-web/Cargo.toml
+++ b/crates/rinch-web/Cargo.toml
@@ -49,6 +49,13 @@ web-sys = { version = "0.3", features = [
     "Blob", "File", "FileReader",
 ] }
 
+# Browser-driven tests for `<style>` injection (#155): they need a real
+# `document.head`, so they only build for wasm. Run with a matching chromedriver:
+#   CHROMEDRIVER=/path/to/chromedriver \
+#     cargo test -p rinch-web --target wasm32-unknown-unknown
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"
+
 [features]
 # Collaborative editing (M9): forwards to the editor view's collab adapter, which
 # is the only thing that links Automerge. Off by default, so a default web build

--- a/crates/rinch-web/src/web_document.rs
+++ b/crates/rinch-web/src/web_document.rs
@@ -210,6 +210,43 @@ pub(crate) fn get_nid(node: &web_sys::Node) -> Option<NodeId> {
         .map(|n| NodeId(n as usize))
 }
 
+/// Marker attribute identifying the one page-global theme `<style>` element.
+///
+/// Private to the theme path on purpose: a theme update *replaces the text* of
+/// the element it matches, so anything else wearing this marker would be
+/// silently clobbered by the next dark-mode toggle. App CSS injected through
+/// [`WebDocument::inject_style`] is deliberately left unmarked (#155).
+const THEME_STYLE_MARKER: &str = "data-rinch-theme";
+const THEME_STYLE_SELECTOR: &str = "[data-rinch-theme]";
+
+/// Append a fresh `<style>` to `<head>`, optionally stamped with a marker attribute.
+fn append_style_element(doc: &web_sys::Document, css: &str, marker: Option<&str>) {
+    let Ok(style) = doc.create_element("style") else {
+        return;
+    };
+    if let Some(marker) = marker {
+        style.set_attribute(marker, "true").ok();
+    }
+    style.set_text_content(Some(css));
+    if let Some(head) = doc.head() {
+        head.append_child(&style).ok();
+    }
+}
+
+/// Update the theme `<style>` in place, or create it if this is the first call.
+///
+/// Updating in place (rather than appending a regenerated sheet) keeps the theme
+/// at a stable document position *before* every app stylesheet, so app CSS always
+/// cascades over it — the same invariant `RinchDocument::set_theme_css` maintains
+/// on desktop.
+fn upsert_theme_style(doc: &web_sys::Document, css: &str) {
+    if let Ok(Some(el)) = doc.query_selector(THEME_STYLE_SELECTOR) {
+        el.set_text_content(Some(css));
+    } else {
+        append_style_element(doc, css, Some(THEME_STYLE_MARKER));
+    }
+}
+
 /// Update (or inject) the page-global theme `<style data-rinch-theme>` in the
 /// document head, independent of any one `WebDocument`.
 ///
@@ -220,15 +257,7 @@ pub fn update_theme_style_global(css: &str) {
     let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
         return;
     };
-    if let Ok(Some(el)) = doc.query_selector("[data-rinch-theme]") {
-        el.set_text_content(Some(css));
-    } else if let Ok(style) = doc.create_element("style") {
-        style.set_attribute("data-rinch-theme", "true").ok();
-        style.set_text_content(Some(css));
-        if let Some(head) = doc.head() {
-            head.append_child(&style).ok();
-        }
-    }
+    upsert_theme_style(&doc, css);
 }
 
 impl WebDocument {
@@ -311,24 +340,19 @@ impl WebDocument {
         &self.browser_doc
     }
 
-    /// Inject CSS as a `<style>` element in `<head>`.
+    /// Inject app CSS as a plain `<style>` element in `<head>`.
+    ///
+    /// The element is deliberately **unmarked**: theme updates only ever rewrite
+    /// the element carrying the private theme marker, so CSS injected here is
+    /// never clobbered by a later dark-mode toggle (#155). Each call appends a
+    /// new element — this is an append, not an upsert.
     pub fn inject_style(&self, css: &str) {
-        if let Ok(style) = self.browser_doc.create_element("style") {
-            style.set_attribute("data-rinch-theme", "true").ok();
-            style.set_text_content(Some(css));
-            if let Some(head) = self.browser_doc.head() {
-                head.append_child(&style).ok();
-            }
-        }
+        append_style_element(&self.browser_doc, css, None);
     }
 
     /// Update the theme `<style>` element, or inject one if it doesn't exist.
     pub fn update_theme_style(&self, css: &str) {
-        if let Ok(Some(el)) = self.browser_doc.query_selector("[data-rinch-theme]") {
-            el.set_text_content(Some(css));
-        } else {
-            self.inject_style(css);
-        }
+        upsert_theme_style(&self.browser_doc, css);
     }
 
     /// Recursively walk a DOM subtree and assign `__nid` + register in HashMap.

--- a/crates/rinch-web/tests/theme_style.rs
+++ b/crates/rinch-web/tests/theme_style.rs
@@ -1,0 +1,144 @@
+//! Browser-driven tests for `<style>` injection and theme updates (#155).
+//!
+//! These need a real `document.head`, which means a real browser. Run them with
+//! a chromedriver matching the installed Chrome:
+//!
+//! ```text
+//! CHROMEDRIVER=/path/to/chromedriver \
+//!   cargo test -p rinch-web --target wasm32-unknown-unknown
+//! ```
+//!
+//! The invariant under test: theme updates rewrite *only* the theme element.
+//! App CSS injected through `inject_style` must survive any number of theme
+//! updates, because a theme update replaces the matched element's text wholesale.
+#![cfg(target_arch = "wasm32")]
+
+use rinch_web::WebDocument;
+use wasm_bindgen::JsCast;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn document() -> web_sys::Document {
+    web_sys::window().unwrap().document().unwrap()
+}
+
+/// Remove every rinch-owned `<style>` so each test starts from a known head.
+///
+/// Both the theme element and any style this module injected are removed; the
+/// harness's own page furniture is left alone.
+fn reset_styles() {
+    let doc = document();
+    for selector in ["[data-rinch-theme]", "[data-test-app-css]"] {
+        while let Ok(Some(el)) = doc.query_selector(selector) {
+            el.remove();
+        }
+    }
+}
+
+/// The CSS text of every theme-marked `<style>` currently in the document.
+fn theme_texts() -> Vec<String> {
+    let doc = document();
+    let list = doc.query_selector_all("[data-rinch-theme]").unwrap();
+    (0..list.length())
+        .filter_map(|i| list.item(i))
+        .map(|n| n.text_content().unwrap_or_default())
+        .collect()
+}
+
+/// Mark a style element so `reset_styles` can find it again.
+fn tag_last_injected_style() -> web_sys::Element {
+    let doc = document();
+    let styles = doc.query_selector_all("head style").unwrap();
+    let el: web_sys::Element = styles
+        .item(styles.length() - 1)
+        .unwrap()
+        .dyn_into()
+        .unwrap();
+    el.set_attribute("data-test-app-css", "true").unwrap();
+    el
+}
+
+/// The #155 regression: app CSS injected before any theme exists must not be
+/// eaten by the first theme update.
+///
+/// Pre-fix this fails — `inject_style` stamped `data-rinch-theme` on the app
+/// style, so it was the first (and only) match the theme upsert rewrote.
+#[wasm_bindgen_test]
+fn theme_update_does_not_clobber_injected_app_css() {
+    reset_styles();
+    let doc = WebDocument::new(document());
+
+    doc.inject_style(".app-sentinel { color: rebeccapurple; }");
+    let app_style = tag_last_injected_style();
+
+    doc.update_theme_style(":root { --rinch-primary-color: blue; }");
+
+    assert_eq!(
+        app_style.text_content().unwrap_or_default(),
+        ".app-sentinel { color: rebeccapurple; }",
+        "theme update overwrote app CSS injected via inject_style"
+    );
+    assert_eq!(
+        theme_texts(),
+        vec![":root { --rinch-primary-color: blue; }".to_string()],
+        "theme CSS should live in its own element"
+    );
+
+    reset_styles();
+}
+
+/// A dark-mode toggle is a *sequence* of theme updates; app CSS survives all of
+/// them, and the theme element is updated in place rather than duplicated.
+#[wasm_bindgen_test]
+fn repeated_theme_updates_upsert_in_place() {
+    reset_styles();
+    let doc = WebDocument::new(document());
+
+    doc.update_theme_style(":root { --mode: light; }");
+    doc.inject_style(".app-sentinel { color: teal; }");
+    let app_style = tag_last_injected_style();
+
+    doc.update_theme_style(":root { --mode: dark; }");
+    doc.update_theme_style(":root { --mode: light; }");
+
+    assert_eq!(
+        theme_texts(),
+        vec![":root { --mode: light; }".to_string()],
+        "theme updates must upsert one element, not append new ones"
+    );
+    assert_eq!(
+        app_style.text_content().unwrap_or_default(),
+        ".app-sentinel { color: teal; }",
+        "app CSS must survive repeated theme updates"
+    );
+
+    reset_styles();
+}
+
+/// `inject_style` appends: two app stylesheets coexist, and neither is a theme.
+#[wasm_bindgen_test]
+fn inject_style_appends_unmarked_elements() {
+    reset_styles();
+    let doc = WebDocument::new(document());
+
+    doc.inject_style(".first { color: red; }");
+    let first = tag_last_injected_style();
+    doc.inject_style(".second { color: green; }");
+    let second = tag_last_injected_style();
+
+    assert_eq!(
+        first.text_content().unwrap_or_default(),
+        ".first { color: red; }"
+    );
+    assert_eq!(
+        second.text_content().unwrap_or_default(),
+        ".second { color: green; }"
+    );
+    assert!(
+        theme_texts().is_empty(),
+        "inject_style must not mark app CSS as theme CSS"
+    );
+
+    reset_styles();
+}


### PR DESCRIPTION
Closes #155.

## The bug

`WebDocument::inject_style` stamped `data-rinch-theme="true"` on **any** CSS injected through it, while the theme update path rewrites the text content of the *first* `[data-rinch-theme]` match. So the moment an app injected non-theme CSS this way, the next runtime theme update (a dark-mode toggle, say) silently overwrote it with the regenerated theme sheet.

Latent today — `inject_style` had no caller other than the theme path's own fallback — but it's a footgun with no warning path, and the API's name and doc comment both promise a general-purpose CSS injector.

## The fix

Option (a) from the issue: give theme CSS its own private marker, and let `inject_style` inject unmarked.

- `THEME_STYLE_MARKER` / `THEME_STYLE_SELECTOR` are private to `web_document`, so nothing outside the theme path can wear the marker.
- `append_style_element(doc, css, marker)` + `upsert_theme_style(doc, css)` are now shared by the instance methods and the free `update_theme_style_global`, which had duplicated the create-and-append logic verbatim.
- `inject_style` appends a plain unmarked `<style>` (append semantics, now documented); `update_theme_style` upserts the single marked theme element.

The in-place upsert (rather than append-a-new-sheet) is preserved deliberately: it keeps the theme at a stable document position *before* every app stylesheet, so app CSS always cascades over it — the same invariant `RinchDocument::set_theme_css` maintains on desktop. That's noted on `upsert_theme_style`.

No in-repo behavior change: the only caller of `inject_style` was `update_theme_style`'s fallback, which now routes through `upsert_theme_style`.

## Tests

This adds the **first browser-driven tests for `rinch-web`** (`crates/rinch-web/tests/theme_style.rs`), following the `rinch-storage` IndexedDB pattern — `wasm-bindgen-test` as a wasm-only dev-dependency, headless Chrome:

| Test | Pins |
|---|---|
| `theme_update_does_not_clobber_injected_app_css` | The #155 regression itself |
| `repeated_theme_updates_upsert_in_place` | A dark-mode toggle sequence leaves app CSS intact and doesn't duplicate the theme element |
| `inject_style_appends_unmarked_elements` | Two app sheets coexist; neither is marked as theme |

**All three verified failing before the fix** (stashed the `web_document.rs` change, kept the tests: `0 passed; 3 failed`) and passing after.

The existing `test-wasm` CI job now runs `-p rinch-web` alongside `-p rinch-storage`, so these actually gate.

Verified locally: full-workspace pre-commit gate (build + clippy + test + fmt + doctests), plus `cargo clippy -p rinch-web --target wasm32-unknown-unknown --all-targets -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)