### PR TITLE
fix(rinch-core): #141 groundwork — cleanups on drop, re-entrant input dispatch, memo root, RAII observer

### DIFF
--- a/crates/rinch-core/src/dom/mod.rs
+++ b/crates/rinch-core/src/dom/mod.rs
@@ -842,4 +842,51 @@ mod tests {
             Some("test".to_string())
         );
     }
+
+    /// `on_cleanup` must fire when a `RenderScope` is merely dropped, not only
+    /// when the by-value `dispose()` is called (issue #141).
+    ///
+    /// This is the shape every real teardown path takes: `Drop for RenderScope`
+    /// does nothing, so while cleanups lived in a second list on `RenderScope`
+    /// they were silently discarded — which is why `unregister_editor` and
+    /// `unregister_render_surface` never ran on a dropped context or a closed
+    /// DevTools window.
+    #[test]
+    fn on_cleanup_runs_when_the_render_scope_is_dropped() {
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let fired = Rc::new(Cell::new(false));
+
+        {
+            let doc = Rc::new(RefCell::new(MockDomDocument::new()));
+            let mut scope = RenderScope::new(doc.clone(), doc.borrow().body());
+            let flag = fired.clone();
+            scope.on_cleanup(move || flag.set(true));
+            assert!(!fired.get(), "cleanup must not run before teardown");
+            // Dropped here — NOT `dispose()`d.
+        }
+
+        assert!(
+            fired.get(),
+            "on_cleanup must run on drop, not only on the by-value dispose()"
+        );
+    }
+
+    /// The explicit `dispose()` path keeps working after the delegation.
+    #[test]
+    fn on_cleanup_runs_on_explicit_dispose() {
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        let fired = Rc::new(Cell::new(false));
+        let doc = Rc::new(RefCell::new(MockDomDocument::new()));
+        let mut scope = RenderScope::new(doc.clone(), doc.borrow().body());
+        let flag = fired.clone();
+        scope.on_cleanup(move || flag.set(true));
+
+        scope.dispose();
+
+        assert!(fired.get(), "on_cleanup must still run on dispose()");
+    }
 }

--- a/crates/rinch-core/src/dom/render_scope.rs
+++ b/crates/rinch-core/src/dom/render_scope.rs
@@ -29,9 +29,9 @@ pub struct RenderScope {
     effects: Vec<Effect>,
     /// Child scopes (for hierarchical cleanup).
     children: Vec<RenderScope>,
-    /// Cleanup functions to run on dispose.
-    cleanups: Vec<Box<dyn FnOnce()>>,
-    /// The reactive scope for effect management.
+    /// The reactive scope for effect management **and cleanups** — see
+    /// [`RenderScope::on_cleanup`]. Cleanups deliberately live here and not in a
+    /// second list on `RenderScope`, so they run on drop as well as on dispose.
     reactive_scope: Scope,
 }
 
@@ -43,7 +43,6 @@ impl RenderScope {
             parent_id,
             effects: Vec::new(),
             children: Vec::new(),
-            cleanups: Vec::new(),
             reactive_scope: Scope::new(),
         }
     }
@@ -145,8 +144,14 @@ impl RenderScope {
     }
 
     /// Register a cleanup function to run when this scope is disposed.
+    ///
+    /// Delegates to the reactive [`Scope`], which runs its cleanups from its own
+    /// `Drop` as well as from `dispose()`. Keeping a second list on `RenderScope`
+    /// meant cleanups were lost on every drop-only teardown, because
+    /// `Drop for RenderScope` does nothing and only the by-value `dispose()`
+    /// drained that list (issue #141).
     pub fn on_cleanup<F: FnOnce() + 'static>(&mut self, f: F) {
-        self.cleanups.push(Box::new(f));
+        self.reactive_scope.on_cleanup(f);
     }
 
     /// Get a handle to the parent node.
@@ -270,25 +275,27 @@ impl RenderScope {
     }
 
     /// Dispose of this scope and all child scopes.
