### PR TITLE
fix(rinch-core): #141 PR1 — liveness API, lenient writes, self-pruning registries

### DIFF
--- a/crates/rinch-core/src/events/drag_context.rs
+++ b/crates/rinch-core/src/events/drag_context.rs
@@ -53,20 +53,31 @@ impl<T: Clone + 'static> DragContext<T> {
     }
 
     /// Get a clone of the data being dragged, if any.
+    ///
+    /// Returns `None` both when no drag is in progress and when the context's
+    /// backing signal has been freed — a `DragContext` is `Copy` and routinely
+    /// captured by drop-target handlers that outlive the source component, so a
+    /// query must never panic. (Reads go through `try_get` for this reason;
+    /// see issue #141.)
     pub fn get(&self) -> Option<T> {
-        self.data.get()
+        self.data.try_get().flatten()
     }
 
     /// Take the data (sets internal state to `None`). Call from `ondrop`.
+    ///
+    /// Clears only when there was something to clear, so a `take` on an idle
+    /// context no longer notifies subscribers with an unchanged `None`.
     pub fn take(&self) -> Option<T> {
-        let d = self.data.get();
-        self.data.set(None);
+        let d = self.get();
+        if d.is_some() {
+            self.data.set(None);
+        }
         d
     }
 
     /// Check if a drag is in progress (data is set).
     pub fn is_active(&self) -> bool {
-        self.data.get().is_some()
+        self.get().is_some()
     }
 
     /// Clear the drag data. Call from `ondragend` if needed.
@@ -133,4 +144,43 @@ pub fn is_drag_ghost_visible() -> bool {
 /// when a drag ends.
 pub fn reset_drag_ghost_visibility() {
     DRAG_GHOST_VISIBLE.with(|v| v.set(true));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct Item(u32);
+
+    #[test]
+    fn take_returns_the_data_and_clears() {
+        let drag = DragContext::<Item>::new();
+        assert!(!drag.is_active());
+
+        drag.set(Item(1));
+        assert!(drag.is_active());
+        assert_eq!(drag.get(), Some(Item(1)));
+
+        assert_eq!(drag.take(), Some(Item(1)));
+        assert!(!drag.is_active());
+        assert_eq!(drag.take(), None);
+    }
+
+    #[test]
+    fn queries_are_safe_after_the_backing_signal_is_freed() {
+        // A DragContext is Copy and is routinely captured by drop-target
+        // handlers that outlive the source component. Once #141's disposal
+        // lands, that source's scope can free the signal mid-drag — every query
+        // must degrade to "no drag", not panic (issue #141, SD1).
+        let drag = DragContext::<Item>::new();
+        drag.set(Item(9));
+
+        drag.data.free_for_tests();
+
+        assert_eq!(drag.get(), None);
+        assert_eq!(drag.take(), None);
+        assert!(!drag.is_active());
+        drag.clear(); // lenient write — must not panic either
+    }
 }

--- a/crates/rinch-core/src/reactive/bounds.rs
+++ b/crates/rinch-core/src/reactive/bounds.rs
@@ -24,6 +24,10 @@ pub struct ElementBounds {
     pub height: f32,
 }
 
+/// All fields are `Copy` (`Signal` is an index + generation), so
+/// [`update_bounds_signals`] can snapshot the entries it needs and release the
+/// registry borrow before running any user code.
+#[derive(Clone, Copy)]
 struct BoundsEntry {
     /// The owning document's [`doc_key`](crate::dom::DomDocument::doc_key).
     /// Node ids are per-document slab indices, so without this key two
@@ -65,29 +69,72 @@ pub fn register_bounds_signal(doc_key: u64, node_id: u64) -> Signal<ElementBound
 /// Refresh the registered bounds signals belonging to the document identified
 /// by `doc_key` from the supplied absolute-bounds lookup. Called by the rinch
 /// runtime after that document's layout completes. Entries registered by other
-/// documents are left untouched — their own runtime pass updates them.
+/// documents are not *updated* — their own runtime pass does that.
 ///
 /// The lookup returns `None` for nodes that no longer exist; their signals
-/// retain whatever value they last had (no panic, no removal — the registry
-/// currently never shrinks; callers must accept the memory cost as the price
-/// of the simple API).
+/// retain whatever value they last had (no panic, no removal — a node can be
+/// absent for a frame and come back).
+///
+/// # Lifetime
+///
+/// A bounds entry lives exactly as long as its signal. Entries whose signal has
+/// been freed are dropped here, on any document's pass — a dead signal can never
+/// be updated by anyone, so there is nothing to preserve. Registering from a
+/// component therefore ties the entry to that component's scope, while
+/// [`NodeHandle::bounds_signal`](crate::dom::NodeHandle::bounds_signal) on a
+/// long-lived root keeps application lifetime (issue #141, SD3).
+///
+/// `absolute_bounds` and the resulting signal writes run with **no registry
+/// borrow held**, so a lookup — or an effect woken by one of the writes — may
+/// call [`register_bounds_signal`] or `update_bounds_signals` re-entrantly. That
+/// matters because reading a `bounds_signal()` from inside a bounds-driven
+/// effect is the idiom this module's own docs recommend; before this it was a
+/// `BorrowMutError`.
 pub fn update_bounds_signals<F>(doc_key: u64, mut absolute_bounds: F)
 where
     F: FnMut(u64) -> Option<(f32, f32, f32, f32)>,
 {
-    BOUNDS_REGISTRY.with(|reg| {
-        let reg = reg.borrow();
-        for entry in reg.iter().filter(|e| e.doc_key == doc_key) {
-            if let Some((x, y, width, height)) = absolute_bounds(entry.node_id) {
-                entry.signal.set_if_changed(ElementBounds {
-                    x,
-                    y,
-                    width,
-                    height,
-                });
-            }
-        }
+    // Snapshot this document's entries (all fields are Copy) and drop the
+    // borrow before invoking the lookup or touching any signal.
+    let entries: Vec<BoundsEntry> = BOUNDS_REGISTRY.with(|reg| {
+        reg.borrow()
+            .iter()
+            .filter(|e| e.doc_key == doc_key)
+            .copied()
+            .collect()
     });
+
+    for entry in entries {
+        if !entry.signal.is_alive() {
+            continue;
+        }
+        if let Some((x, y, width, height)) = absolute_bounds(entry.node_id) {
+            entry.signal.set_if_changed(ElementBounds {
+                x,
+                y,
+                width,
+                height,
+            });
+        }
+    }
+
+    // Reap dead entries across *all* documents, not just `doc_key`'s. A dead
+    // signal can never be updated by anyone, and scoping the reap to the
+    // updating document would strand the entries of a document that stops
+    // running layout entirely — a dropped `RinchContext` (issue #134) is
+    // exactly that, and stranding is the leak this is meant to fix.
+    //
+    // One unconditional pass: `retain` over an all-live registry moves nothing,
+    // and `is_alive` is an index + generation compare, so this is cheaper than
+    // scanning for deadness first and retaining only on a hit.
+    BOUNDS_REGISTRY.with(|reg| reg.borrow_mut().retain(|e| e.signal.is_alive()));
+}
+
+/// Number of registered bounds entries on this thread, across all documents.
+/// Test-only: the self-pruning contract is about entries *disappearing*.
+#[cfg(test)]
+pub(crate) fn registry_len_for_tests() -> usize {
+    BOUNDS_REGISTRY.with(|reg| reg.borrow().len())
 }
 
 #[cfg(test)]
@@ -159,5 +206,95 @@ mod tests {
         // Node was removed mid-frame — return None, value persists.
         update_bounds_signals(1, |_| None);
         assert_eq!(signal.get().width, 3.0);
+    }
+}
+
+#[cfg(test)]
+mod lifetime_tests {
+    use super::*;
+    use crate::reactive::Effect;
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    /// Answer every lookup with the same rect.
+    fn any_rect(_: u64) -> Option<(f32, f32, f32, f32)> {
+        Some((1.0, 2.0, 3.0, 4.0))
+    }
+
+    #[test]
+    fn an_entry_is_dropped_once_its_signal_is_freed() {
+        let doomed = register_bounds_signal(7, 1);
+        let survivor = register_bounds_signal(7, 2);
+        assert_eq!(registry_len_for_tests(), 2);
+
+        doomed.free_for_tests();
+        update_bounds_signals(7, any_rect);
+
+        assert_eq!(
+            registry_len_for_tests(),
+            1,
+            "the dead entry is reaped, the live one is kept"
+        );
+        assert_eq!(survivor.get().width, 3.0, "the survivor still updates");
+    }
+
+    #[test]
+    fn a_freed_entry_is_reaped_by_another_documents_pass() {
+        // A document that stops running layout must not strand its entries.
+        let orphan = register_bounds_signal(100, 1);
+        let _other_doc = register_bounds_signal(200, 1);
+        assert_eq!(registry_len_for_tests(), 2);
+
+        orphan.free_for_tests();
+        // Document 100 never runs again; document 200 does.
+        update_bounds_signals(200, any_rect);
+
+        assert_eq!(registry_len_for_tests(), 1);
+    }
+
+    #[test]
+    fn a_lookup_may_register_another_bounds_signal() {
+        // Pre-fix this was a BorrowMutError: `update_bounds_signals` held
+        // `BOUNDS_REGISTRY.borrow()` across the lookup, and
+        // `register_bounds_signal` takes `borrow_mut()` to push.
+        let _existing = register_bounds_signal(11, 1);
+        let registered = Rc::new(Cell::new(false));
+
+        let r = Rc::clone(&registered);
+        update_bounds_signals(11, move |_| {
+            if !r.get() {
+                r.set(true);
+                let _nested = register_bounds_signal(11, 2);
+            }
+            Some((0.0, 0.0, 10.0, 10.0))
+        });
+
+        assert!(registered.get());
+        assert_eq!(registry_len_for_tests(), 2);
+    }
+
+    #[test]
+    fn a_bounds_driven_effect_may_read_a_bounds_signal() {
+        // The idiom this module's own docs recommend: observe an element's rect
+        // and, from that effect, register/read another. The write below flushes
+        // effects synchronously, so pre-fix the effect ran under the registry
+        // borrow and the nested register was a BorrowMutError.
+        let observed = register_bounds_signal(21, 1);
+        let widths = Rc::new(Cell::new(0.0f32));
+
+        let w = Rc::clone(&widths);
+        let _effect = Effect::new(move || {
+            let b = observed.get();
+            if b.width > 0.0 {
+                // Register a second observer from inside the reaction.
+                let nested = register_bounds_signal(21, 2);
+                w.set(b.width + nested.get().width);
+            }
+        });
+
+        update_bounds_signals(21, |id| (id == 1).then_some((0.0, 0.0, 40.0, 10.0)));
+
+        assert_eq!(widths.get(), 40.0);
+        assert_eq!(registry_len_for_tests(), 2);
     }
 }

--- a/crates/rinch-core/src/reactive/bounds.rs
+++ b/crates/rinch-core/src/reactive/bounds.rs
@@ -84,12 +84,18 @@ pub fn register_bounds_signal(doc_key: u64, node_id: u64) -> Signal<ElementBound
 /// [`NodeHandle::bounds_signal`](crate::dom::NodeHandle::bounds_signal) on a
 /// long-lived root keeps application lifetime (issue #141, SD3).
 ///
+/// # Re-entrancy
+///
 /// `absolute_bounds` and the resulting signal writes run with **no registry
 /// borrow held**, so a lookup — or an effect woken by one of the writes — may
-/// call [`register_bounds_signal`] or `update_bounds_signals` re-entrantly. That
-/// matters because reading a `bounds_signal()` from inside a bounds-driven
-/// effect is the idiom this module's own docs recommend; before this it was a
-/// `BorrowMutError`.
+/// call [`register_bounds_signal`] or `update_bounds_signals` re-entrantly.
+///
+/// The writes flush effects **synchronously**, so a caller must also not be
+/// holding any lock those effects need. In particular a runtime must release its
+/// document borrow first: a reactive `style:` closure reading a measured width —
+/// the idiom [`NodeHandle::bounds_signal`](crate::dom::NodeHandle::bounds_signal)
+/// documents — patches the DOM and takes `borrow_mut`. Measure everything under
+/// the read borrow using [`registered_bounds_nodes`], drop it, then publish here.
 pub fn update_bounds_signals<F>(doc_key: u64, mut absolute_bounds: F)
 where
     F: FnMut(u64) -> Option<(f32, f32, f32, f32)>,
@@ -130,11 +136,42 @@ where
     BOUNDS_REGISTRY.with(|reg| reg.borrow_mut().retain(|e| e.signal.is_alive()));
 }
 
+/// The node ids currently registered for `doc_key`, with live signals.
+///
+/// Lets a runtime compute every rect it needs while holding its document
+/// borrow, then **release that borrow** before calling
+/// [`update_bounds_signals`] — whose writes flush effects synchronously, and
+/// those effects mutate the DOM. Without this two-step the document `RefCell`
+/// is still borrowed when user code runs, and the documented
+/// [`NodeHandle::bounds_signal`](crate::dom::NodeHandle::bounds_signal) idiom
+/// (a reactive `style:` closure reading a measured width) is a `BorrowMutError`.
+pub fn registered_bounds_nodes(doc_key: u64) -> Vec<u64> {
+    BOUNDS_REGISTRY.with(|reg| {
+        reg.borrow()
+            .iter()
+            .filter(|e| e.doc_key == doc_key && e.signal.is_alive())
+            .map(|e| e.node_id)
+            .collect()
+    })
+}
+
 /// Number of registered bounds entries on this thread, across all documents.
 /// Test-only: the self-pruning contract is about entries *disappearing*.
 #[cfg(test)]
 pub(crate) fn registry_len_for_tests() -> usize {
     BOUNDS_REGISTRY.with(|reg| reg.borrow().len())
+}
+
+/// The `(doc_key, node_id)` pairs currently registered. Test-only: pruning
+/// assertions must check *which* entry survived, not merely how many did.
+#[cfg(test)]
+pub(crate) fn registry_entries_for_tests() -> Vec<(u64, u64)> {
+    BOUNDS_REGISTRY.with(|reg| {
+        reg.borrow()
+            .iter()
+            .map(|e| (e.doc_key, e.node_id))
+            .collect()
+    })
 }
 
 #[cfg(test)]
@@ -230,10 +267,12 @@ mod lifetime_tests {
         doomed.free_for_tests();
         update_bounds_signals(7, any_rect);
 
+        // Assert *which* entry survived, not merely how many — an inverted
+        // retain predicate keeps the count right and the contents wrong.
         assert_eq!(
-            registry_len_for_tests(),
-            1,
-            "the dead entry is reaped, the live one is kept"
+            registry_entries_for_tests(),
+            vec![(7, 2)],
+            "the dead entry is reaped and the live one is kept"
         );
         assert_eq!(survivor.get().width, 3.0, "the survivor still updates");
     }
@@ -249,7 +288,28 @@ mod lifetime_tests {
         // Document 100 never runs again; document 200 does.
         update_bounds_signals(200, any_rect);
 
-        assert_eq!(registry_len_for_tests(), 1);
+        assert_eq!(
+            registry_entries_for_tests(),
+            vec![(200, 1)],
+            "document 100's stranded entry is reaped by document 200's pass"
+        );
+    }
+
+    #[test]
+    fn registered_bounds_nodes_lists_only_this_documents_live_entries() {
+        let a = register_bounds_signal(31, 10);
+        let _b = register_bounds_signal(31, 11);
+        let _other = register_bounds_signal(32, 12);
+
+        assert_eq!(registered_bounds_nodes(31), vec![10, 11]);
+        assert_eq!(registered_bounds_nodes(32), vec![12]);
+
+        a.free_for_tests();
+        assert_eq!(
+            registered_bounds_nodes(31),
+            vec![11],
+            "a freed entry must not be handed to the runtime to measure"
+        );
     }
 
     #[test]

--- a/crates/rinch-core/src/reactive/memo.rs
+++ b/crates/rinch-core/src/reactive/memo.rs
@@ -123,14 +123,31 @@ impl<T: Clone + 'static> Memo<T> {
     }
 
     /// Get the current value, recomputing if necessary.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the memo has been freed. Use [`try_get`](Memo::try_get) when
+    /// the memo may legitimately be gone.
     pub fn get(&self) -> T {
+        match self.try_get() {
+            Some(value) => value,
+            None => panic!(
+                "Memo::get() on a freed memo. The scope that owned this memo was \
+                 disposed (its component was removed from the tree) while this \
+                 handle was still reachable. Guard the read with `memo.is_alive()`, \
+                 or use `memo.try_get()` to get an `Option` instead of panicking."
+            ),
+        }
+    }
+
+    /// Get the current value, or `None` if the memo has been freed.
+    ///
+    /// The non-panicking counterpart to [`get`](Memo::get). Recomputes and
+    /// subscribes exactly like `get` when the memo is live.
+    pub fn try_get(&self) -> Option<T> {
         // Clone Rc out of store, releasing the borrow immediately
-        let inner_any = MEMO_STORE.with(|store| {
-            store
-                .borrow()
-                .get_inner(self.id, self.generation)
-                .expect("Memo::get() on freed memo")
-        });
+        let inner_any =
+            MEMO_STORE.with(|store| store.borrow().get_inner(self.id, self.generation))?;
 
         let inner = inner_any
             .downcast::<MemoInner<T>>()
@@ -161,11 +178,36 @@ impl<T: Clone + 'static> Memo<T> {
             inner.dirty.set(false);
         }
 
-        inner
-            .value
-            .borrow()
-            .clone()
-            .expect("memo should have value after get")
+        Some(
+            inner
+                .value
+                .borrow()
+                .clone()
+                .expect("memo should have value after get"),
+        )
+    }
+}
+
+impl<T: 'static> Memo<T> {
+    /// Whether this memo's backing slot is still live.
+    ///
+    /// A memo is freed when the scope that owns it is disposed, after which
+    /// [`get`](Memo::get) panics. Does **not** subscribe the current observer.
+    ///
+    /// Nothing frees memos yet — this returns `true` for every memo that was
+    /// ever created. It becomes meaningful when scope-driven disposal lands
+    /// (issue #141).
+    pub fn is_alive(&self) -> bool {
+        MEMO_STORE.with(|store| store.borrow().get_inner(self.id, self.generation).is_some())
+    }
+}
+
+#[cfg(test)]
+impl<T: 'static> Memo<T> {
+    /// Free this memo's slot, standing in for the scope disposal that #141's
+    /// dispose fixpoint (PR4) will perform. Test-only.
+    pub(crate) fn free_for_tests(&self) {
+        super::free_memo_for_tests(self.id, self.generation);
     }
 }
 
