### PR TITLE
fix(rinch-core): guarantee registration-order effect execution (#154)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1433,6 +1433,8 @@ Without the closure, expressions like `{count.get()}` are captured once at initi
 3. **Signal Changes**: Effects run and surgically update their target nodes
 4. **Batched Updates**: Multiple updates are collected for efficient re-layout
 
+**Execution order is a contract** (#154): effects observing the same signal run in **registration order** (the order their `Effect`/`Memo` was created), and the pending queue drains FIFO — so an effect registered *after* an `rsx!` tree sees the post-patch DOM in the same flush ("run me last"), and a signal written from inside an effect queues its observers *behind* the current flush rather than preempting it. Enforced by `BTreeSet<ObserverId>` subscriber sets (ids are monotonic and never reused, so ascending id *is* registration order) plus `pop_front` in `flush_effects`. Don't swap either for a `HashSet`/LIFO. See `docs/src/guide/reactivity.md#execution-order`.
+
 ### Native Control Flow (if / for / match)
 
 The `rsx!` macro supports native Rust control flow. All control flow is **always reactive** — conditions, iterators, and scrutinees are automatically wrapped in closures and tracked by Effects.

--- a/crates/rinch-core/src/reactive/effect.rs
+++ b/crates/rinch-core/src/reactive/effect.rs
@@ -154,12 +154,18 @@ pub(super) fn run_effect(id: ObserverId) {
     }
 }
 
-/// Flush all pending effects
+/// Flush all pending effects, in the order they were queued.
+///
+/// FIFO (`pop_front`), so the registration-order guarantee established when
+/// enqueuing survives the flush. Draining from the back would run same-signal
+/// effects in *reverse* registration order, and would run effects queued by a
+/// running effect ahead of ones queued before it. See the "Execution order"
+/// section of the [`reactive`](crate::reactive) module docs.
 pub(super) fn flush_effects() {
     loop {
         let effect_id = RUNTIME.with(|rt| {
             let mut rt = rt.borrow_mut();
-            let id = rt.pending_effects.pop();
+            let id = rt.pending_effects.pop_front();
             if id.is_some() {
                 // Remove from set when dequeuing
                 if let Some(ref observer) = id {

--- a/crates/rinch-core/src/reactive/memo.rs
+++ b/crates/rinch-core/src/reactive/memo.rs
@@ -2,7 +2,7 @@
 
 use std::any::Any;
 use std::cell::{Cell, RefCell};
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::fmt;
 use std::marker::PhantomData;
 use std::rc::Rc;
@@ -49,7 +49,9 @@ struct MemoInner<T> {
     value: RefCell<Option<T>>,
     f: RefCell<Box<dyn Fn() -> T>>,
     dirty: Cell<bool>,
-    subscribers: RefCell<HashSet<ObserverId>>,
+    /// Observers to notify, ordered — same contract (and same reason) as
+    /// `SignalSlot::subscribers`: a memo's dependents run in registration order.
+    subscribers: RefCell<BTreeSet<ObserverId>>,
 }
 
 impl<T: Clone + 'static> Memo<T> {
@@ -65,7 +67,7 @@ impl<T: Clone + 'static> Memo<T> {
             value: RefCell::new(None),
             f: RefCell::new(Box::new(f)),
             dirty: Cell::new(true),
-            subscribers: RefCell::new(HashSet::new()),
+            subscribers: RefCell::new(BTreeSet::new()),
         });
 
         // Store memo as an effect so it can be notified
@@ -89,7 +91,7 @@ impl<T: Clone + 'static> Memo<T> {
                         let mut rt = rt.borrow_mut();
                         for observer in subscribers {
                             if rt.pending_effects_set.insert(observer) {
-                                rt.pending_effects.push(observer);
+                                rt.pending_effects.push_back(observer);
                             }
                         }
                     });

--- a/crates/rinch-core/src/reactive/mod.rs
+++ b/crates/rinch-core/src/reactive/mod.rs
@@ -8,6 +8,26 @@
 //! - **Effect**: A side-effect that re-runs when its dependencies change
 //! - **Memo**: A cached computed value that only recomputes when dependencies change
 //!
+//! # Execution order
+//!
+//! When several observers depend on the same signal, they run in **registration
+//! order** — the order their [`Effect`]s/[`Memo`]s were created. This is a
+//! guaranteed contract, not an implementation detail (issue #154), and it makes
+//! the "run me last" idiom well-defined: an effect registered *after* an `rsx!`
+//! tree observes the post-patch DOM in the same synchronous flush, so measuring
+//! effects can be layered on top of rendering effects.
+//!
+//! Two mechanisms enforce it, and both are load-bearing:
+//!
+//! 1. Subscriber sets are [`BTreeSet<ObserverId>`](std::collections::BTreeSet).
+//!    `ObserverId`s come from one monotonic counter and are never reused, so
+//!    ascending id *is* registration order — the ordering is intrinsic to the
+//!    data structure rather than a sort someone can forget to apply.
+//! 2. The pending queue is drained FIFO, so the order observers were queued in
+//!    is the order they run in. (An effect that writes a signal while running
+//!    queues that signal's observers *behind* the current flush, rather than
+//!    ahead of it.)
+//!
 //! # Example
 //!
 //! ```ignore
@@ -38,7 +58,7 @@ pub use signal::Signal;
 
 use std::any::Any;
 use std::cell::RefCell;
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet, VecDeque};
 use std::rc::Rc;
 use std::sync::{Mutex, OnceLock};
 
@@ -63,8 +83,12 @@ pub(crate) struct Runtime {
     /// Stack of currently executing observers
     pub(crate) observer_stack: Vec<ObserverId>,
 
-    /// Effects that need to run
-    pub(crate) pending_effects: Vec<ObserverId>,
+    /// Effects that need to run, drained front-to-back.
+    ///
+    /// FIFO, not LIFO: the queue order *is* the execution order, so the
+    /// registration-order guarantee established when enqueuing survives the
+    /// flush. See the module-level "Execution order" docs.
+    pub(crate) pending_effects: VecDeque<ObserverId>,
 
     /// Set for O(1) duplicate check when enqueuing pending effects
     pub(crate) pending_effects_set: HashSet<ObserverId>,
@@ -94,7 +118,7 @@ impl Runtime {
     fn new() -> Self {
         Self {
             observer_stack: Vec::new(),
-            pending_effects: Vec::new(),
+            pending_effects: VecDeque::new(),
             pending_effects_set: HashSet::new(),
             batching: false,
             next_id: 0,
@@ -308,8 +332,13 @@ pub fn run_on_main_thread(f: impl FnOnce() + Send + 'static) {
     }
 }
 
-/// Unique identifier for an observer (effect or memo)
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+/// Unique identifier for an observer (effect or memo).
+///
+/// Allocated from a single monotonic counter ([`Runtime::next_id`]) and never
+/// reused, so **ascending id is registration order** — which is what makes the
+/// `BTreeSet` subscriber sets order observers correctly. Anything that starts
+/// recycling ids breaks the execution-order contract, not just uniqueness.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub(crate) struct ObserverId(pub(crate) usize);
 
 // ============================================================================
@@ -326,7 +355,10 @@ thread_local! {
 
 pub(crate) struct SignalSlot {
     pub(crate) value: Box<dyn Any>,
-    pub(crate) subscribers: HashSet<ObserverId>,
+    /// Observers to notify, ordered. `BTreeSet` (not `HashSet`) so iteration
+    /// yields ascending `ObserverId` = registration order; see the module-level
+    /// "Execution order" docs.
+    pub(crate) subscribers: BTreeSet<ObserverId>,
     pub(crate) generation: u32,
 }
 
@@ -356,7 +388,7 @@ impl SignalStore {
 
         let slot = SignalSlot {
             value: Box::new(value),
-            subscribers: HashSet::new(),
+            subscribers: BTreeSet::new(),
             generation,
         };
 
@@ -526,8 +558,140 @@ pub fn untracked<R>(f: impl FnOnce() -> R) -> R {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::cell::Cell;
+    use std::cell::{Cell, RefCell};
     use std::rc::Rc;
+
+    /// How many observers each ordering test registers.
+    ///
+    /// Large enough that hash-iteration order coinciding with registration
+    /// order is a 1-in-40320 accident rather than a coin flip — these tests
+    /// have to *fail* against the old `HashSet` + LIFO pair to be worth having.
+    const OBSERVERS: usize = 8;
+
+    /// Effects sharing a signal run in registration order (#154).
+    #[test]
+    fn same_signal_effects_run_in_registration_order() {
+        let log = Rc::new(RefCell::new(Vec::new()));
+        let sig = Signal::new(0);
+
+        let _effects: Vec<Effect> = (0..OBSERVERS)
+            .map(|i| {
+                let log = log.clone();
+                Effect::new(move || {
+                    sig.get();
+                    log.borrow_mut().push(i);
+                })
+            })
+            .collect();
+
+        // Discard the runs that `Effect::new` performs at creation.
+        log.borrow_mut().clear();
+        sig.set(1);
+
+        assert_eq!(
+            *log.borrow(),
+            (0..OBSERVERS).collect::<Vec<_>>(),
+            "effects on one signal must run in the order they were created"
+        );
+    }
+
+    /// The same guarantee for a memo's dependents: notification flows through
+    /// `MemoInner::subscribers`, which is a separate set from the signal's.
+    #[test]
+    fn memo_dependents_run_in_registration_order() {
+        let log = Rc::new(RefCell::new(Vec::new()));
+        let sig = Signal::new(0);
+        let doubled = Memo::new(move || sig.get() * 2);
+
+        let _effects: Vec<Effect> = (0..OBSERVERS)
+            .map(|i| {
+                let log = log.clone();
+                Effect::new(move || {
+                    doubled.get();
+                    log.borrow_mut().push(i);
+                })
+            })
+            .collect();
+
+        log.borrow_mut().clear();
+        sig.set(1);
+
+        assert_eq!(
+            *log.borrow(),
+            (0..OBSERVERS).collect::<Vec<_>>(),
+            "effects on one memo must run in the order they were created"
+        );
+    }
+
+    /// The idiom the contract exists to protect: an effect registered *after*
+    /// a tree of rendering effects observes their post-write state in the same
+    /// synchronous flush ("run me last").
+    ///
+    /// Here `dom` stands in for the patched DOM — the measuring effect must
+    /// read the width the rendering effect just wrote, not the previous one.
+    #[test]
+    fn an_effect_registered_last_observes_earlier_effects_writes() {
+        let dom = Rc::new(RefCell::new(String::new()));
+        let measured = Rc::new(RefCell::new(Vec::new()));
+        let width = Signal::new(1);
+
+        let render_dom = dom.clone();
+        let _render = Effect::new(move || {
+            *render_dom.borrow_mut() = "x".repeat(width.get());
+        });
+
+        let measure_dom = dom.clone();
+        let measure_log = measured.clone();
+        let _measure = Effect::new(move || {
+            width.get();
+            let len = measure_dom.borrow().len();
+            measure_log.borrow_mut().push(len);
+        });
+
+        width.set(5);
+
+        assert_eq!(
+            *measured.borrow(),
+            vec![1, 5],
+            "the later-registered effect must observe the post-write state"
+        );
+    }
+
+    /// A signal written *during* a flush queues its observers behind the rest
+    /// of that flush (FIFO), rather than jumping ahead of already-queued work.
+    #[test]
+    fn effects_queued_during_a_flush_run_after_the_already_queued_ones() {
+        let log = Rc::new(RefCell::new(Vec::new()));
+        let trigger = Signal::new(0);
+        let cascade = Signal::new(0);
+
+        let writer_log = log.clone();
+        let _writer = Effect::new(move || {
+            writer_log.borrow_mut().push("writer");
+            cascade.set(trigger.get());
+        });
+
+        let other_log = log.clone();
+        let _other = Effect::new(move || {
+            trigger.get();
+            other_log.borrow_mut().push("other");
+        });
+
+        let cascaded_log = log.clone();
+        let _cascaded = Effect::new(move || {
+            cascade.get();
+            cascaded_log.borrow_mut().push("cascaded");
+        });
+
+        log.borrow_mut().clear();
+        trigger.set(1);
+
+        assert_eq!(
+            *log.borrow(),
+            vec!["writer", "other", "cascaded"],
+            "the cascade must not preempt an effect already queued for this flush"
+        );
+    }
 
     #[test]
     fn signal_change_subscriptions_are_independent() {

--- a/crates/rinch-core/src/reactive/signal.rs
+++ b/crates/rinch-core/src/reactive/signal.rs
@@ -88,6 +88,11 @@ impl<T: 'static> Signal<T> {
     }
 
     /// Notify all subscribers that the value has changed.
+    ///
+    /// Subscribers are queued in registration order (the `BTreeSet` iterates
+    /// ascending `ObserverId`) and the queue drains FIFO, so effects sharing a
+    /// signal run in the order they were created — see the "Execution order"
+    /// section of the [`reactive`](crate::reactive) module docs.
     fn notify(&self) {
         let subscribers: Vec<ObserverId> = SIGNAL_STORE.with(|store| {
             store
@@ -111,7 +116,7 @@ impl<T: 'static> Signal<T> {
 
             for observer in subscribers {
                 if rt.pending_effects_set.insert(observer) {
-                    rt.pending_effects.push(observer);
+                    rt.pending_effects.push_back(observer);
                 }
             }
 

--- a/docs/src/guide/reactivity.md
+++ b/docs/src/guide/reactivity.md
@@ -85,6 +85,34 @@ This happens automatically—you never manually specify dependencies.
                                            effects re-run
 ```
 
+## Execution Order
+
+When several effects observe the **same** signal, they run in **registration order** — the order the `Effect`s (or `Memo`s) were created. This is a guaranteed contract, not an implementation detail.
+
+That makes the "run me last" idiom well-defined: an effect registered *after* a tree of rendering effects observes their writes in the same synchronous flush, so a measuring effect can read the post-patch DOM rather than the previous frame's.
+
+```rust
+let width = Signal::new(100);
+
+// Registered first — writes.
+Effect::new(move || resize_panel(width.get()));
+
+// Registered second — reads what the first one just wrote.
+Effect::new(move || {
+    width.get();
+    record_measurement(measure_panel());
+});
+
+width.set(250); // resize_panel runs, then record_measurement sees the new size
+```
+
+Two related guarantees follow from the same queue:
+
+- **Effects run in the order they were queued.** Notifying signal A then signal B runs A's effects before B's.
+- **A signal written from inside an effect queues its observers *behind* the current flush**, not ahead of it. Cascading updates therefore run breadth-first, and an effect already scheduled for this flush is never preempted.
+
+Effects are still de-duplicated per flush: an effect observing two signals that both change in one `batch()` runs once, at the position of its first enqueue.
+
 ## Batching Updates
 
 When you update multiple signals, effects run after each update. To avoid redundant runs, use `batch()`:


### PR DESCRIPTION
Closes #154.

## The problem

Same-signal effect ordering was emergent, not defined. Two independent sources:

- `Signal::notify` collected subscribers from a `HashSet<ObserverId>` — hash-iteration order.
- `flush_effects` drained `pending_effects` with `pop()` — LIFO.

They happened to compose into registration order, so the "run me last" idiom works today: register a DOM-measuring effect *after* an `rsx!` tree and it observes the post-patch DOM in the same synchronous flush. Nothing promised that. On native the hash seed is per-process, so the order genuinely varies between runs — the counterfactual below shows one of these tests failing only on the third run against the old code, which is precisely the issue's point.

## The contract

Observers of one signal run in **registration order** — the order their `Effect`/`Memo` was created. Enforced by two mechanisms, both load-bearing and both documented as such:

1. **Subscriber sets are `BTreeSet<ObserverId>`.** `ObserverId`s come from one monotonic counter and are never reused, so ascending id *is* registration order. Making it intrinsic to the data structure beats sorting at the notify site, which a future edit could forget. Applied to **both** `SignalSlot::subscribers` and `MemoInner::subscribers` — a memo's dependents went through a separate `HashSet` with the identical flaw, and the guarantee would be holey without it.
2. **`pending_effects` is a `VecDeque` drained `pop_front()`.** FIFO preserves the enqueue order mechanism 1 establishes; LIFO reverses it.

## Behavior change worth flagging

Point 2 goes beyond same-signal ordering: a signal written *from inside* a running effect now queues its observers **behind** the current flush instead of preempting it, so cascades run breadth-first rather than depth-first. That is a deliberate consequence of making the queue order the execution order, and it gets its own test (`effects_queued_during_a_flush_run_after_the_already_queued_ones`) rather than being left implicit.

De-duplication is unchanged: an effect observing two signals that both change in one `batch()` still runs once, now at the position of its first enqueue.

## Tests

Four tests in `reactive::tests`, each registering 8 observers so a hash order coinciding with registration order is a 1-in-40320 accident rather than a coin flip:

| Test | Pins |
|---|---|
| `same_signal_effects_run_in_registration_order` | The core contract |
| `memo_dependents_run_in_registration_order` | Same, through the memo subscriber set |
| `an_effect_registered_last_observes_earlier_effects_writes` | The "run me last" idiom the contract exists to protect |
| `effects_queued_during_a_flush_run_after_the_already_queued_ones` | The FIFO/breadth-first consequence |

**Counterfactual** — reverted only the two mechanisms (`BTreeSet`→`HashSet`, `pop_front`→`pop_back`), kept the tests, ran three times:

```
run 1: same_signal FAILED  memo_dependents FAILED  effects_queued FAILED  registered_last ok
run 2: same_signal FAILED  memo_dependents FAILED  effects_queued FAILED  registered_last ok
run 3: same_signal FAILED  memo_dependents FAILED  effects_queued FAILED  registered_last FAILED
```

Three fail deterministically; the fourth flips between runs — the emergent-ordering hazard, reproduced.

## Verification

- Full workspace suite green (`cargo test --workspace`), plus the pre-commit gate (build + clippy + test + fmt + doctests).
- Live `ui-zoo-desktop` pass, since this changes core reactive semantics: initial render, menu interaction, dark-mode toggle (a full reactive restyle), section navigation, controlled `TextInput` (`value_fn` + `oninput`), and typing into the rich-text editor (the heaviest measuring-effect consumer). All correct.

## Docs

Reactive module docs get an "Execution order" section; `docs/src/guide/reactivity.md` gets a user-facing one with the render-then-measure example; CLAUDE.md records the contract and the "don't swap either for `HashSet`/LIFO" warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)