+    ///
+    /// Equivalent to dropping it: cleanups and effects both live on
+    /// `reactive_scope`, whose own `Drop` disposes it. This exists for callers
+    /// that want teardown to happen at a definite point.
     pub fn dispose(mut self) {
         // Dispose child scopes first
         for child in self.children.drain(..) {
             child.dispose();
         }
 
-        // Dispose effects
+        // Disposes effects and runs cleanups (see `on_cleanup`).
         self.reactive_scope.dispose();
-
-        // Run cleanup functions
-        for cleanup in self.cleanups.drain(..) {
-            cleanup();
-        }
     }
 }
 
 impl Drop for RenderScope {
     fn drop(&mut self) {
-        // Effects and cleanups are handled by the Scope and cleanups vec
+        // Nothing to do: `children` are `RenderScope`s that drop recursively,
+        // and effects + cleanups belong to `reactive_scope`, whose `Drop` calls
+        // its own iterative `dispose()`. This is what makes `on_cleanup` fire on
+        // drop-only teardown paths (issue #141).
     }
 }
 

--- a/crates/rinch-core/src/events/handlers.rs
+++ b/crates/rinch-core/src/events/handlers.rs
@@ -402,16 +402,25 @@ pub fn get_input_context() -> InputContext {
 /// Also sets the `INPUT_EVENT_HANDLED` flag which can be checked with
 /// `check_and_clear_input_handled()`.
 pub fn dispatch_input_event(id: EventHandlerId, value: String) -> bool {
-    INPUT_REGISTRY.with(|registry| {
-        if let Some(handler) = registry.borrow().handlers.get(&id) {
-            handler.invoke(value);
-            // Signal that an input event was handled - caller should re-render
-            INPUT_EVENT_HANDLED.with(|flag| *flag.borrow_mut() = true);
-            true
-        } else {
-            false
-        }
-    })
+    // Clone the handler out of the registry so the borrow is released before
+    // calling it — the same reason `dispatch_event` does. An input handler
+    // typically writes a signal, and `Signal::set` flushes effects
+    // synchronously outside `batch()`; those effects can register new handlers
+    // (an `if` flipping to a branch with a button) or re-enter this registry.
+    // Holding `borrow()` across `invoke` makes that a BorrowMutError.
+    let handler: Option<InputCallback> = INPUT_REGISTRY.with(|registry| {
+        let reg = registry.borrow();
+        reg.handlers.get(&id).cloned()
+    });
+
+    if let Some(h) = handler {
+        h.invoke(value);
+        // Signal that an input event was handled - caller should re-render
+        INPUT_EVENT_HANDLED.with(|flag| *flag.borrow_mut() = true);
+        true
+    } else {
+        false
+    }
 }
 
 /// Register a file-drop event handler and return its ID.

--- a/crates/rinch-core/src/events/mod.rs
+++ b/crates/rinch-core/src/events/mod.rs
@@ -327,4 +327,73 @@ mod tests {
         assert_eq!(handler_count(), 0);
         assert!(!dispatch_event(id));
     }
+
+    /// An input handler must be able to touch the input registry while it runs
+    /// (issue #141).
+    ///
+    /// This is not exotic: an `oninput` writes a signal, `Signal::set` flushes
+    /// effects synchronously outside `batch()`, and an effect that flips an `if`
+    /// renders new content which registers new handlers. `dispatch_input_event`
+    /// used to hold `INPUT_REGISTRY.borrow()` across the callback, so that path
+    /// was a BorrowMutError on the first such keystroke. Pre-fix this test
+    /// panics with "already borrowed".
+    #[test]
+    fn input_handler_may_register_another_handler_while_running() {
+        clear_handlers();
+
+        let registered: std::rc::Rc<std::cell::Cell<bool>> =
+            std::rc::Rc::new(std::cell::Cell::new(false));
+        let flag = registered.clone();
+
+        let id = register_input_handler(InputCallback::new(move |_value: String| {
+            // Re-enters INPUT_REGISTRY while the dispatch is on the stack.
+            register_input_handler(InputCallback::new(|_| {}));
+            flag.set(true);
+        }));
+
+        assert!(dispatch_input_event(id, "hello".to_string()));
+        assert!(registered.get(), "the nested registration must have run");
+
+        clear_handlers();
+    }
+
+    /// The same re-entrancy reached the way production actually reaches it: the
+    /// handler writes a signal, `Signal::set` flushes effects synchronously, and
+    /// an effect renders a branch containing an input — which registers a
+    /// handler while the outer dispatch is still on the stack.
+    ///
+    /// This is the exact shape of "typing in a box that reveals another box".
+    /// Pre-fix it panics with "already borrowed: BorrowMutError".
+    #[test]
+    fn input_handler_writing_a_signal_may_trigger_handler_registration() {
+        use crate::reactive::{Effect, Signal};
+        use std::cell::Cell;
+        use std::rc::Rc;
+
+        clear_handlers();
+
+        let show_second = Signal::new(false);
+        let registrations = Rc::new(Cell::new(0));
+        let count = registrations.clone();
+
+        // Stands in for an `if show_second { TextInput {} }` branch.
+        let _effect = Effect::new(move || {
+            if show_second.get() {
+                register_input_handler(InputCallback::new(|_| {}));
+                count.set(count.get() + 1);
+            }
+        });
+        assert_eq!(registrations.get(), 0, "branch starts hidden");
+
+        let first = register_input_handler(InputCallback::new(move |_| show_second.set(true)));
+
+        assert!(dispatch_input_event(first, "hello".to_string()));
+        assert_eq!(
+            registrations.get(),
+            1,
+            "the revealed branch must have registered its handler"
+        );
+
+        clear_handlers();
+    }
 }

