### PR TITLE
ci: pin feature-gated test combinations instead of inheriting them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,14 +54,34 @@ jobs:
       - name: Run tests
         run: cargo test --workspace
 
-      # The `serde` feature gates the durable DocNode wire format, and
-      # `cargo test --workspace` never enables it — so that surface went unrun
-      # until #123, where a lossless-round-trip test had been failing on main
-      # unnoticed. Same for `collaboration`, which gates the CRDT adapter wiring.
+      # Feature-gated tests. A test file whose `cfg` is false is not "skipped" —
+      # it compiles to an EMPTY binary that still prints `Running tests/x.rs` and
+      # then `running 0 tests`. Only the COUNT reveals it; grepping for the
+      # `Running` line will report a dead file as alive.
+      #
+      # `cargo test --workspace` unifies features across members, so a gated test
+      # can be alive purely because some unrelated example turns its feature on:
+      #   * rinch/tests/multi_context.rs (cfg(any(gpu, embed)) — the #134/#136/#138
+      #     pins) runs only because examples/game-embed and examples/gpu-device-config
+      #     enable `rinch/gpu`.
+      #   * event_dispatch.rs::paste_image_tests (cfg(all(test, desktop, clipboard)))
+      #     runs only because four examples enable `rinch/clipboard`.
+      # Retarget or drop those examples and the pins go dead silently, so name the
+      # combinations here rather than inheriting them by luck.
+      #
+      # One set was genuinely dead: rinch-editor-core/tests/serialize.rs is
+      # cfg(all(serde, markdown)) and NOTHING in the workspace enables `markdown`,
+      # so its 13 tests — the round-trip surface this step was added for in #123 —
+      # ran nowhere at all. `--features serde` alone was never enough.
+      #
+      # `--all-features` would cover the whole class, but it does not build: it
+      # pulls a transitive `ashpd` 0.11.1 that fails to compile. Hence explicit sets.
+      # When adding a feature-gated test, add its combination here.
       - name: Run feature-gated tests
         run: |
-          cargo test -p rinch-editor-core --features serde
+          cargo test -p rinch-editor-core --features serde,markdown
           cargo test -p rinch-editor-view --features collaboration
+          cargo test -p rinch --features embed,theme,clipboard
 
   clippy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up from the twelve-PR merge. **Correction from an earlier revision of this PR:** I first claimed three test sets never ran in CI. That was wrong for two of them — see below. One set really was dead, and the other two are alive only by accident, which is still worth fixing.

## What's actually true

`cargo test --workspace` **unifies features across workspace members**, so a `cfg`-gated test can be alive purely because some unrelated example turns its feature on.

| Site | Gate | Under `cargo test --workspace` | Why |
|---|---|---|---|
| `rinch-editor-core/tests/serialize.rs` | `cfg(all(serde, markdown))` | **0 tests — genuinely dead** | nothing in the workspace enables `markdown` |
| `rinch/tests/multi_context.rs` | `cfg(any(gpu, embed))` | 7 tests — alive | `examples/game-embed` + `examples/gpu-device-config` enable `rinch/gpu` |
| `event_dispatch.rs::paste_image_tests` | `cfg(all(test, desktop, clipboard))` | alive | four examples enable `rinch/clipboard` |

**The diagnostic trap** that produced the wrong first claim: a test file whose `cfg` is false is not skipped — it compiles to an *empty binary* that still prints `Running tests/serialize.rs` and then `running 0 tests`. Grepping for the `Running` line reports a dead file as alive. Only the count discriminates. My first probe also used a single-package build (`cargo test -p rinch-editor-core --features serde`), which gets no workspace unification, so it wasn't representative of what CI does.

## Why this is still worth merging

1. **A real fix.** `serialize.rs`'s 13 tests ran nowhere at all. This step passed `--features serde`, and `markdown` is not a default nor enabled by any member. That is precisely the round-trip surface this step exists for — its own comment cites #123, "a lossless-round-trip test had been failing on main unnoticed." `--features serde,markdown` makes them run.

2. **Removing luck from the other two.** `multi_context.rs` holds the #134/#136/#138 regression pins — the guards for three of the twelve PRs just merged — and it runs today only because two GPU *examples* happen to enable `rinch/gpu`. Retarget or drop those examples and the pins go dead with no signal at all. `cargo test -p rinch --features embed,theme,clipboard` names both combinations directly (it covers `multi_context.rs` and `paste_image_tests` in one invocation), so coverage no longer depends on an unrelated example's feature list.

`--all-features` would cover the class rather than the instances, and I tried it first: it doesn't build, pulling a transitive `ashpd` 0.11.1 that fails to compile (upstream, unrelated to rinch). So the sets stay explicit, with a comment recording the trap and the rule.

## Verification

```
cargo test -p rinch-editor-core --features serde,markdown   -> serialize.rs 13 tests (was 0)
cargo test -p rinch-editor-view --features collaboration    -> 68 passing
cargo test -p rinch --features embed,theme,clipboard        -> multi_context 7 + paste_image_tests 2
```

Full pre-commit gate green; the prior revision's CI run was green on all seven jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