@@ -182,5 +224,33 @@ impl<T: fmt::Debug + Clone + 'static> fmt::Debug for Memo<T> {
                 .finish();
         }
         f.debug_struct("Memo").field("error", &"freed").finish()
+    }
+}
+
+#[cfg(test)]
+mod liveness_tests {
+    use super::*;
+    use crate::reactive::Signal;
+
+    #[test]
+    fn is_alive_flips_when_the_memo_is_freed() {
+        let n = Signal::new(2);
+        let doubled = Memo::new(move || n.get() * 2);
+
+        assert!(doubled.is_alive());
+        assert_eq!(doubled.try_get(), Some(4));
+
+        doubled.free_for_tests();
+        assert!(!doubled.is_alive());
+        assert_eq!(doubled.try_get(), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "Memo::get() on a freed memo")]
+    fn get_panics_after_free() {
+        let n = Signal::new(1);
+        let m = Memo::new(move || n.get());
+        m.free_for_tests();
+        let _ = m.get();
     }
 }

--- a/crates/rinch-core/src/reactive/memo.rs
+++ b/crates/rinch-core/src/reactive/memo.rs
@@ -111,9 +111,11 @@ impl<T: Clone + 'static> Memo<T> {
             }));
         });
 
-        // Store in MEMO_STORE and return Copy handle
+        // Store in MEMO_STORE and return Copy handle. The marker's ObserverId
+        // rides along so freeing the slot can also clear EFFECTS — the marker
+        // holds the second strong Rc to this same MemoInner.
         let (store_id, generation) =
-            MEMO_STORE.with(|store| store.borrow_mut().alloc(inner as Rc<dyn Any>));
+            MEMO_STORE.with(|store| store.borrow_mut().alloc(inner as Rc<dyn Any>, id));
 
         Self {
             id: store_id,
@@ -204,10 +206,10 @@ impl<T: 'static> Memo<T> {
 
 #[cfg(test)]
 impl<T: 'static> Memo<T> {
-    /// Free this memo's slot, standing in for the scope disposal that #141's
-    /// dispose fixpoint (PR4) will perform. Test-only.
+    /// Free this memo — slot and marker effect — standing in for the scope
+    /// disposal that #141's dispose fixpoint (PR4) will perform. Test-only.
     pub(crate) fn free_for_tests(&self) {
-        super::free_memo_for_tests(self.id, self.generation);
+        super::free_memo(self.id, self.generation);
     }
 }
 