--- a/crates/rinch-core/src/reactive/effect.rs
+++ b/crates/rinch-core/src/reactive/effect.rs
@@ -129,6 +129,32 @@ impl Drop for Effect {
     }
 }
 
+/// RAII guard for the observer stack.
+///
+/// Pushes an [`ObserverId`] on construction and pops it on drop — including
+/// while unwinding. A bare push/pop pair leaks the id when user code panics
+/// between them, and a stale observer then subscribes itself to every signal
+/// read for the rest of the thread's life (issue #141).
+pub(super) struct ObserverGuard;
+
+impl ObserverGuard {
+    pub(super) fn push(id: ObserverId) -> Self {
+        RUNTIME.with(|rt| rt.borrow_mut().observer_stack.push(id));
+        ObserverGuard
+    }
+}
+
+impl Drop for ObserverGuard {
+    fn drop(&mut self) {
+        // `try_with`: TLS may already be torn down at thread exit.
+        let _ = RUNTIME.try_with(|rt| {
+            if let Ok(mut rt) = rt.try_borrow_mut() {
+                rt.observer_stack.pop();
+            }
+        });
+    }
+}
+
 /// Run a specific effect by ID
 pub(super) fn run_effect(id: ObserverId) {
     let effect = EFFECTS.with(|effects| effects.borrow().get(id.0).and_then(|e| e.clone()));
@@ -146,20 +172,14 @@ pub(super) fn run_effect(id: ObserverId) {
         // (issue #136).
         let _root_guard = crate::context::push_context_root(inner.root);
 
-        // Push this effect as the current observer
-        RUNTIME.with(|rt| {
-            rt.borrow_mut().observer_stack.push(id);
-        });
+        // Push this effect as the current observer. RAII so a panic in the
+        // effect body cannot strand it on the stack (issue #141).
+        let _observer_guard = ObserverGuard::push(id);
 
         // Run the effect
         (inner.f.borrow_mut())();
 
         tracing::debug!("run_effect({}): done", id.0);
-
-        // Pop the observer
-        RUNTIME.with(|rt| {
-            rt.borrow_mut().observer_stack.pop();
-        });
     } else {
         tracing::debug!("run_effect({}): SKIPPED - no effect found (dropped?)", id.0);
     }

--- a/crates/rinch-core/src/reactive/memo.rs
+++ b/crates/rinch-core/src/reactive/memo.rs
@@ -49,6 +49,15 @@ struct MemoInner<T> {
     value: RefCell<Option<T>>,
     f: RefCell<Box<dyn Fn() -> T>>,
     dirty: Cell<bool>,
+    /// The context root current when this memo was created, re-entered around
+    /// the recompute in [`Memo::get`].
+    ///
+    /// A memo is *lazy*: the user computation does not run in the dirty-marker
+    /// effect (which carries its own root) but in whichever call site first
+    /// reads the memo after invalidation. Without this, a memo created in
+    /// context A but first read from context B resolved B's stores (issue #136
+    /// follow-up, issue #141). `0` = the thread-global fallback root.
+    root: u64,
     /// Observers to notify, ordered — same contract (and same reason) as
     /// `SignalSlot::subscribers`: a memo's dependents run in registration order.
     subscribers: RefCell<BTreeSet<ObserverId>>,
@@ -67,6 +76,7 @@ impl<T: Clone + 'static> Memo<T> {
             value: RefCell::new(None),
             f: RefCell::new(Box::new(f)),
             dirty: Cell::new(true),
+            root: crate::context::current_context_root(),
             subscribers: RefCell::new(BTreeSet::new()),
         });
 
@@ -134,19 +144,21 @@ impl<T: Clone + 'static> Memo<T> {
             }
         });
 
-        // Recompute if dirty
+        // Recompute if dirty.
+        //
+        // The computation runs HERE, at the first read after invalidation — not
+        // in the dirty-marker effect. So the marker's root is irrelevant to it,
+        // and the memo must re-enter its own creation root, or a memo created in
+        // one context but first read from another resolves the wrong stores
+        // (issue #136 follow-up). Both guards are RAII so a panic in the user
+        // computation cannot strand state (issue #141).
         if inner.dirty.get() {
-            RUNTIME.with(|rt| {
-                rt.borrow_mut().observer_stack.push(inner.id);
-            });
+            let _root_guard = crate::context::push_context_root(inner.root);
+            let _observer_guard = super::effect::ObserverGuard::push(inner.id);
 
             let value = (inner.f.borrow())();
             *inner.value.borrow_mut() = Some(value);
             inner.dirty.set(false);
-
-            RUNTIME.with(|rt| {
-                rt.borrow_mut().observer_stack.pop();
-            });
         }
 
         inner

--- a/crates/rinch-core/src/reactive/mod.rs
+++ b/crates/rinch-core/src/reactive/mod.rs
@@ -693,6 +693,67 @@ mod tests {
         );
     }
 
+    /// A panic inside an effect must not strand its `ObserverId` on the
+    /// observer stack (issue #141).
+    ///
+    /// The stack is what `Signal::track` reads to decide who subscribes, so a
+    /// stranded id silently subscribes itself to *every* signal read for the
+    /// rest of the thread's life — and that observer's slot is gone, so the
+    /// symptom is unbounded queue churn far from the panic that caused it.
+    #[test]
+    fn a_panicking_effect_does_not_strand_its_observer() {
+        let depth_before = RUNTIME.with(|rt| rt.borrow().observer_stack.len());
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            Effect::new(|| panic!("boom"));
+        }));
+        assert!(result.is_err(), "the effect body must have panicked");
+
+        let depth_after = RUNTIME.with(|rt| rt.borrow().observer_stack.len());
+        assert_eq!(
+            depth_after, depth_before,
+            "the observer stack must unwind with the panic"
+        );
+
+        // Positive control: the runtime is still usable afterwards, and a
+        // signal read at top level (outside any effect) does not wake anyone.
+        // With a stranded observer this signal would acquire a subscriber whose
+        // slot is gone, and every later `set` would queue it forever.
+        let sig = Signal::new(0);
+        let runs = Rc::new(Cell::new(0));
+        let r = runs.clone();
+        let _e = Effect::new(move || {
+            sig.get();
+            r.set(r.get() + 1);
+        });
+        assert_eq!(runs.get(), 1, "the new effect runs once at creation");
+
+        sig.get(); // top-level read: must not subscribe anything
+        sig.set(1);
+        assert_eq!(
+            runs.get(),
+            2,
+            "exactly the one live subscriber re-runs, no more"
+        );
+    }
+
+    /// The same guarantee for a memo, whose user computation runs lazily in
+    /// `Memo::get` rather than in its dirty-marker effect.
+    #[test]
+    fn a_panicking_memo_computation_does_not_strand_its_observer() {
+        let depth_before = RUNTIME.with(|rt| rt.borrow().observer_stack.len());
+
+        let memo = Memo::new(|| -> i32 { panic!("boom") });
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| memo.get()));
+        assert!(result.is_err(), "the memo computation must have panicked");
+
+        let depth_after = RUNTIME.with(|rt| rt.borrow().observer_stack.len());
+        assert_eq!(
+            depth_after, depth_before,
+            "the observer stack must unwind with the panic"
+        );
+    }
+
     #[test]
     fn signal_change_subscriptions_are_independent() {
         let a = Rc::new(Cell::new(0));

--- a/crates/rinch/tests/multi_context.rs
+++ b/crates/rinch/tests/multi_context.rs
@@ -358,6 +358,66 @@ fn store_root_zero_fallback() {
     });
 }
 