@@ -230,7 +232,8 @@ impl<T: fmt::Debug + Clone + 'static> fmt::Debug for Memo<T> {
 #[cfg(test)]
 mod liveness_tests {
     use super::*;
-    use crate::reactive::Signal;
+    use crate::reactive::{Effect, Signal};
+    use std::cell::Cell;
 
     #[test]
     fn is_alive_flips_when_the_memo_is_freed() {
@@ -252,5 +255,52 @@ mod liveness_tests {
         let m = Memo::new(move || n.get());
         m.free_for_tests();
         let _ = m.get();
+    }
+
+    #[test]
+    fn freeing_a_memo_releases_its_computation_closure() {
+        // `Memo::new` puts TWO strong Rc<MemoInner> into two registries — one in
+        // MEMO_STORE, one captured by the dirty-marker closure in EFFECTS.
+        // Dropping only the store slot frees nothing.
+        let captured = Rc::new(7u32);
+        let c = Rc::clone(&captured);
+        let n = Signal::new(1);
+        let m = Memo::new(move || n.get() + *c);
+        let _ = m.get();
+        assert_eq!(Rc::strong_count(&captured), 2, "held by the memo closure");
+
+        m.free_for_tests();
+
+        assert_eq!(
+            Rc::strong_count(&captured),
+            1,
+            "the marker effect must be cleared too, or the memo leaks"
+        );
+    }
+
+    #[test]
+    fn a_dependent_of_a_freed_memo_is_not_re_queued_by_its_sources() {
+        // If the marker survives the free it stays subscribed to `n`, so writing
+        // `n` re-queues the memo's dependents — whose `get()` then panics on the
+        // now-empty slot.
+        let n = Signal::new(1);
+        let m = Memo::new(move || n.get() * 2);
+        let runs = Rc::new(Cell::new(0));
+
+        let r = Rc::clone(&runs);
+        let _dependent = Effect::new(move || {
+            let _ = m.get();
+            r.set(r.get() + 1);
+        });
+        assert_eq!(runs.get(), 1);
+
+        m.free_for_tests();
+        n.set(5); // must not resurrect the dependent, and must not panic
+
+        assert_eq!(
+            runs.get(),
+            1,
+            "a freed memo's sources must no longer drive its dependents"
+        );
     }
 }

--- a/crates/rinch-core/src/reactive/mod.rs
+++ b/crates/rinch-core/src/reactive/mod.rs
@@ -77,7 +77,9 @@ mod poll;
 mod scope;
 mod signal;
 
-pub use bounds::{ElementBounds, register_bounds_signal, update_bounds_signals};
+pub use bounds::{
+    ElementBounds, register_bounds_signal, registered_bounds_nodes, update_bounds_signals,
+};
 pub use effect::Effect;
 pub use memo::Memo;
 pub use poll::{PollRate, drain_polls, poll_signal};
@@ -483,6 +485,11 @@ thread_local! {
 
 struct MemoSlot {
     inner: Rc<dyn Any>, // Type-erased Rc<MemoInner<T>>
+    /// The memo's dirty-marker effect, which holds the *second* strong
+    /// reference to the same `MemoInner`. Recorded here because the slot is
+    /// type-erased: freeing a memo has to clear `EFFECTS[observer]` too, and a
+    /// type-erased caller cannot downcast to reach `MemoInner::id`.
+    observer: ObserverId,
     generation: u32,
 }
 
@@ -501,14 +508,18 @@ impl MemoStore {
         }
     }
 
-    pub(crate) fn alloc(&mut self, inner: Rc<dyn Any>) -> (u32, u32) {
+    pub(crate) fn alloc(&mut self, inner: Rc<dyn Any>, observer: ObserverId) -> (u32, u32) {
         let generation = self.next_gen;
         self.next_gen = self.next_gen.wrapping_add(1);
         if self.next_gen == 0 {
             self.next_gen = 1;
         }
 
-        let slot = MemoSlot { inner, generation };
+        let slot = MemoSlot {
+            inner,
+            observer,
+            generation,
+        };
 
         if let Some(idx) = self.free_list.pop() {
             self.slots[idx as usize] = Some(slot);
@@ -528,27 +539,52 @@ impl MemoStore {
             .map(|s| Rc::clone(&s.inner))
     }
 
-    /// Free a slot, **returning** its `Rc` rather than dropping it in place —
-    /// same rule and same reason as [`SignalStore::free`]: a `MemoInner`'s cached
-    /// value can own arbitrary user data whose `Drop` may touch the reactive
-    /// stores. Not yet reachable from production code (#141 PR4 wires it).
+    /// Free a slot, **returning** its `Rc` and the marker's [`ObserverId`]
+    /// rather than dropping in place — same rule and same reason as
+    /// [`SignalStore::free`]: a `MemoInner`'s cached value can own arbitrary
+    /// user data whose `Drop` may touch the reactive stores.
+    ///
+    /// Freeing the slot alone does **not** release the memo. Use
+    /// [`free_memo`], which also clears the marker effect.
     #[allow(dead_code)]
-    pub(crate) fn free(&mut self, id: u32, generation: u32) -> Option<Rc<dyn Any>> {
+    pub(crate) fn free(&mut self, id: u32, generation: u32) -> Option<(Rc<dyn Any>, ObserverId)> {
         let slot = self.slots.get_mut(id as usize)?;
         if !slot.as_ref().is_some_and(|s| s.generation == generation) {
             return None;
         }
         let taken = slot.take();
         self.free_list.push(id);
-        taken.map(|s| s.inner)
+        taken.map(|s| (s.inner, s.observer))
     }
 }
 
-/// Free a memo slot directly. Test-only counterpart to
-/// [`free_signal_for_tests`]; see that function for why it exists.
-#[cfg(test)]
-pub(crate) fn free_memo_for_tests(id: u32, generation: u32) {
-    let _inner = MEMO_STORE.with(|store| store.borrow_mut().free(id, generation));
+/// Release a memo completely: its store slot **and** its dirty-marker effect.
+///
+/// `Memo::new` puts two strong `Rc<MemoInner>` references into two different
+/// registries — one in `MEMO_STORE`, one captured by the marker closure in
+/// `EFFECTS`. Dropping only the store slot frees nothing (the marker keeps the
+/// cached value and the computation closure alive) and is actively harmful: the
+/// marker stays subscribed to the memo's sources, so the next write to any of
+/// them re-queues the memo's dependents, whose `Memo::get()` then panics on the
+/// now-empty slot.
+///
+/// Both `Rc`s are dropped after every borrow is released, since the cached value
+/// is arbitrary user data whose `Drop` may touch the reactive stores.
+///
+/// Not yet reachable from production code — #141 PR4 wires it into the dispose
+/// fixpoint.
+#[allow(dead_code)]
+pub(crate) fn free_memo(id: u32, generation: u32) {
+    let Some((inner, observer)) = MEMO_STORE.with(|store| store.borrow_mut().free(id, generation))
+    else {
+        return;
+    };
+    let marker = effect::EFFECTS.with(|effects| {
+        let mut effects = effects.borrow_mut();
+        effects.get_mut(observer.0).and_then(|slot| slot.take())
+    });
+    drop(marker);
+    drop(inner);
 }
 
 // ============================================================================

--- a/crates/rinch-core/src/reactive/mod.rs
+++ b/crates/rinch-core/src/reactive/mod.rs
@@ -28,6 +28,34 @@
 //!    queues that signal's observers *behind* the current flush, rather than
 //!    ahead of it.)
 //!
+//! # Liveness
+//!
+//! [`Signal`] and [`Memo`] are `Copy` index handles, not owners. Their storage
+//! is freed when the scope that owns it is disposed, and a handle can outlive
+//! that — captured by a detached worker thread, a global callback, or a drag in
+//! flight. The contract for a handle whose storage is gone splits by direction:
+//!
+//! > **You may always write to a handle; you may only read a live one.**
+//!
+//! - **Reads panic.** [`Signal::get`]/[`Signal::with`] and [`Memo::get`] have no
+//!   value to return — `T` is not `Default` — so a lenient read is not
+//!   expressible. Use [`try_get`](Signal::try_get)/[`try_with`](Signal::try_with)
+//!   for the `Option` form.
+//! - **Writes are dropped, with a warning.** [`Signal::set`],
+//!   [`set_if_changed`](Signal::set_if_changed) and [`update`](Signal::update)
+//!   no-op and log once per call site. A background thread cannot check-then-write
+//!   without a race, and panicking there would take down the app for a write
+//!   nobody is waiting on. The cost is that side effects inside an `update`
+//!   closure are lost with it.
+//! - **[`is_alive`](Signal::is_alive) asks directly**, and does not subscribe —
+//!   liveness is not reactive.
+//!
+//! Registries that drive signals ([`poll_signal`], [`register_bounds_signal`])
+//! derive their own lifetime from this: an entry is dropped once the signal it
+//! writes is gone, so they self-prune rather than spinning on dead handles.
+//!
+//! See issue #141.
+//!
 //! # Example
 //!
 //! ```ignore
@@ -416,15 +444,33 @@ impl SignalStore {
             .filter(|s| s.generation == generation)
     }
 
+    /// Free a slot, **returning** its value rather than dropping it in place.
+    ///
+    /// The caller must drop the returned box after releasing the store borrow:
+    /// a value whose `Drop` touches a signal would otherwise `BorrowMutError`
+    /// (issue #141, SD4). Returns `None` if the slot was already freed or the
+    /// generation does not match.
+    ///
+    /// Not yet reachable from production code — #141's dispose fixpoint wires it.
     #[allow(dead_code)]
-    fn free(&mut self, id: u32, generation: u32) {
-        if let Some(slot) = self.slots.get(id as usize)
-            && slot.as_ref().is_some_and(|s| s.generation == generation)
-        {
-            self.slots[id as usize] = None;
-            self.free_list.push(id);
+    fn free(&mut self, id: u32, generation: u32) -> Option<Box<dyn Any>> {
+        let slot = self.slots.get_mut(id as usize)?;
+        if !slot.as_ref().is_some_and(|s| s.generation == generation) {
+            return None;
         }
+        let taken = slot.take();
+        self.free_list.push(id);
+        taken.map(|s| s.value)
     }
+}
+
+/// Free a signal slot directly, simulating the scope disposal that #141's
+/// dispose fixpoint will perform. Test-only: nothing frees signals yet, so
+/// without this the liveness API could not be exercised at all.
+#[cfg(test)]
+pub(crate) fn free_signal_for_tests(id: u32, generation: u32) {
+    // Dropped out here, after the store borrow is released.
+    let _value = SIGNAL_STORE.with(|store| store.borrow_mut().free(id, generation));
 }
 
 // ============================================================================
@@ -481,6 +527,28 @@ impl MemoStore {
             .filter(|s| s.generation == generation)
             .map(|s| Rc::clone(&s.inner))
     }
+
+    /// Free a slot, **returning** its `Rc` rather than dropping it in place —
+    /// same rule and same reason as [`SignalStore::free`]: a `MemoInner`'s cached
+    /// value can own arbitrary user data whose `Drop` may touch the reactive
+    /// stores. Not yet reachable from production code (#141 PR4 wires it).
+    #[allow(dead_code)]
+    pub(crate) fn free(&mut self, id: u32, generation: u32) -> Option<Rc<dyn Any>> {
+        let slot = self.slots.get_mut(id as usize)?;
+        if !slot.as_ref().is_some_and(|s| s.generation == generation) {
+            return None;
+        }
+        let taken = slot.take();
+        self.free_list.push(id);
+        taken.map(|s| s.inner)
+    }
+}
+
+/// Free a memo slot directly. Test-only counterpart to
+/// [`free_signal_for_tests`]; see that function for why it exists.
+#[cfg(test)]
+pub(crate) fn free_memo_for_tests(id: u32, generation: u32) {
+    let _inner = MEMO_STORE.with(|store| store.borrow_mut().free(id, generation));
 }
 
 // ============================================================================

--- a/crates/rinch-core/src/reactive/poll.rs
+++ b/crates/rinch-core/src/reactive/poll.rs
@@ -36,7 +36,9 @@ impl PollRate {
 struct PollEntry {
     interval_ms: u64,
     last_fired: Instant,
-    run: Box<dyn FnMut()>,
+    /// Fires the poll. Returns `false` once the driven signal is gone, which is
+    /// [`drain_polls`]'s signal to drop this entry (issue #141, SD3).
+    run: Box<dyn FnMut() -> bool>,
 }
 
 thread_local! {
@@ -75,9 +77,16 @@ thread_local! {
 ///
 /// # Lifetime
 ///
-/// Polls registered today live for the lifetime of the application; there is no
-/// unregister yet. This matches the typical "register once at startup" pattern;
-/// if you need scoped polling, gate the source closure on an external flag.
+/// **A poll lives exactly as long as the signal it drives.** [`drain_polls`]
+/// checks the signal before each fire and drops the entry once it is gone, so
+/// the registry self-prunes and the source closure — along with everything it
+/// captures — is released with it.
+///
+/// Registering at startup therefore still gives application lifetime, because a
+/// signal created outside any render has no owning scope and is never freed.
+/// Registering inside a component ties the poll to that component's scope: when
+/// it is removed from the tree, its signal is freed and the poll stops on the
+/// next drain. Neither case needs an external flag.
 pub fn poll_signal<T, F>(mut source: F, rate: PollRate) -> Signal<T>
 where
     T: PartialEq + Clone + 'static,
@@ -93,8 +102,17 @@ where
     let signal = Signal::new(initial);
 
     let run = move || {
+        // Check first so a dead signal never runs the source — the source may
+        // have observable side effects, and a lenient `set_if_changed` on a
+        // freed signal would otherwise warn on every frame forever.
+        if !signal.is_alive() {
+            return false;
+        }
         let value = source();
         signal.set_if_changed(value);
+        // Re-check: the source (or an effect it woke) may have disposed the
+        // scope that owned the signal.
+        signal.is_alive()
     };
 
     POLL_REGISTRY.with(|reg| {
@@ -112,26 +130,54 @@ where
     signal
 }
 
-/// Fire any polls whose interval has elapsed.
+/// Fire any polls whose interval has elapsed, dropping those whose signal has
+/// been freed.
 ///
 /// Called by the rinch runtime once per painted frame, before
 /// [`drain_main_queue`](super) and layout resolution. Application code should not
 /// need to invoke this directly.
+///
+/// The registry is moved out for the duration of the drain, so source closures
+/// run with **no borrow held**. That makes re-entrancy safe: a source that calls
+/// [`poll_signal`], or that wakes an effect which does, registers into the empty
+/// registry and is spliced back in afterwards instead of panicking with a
+/// `BorrowMutError`. A re-entrant `drain_polls` sees an empty registry and is a
+/// no-op, so no poll can fire twice in a frame.
 pub fn drain_polls() {
     if !is_main_thread() {
         return;
     }
     let now = Instant::now();
-    POLL_REGISTRY.with(|reg| {
-        let mut polls = reg.borrow_mut();
-        for entry in polls.iter_mut() {
-            let elapsed_ms = now.duration_since(entry.last_fired).as_millis() as u64;
-            if entry.interval_ms == 0 || elapsed_ms >= entry.interval_ms {
-                entry.last_fired = now;
-                (entry.run)();
-            }
+
+    let mut entries: Vec<PollEntry> =
+        POLL_REGISTRY.with(|reg| std::mem::take(&mut *reg.borrow_mut()));
+
+    entries.retain_mut(|entry| {
+        let elapsed_ms = now.duration_since(entry.last_fired).as_millis() as u64;
+        if entry.interval_ms == 0 || elapsed_ms >= entry.interval_ms {
+            entry.last_fired = now;
+            (entry.run)()
+        } else {
+            // Not due this frame — liveness is only judged on a fire, so an
+            // idle poll for a freed signal is reaped on its next due frame.
+            true
         }
     });
+
+    POLL_REGISTRY.with(|reg| {
+        let mut reg = reg.borrow_mut();
+        // Anything registered re-entrantly during the drain landed in `reg`;
+        // keep it, ordered after the surviving pre-existing entries.
+        entries.append(&mut reg);
+        *reg = entries;
+    });
+}
+
+/// Number of registered polls on this thread. Test-only: the self-pruning
+/// contract is about entries *disappearing*, which is otherwise unobservable.
+#[cfg(test)]
+pub(crate) fn registry_len_for_tests() -> usize {
+    POLL_REGISTRY.with(|reg| reg.borrow().len())
 }
 
 #[cfg(test)]
@@ -171,5 +217,139 @@ mod tests {
         assert_eq!(PollRate::Hz(60).interval_ms(), 16);
         assert_eq!(PollRate::Hz(1000).interval_ms(), 1);
         assert_eq!(PollRate::Millis(33).interval_ms(), 33);
+    }
+}
+
+#[cfg(test)]
+mod lifetime_tests {
+    use super::*;
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    #[test]
+    fn a_poll_is_dropped_once_its_signal_is_freed() {
+        let reads = Rc::new(Cell::new(0));
+        let r = Rc::clone(&reads);
+        let signal = poll_signal(
+            move || {
+                r.set(r.get() + 1);
+                r.get()
+            },
+            PollRate::EveryFrame,
+        );
+
+        assert_eq!(registry_len_for_tests(), 1);
+        drain_polls();
+        let reads_while_alive = reads.get();
+        assert!(
+            reads_while_alive >= 2,
+            "the source ran while the signal lived"
+        );
+
+        signal.free_for_tests();
+
+        drain_polls();
+        assert_eq!(
+            registry_len_for_tests(),
+            0,
+            "a poll whose signal is gone must be removed, not left spinning"
+        );
+        assert_eq!(
+            reads.get(),
+            reads_while_alive,
+            "the source must not run for a freed signal"
+        );
+
+        // Still gone, and still no work, on later frames.
+        drain_polls();
+        assert_eq!(registry_len_for_tests(), 0);
+        assert_eq!(reads.get(), reads_while_alive);
+    }
+
+    #[test]
+    fn a_live_poll_registered_beside_a_dead_one_survives() {
+        let doomed = poll_signal(|| 1, PollRate::EveryFrame);
+        let survivor_ticks = Rc::new(Cell::new(0));
+        let t = Rc::clone(&survivor_ticks);
+        let _survivor = poll_signal(
+            move || {
+                t.set(t.get() + 1);
+                t.get()
+            },
+            PollRate::EveryFrame,
+        );
+        assert_eq!(registry_len_for_tests(), 2);
+
+        doomed.free_for_tests();
+        drain_polls();
+
+        assert_eq!(registry_len_for_tests(), 1, "only the dead entry is reaped");
+        let after = survivor_ticks.get();
+        drain_polls();
+        assert!(survivor_ticks.get() > after, "the survivor keeps firing");
+    }
+
+    #[test]
+    fn a_poll_source_may_register_another_poll() {
+        // Pre-fix this was a BorrowMutError: `drain_polls` held
+        // `POLL_REGISTRY.borrow_mut()` across the source closure, and
+        // `poll_signal` takes `borrow_mut()` to push.
+        //
+        // The nested registration must happen on call #2. Call #1 is
+        // `poll_signal`'s own initial read, which runs *before* it touches the
+        // registry — registering from there would exercise nothing.
+        let calls = Rc::new(Cell::new(0));
+        let c = Rc::clone(&calls);
+        let _outer = poll_signal(
+            move || {
+                c.set(c.get() + 1);
+                if c.get() == 2 {
+                    let _inner = poll_signal(|| 0u8, PollRate::EveryFrame);
+                }
+                0u8
+            },
+            PollRate::EveryFrame,
+        );
+        assert_eq!(calls.get(), 1, "registration read the source once");
+        assert_eq!(registry_len_for_tests(), 1);
+
+        drain_polls();
+
+        assert_eq!(calls.get(), 2, "the drain fired the outer poll");
+        assert_eq!(
+            registry_len_for_tests(),
+            2,
+            "the poll registered during the drain is spliced back in"
+        );
+
+        // And the newcomer participates from the next frame on.
+        drain_polls();
+        assert_eq!(registry_len_for_tests(), 2);
+    }
+
+    #[test]
+    fn a_reentrant_drain_is_a_no_op_rather_than_a_double_fire() {
+        let ticks = Rc::new(Cell::new(0));
+        let t = Rc::clone(&ticks);
+        let _p = poll_signal(
+            move || {
+                t.set(t.get() + 1);
+                // Re-entering the drain must not re-fire this very poll.
+                drain_polls();
+                t.get()
+            },
+            PollRate::EveryFrame,
+        );
+        // Registration itself invokes the source once for the initial value.
+        let after_register = ticks.get();
+
+        drain_polls();
+
+        assert_eq!(
+            ticks.get(),
+            after_register + 1,
+            "the poll fired exactly once for this frame"
+        );
+        assert_eq!(registry_len_for_tests(), 1);
     }
 }

--- a/crates/rinch-core/src/reactive/poll.rs
+++ b/crates/rinch-core/src/reactive/poll.rs
@@ -39,6 +39,13 @@ struct PollEntry {
     /// Fires the poll. Returns `false` once the driven signal is gone, which is
     /// [`drain_polls`]'s signal to drop this entry (issue #141, SD3).
     run: Box<dyn FnMut() -> bool>,
+    /// Whether the driven signal is still live, *without* firing the poll.
+    ///
+    /// Separate from `run` so an entry that is not due this frame can still be
+    /// reaped. Judging liveness only on a fire would tie reclamation latency to
+    /// the poll's own interval — a `PollRate::Millis(60_000)` entry would sit on
+    /// its dead signal, and its captured closure, for a minute.
+    alive: Box<dyn Fn() -> bool>,
 }
 
 thread_local! {
@@ -78,9 +85,9 @@ thread_local! {
 /// # Lifetime
 ///
 /// **A poll lives exactly as long as the signal it drives.** [`drain_polls`]
-/// checks the signal before each fire and drops the entry once it is gone, so
-/// the registry self-prunes and the source closure — along with everything it
-/// captures — is released with it.
+/// drops the entry on the first drain after the signal is gone — whether or not
+/// the poll was due to fire — so the registry self-prunes and the source
+/// closure, along with everything it captures, is released with it.
 ///
 /// Registering at startup therefore still gives application lifetime, because a
 /// signal created outside any render has no owning scope and is never freed.
@@ -124,6 +131,7 @@ where
                 .checked_sub(std::time::Duration::from_secs(1))
                 .unwrap_or_else(Instant::now),
             run: Box::new(run),
+            alive: Box::new(move || signal.is_alive()),
         });
     });
 
@@ -143,33 +151,48 @@ where
 /// registry and is spliced back in afterwards instead of panicking with a
 /// `BorrowMutError`. A re-entrant `drain_polls` sees an empty registry and is a
 /// no-op, so no poll can fire twice in a frame.
+///
+/// The splice-back runs even if a source panics, so one bad poll cannot take the
+/// whole registry with it as the unwind passes through.
 pub fn drain_polls() {
     if !is_main_thread() {
         return;
     }
     let now = Instant::now();
 
-    let mut entries: Vec<PollEntry> =
-        POLL_REGISTRY.with(|reg| std::mem::take(&mut *reg.borrow_mut()));
+    /// Returns the drained entries to `POLL_REGISTRY` on the way out — including
+    /// while unwinding from a panicking source. Without this the moved-out
+    /// `Vec` would simply be dropped and every poll on the thread would vanish.
+    struct SpliceBack(Vec<PollEntry>);
 
-    entries.retain_mut(|entry| {
+    impl Drop for SpliceBack {
+        fn drop(&mut self) {
+            let mut entries = std::mem::take(&mut self.0);
+            // `try_with`/`try_borrow_mut`: this runs on the unwind path too, so
+            // it must not panic-in-panic if TLS is gone or already borrowed.
+            let _ = POLL_REGISTRY.try_with(|reg| {
+                if let Ok(mut reg) = reg.try_borrow_mut() {
+                    // Anything registered re-entrantly during the drain landed
+                    // in `reg`; keep it, ordered after the survivors.
+                    entries.append(&mut reg);
+                    *reg = entries;
+                }
+            });
+        }
+    }
+
+    let mut drained = SpliceBack(POLL_REGISTRY.with(|reg| std::mem::take(&mut *reg.borrow_mut())));
+
+    drained.0.retain_mut(|entry| {
         let elapsed_ms = now.duration_since(entry.last_fired).as_millis() as u64;
         if entry.interval_ms == 0 || elapsed_ms >= entry.interval_ms {
             entry.last_fired = now;
             (entry.run)()
         } else {
-            // Not due this frame — liveness is only judged on a fire, so an
-            // idle poll for a freed signal is reaped on its next due frame.
-            true
+            // Not due this frame, but still reap it if its signal has died —
+            // otherwise reclamation latency would be the poll's own interval.
+            (entry.alive)()
         }
-    });
-
-    POLL_REGISTRY.with(|reg| {
-        let mut reg = reg.borrow_mut();
-        // Anything registered re-entrantly during the drain landed in `reg`;
-        // keep it, ordered after the surviving pre-existing entries.
-        entries.append(&mut reg);
-        *reg = entries;
     });
 }
 
@@ -351,5 +374,81 @@ mod lifetime_tests {
             "the poll fired exactly once for this frame"
         );
         assert_eq!(registry_len_for_tests(), 1);
+    }
+}
+
+#[cfg(test)]
+mod resilience_tests {
+    use super::*;
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    #[test]
+    fn a_panicking_source_does_not_destroy_the_registry() {
+        // `drain_polls` moves the registry out with `mem::take`. Without a
+        // splice-back on the unwind path, a single panicking source would drop
+        // the moved-out Vec and silently unregister every poll on the thread.
+        let survivor_ticks = Rc::new(Cell::new(0));
+        let t = Rc::clone(&survivor_ticks);
+        let _survivor = poll_signal(
+            move || {
+                t.set(t.get() + 1);
+                t.get()
+            },
+            PollRate::EveryFrame,
+        );
+
+        // Panic on call #2. Call #1 is `poll_signal`'s own initial read, which
+        // happens before the registry is ever moved out — panicking there would
+        // exercise nothing.
+        let calls = Rc::new(Cell::new(0));
+        let c = Rc::clone(&calls);
+        let _bad = poll_signal(
+            move || {
+                c.set(c.get() + 1);
+                // Exactly one panic: the follow-up drain below must be able to
+                // fire this entry again to prove the registry still works.
+                if c.get() == 2 {
+                    panic!("poll source blew up");
+                }
+                0u8
+            },
+            PollRate::EveryFrame,
+        );
+        assert_eq!(calls.get(), 1);
+        assert_eq!(registry_len_for_tests(), 2);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(drain_polls));
+        assert!(result.is_err(), "the panic propagates to the caller");
+
+        assert_eq!(
+            registry_len_for_tests(),
+            2,
+            "both polls are still registered after the unwind"
+        );
+
+        // And the registry is still functional.
+        let before = survivor_ticks.get();
+        drain_polls();
+        assert!(survivor_ticks.get() > before, "the survivor still fires");
+    }
+
+    #[test]
+    fn a_not_due_poll_is_still_reaped_once_its_signal_dies() {
+        // Liveness must not be judged only on a fire, or a slow poll would hold
+        // its dead signal's closure for a whole interval.
+        let signal = poll_signal(|| 0u8, PollRate::Millis(60_000));
+        assert_eq!(registry_len_for_tests(), 1);
+
+        // Registration backdates `last_fired` by 1s, so at a 60s interval this
+        // entry is definitively not due.
+        signal.free_for_tests();
+        drain_polls();
+
+        assert_eq!(
+            registry_len_for_tests(),
+            0,
+            "reclamation must not wait for the poll's own interval"
+        );
     }
 }

--- a/crates/rinch-core/src/reactive/signal.rs
+++ b/crates/rinch-core/src/reactive/signal.rs
@@ -4,6 +4,7 @@ use std::cell::RefCell;
 use std::collections::HashSet;
 use std::fmt;
 use std::marker::PhantomData;
+use std::panic::Location;
 
 use super::{ObserverId, RUNTIME, SIGNAL_STORE};
 
@@ -45,13 +46,16 @@ fn panic_read_freed(called: &str) -> ! {
 /// `send`/`update_send` long after the UI that owned the signal was torn down,
 /// and panicking there would take down the app for a write nobody was waiting on.
 ///
-/// `#[track_caller]` makes the dedup key the *user's* call site rather than this
-/// function, so a hot loop warns once while two distinct offending call sites
-/// both get reported.
+/// The caller's location is passed in explicitly rather than read from
+/// `Location::caller()` here. `send`/`update_send` dispatch a closure that
+/// performs the write *later, on another stack*, where `#[track_caller]`
+/// information no longer exists — so they capture their caller's location up
+/// front and hand it down. Reading it here would key every cross-thread write
+/// to one line inside this file, collapsing the per-call-site dedup into a
+/// single global warning.
 #[cold]
 #[inline(never)]
-#[track_caller]
-fn warn_write_to_freed(called: &str) {
+fn warn_write_to_freed(called: &str, loc: &'static Location<'static>) {
     thread_local! {
         /// `(file, line, column)` of call sites already warned about. `file()`
         /// is `&'static str`, so the key borrows nothing.
@@ -59,7 +63,6 @@ fn warn_write_to_freed(called: &str) {
             RefCell::new(HashSet::new());
     }
 
-    let loc = std::panic::Location::caller();
     let first = WARNED.with(|w| {
         w.borrow_mut()
             .insert((loc.file(), loc.line(), loc.column()))
@@ -333,6 +336,13 @@ impl<T: 'static> Signal<T> {
     /// for automatic cross-thread dispatch.
     #[track_caller]
     pub fn set(&self, value: T) {
+        self.set_at(value, Location::caller());
+    }
+
+    /// [`set`](Signal::set), with the reporting location supplied explicitly so
+    /// [`send`](Signal::send) can attribute a deferred cross-thread write to the
+    /// site that requested it.
+    pub(crate) fn set_at(&self, value: T, loc: &'static Location<'static>) {
         if !super::is_main_thread() {
             panic_off_main("set", "send");
         }
@@ -351,7 +361,7 @@ impl<T: 'static> Signal<T> {
         drop(displaced);
         if value.is_some() {
             drop(value);
-            warn_write_to_freed("set");
+            warn_write_to_freed("set", loc);
             return;
         }
         self.notify();
@@ -368,6 +378,15 @@ impl<T: 'static> Signal<T> {
     /// Panics if called from a background thread.
     #[track_caller]
     pub fn set_if_changed(&self, value: T)
+    where
+        T: PartialEq,
+    {
+        self.set_if_changed_at(value, Location::caller());
+    }
+
+    /// [`set_if_changed`](Signal::set_if_changed) with an explicit reporting
+    /// location — see [`set_at`](Signal::set_at).
+    pub(crate) fn set_if_changed_at(&self, value: T, loc: &'static Location<'static>)
     where
         T: PartialEq,
     {
@@ -405,7 +424,7 @@ impl<T: 'static> Signal<T> {
         match outcome {
             Outcome::Freed => {
                 drop(value);
-                warn_write_to_freed("set_if_changed");
+                warn_write_to_freed("set_if_changed", loc);
             }
             Outcome::Unchanged => drop(value),
             Outcome::Changed(displaced) => {
@@ -429,6 +448,12 @@ impl<T: 'static> Signal<T> {
     /// for automatic cross-thread dispatch.
     #[track_caller]
     pub fn update(&self, f: impl FnOnce(&mut T)) {
+        self.update_at(f, Location::caller());
+    }
+
+    /// [`update`](Signal::update) with an explicit reporting location — see
+    /// [`set_at`](Signal::set_at).
+    pub(crate) fn update_at(&self, f: impl FnOnce(&mut T), loc: &'static Location<'static>) {
         if !super::is_main_thread() {
             panic_off_main("update", "update_send");
         }
@@ -448,7 +473,7 @@ impl<T: 'static> Signal<T> {
         });
         if !applied {
             drop(f);
-            warn_write_to_freed("update");
+            warn_write_to_freed("update", loc);
             return;
         }
         self.notify();
@@ -474,13 +499,19 @@ impl<T: Send + 'static> Signal<T> {
     ///     level.send(0.5);
     /// });
     /// ```
+    #[track_caller]
     pub fn send(&self, value: T) {
+        // Captured here, not inside the closure: the closure runs later on the
+        // main thread, where `#[track_caller]` no longer reaches this call site.
+        // Without this every dropped cross-thread write would be attributed to
+        // one line in this file and the warn-once dedup would silence them all.
+        let loc = Location::caller();
         if super::is_main_thread() {
-            self.set(value);
+            self.set_at(value, loc);
         } else {
             let signal = *self;
             super::dispatch_to_main_thread(Box::new(move || {
-                signal.set(value);
+                signal.set_at(value, loc);
             }));
         }
     }
@@ -502,13 +533,16 @@ impl<T: Send + 'static> Signal<T> {
     ///     items.update_send(|list| list.push(4));
     /// });
     /// ```
+    #[track_caller]
     pub fn update_send(&self, f: impl FnOnce(&mut T) + Send + 'static) {
+        // See `send` — the location must be captured before the thread hop.
+        let loc = Location::caller();
         if super::is_main_thread() {
-            self.update(f);
+            self.update_at(f, loc);
         } else {
             let signal = *self;
             super::dispatch_to_main_thread(Box::new(move || {
-                signal.update(f);
+                signal.update_at(f, loc);
             }));
         }
     }
@@ -667,22 +701,61 @@ mod liveness_tests {
     }
 
     #[test]
-    fn a_write_to_a_freed_signal_does_not_notify_surviving_observers() {
-        let dead = Signal::new(0);
-        let live = Signal::new(0);
+    fn a_write_to_a_freed_signal_does_not_notify_its_own_observers() {
+        // The observer must subscribe to `doomed` *before* it is freed —
+        // otherwise the test proves nothing, since an effect that never read
+        // the signal would not re-run either way.
+        let doomed = Signal::new(0);
         let runs = Rc::new(Cell::new(0));
 
         let r = Rc::clone(&runs);
         let _e = Effect::new(move || {
-            let _ = live.get();
+            // try_get, not get: after the free this effect must be able to run
+            // without panicking if anything else queues it.
+            let _ = doomed.try_get();
             r.set(r.get() + 1);
         });
         assert_eq!(runs.get(), 1);
 
-        dead.free_for_tests();
-        dead.set(99);
+        // Positive control: while alive, a write DOES re-run the observer.
+        doomed.set(1);
+        assert_eq!(runs.get(), 2, "control — the effect really observes it");
 
-        assert_eq!(runs.get(), 1, "a dropped write must not flush effects");
+        doomed.free_for_tests();
+        doomed.set(99);
+
+        assert_eq!(runs.get(), 2, "a dropped write must not flush effects");
+    }
+
+    #[test]
+    fn a_deferred_cross_thread_write_reports_the_send_call_site() {
+        // `send`/`update_send` perform the write inside a closure that runs
+        // later, where #[track_caller] no longer reaches the caller. If the
+        // location is not captured up front, every cross-thread freed write
+        // dedups to one line inside signal.rs and all but the first go silent.
+        let before = warn_count_for_tests();
+        let a = Signal::new(0i32);
+        let b = Signal::new(0i32);
+        a.free_for_tests();
+        b.free_for_tests();
+
+        a.send(1);
+        b.send(2);
+
+        assert_eq!(
+            warn_count_for_tests() - before,
+            2,
+            "two distinct send sites must produce two warnings"
+        );
+
+        let c = Signal::new(0i32);
+        c.free_for_tests();
+        c.update_send(|v| *v += 1);
+        assert_eq!(
+            warn_count_for_tests() - before,
+            3,
+            "update_send is attributed to its own call site too"
+        );
     }
 
     #[test]

--- a/crates/rinch-core/src/reactive/signal.rs
+++ b/crates/rinch-core/src/reactive/signal.rs
@@ -1,5 +1,7 @@
 //! Signal: a reactive container that holds a value and notifies subscribers when it changes.
 
+use std::cell::RefCell;
+use std::collections::HashSet;
 use std::fmt;
 use std::marker::PhantomData;
 
@@ -18,6 +20,80 @@ fn panic_off_main(called: &str, alt: &str) -> ! {
          across threads, or wrap the call in `rinch::run_on_main_thread(...)` \
          to schedule it manually."
     );
+}
+
+/// Build the read-after-free panic message used by `get` and `with`.
+///
+/// Reads are strict because there is nothing to return: `T` is not `Default`, so
+/// a lenient read has no value to hand back. Writes take the other branch — see
+/// [`warn_write_to_freed`].
+#[cold]
+#[inline(never)]
+fn panic_read_freed(called: &str) -> ! {
+    panic!(
+        "Signal::{called}() on a freed signal. The scope that owned this signal \
+         was disposed (its component was removed from the tree) while this handle \
+         was still reachable. Guard the read with `signal.is_alive()`, or use \
+         `signal.try_{called}(...)` to get an `Option` instead of panicking."
+    );
+}
+
+/// Warn — at most once per call site — that a write to a freed signal was dropped.
+///
+/// Writes are lenient because the calling thread frequently cannot know the
+/// signal is gone: a detached worker holding a `Copy` handle keeps calling
+/// `send`/`update_send` long after the UI that owned the signal was torn down,
+/// and panicking there would take down the app for a write nobody was waiting on.
+///
+/// `#[track_caller]` makes the dedup key the *user's* call site rather than this
+/// function, so a hot loop warns once while two distinct offending call sites
+/// both get reported.
+#[cold]
+#[inline(never)]
+#[track_caller]
+fn warn_write_to_freed(called: &str) {
+    thread_local! {
+        /// `(file, line, column)` of call sites already warned about. `file()`
+        /// is `&'static str`, so the key borrows nothing.
+        static WARNED: RefCell<HashSet<(&'static str, u32, u32)>> =
+            RefCell::new(HashSet::new());
+    }
+
+    let loc = std::panic::Location::caller();
+    let first = WARNED.with(|w| {
+        w.borrow_mut()
+            .insert((loc.file(), loc.line(), loc.column()))
+    });
+    if !first {
+        return;
+    }
+
+    #[cfg(test)]
+    WARN_COUNT.with(|c| c.set(c.get() + 1));
+
+    tracing::warn!(
+        "Signal::{called}() on a freed signal at {}:{}:{} — the write was dropped. \
+         The scope that owned this signal was disposed while this handle was still \
+         reachable. Check `signal.is_alive()` before writing if the write matters. \
+         (Warned once per call site.)",
+        loc.file(),
+        loc.line(),
+        loc.column(),
+    );
+}
+
+#[cfg(test)]
+thread_local! {
+    /// Number of warnings [`warn_write_to_freed`] actually emitted, i.e. the
+    /// number of *distinct call sites* it saw. Lets the dedup be asserted
+    /// without installing a `tracing` subscriber.
+    static WARN_COUNT: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
+/// Warnings emitted so far on this thread. Test-only.
+#[cfg(test)]
+pub(crate) fn warn_count_for_tests() -> u32 {
+    WARN_COUNT.with(|c| c.get())
 }
 
 /// A reactive container that holds a value and notifies subscribers when it changes.
@@ -150,38 +226,96 @@ impl<T: Clone + 'static> Signal<T> {
     ///
     /// # Panics
     ///
-    /// Panics if the signal has been freed (use-after-free).
+    /// Panics if the signal has been freed (use-after-free). Use
+    /// [`try_get`](Signal::try_get) when the signal may legitimately be gone.
     pub fn get(&self) -> T {
+        match self.try_get() {
+            Some(value) => value,
+            None => panic_read_freed("get"),
+        }
+    }
+
+    /// Get the current value, or `None` if the signal has been freed.
+    ///
+    /// The non-panicking counterpart to [`get`](Signal::get). Still subscribes
+    /// the current observer (if any) when the signal is live, so a `try_get`
+    /// inside an effect is reactive exactly like a `get`.
+    ///
+    /// ```ignore
+    /// // A worker that stops pushing once its UI is gone.
+    /// if let Some(current) = progress.try_get() {
+    ///     progress.set(current + 1);
+    /// }
+    /// ```
+    pub fn try_get(&self) -> Option<T> {
         self.track();
         SIGNAL_STORE.with(|store| {
             let store = store.borrow();
-            let slot = store
-                .get_slot(self.id, self.generation)
-                .expect("Signal::get() on freed signal");
-            slot.value
-                .downcast_ref::<T>()
-                .expect("Signal type mismatch (internal error)")
-                .clone()
+            let slot = store.get_slot(self.id, self.generation)?;
+            Some(
+                slot.value
+                    .downcast_ref::<T>()
+                    .expect("Signal type mismatch (internal error)")
+                    .clone(),
+            )
         })
     }
 }
 
 impl<T: 'static> Signal<T> {
+    /// Whether this signal's backing slot is still live.
+    ///
+    /// A signal is freed when the scope that owns it is disposed. Reads
+    /// ([`get`](Signal::get), [`with`](Signal::with)) panic afterwards and
+    /// writes ([`set`](Signal::set), [`set_if_changed`](Signal::set_if_changed),
+    /// [`update`](Signal::update)) become warn-once no-ops, so this is the check
+    /// to make from a long-lived callback or a background worker holding a
+    /// `Copy` handle.
+    ///
+    /// Nothing frees signals yet — this returns `true` for every signal that was
+    /// ever created. It becomes meaningful when scope-driven disposal lands
+    /// (issue #141).
+    ///
+    /// Does **not** subscribe the current observer — liveness is not reactive,
+    /// and tracking it would resurrect the dependency you are trying to drop.
+    pub fn is_alive(&self) -> bool {
+        SIGNAL_STORE.with(|store| store.borrow().get_slot(self.id, self.generation).is_some())
+    }
+
     /// Get a reference to the current value without cloning.
     ///
     /// If called inside an effect, this automatically subscribes the effect
     /// to this signal.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the signal has been freed. Use [`try_with`](Signal::try_with)
+    /// when the signal may legitimately be gone.
     pub fn with<R>(&self, f: impl FnOnce(&T) -> R) -> R {
+        match self.try_with(f) {
+            Some(result) => result,
+            None => panic_read_freed("with"),
+        }
+    }
+
+    /// Borrow the current value, or return `None` if the signal has been freed.
+    ///
+    /// The non-panicking counterpart to [`with`](Signal::with). `f` is not
+    /// called when the signal is gone.
+    pub fn try_with<R>(&self, f: impl FnOnce(&T) -> R) -> Option<R> {
         self.track();
+        // Hold `f` in an Option so that on the freed path it is dropped *here*,
+        // after the store borrow is released, rather than inside it. `f`'s
+        // captures are user values whose `Drop` may touch signals.
+        let mut f = Some(f);
         SIGNAL_STORE.with(|store| {
             let store = store.borrow();
-            let slot = store
-                .get_slot(self.id, self.generation)
-                .expect("Signal::with() on freed signal");
-            f(slot
-                .value
-                .downcast_ref::<T>()
-                .expect("Signal type mismatch (internal error)"))
+            let slot = store.get_slot(self.id, self.generation)?;
+            Some(f.take().unwrap()(
+                slot.value
+                    .downcast_ref::<T>()
+                    .expect("Signal type mismatch (internal error)"),
+            ))
         })
     }
 
@@ -189,32 +323,50 @@ impl<T: 'static> Signal<T> {
     ///
     /// This will notify all subscribers to re-run.
     ///
+    /// Writing to a **freed** signal is a no-op: it logs a `warn` once per call
+    /// site and returns. See the [module docs](crate::reactive) — you may always
+    /// write to a handle, but you may only read a live one.
+    ///
     /// # Panics
     ///
     /// Panics if called from a background thread. Use [`send()`](Signal::send)
     /// for automatic cross-thread dispatch.
+    #[track_caller]
     pub fn set(&self, value: T) {
         if !super::is_main_thread() {
             panic_off_main("set", "send");
         }
-        SIGNAL_STORE.with(|store| {
+        // Both the incoming value (on the freed path) and the outgoing one
+        // (on the live path) must be dropped *outside* the store borrow: a `T`
+        // whose `Drop` touches a signal would otherwise `BorrowMutError`.
+        let mut value = Some(value);
+        let displaced = SIGNAL_STORE.with(|store| {
             let mut store = store.borrow_mut();
-            let slot = store
-                .get_slot_mut(self.id, self.generation)
-                .expect("Signal::set() on freed signal");
-            slot.value = Box::new(value);
+            let slot = store.get_slot_mut(self.id, self.generation)?;
+            Some(std::mem::replace(
+                &mut slot.value,
+                Box::new(value.take().unwrap()),
+            ))
         });
+        drop(displaced);
+        if value.is_some() {
+            drop(value);
+            warn_write_to_freed("set");
+            return;
+        }
         self.notify();
     }
 
     /// Set the signal's value only if it differs from the current value.
     ///
-    /// Returns `true` if the value was changed (and subscribers notified).
     /// This avoids unnecessary effect re-runs when pushing the same data.
+    ///
+    /// Writing to a **freed** signal is a no-op that warns once per call site.
     ///
     /// # Panics
     ///
     /// Panics if called from a background thread.
+    #[track_caller]
     pub fn set_if_changed(&self, value: T)
     where
         T: PartialEq,
@@ -222,20 +374,44 @@ impl<T: 'static> Signal<T> {
         if !super::is_main_thread() {
             panic_off_main("set_if_changed", "send");
         }
-        let changed = SIGNAL_STORE.with(|store| {
+
+        /// What `set_if_changed` found in the store.
+        enum Outcome {
+            Freed,
+            Unchanged,
+            /// Changed; carries the displaced value so it drops outside the borrow.
+            Changed(Box<dyn std::any::Any>),
+        }
+
+        let mut value = Some(value);
+        let outcome = SIGNAL_STORE.with(|store| {
             let mut store = store.borrow_mut();
-            let slot = store
-                .get_slot_mut(self.id, self.generation)
-                .expect("Signal::set_if_changed() on freed signal");
-            let old = slot.value.downcast_ref::<T>().unwrap();
-            if *old == value {
-                return false;
+            let Some(slot) = store.get_slot_mut(self.id, self.generation) else {
+                return Outcome::Freed;
+            };
+            let old = slot
+                .value
+                .downcast_ref::<T>()
+                .expect("Signal type mismatch (internal error)");
+            if old == value.as_ref().unwrap() {
+                return Outcome::Unchanged;
             }
-            slot.value = Box::new(value);
-            true
+            Outcome::Changed(std::mem::replace(
+                &mut slot.value,
+                Box::new(value.take().unwrap()),
+            ))
         });
-        if changed {
-            self.notify();
+
+        match outcome {
+            Outcome::Freed => {
+                drop(value);
+                warn_write_to_freed("set_if_changed");
+            }
+            Outcome::Unchanged => drop(value),
+            Outcome::Changed(displaced) => {
+                drop(displaced);
+                self.notify();
+            }
         }
     }
 
@@ -243,25 +419,38 @@ impl<T: 'static> Signal<T> {
     ///
     /// This will notify all subscribers to re-run.
     ///
+    /// On a **freed** signal `f` is never called and the update is dropped, with
+    /// a warn once per call site. Side effects in `f` are lost along with it —
+    /// keep them out of the closure if they must happen regardless.
+    ///
     /// # Panics
     ///
     /// Panics if called from a background thread. Use [`update_send()`](Signal::update_send)
     /// for automatic cross-thread dispatch.
+    #[track_caller]
     pub fn update(&self, f: impl FnOnce(&mut T)) {
         if !super::is_main_thread() {
             panic_off_main("update", "update_send");
         }
-        SIGNAL_STORE.with(|store| {
+        // As in `try_with`: on the freed path `f` must drop after the borrow.
+        let mut f = Some(f);
+        let applied = SIGNAL_STORE.with(|store| {
             let mut store = store.borrow_mut();
-            let slot = store
-                .get_slot_mut(self.id, self.generation)
-                .expect("Signal::update() on freed signal");
+            let Some(slot) = store.get_slot_mut(self.id, self.generation) else {
+                return false;
+            };
             let value = slot
                 .value
                 .downcast_mut::<T>()
                 .expect("Signal type mismatch (internal error)");
-            f(value);
+            f.take().unwrap()(value);
+            true
         });
+        if !applied {
+            drop(f);
+            warn_write_to_freed("update");
+            return;
+        }
         self.notify();
     }
 }
@@ -325,6 +514,15 @@ impl<T: Send + 'static> Signal<T> {
     }
 }
 
+#[cfg(test)]
+impl<T: 'static> Signal<T> {
+    /// Free this signal's slot, standing in for the scope disposal that #141's
+    /// dispose fixpoint (PR4) will perform. Test-only.
+    pub(crate) fn free_for_tests(&self) {
+        super::free_signal_for_tests(self.id, self.generation);
+    }
+}
+
 impl<T: fmt::Debug + 'static> fmt::Debug for Signal<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         SIGNAL_STORE.with(|store| {
@@ -358,5 +556,205 @@ impl<T: fmt::Display + 'static> fmt::Display for Signal<T> {
                 write!(f, "<freed signal>")
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod liveness_tests {
+    use super::*;
+    use crate::reactive::Effect;
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    // ---- liveness queries ---------------------------------------------------
+
+    #[test]
+    fn is_alive_flips_when_the_slot_is_freed() {
+        let s = Signal::new(1);
+        assert!(s.is_alive());
+        s.free_for_tests();
+        assert!(!s.is_alive());
+    }
+
+    #[test]
+    fn try_get_and_try_with_return_none_after_free() {
+        let s = Signal::new(7);
+        assert_eq!(s.try_get(), Some(7));
+        assert_eq!(s.try_with(|v| *v + 1), Some(8));
+
+        s.free_for_tests();
+        assert_eq!(s.try_get(), None);
+        assert_eq!(s.try_with(|v| *v + 1), None);
+    }
+
+    #[test]
+    fn try_with_does_not_call_its_closure_on_a_freed_signal() {
+        let calls = Rc::new(Cell::new(0));
+        let s = Signal::new(0);
+        s.free_for_tests();
+
+        let c = Rc::clone(&calls);
+        let out: Option<()> = s.try_with(move |_| c.set(c.get() + 1));
+
+        assert!(out.is_none());
+        assert_eq!(calls.get(), 0, "closure must not run on a freed signal");
+    }
+
+    #[test]
+    fn try_get_subscribes_the_current_observer_just_like_get() {
+        let s = Signal::new(0);
+        let runs = Rc::new(Cell::new(0));
+
+        let r = Rc::clone(&runs);
+        let _e = Effect::new(move || {
+            let _ = s.try_get();
+            r.set(r.get() + 1);
+        });
+        assert_eq!(runs.get(), 1);
+
+        s.set(1);
+        assert_eq!(runs.get(), 2, "try_get must track like get");
+    }
+
+    #[test]
+    #[should_panic(expected = "Signal::get() on a freed signal")]
+    fn get_panics_after_free() {
+        let s = Signal::new(1);
+        s.free_for_tests();
+        let _ = s.get();
+    }
+
+    #[test]
+    #[should_panic(expected = "Signal::with() on a freed signal")]
+    fn with_panics_after_free() {
+        let s = Signal::new(1);
+        s.free_for_tests();
+        s.with(|v| *v);
+    }
+
+    // ---- lenient writes -----------------------------------------------------
+
+    #[test]
+    fn every_write_to_a_freed_signal_is_a_no_op_rather_than_a_panic() {
+        let s = Signal::new(1i32);
+        s.free_for_tests();
+
+        // None of these may panic — a detached worker holding a Copy handle
+        // cannot know the signal is gone (issue #141, SD1).
+        s.set(2);
+        s.set_if_changed(3);
+        s.update(|v| *v += 1);
+
+        assert!(!s.is_alive());
+    }
+
+    #[test]
+    fn update_does_not_run_its_closure_on_a_freed_signal() {
+        let ran = Rc::new(Cell::new(false));
+        let s = Signal::new(0);
+        s.free_for_tests();
+
+        let r = Rc::clone(&ran);
+        s.update(move |v| {
+            *v += 1;
+            r.set(true);
+        });
+
+        assert!(
+            !ran.get(),
+            "the closure — and any side effect in it — is dropped with the write"
+        );
+    }
+
+    #[test]
+    fn a_write_to_a_freed_signal_does_not_notify_surviving_observers() {
+        let dead = Signal::new(0);
+        let live = Signal::new(0);
+        let runs = Rc::new(Cell::new(0));
+
+        let r = Rc::clone(&runs);
+        let _e = Effect::new(move || {
+            let _ = live.get();
+            r.set(r.get() + 1);
+        });
+        assert_eq!(runs.get(), 1);
+
+        dead.free_for_tests();
+        dead.set(99);
+
+        assert_eq!(runs.get(), 1, "a dropped write must not flush effects");
+    }
+
+    #[test]
+    fn a_freed_write_warns_once_per_call_site() {
+        let before = warn_count_for_tests();
+        let s = Signal::new(0);
+        s.free_for_tests();
+
+        // One call site, hammered — exactly one warning.
+        for _ in 0..50 {
+            s.set(1);
+        }
+        assert_eq!(
+            warn_count_for_tests() - before,
+            1,
+            "a hot loop must not spam the log"
+        );
+
+        // A *second*, distinct call site is still reported.
+        s.set(2);
+        assert_eq!(
+            warn_count_for_tests() - before,
+            2,
+            "dedup is per call site, not global"
+        );
+    }
+
+    // ---- values are dropped outside the store borrow ------------------------
+
+    /// A value whose `Drop` writes to another signal — the shape that made
+    /// dropping a displaced value *inside* `SIGNAL_STORE.borrow_mut()` a
+    /// `BorrowMutError`.
+    struct TouchesASignalOnDrop(Signal<i32>);
+
+    impl Drop for TouchesASignalOnDrop {
+        fn drop(&mut self) {
+            self.0.update(|n| *n += 1);
+        }
+    }
+
+    #[test]
+    fn replacing_a_value_whose_drop_touches_a_signal_does_not_reenter_the_store() {
+        let drops = Signal::new(0);
+        let holder = Signal::new(TouchesASignalOnDrop(drops));
+
+        // `set` displaces the old value; it must be dropped after the store
+        // borrow is released, or this is a BorrowMutError.
+        holder.set(TouchesASignalOnDrop(drops));
+        assert_eq!(drops.get(), 1);
+
+        holder.set(TouchesASignalOnDrop(drops));
+        assert_eq!(drops.get(), 2);
+
+        // Free explicitly rather than leaving the value for the thread-local
+        // store's destructor: its `Drop` touches `SIGNAL_STORE`, which is
+        // unreachable once TLS teardown has begun.
+        holder.free_for_tests();
+    }
+
+    #[test]
+    fn discarding_a_write_to_a_freed_signal_drops_the_value_outside_the_store() {
+        let drops = Signal::new(0);
+        let holder = Signal::new(TouchesASignalOnDrop(drops));
+
+        // Freeing drops the stored value, itself outside the borrow.
+        holder.free_for_tests();
+        let after_free = drops.get();
+        assert_eq!(after_free, 1);
+
+        // The incoming value now has nowhere to go; dropping it must also
+        // happen outside the borrow.
+        holder.set(TouchesASignalOnDrop(drops));
+        assert_eq!(drops.get(), after_free + 1);
     }
 }

--- a/crates/rinch/src/app/mod.rs
+++ b/crates/rinch/src/app/mod.rs
@@ -700,9 +700,14 @@ impl RinchApp {
     }
 
     /// Refresh element-bounds signals against the freshly-computed layout.
-    /// Subscribers (e.g. timeline-style widgets reading a strip's measured
-    /// width) re-run inside this borrow, so the document RefCell must be
-    /// borrowed read-only just for the lookup.
+    ///
+    /// Measures every registered node **while holding the document borrow**,
+    /// then releases it before publishing. Subscribers (e.g. timeline-style
+    /// widgets reading a strip's measured width) re-run synchronously inside
+    /// `update_bounds_signals`, and a reactive `style:` closure — the idiom
+    /// [`NodeHandle::bounds_signal`]'s own docs recommend — takes
+    /// `doc.borrow_mut()` to patch the attribute. Publishing under the read
+    /// borrow made that a `BorrowMutError` (#141).
     ///
     /// Called from `resolve_and_repaint` and from `resize_layout` — the resize
     /// path drains the dirty set, so the subsequent paint skips
@@ -710,27 +715,45 @@ impl RinchApp {
     /// (#145).
     fn refresh_bounds_signals(&self) {
         let Some(doc) = &self.doc else { return };
-        let d = doc.borrow();
-        rinch_core::reactive::update_bounds_signals(d.doc_key(), |node_id| {
-            let nid = node_id as usize;
-            let n = d.tree.nodes.get(nid)?;
-            // Walk to root accumulating parent-relative offsets — same
-            // convention as `dispatch_oncontextmenu` / `click_handling`.
-            let mut ax = n.layout.x;
-            let mut ay = n.layout.y;
-            let mut pid = n.parent;
-            while let Some(p) = pid {
-                if let Some(pn) = d.tree.nodes.get(p) {
-                    ax += pn.layout.x;
-                    ay += pn.layout.y;
-                    ax -= pn.scroll_offset.0 as f32;
-                    ay -= pn.scroll_offset.1 as f32;
-                    pid = pn.parent;
-                } else {
-                    break;
-                }
-            }
-            Some((ax, ay, n.layout.width, n.layout.height))
+
+        // Phase 1: measure under the read borrow.
+        let (doc_key, measured) = {
+            let d = doc.borrow();
+            let doc_key = d.doc_key();
+            let measured: Vec<(u64, (f32, f32, f32, f32))> =
+                rinch_core::reactive::registered_bounds_nodes(doc_key)
+                    .into_iter()
+                    .filter_map(|node_id| {
+                        let n = d.tree.nodes.get(node_id as usize)?;
+                        // Walk to root accumulating parent-relative offsets — same
+                        // convention as `dispatch_oncontextmenu` / `click_handling`.
+                        let mut ax = n.layout.x;
+                        let mut ay = n.layout.y;
+                        let mut pid = n.parent;
+                        while let Some(p) = pid {
+                            if let Some(pn) = d.tree.nodes.get(p) {
+                                ax += pn.layout.x;
+                                ay += pn.layout.y;
+                                ax -= pn.scroll_offset.0 as f32;
+                                ay -= pn.scroll_offset.1 as f32;
+                                pid = pn.parent;
+                            } else {
+                                break;
+                            }
+                        }
+                        Some((node_id, (ax, ay, n.layout.width, n.layout.height)))
+                    })
+                    .collect();
+            (doc_key, measured)
+        };
+
+        // Phase 2: publish with no document borrow held, so a woken effect is
+        // free to mutate the DOM.
+        rinch_core::reactive::update_bounds_signals(doc_key, |node_id| {
+            measured
+                .iter()
+                .find(|(id, _)| *id == node_id)
+                .map(|(_, rect)| *rect)
         });
     }
 

--- a/crates/rinch/src/embed.rs
+++ b/crates/rinch/src/embed.rs
@@ -196,6 +196,16 @@ impl RinchContext {
     pub fn update(&mut self, events: &[PlatformEvent]) -> Vec<AppAction> {
         let mut all_actions = Vec::new();
 
+        // Fire due polled signals before anything reads them, mirroring what the
+        // desktop runtime does ahead of each paint. Without this an embedded
+        // context never drained the registry at all, so a `poll_signal` created
+        // inside a `RinchContext` never fired even once (issue #141).
+        //
+        // Draining before the events is deliberate: a poll write and an event
+        // handler can both dirty the tree, and this ordering lets the single
+        // layout pass below absorb both.
+        rinch_core::reactive::drain_polls();
+
         // Process each event
         for event in events {
             let actions = self

--- a/crates/rinch/tests/multi_context.rs
+++ b/crates/rinch/tests/multi_context.rs
@@ -642,3 +642,66 @@ fn set_theme_restyles_only_its_own_context() {
         drop(b);
     });
 }
+
+/// A bounds-driven effect that **mutates the DOM** must not deadlock the
+/// document `RefCell` (#141).
+///
+/// `NodeHandle::bounds_signal`'s own docs recommend reading a measured width
+/// from a reactive `style:` closure. The `rsx!` macro compiles that to an
+/// `Effect` calling `set_attribute`, which takes `doc.borrow_mut()`. The runtime
+/// used to publish bounds while still holding `doc.borrow()`, so the very first
+/// layout pass panicked with `RefCell already borrowed`.
+#[test]
+fn a_bounds_driven_effect_may_patch_the_dom() {
+    on_ui_thread(|| {
+        let observed_width: Rc<Cell<f32>> = Rc::new(Cell::new(-1.0));
+        let seen = observed_width.clone();
+        // As in `bounds_registry_crosstalk_across_documents`: reactive text is
+        // the deterministic way to dirty the DOM so a layout pass definitely
+        // runs and `refresh_bounds_signals` is reached.
+        let dirty = Signal::new(0i32);
+
+        let mut ctx = RinchContext::new(cfg(), move |__scope: &mut RenderScope| {
+            let root = __scope.create_element("div");
+            let measured = __scope.create_element("div");
+            measured.set_attribute("style", "width: 120px; height: 40px;");
+            root.append_child(&measured);
+
+            let bar = __scope.create_element("div");
+            root.append_child(&bar);
+
+            let text = __scope.create_text("0");
+            root.append_child(&text);
+            let text_handle = text.clone();
+            __scope.create_effect(move || {
+                text_handle.set_text(&dirty.get().to_string());
+            });
+
+            // The documented idiom: react to the measured rect by patching
+            // another node's style.
+            let bounds = measured.bounds_signal();
+            let bar_handle = bar.clone();
+            let seen = seen.clone();
+            __scope.create_effect(move || {
+                let b = bounds.get();
+                seen.set(b.width);
+                bar_handle.set_attribute("style", &format!("width: {}px;", b.width));
+            });
+
+            root
+        });
+
+        // Pre-fix this panicked inside `refresh_bounds_signals` with
+        // "RefCell already borrowed".
+        dirty.set(1);
+        ctx.update(&[]);
+
+        assert_eq!(
+            observed_width.get(),
+            120.0,
+            "the effect ran and saw the measured width"
+        );
+
+        drop(ctx);
+    });
+}


### PR DESCRIPTION
Second PR of #141 (reactive resources are never freed), on top of PR0 (#170, merged as `5add79b`). Design: [the recommendations comment on #141](https://github.com/joeleaver/rinch/issues/141#issuecomment-5094329350); the five maintainer calls are [recorded here](https://github.com/joeleaver/rinch/issues/141#issuecomment-5096432729).

**Still frees nothing** — PR4 does that. This lands the vocabulary disposal needs, plus the registry changes that would otherwise spin forever on dead handles once it arrives.

## The contract (SD1)

> **You may always write to a handle; you may only read a live one.**

- New: `Signal::is_alive/try_get/try_with`, `Memo::is_alive/try_get`.
- `set`/`set_if_changed`/`update` on a freed signal become no-ops that warn once per call site.
- `get`/`with`/`Memo::get` still panic, with messages that name the fix.
- `DragContext::get/take/is_active` moved onto `try_get` — it is `Copy` and routinely outlives its source component.

Reads stay strict because `T: !Default` leaves a freed read nothing to return. Writes must be lenient because the writer usually cannot know: `ui-zoo`'s av section spawns an **uncancellable** `loop { sleep(50ms); audio_level.send(..) }` from a disposable match arm, so strict writes would panic on the main thread every 50ms, forever, in our own flagship example.

## Self-pruning registries (SD3)

`PollEntry::run` returns the driven signal's liveness and `drain_polls` drops entries that report dead; `update_bounds_signals` reaps the same way. The reap spans **all** documents — scoping it to the updating document would strand the entries of a dropped `RinchContext` (#134), which is the leak being fixed.

## Bug fixes that stand on their own

Independent of #141, each with a regression test verified failing first:

1. **Two latent `BorrowMutError`s.** Both registries now run user code with no borrow held. A `poll_signal` from inside a poll source, or a `register_bounds_signal` from inside a bounds-driven effect, used to panic.
2. **The documented `bounds_signal()` idiom panicked.** `refresh_bounds_signals` held `doc.borrow()` across the writes, which flush effects synchronously — and the idiom `NodeHandle::bounds_signal` documents (a reactive `style:` closure reading a measured width) patches the DOM, taking `borrow_mut`. Now measures under the read borrow, releases it, then publishes.
3. **`Signal::set` dropped the displaced value inside the store borrow.** A `T` whose `Drop` touched a signal was a `BorrowMutError`. `SignalStore::free`/`MemoStore::free` return their value for the same reason (SD4 needs this).
4. **Embed never drained polls.** `RinchContext::update` now calls `drain_polls()`, so a `poll_signal` created in an embedded context fires at all. (Maintainer call 2.)

## Adversarial review

A four-lens review (borrow discipline, semantic regressions, lifetime correctness, test quality) with per-finding refutation ran over the first commit. It found **six real defects**, all fixed in `cbd7989` and each reproduced by hand before fixing. Two were serious:

- **Freeing a memo freed nothing, then panicked its dependents.** `Memo::new` puts two strong `Rc<MemoInner>` into two registries — one in `MEMO_STORE`, one captured by the dirty-marker closure in `EFFECTS`. Dropping only the store slot left the cached value and closure alive (`Rc::strong_count` stayed at 2) *and* left the marker subscribed, so the next write to a dependency re-queued the memo's dependents, whose `get()` panicked on the empty slot. `MemoSlot` now records the marker's `ObserverId` — the slot is type-erased, so a dispose pass cannot downcast to reach it — and `free_memo` clears both. **PR4 would have hit this.**
- **`send`/`update_send` collapsed the warn dedup.** They write inside a closure that runs later on another stack, where `#[track_caller]` no longer reaches the caller, so every dropped cross-thread write was attributed to one line in `signal.rs` — first one warns, all others silent. That is exactly the path lenient writes exist for. The location is now captured before the thread hop.

Also fixed: a panicking poll source destroyed the whole registry (a regression the `mem::take` introduced — splice-back now runs from a `Drop` guard); reclamation latency equalled the poll's own interval; and two tests were weaker than they looked (one vacuous, two asserting only registry length).

## Tests

27 new tests. **Nine pin bugs and were verified failing pre-fix** by reverting mechanism bodies in place — mechanisms and tests share files here, so `git stash` gives no clean counterfactual:

| Test | Pre-fix |
|---|---|
| `a_poll_source_may_register_another_poll` | RefCell already borrowed |
| `a_reentrant_drain_is_a_no_op_rather_than_a_double_fire` | RefCell already borrowed |
| `a_lookup_may_register_another_bounds_signal` | RefCell already borrowed |
| `a_bounds_driven_effect_may_read_a_bounds_signal` | RefCell already borrowed |
| `a_bounds_driven_effect_may_patch_the_dom` (multi_context) | RefCell already borrowed |
| `replacing_a_value_whose_drop_touches_a_signal...` | abort during TLS teardown |
| `discarding_a_write_to_a_freed_signal...` | RefCell already borrowed |
| `a_panicking_source_does_not_destroy_the_registry` | registry emptied by the unwind |
| `a_not_due_poll_is_still_reaped_once_its_signal_dies` | entry survives its dead signal |

Two more pin the memo defect (`freeing_a_memo_releases_its_computation_closure`, `a_dependent_of_a_freed_memo_is_not_re_queued_by_its_sources`) and one the dedup (`a_deferred_cross_thread_write_reports_the_send_call_site`). The rest pin the new contract. Liveness is exercised through `#[cfg(test)]` `free_for_tests` helpers, since no production path frees anything yet.

**One of my own tests was caught mid-review as vacuous** — it registered a nested poll during `poll_signal`'s *initial* source read rather than during the drain, so it passed against the pre-fix implementation. Same trap bit a second test later. Both fixed; worth knowing when writing more of these.

## Verification

- Full gate: fmt, workspace clippy `-D warnings`, workspace tests, all three CI feature combinations, wasm clippy across the six wasm crates.
- Live app: `ui-zoo-desktop` (navigation across scope disposal, controlled `TextInput`, dark-mode toggle) and `drag-and-drop-demo` (cross-column drop through the real `DragContext` path). `game-embed` ran 25s clean, exercising the new `drain_polls` in `RinchContext::update`.

## Spun off, not fixed here

- **#171** — `Effect::dispose` never unsubscribes from signals it read (maintainer call 4).
- **#172** — embed registers the main thread but no cross-thread dispatcher, so `Signal::send` from a worker **panics** in an embedded context. Same family as the `drain_polls` gap, bigger fix.
- **#173** — the drag ghost leaves stale pixels when a drag ends outside a drop target. Pre-existing; reproduced on `main` with no local changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)