+#[derive(Clone, Copy)]
+struct MemoStore {
+    which: Signal<i32>,
+}
+
+/// FIXED (#141): a `Memo` re-enters its own creation root when it recomputes.
+///
+/// A memo is *lazy* — the user computation does not run in its dirty-marker
+/// effect (which carries a root) but at whichever call site first reads it after
+/// invalidation. So capturing a root on the marker, as #136 did for effects, is
+/// not enough: it is inert for the computation. Here the memo is created inside
+/// context A but never read there, then read for the first time from context B.
+/// Before the fix the computation ran under B's root and resolved B's store,
+/// silently returning 2.
+#[test]
+fn memo_recompute_resolves_its_creation_context_store() {
+    on_ui_thread(|| {
+        // Carries the Copy memo handle out of A and into B.
+        let slot: Rc<std::cell::RefCell<Option<Memo<i32>>>> =
+            Rc::new(std::cell::RefCell::new(None));
+
+        let a_slot = slot.clone();
+        let mut a = RinchContext::new(cfg(), move |__scope: &mut RenderScope| {
+            create_store(MemoStore {
+                which: Signal::new(1),
+            });
+            // Created under A's root — but deliberately NOT read here, so the
+            // computation is still pending when B mounts.
+            *a_slot.borrow_mut() = Some(Memo::new(|| use_store::<MemoStore>().which.get()));
+            rsx! { div { p { "A" } } }
+        });
+        a.update(&[]);
+
+        let b_slot = slot.clone();
+        let mut b = RinchContext::new(cfg(), move |__scope: &mut RenderScope| {
+            create_store(MemoStore {
+                which: Signal::new(2),
+            });
+            let memo = b_slot.borrow().expect("A created the memo");
+            rsx! {
+                div {
+                    p { {move || format!("memo:{}", memo.get())} }
+                }
+            }
+        });
+        b.update(&[]);
+
+        let text = doc_text(&b);
+        assert!(
+            text.contains("memo:1"),
+            "a memo created in A must resolve A's store even when first read \
+             from B (#141); got: {text}"
+        );
+
+        drop(b);
+        drop(a);
+        rinch_core::clear_context();
+    });
+}
+
 // ── 4. BOUNDS_REGISTRY per-document scoping ──────────────────────────────────
 
 /// FIXED (#134): bounds-signal registry entries carry their document's


### PR DESCRIPTION
Groundwork for #141 (reactive resources never freed). **This PR frees nothing** — it lands the four prerequisites the lifecycle work needs, each of which is an independent bug fix that stands on its own. Sequenced first deliberately, so the risky part (actual reclamation) lands on a clean base.

Design context: [the recommendations comment on #141](https://github.com/joeleaver/rinch/issues/141#issuecomment-5094329350).

## 1. Cleanups were silently dropped on every drop-only teardown

`RenderScope::on_cleanup` pushed onto a `RenderScope`-local `cleanups: Vec` that **only the by-value `RenderScope::dispose()` drained** — and `Drop for RenderScope` did nothing. So a `RinchContext` field drop, a closed DevTools window, or a runtime teardown ran no cleanups at all.

There are exactly two production callers, and both were affected:
- `rinch-editor-view/src/component.rs:63` → `unregister_editor`
- `rinch/src/render_surface.rs:1104` → `unregister_render_surface`

Neither ever ran on those paths. `on_cleanup` now delegates to the reactive `Scope`, which runs its cleanups from its own `Drop` as well as from `dispose()`. The second list is deleted, so there is one place cleanups can live.

**Ordering consequence, stated explicitly:** cleanups now run inside `Scope::dispose_into_queue`, i.e. *before* the queued effects are disposed by the root loop, where `RenderScope::dispose` previously ran them *after*. Both production cleanups are order-insensitive registry removals. (#141's SD4 will formalise cleanups-before-frees; this PR just stops losing them.)

## 2. `dispatch_input_event` held its borrow across the callback

It was the only one of the four dispatchers to do so — `dispatch_event`, `dispatch_file_drop_event` and `dispatch_scroll_event` all clone the handler out first, and `dispatch_event`'s comment says exactly why.

This is not theoretical. An `oninput` writes a signal; `Signal::set` flushes effects **synchronously** outside `batch()`; an effect that flips an `if` renders content that registers handlers — a `borrow_mut` under the live `borrow()`. Typing in a box that reveals another box was a `BorrowMutError`.

It is also the hard blocker for the rest of #141: show/match/for/virtual_list all dispose inside that same synchronous flush, so **any** dispose-time `borrow_mut` on the handler registries would panic on the first such keystroke.

## 3. A memo did not re-enter its creation context on recompute

#136 gave the dirty-marker effect a context root, but a memo is **lazy**: the user computation does not run in the marker, it runs at whichever call site first reads the memo after invalidation. So the marker's root was inert for it, and a memo created in context A but first read from context B resolved **B's** stores.

`MemoInner` now carries its own `root`, pushed around the recompute. (This is one of the two follow-up items PR #164's review filed against this issue.)

## 4. The observer stack leaked on panic

`run_effect` and `Memo::get` pushed and popped an `ObserverId` by hand. A panic in user code between the two stranded it — and `Signal::track` reads that stack to decide who subscribes, so a stranded observer silently subscribes itself to **every later signal read on that thread**, with a symptom arbitrarily far from the cause. Both now use an RAII `ObserverGuard` that pops while unwinding.

## Tests

Six regression tests. **Five verified failing before the fix**; the sixth (`on_cleanup_runs_on_explicit_dispose`) guards the path that already worked and is a don't-regress guard, not a bug pin.

| Test | Pins |
|---|---|
| `on_cleanup_runs_when_the_render_scope_is_dropped` | #1 — the actual bug |
| `on_cleanup_runs_on_explicit_dispose` | #1 — the path that already worked |
| `input_handler_may_register_another_handler_while_running` | #2 directly |
| `input_handler_writing_a_signal_may_trigger_handler_registration` | #2 via the real production shape (signal write → sync flush → registration) |
| `a_panicking_effect_does_not_strand_its_observer` | #4, with a positive control that exactly one live subscriber re-runs afterwards |
| `a_panicking_memo_computation_does_not_strand_its_observer` | #4 on the lazy path |
| `memo_recompute_resolves_its_creation_context_store` (multi_context.rs) | #3 — needs two real contexts |

Counterfactual method: the mechanisms and their tests live in separate files, so `git stash`ing the four mechanism files while keeping the tests gives a clean pre-fix run — 5 failed, 1 passed as designed.

## Verification

- Full pre-commit gate: fmt, workspace clippy `-D warnings`, workspace tests, wasm check.
- All three CI feature-gated invocations green, including `-p rinch --features embed,theme,clipboard` (8 multi_context tests).
- **Live app check of the one behavioural risk.** Because cleanups now fire where they never did, `unregister_editor` runs on teardowns it previously skipped. Drove `ui-zoo-desktop`: typed into the editor, navigated away (disposing its scope), navigated back, then confirmed both typing **and** a toolbar command (Bold) still work. The unregister → re-register round-trip is sound.
- Adversarial review across four independent lenses (cleanup ordering, input dispatch, memo root, observer guard), each instructed to find a concrete failure with file:line. Zero findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
