### PR TITLE
fix(rinch-core,rinch,rinch-web): #141 PR2 — ambient owner plumbing

### DIFF
--- a/crates/rinch-core/src/dom/mod.rs
+++ b/crates/rinch-core/src/dom/mod.rs
@@ -732,7 +732,14 @@ where
         // Render fresh
         if let Some(doc) = doc_weak.upgrade() {
             let mut child_scope = RenderScope::new(doc, parent_id);
-            let node = render_fn(&mut child_scope);
+            // The component's own resources belong to its own scope, not to the
+            // effect that re-renders it (issue #141). This is the deepest reach
+            // of the ambient owner: `render_fn` runs arbitrary user
+            // `Component::render` code.
+            let node = {
+                let _owner = child_scope.push_owner();
+                render_fn(&mut child_scope)
+            };
             m.insert_after(&node);
             cc.borrow_mut().push(node);
             *cs.borrow_mut() = Some(child_scope);
@@ -750,6 +757,55 @@ where
 mod tests {
     use super::*;
     use mock::MockDomDocument;
+
+    /// A component's own resources are attributed to the component's child
+    /// scope, not to the effect that re-renders it (issue #141).
+    ///
+    /// This is the deepest reach of the ambient owner: `render_fn` runs
+    /// arbitrary user `Component::render` code, and it is always inside
+    /// `run_effect`, so the item guard has to nest under the effect's push.
+    #[test]
+    fn a_component_body_is_attributed_to_its_own_child_scope() {
+        use crate::reactive::{Owner, Signal, current_owner};
+
+        let doc = Rc::new(RefCell::new(MockDomDocument::new()));
+        let body = doc.borrow().body();
+        let mut scope = RenderScope::new(doc.clone(), body);
+        let parent = scope.parent();
+
+        let version = Signal::new(0);
+        let seen: Rc<RefCell<Vec<Option<Owner>>>> = Rc::new(RefCell::new(Vec::new()));
+
+        let log = seen.clone();
+        let marker = reactive_component_dom(&mut scope, &parent, move |s: &mut RenderScope| {
+            version.get();
+            log.borrow_mut().push(current_owner());
+            Signal::new(0);
+            s.create_element("div")
+        });
+        let _ = marker;
+
+        version.set(1); // re-render: disposes the old child scope, builds a new one
+
+        let seen = seen.borrow();
+        assert_eq!(seen.len(), 2, "initial render plus one re-render");
+
+        let first = seen[0].clone().expect("the component runs under an owner");
+        let second = seen[1].clone().expect("the component runs under an owner");
+        assert_ne!(first, second, "each re-render gets a fresh child scope");
+        assert_ne!(
+            second,
+            scope.owner(),
+            "the component is not attributed to the scope that hosts it"
+        );
+        assert!(!first.is_alive(), "the previous child scope was disposed");
+        assert_eq!(
+            second.owned_counts().map(|c| c.signals),
+            Some(1),
+            "the component owns the signal its body created"
+        );
+        assert_eq!(scope.owned_counts().signals, 0);
+    }
 
     #[test]
     fn test_node_handle_text() {

--- a/crates/rinch-core/src/dom/render_scope.rs
+++ b/crates/rinch-core/src/dom/render_scope.rs
@@ -110,9 +110,48 @@ impl RenderScope {
         NodeHandle::new(node_id, self.doc.clone())
     }
 
+    /// Make this scope the ambient owner until the returned guard drops.
+    ///
+    /// Resources created while the guard is live — signals, memos, effects,
+    /// event handlers — are attributed to this scope (issue #141). The render
+    /// sites wrap exactly the user render call:
+    ///
+    /// ```ignore
+    /// let node = { let _owner = child_scope.push_owner(); view(&item, &mut child_scope) };
+    /// ```
+    ///
+    /// Takes `&self` and returns a lifetime-free guard, so the `&mut` borrow of
+    /// the same scope on the next line is still legal.
+    #[doc(hidden)]
+    pub fn push_owner(&self) -> crate::reactive::OwnerGuard {
+        self.reactive_scope.push_owner()
+    }
+
+    /// What this scope owns. See [`OwnedCounts`](crate::reactive::OwnedCounts).
+    #[doc(hidden)]
+    pub fn owned_counts(&self) -> crate::reactive::OwnedCounts {
+        self.reactive_scope.owned_counts()
+    }
+
+    /// A non-owning reference to this scope's reactive scope, for comparison
+    /// and diagnostics. See [`Owner`](crate::reactive::Owner).
+    #[doc(hidden)]
+    pub fn owner(&self) -> crate::reactive::Owner {
+        self.reactive_scope.owner()
+    }
+
     /// Create a child scope for nested rendering.
     ///
     /// Child scopes are cleaned up when the parent scope is disposed.
+    ///
+    /// # Warning
+    ///
+    /// Resources created through the returned `&mut` are attributed to the
+    /// **ambient** owner — normally the parent — not to the child, because the
+    /// returned reference outlives any guard this method could hand back. Its
+    /// only caller is a test; prefer [`RenderScope::new`] plus
+    /// [`push_owner`](RenderScope::push_owner).
+    #[doc(hidden)]
     pub fn child_scope(&mut self, parent: &NodeHandle) -> &mut RenderScope {
         let scope = RenderScope::new(self.doc().expect("Document dropped"), parent.node_id);
         self.children.push(scope);

--- a/crates/rinch-core/src/events/handlers.rs
+++ b/crates/rinch-core/src/events/handlers.rs
@@ -164,6 +164,14 @@ pub fn next_handler_id() -> EventHandlerId {
 }
 
 /// Reset the handler ID counter (useful for testing or re-rendering).
+///
+/// # Warning
+///
+/// Rewinding a process-global counter aliases any [`EventHandlerId`] still
+/// recorded against a live scope (issue #141): a later registration can reuse an
+/// id that a surviving scope still believes it owns. This is safe today only
+/// because every production caller runs at startup, before any scope exists.
+/// Do not call it once a tree is mounted.
 pub fn reset_handler_ids() {
     NEXT_HANDLER_ID.store(0, Ordering::SeqCst);
 }
@@ -185,6 +193,30 @@ pub fn remove_handlers_in_range(start: EventHandlerId, end: EventHandlerId) {
     INPUT_REGISTRY.with(|r| r.borrow_mut().handlers.retain(|k, _| !range.contains(&k.0)));
     FILE_DROP_REGISTRY.with(|r| r.borrow_mut().handlers.retain(|k, _| !range.contains(&k.0)));
     SCROLL_REGISTRY.with(|r| r.borrow_mut().handlers.retain(|k, _| !range.contains(&k.0)));
+}
+
+/// Remove a single handler, by id, from whichever registry holds it.
+///
+/// The per-id counterpart of [`remove_handlers_in_range`], which #141's dispose
+/// fixpoint (PR4) needs: id *ranges* do not nest correctly once several roots
+/// interleave registrations, but a scope's recorded ids always do.
+///
+/// Each removed callback is moved into a local and dropped **after** its
+/// registry borrow is released. The callbacks are `Rc<dyn Fn(..)>` closing over
+/// arbitrary user state whose `Drop` may touch these same registries, and
+/// `remove_handlers_in_range`'s `retain` drops them *inside* the borrow.
+///
+/// Not yet reachable from production code — PR4 wires it in.
+#[allow(dead_code)]
+pub fn unregister_handler(id: EventHandlerId) {
+    let click = EVENT_REGISTRY.with(|r| r.borrow_mut().handlers.remove(&id));
+    drop(click);
+    let input = INPUT_REGISTRY.with(|r| r.borrow_mut().handlers.remove(&id));
+    drop(input);
+    let file_drop = FILE_DROP_REGISTRY.with(|r| r.borrow_mut().handlers.remove(&id));
+    drop(file_drop);
+    let scroll = SCROLL_REGISTRY.with(|r| r.borrow_mut().handlers.remove(&id));
+    drop(scroll);
 }
 
 // Thread-local event handler registry.
@@ -281,8 +313,17 @@ pub fn register_handler(callback: EventCallback) -> EventHandlerId {
     // the handler was built under — a handler inside a mounted root resolves
     // that root's stores/contexts (issue #136).
     let root = crate::context::current_context_root();
+    // Attribute the handler to the scope registering it, and re-enter that scope
+    // on dispatch so a `Signal::new` inside the callback belongs to the
+    // component that installed it (issue #141). `Owner` is a `Weak`, so the
+    // capture does not keep the scope alive — unlike `root`, which is a `Copy`
+    // `u64` and retains nothing, this is the edge that would make every desktop
+    // scope immortal if it were strong.
+    crate::reactive::record_handler(id);
+    let owner = crate::reactive::Owner::current();
     let callback: EventCallback = Rc::new(move || {
         let _root = crate::context::push_context_root(root);
+        let _owner = owner.push();
         callback();
     });
     EVENT_REGISTRY.with(|registry| {
@@ -372,10 +413,14 @@ pub fn dispatch_event(id: EventHandlerId) -> bool {
 #[doc(hidden)]
 pub fn register_input_handler(callback: InputCallback) -> EventHandlerId {
     let id = next_handler_id();
-    // Re-enter the registration-time context root on dispatch (issue #136).
+    // Re-enter the registration-time context root and owner on dispatch
+    // (issues #136, #141).
     let root = crate::context::current_context_root();
+    crate::reactive::record_handler(id);
+    let owner = crate::reactive::Owner::current();
     let callback = InputCallback::new(move |value| {
         let _root = crate::context::push_context_root(root);
+        let _owner = owner.push();
         callback.invoke(value);
     });
     INPUT_REGISTRY.with(|registry| {
@@ -430,10 +475,14 @@ pub fn dispatch_input_event(id: EventHandlerId, value: String) -> bool {
 #[doc(hidden)]
 pub fn register_file_drop_handler(callback: FileDropCallback) -> EventHandlerId {
     let id = next_handler_id();
-    // Re-enter the registration-time context root on dispatch (issue #136).
+    // Re-enter the registration-time context root and owner on dispatch
+    // (issues #136, #141).
     let root = crate::context::current_context_root();
+    crate::reactive::record_handler(id);
+    let owner = crate::reactive::Owner::current();
     let callback = FileDropCallback::new(move |paths| {
         let _root = crate::context::push_context_root(root);
+        let _owner = owner.push();
         callback.invoke(paths);
     });
     FILE_DROP_REGISTRY.with(|registry| {
@@ -463,10 +512,14 @@ pub fn dispatch_file_drop_event(id: EventHandlerId, paths: Vec<PathBuf>) -> bool
 #[doc(hidden)]
 pub fn register_scroll_handler(callback: ScrollCallback) -> EventHandlerId {
     let id = next_handler_id();
-    // Re-enter the registration-time context root on dispatch (issue #136).
+    // Re-enter the registration-time context root and owner on dispatch
+    // (issues #136, #141).
     let root = crate::context::current_context_root();
+    crate::reactive::record_handler(id);
+    let owner = crate::reactive::Owner::current();
     let callback = ScrollCallback::new(move |scroll_top| {
         let _root = crate::context::push_context_root(root);
+        let _owner = owner.push();
         callback.invoke(scroll_top);
     });
     SCROLL_REGISTRY.with(|registry| {
@@ -523,4 +576,157 @@ pub fn clear_handlers() {
 /// Get the number of registered handlers (for debugging).
 pub fn handler_count() -> usize {
     EVENT_REGISTRY.with(|registry| registry.borrow().handlers.len())
+}
+
+#[cfg(test)]
+mod owner_tests {
+    //! A signal created inside an event handler belongs to the scope that
+    //! *registered* the handler (issue #141, maintainer decision 1).
+    //!
+    //! Dispatch happens from the event loop with an empty owner stack, so
+    //! without the re-entry in the registration wrapper these signals would have
+    //! app lifetime and never be reclaimed.
+    //!
+    //! # Harness note
+    //!
+    //! `NEXT_HANDLER_ID` is a **process-global** `AtomicUsize` while the
+    //! registries are thread-local, and `clear_handlers()` — which other tests
+    //! call from other threads — rewinds it. A test that registers two handlers
+    //! into the *same* registry could therefore see the second overwrite the
+    //! first. Hence: one handler per registry per test.
+
+    use super::*;
+    use crate::reactive::{Scope, Signal, current_owner};
+
+    /// Register one handler under `scope`, dispatch it from an empty owner
+    /// stack, and report what the callback saw.
+    fn check_handler_owner(
+        scope: &Scope,
+        register: impl FnOnce() -> EventHandlerId,
+        dispatch: impl FnOnce(EventHandlerId) -> bool,
+    ) {
+        let id = {
+            let _owner = scope.push_owner();
+            register()
+        };
+        assert_eq!(
+            scope.owned_counts().handlers,
+            1,
+            "the handler is attributed at registration time"
+        );
+
+        assert!(
+            current_owner().is_none(),
+            "dispatch must run from an empty owner stack for this to prove anything"
+        );
+        assert!(dispatch(id), "the handler must have been found");
+
+        assert!(
+            current_owner().is_none(),
+            "the wrapper's owner push must be RAII"
+        );
+        assert_eq!(
+            scope.owned_counts().signals,
+            1,
+            "a signal created inside the handler belongs to the registering scope"
+        );
+    }
+
+    #[test]
+    fn a_signal_created_in_a_click_handler_belongs_to_the_registering_scope() {
+        let scope = Scope::new();
+        check_handler_owner(
+            &scope,
+            || {
+                register_handler(Rc::new(|| {
+                    Signal::new(0);
+                }))
+            },
+            dispatch_event,
+        );
+    }
+
+    #[test]
+    fn a_signal_created_in_an_input_handler_belongs_to_the_registering_scope() {
+        let scope = Scope::new();
+        check_handler_owner(
+            &scope,
+            || {
+                register_input_handler(InputCallback::new(|_value: String| {
+                    Signal::new(0);
+                }))
+            },
+            |id| dispatch_input_event(id, "hello".into()),
+        );
+    }
+
+    #[test]
+    fn a_signal_created_in_a_file_drop_handler_belongs_to_the_registering_scope() {
+        let scope = Scope::new();
+        check_handler_owner(
+            &scope,
+            || {
+                register_file_drop_handler(FileDropCallback::new(|_paths: Vec<PathBuf>| {
+                    Signal::new(0);
+                }))
+            },
+            |id| dispatch_file_drop_event(id, Vec::new()),
+        );
+    }
+
+    #[test]
+    fn a_signal_created_in_a_scroll_handler_belongs_to_the_registering_scope() {
+        let scope = Scope::new();
+        check_handler_owner(
+            &scope,
+            || {
+                register_scroll_handler(ScrollCallback::new(|_top: f64| {
+                    Signal::new(0);
+                }))
+            },
+            |id| dispatch_scroll_event(id, 12.0),
+        );
+    }
+
+    /// A handler that dispatches another handler nests the owner pushes, so each
+    /// callback's allocations land in its own registering scope.
+    ///
+    /// The two handlers deliberately live in **different registries**: that makes
+    /// the test immune to the process-global id counter being rewound between
+    /// the two registrations (see the module note).
+    #[test]
+    fn a_re_entrant_dispatch_nests_owner_pushes() {
+        let outer = Scope::new();
+        let inner = Scope::new();
+
+        let inner_id = {
+            let _owner = inner.push_owner();
+            register_input_handler(InputCallback::new(|_value: String| {
+                Signal::new(0);
+            }))
+        };
+
+        let outer_id = {
+            let _owner = outer.push_owner();
+            register_handler(Rc::new(move || {
+                Signal::new(0); // before the nested dispatch
+                assert!(dispatch_input_event(inner_id, "x".into()));
+                Signal::new(0); // after it — the outer owner must be restored
+            }))
+        };
+
+        assert!(dispatch_event(outer_id));
+
+        assert_eq!(
+            outer.owned_counts().signals,
+            2,
+            "both of the outer handler's signals belong to the outer scope"
+        );
+        assert_eq!(
+            inner.owned_counts().signals,
+            1,
+            "the nested handler's signal belongs to the inner scope"
+        );
+        assert!(current_owner().is_none(), "the stack drains completely");
+    }
 }

--- a/crates/rinch-core/src/for_loop.rs
+++ b/crates/rinch-core/src/for_loop.rs
@@ -164,7 +164,13 @@ where
         for item in initial_items {
             if let Some(doc) = doc_weak.upgrade() {
                 let mut child_scope = RenderScope::new(doc, parent_id);
-                let node = view(&item, &mut child_scope);
+                // Each item owns what its view creates (issue #141). The guard
+                // ends before `state.insert` below, which can displace — and so
+                // dispose — a live item scope on a duplicate key.
+                let node = {
+                    let _owner = child_scope.push_owner();
+                    view(&item, &mut child_scope)
+                };
 
                 if initial_nodes.is_empty() {
                     marker.insert_after(&node);
@@ -242,8 +248,15 @@ where
                         // Wrap in untracked so signal reads during view rendering
                         // don't subscribe the for-loop's parent effect. Items create
                         // their own effects for reactivity via {|| expr} closures.
-                        let node =
-                            crate::reactive::untracked(|| view_clone(item, &mut child_scope));
+                        //
+                        // The owner guard is a separate stack from `untracked`'s
+                        // observer stack (issue #141). It must stay inside this
+                        // match arm: the `Remove` arm disposes scopes, and that
+                        // must run under the reconcile effect's owner.
+                        let node = {
+                            let _owner = child_scope.push_owner();
+                            crate::reactive::untracked(|| view_clone(item, &mut child_scope))
+                        };
 
                         // Insert at the correct position as sibling.
                         // Find the node to insert after: either the previous
@@ -353,8 +366,13 @@ where
                                 old_scope.dispose();
                             }
                             let mut child_scope = RenderScope::new(doc, parent_id);
-                            let new_node =
-                                crate::reactive::untracked(|| view_clone(item, &mut child_scope));
+                            // The re-rendered item owns its new resources
+                            // (issue #141); the old scope was disposed above,
+                            // under the reconcile effect's owner.
+                            let new_node = {
+                                let _owner = child_scope.push_owner();
+                                crate::reactive::untracked(|| view_clone(item, &mut child_scope))
+                            };
                             old_state.node.insert_after(&new_node);
                             old_state.node.remove();
                             old_state.node = new_node;
@@ -529,6 +547,92 @@ mod tests {
     struct TestItem {
         id: String,
         name: String,
+    }
+
+    /// Each item body is attributed to that item's own child scope, across all
+    /// three of the `for` loop's render sites: the initial build, an `Insert`
+    /// during reconcile, and a data-change re-render (issue #141).
+    ///
+    /// Also proves the item guards nest correctly *inside* `run_effect`'s push —
+    /// the reconcile effect is itself running with its own owner ambient when
+    /// sites 7 and 8 fire.
+    #[test]
+    fn an_item_body_is_attributed_to_its_own_item_scope() {
+        use crate::dom::traits::DomDocument;
+        use crate::dom::{RenderScope, mock::MockDomDocument};
+        use crate::reactive::{Owner, Signal, current_owner};
+        use std::cell::RefCell;
+
+        let doc = Rc::new(RefCell::new(MockDomDocument::new()));
+        let body = doc.borrow().body();
+        let mut scope = RenderScope::new(doc.clone(), body);
+        let parent = scope.parent();
+
+        let items = Signal::new(vec![TestItem {
+            id: "a".into(),
+            name: "A".into(),
+        }]);
+        #[allow(clippy::type_complexity)]
+        let seen: Rc<RefCell<Vec<(String, Option<Owner>)>>> = Rc::new(RefCell::new(Vec::new()));
+
+        let log = seen.clone();
+        let marker = super::for_each_dom_typed(
+            &mut scope,
+            &parent,
+            move || items.get(),
+            |item: &TestItem| item.id.clone(),
+            move |item: TestItem, s: &mut RenderScope| {
+                log.borrow_mut().push((item.name.clone(), current_owner()));
+                Signal::new(0);
+                s.create_element("div")
+            },
+        );
+        let _ = marker;
+
+        // Site 7: reconcile inserts a new key.
+        items.update(|v| {
+            v.push(TestItem {
+                id: "b".into(),
+                name: "B".into(),
+            })
+        });
+        // Site 8: an existing key's data changes, forcing a re-render.
+        items.update(|v| v[0].name = "A2".into());
+
+        let seen = seen.borrow();
+        let names: Vec<&str> = seen.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, ["A", "B", "A2"], "all three render sites fired");
+
+        let owners: Vec<Owner> = seen
+            .iter()
+            .map(|(n, o)| o.clone().unwrap_or_else(|| panic!("{n} ran with no owner")))
+            .collect();
+
+        for (i, owner) in owners.iter().enumerate() {
+            assert_ne!(
+                *owner,
+                scope.owner(),
+                "render {i} must not be attributed to the parent scope"
+            );
+            for (j, other) in owners.iter().enumerate().skip(i + 1) {
+                assert_ne!(*owner, *other, "renders {i} and {j} must have own scopes");
+            }
+        }
+
+        assert!(
+            !owners[0].is_alive(),
+            "the re-rendered item's original scope was disposed"
+        );
+        assert_eq!(
+            owners[1].owned_counts().map(|c| c.signals),
+            Some(1),
+            "the inserted item owns its own signal"
+        );
+        assert_eq!(
+            owners[2].owned_counts().map(|c| c.signals),
+            Some(1),
+            "the re-rendered item owns its own signal"
+        );
     }
 
     #[test]

--- a/crates/rinch-core/src/lib.rs
+++ b/crates/rinch-core/src/lib.rs
@@ -46,11 +46,11 @@ pub use timer::{TimeoutHandle, clear_timeout, fire_timeout, set_timeout, set_tim
 
 // Re-export reactive types for convenience
 pub use reactive::{
-    Effect, ElementBounds, Memo, PollRate, Scope, Signal, SignalChangeSubscription, batch,
-    clear_on_signal_change, clear_signals_changed, derived, drain_polls, poll_signal,
-    register_bounds_signal, register_main_thread, run_on_main_thread, set_cross_thread_dispatcher,
-    set_on_signal_change, signals_changed, subscribe_signal_change, untracked,
-    update_bounds_signals,
+    Effect, ElementBounds, Memo, OwnedCounts, Owner, PollRate, Scope, Signal,
+    SignalChangeSubscription, batch, clear_on_signal_change, clear_signals_changed, current_owner,
+    derived, drain_polls, poll_signal, register_bounds_signal, register_main_thread,
+    run_on_main_thread, set_cross_thread_dispatcher, set_on_signal_change, signals_changed,
+    subscribe_signal_change, unowned, untracked, update_bounds_signals,
 };
 
 // Re-export context for sharing state across components

--- a/crates/rinch-core/src/match_dom.rs
+++ b/crates/rinch-core/src/match_dom.rs
@@ -79,7 +79,12 @@ where
     ) {
         if let Some(doc) = doc_weak.upgrade() {
             let mut child_scope = RenderScope::new(doc, parent_id);
-            let content = branch_fn(&mut child_scope);
+            // Attribute the branch's resources to the branch's own scope
+            // (issue #141). Covers the initial render and the arm swap alike.
+            let content = {
+                let _owner = child_scope.push_owner();
+                branch_fn(&mut child_scope)
+            };
             marker.insert_after(&content);
             current_content.borrow_mut().push(content);
             *current_scope.borrow_mut() = Some(child_scope);
@@ -146,4 +151,67 @@ where
     scope.create_effect_from(effect);
 
     marker
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::dom::traits::DomDocument;
+    use crate::dom::{RenderScope, mock::MockDomDocument};
+    use crate::reactive::{Owner, Signal, current_owner};
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    /// Each `match` arm body is attributed to that arm's own child scope, and
+    /// switching arms disposes the outgoing one (issue #141).
+    ///
+    /// Both entry paths — the initial render and the effect-driven arm swap —
+    /// run through the same `render_branch` helper, so one guard covers both.
+    #[test]
+    fn an_arm_body_is_attributed_to_its_own_child_scope() {
+        let doc = Rc::new(RefCell::new(MockDomDocument::new()));
+        let body = doc.borrow().body();
+        let mut scope = RenderScope::new(doc.clone(), body);
+        let parent = scope.parent();
+
+        let which = Signal::new(0usize);
+        let seen: Rc<RefCell<Vec<Option<Owner>>>> = Rc::new(RefCell::new(Vec::new()));
+
+        let branches: Vec<super::BranchFn> = (0..2)
+            .map(|_| {
+                let log = seen.clone();
+                Box::new(move |s: &mut RenderScope| {
+                    log.borrow_mut().push(current_owner());
+                    Signal::new(0);
+                    s.create_element("div")
+                }) as super::BranchFn
+            })
+            .collect();
+
+        let marker = super::match_dom(&mut scope, &parent, move || which.get(), branches);
+        let _ = marker;
+
+        which.set(1); // swap arms
+
+        let seen = seen.borrow();
+        assert_eq!(seen.len(), 2, "initial render plus one arm swap");
+
+        let first = seen[0].clone().expect("an arm runs under an owner");
+        let second = seen[1].clone().expect("an arm runs under an owner");
+        assert_ne!(first, second, "each arm gets its own child scope");
+        assert_ne!(
+            second,
+            scope.owner(),
+            "an arm is not attributed to the scope hosting the `match`"
+        );
+        assert!(
+            !first.is_alive(),
+            "switching arms disposed the outgoing one"
+        );
+        assert_eq!(
+            second.owned_counts().map(|c| c.signals),
+            Some(1),
+            "the live arm owns the signal its body created"
+        );
+        assert_eq!(scope.owned_counts().signals, 0);
+    }
 }

--- a/crates/rinch-core/src/reactive/effect.rs
+++ b/crates/rinch-core/src/reactive/effect.rs
@@ -40,6 +40,13 @@ pub(super) struct EffectInner {
     /// every run so `use_context`/`use_store` resolve the same namespace as at
     /// build time (issue #136). `0` = the thread-global fallback root.
     pub(super) root: u64,
+    /// The scope that owned this effect when it was created, re-entered on every
+    /// run so resources the body creates are attributed to the component that
+    /// built it rather than to whatever happened to be rendering when the flush
+    /// fired (issue #141). Weak by construction — see [`Owner`](super::Owner);
+    /// a strong reference here would make every scope immortal, since `EFFECTS`
+    /// holds the `Rc<EffectInner>` until `Scope::dispose` clears it.
+    pub(super) owner: super::Owner,
 }
 
 impl Effect {
@@ -55,6 +62,7 @@ impl Effect {
             f: RefCell::new(Box::new(f)),
             disposed: Cell::new(false),
             root: crate::context::current_context_root(),
+            owner: super::Owner::current(),
         });
 
         // Store the effect
@@ -66,6 +74,10 @@ impl Effect {
             }
             effects[idx] = Some(Rc::clone(&inner));
         });
+
+        // Attribute before the first run: the body runs synchronously below and
+        // may create resources of its own (issue #141).
+        super::scope::record_effect(id);
 
         // Run the effect immediately
         run_effect(id);
@@ -85,6 +97,7 @@ impl Effect {
             f: RefCell::new(Box::new(f)),
             disposed: Cell::new(false),
             root: crate::context::current_context_root(),
+            owner: super::Owner::current(),
         });
 
         EFFECTS.with(|effects| {
@@ -95,6 +108,8 @@ impl Effect {
             }
             effects[idx] = Some(inner);
         });
+
+        super::scope::record_effect(id);
 
         Effect { id }
     }
@@ -171,6 +186,12 @@ pub(super) fn run_effect(id: ObserverId) {
         // use_context/use_store resolve the same namespace as at build time
         // (issue #136).
         let _root_guard = crate::context::push_context_root(inner.root);
+
+        // Re-enter the scope that owned this effect at creation, for the same
+        // reason: `flush_effects` runs from arbitrary stacks (an event handler,
+        // a timer, the cross-thread drain), so the ambient owner at flush time
+        // is unrelated to the component this effect belongs to (issue #141).
+        let _owner_guard = inner.owner.push();
 
         // Push this effect as the current observer. RAII so a panic in the
         // effect body cannot strand it on the stack (issue #141).

--- a/crates/rinch-core/src/reactive/memo.rs
+++ b/crates/rinch-core/src/reactive/memo.rs
@@ -58,6 +58,10 @@ struct MemoInner<T> {
     /// context A but first read from context B resolved B's stores (issue #136
     /// follow-up, issue #141). `0` = the thread-global fallback root.
     root: u64,
+    /// The scope that owned this memo at creation, re-entered around the lazy
+    /// recompute for the same reason `root` is (issue #141). Weak by
+    /// construction — see [`Owner`](super::Owner).
+    owner: super::Owner,
     /// Observers to notify, ordered — same contract (and same reason) as
     /// `SignalSlot::subscribers`: a memo's dependents run in registration order.
     subscribers: RefCell<BTreeSet<ObserverId>>,
@@ -77,6 +81,7 @@ impl<T: Clone + 'static> Memo<T> {
             f: RefCell::new(Box::new(f)),
             dirty: Cell::new(true),
             root: crate::context::current_context_root(),
+            owner: super::Owner::current(),
             subscribers: RefCell::new(BTreeSet::new()),
         });
 
@@ -108,6 +113,10 @@ impl<T: Clone + 'static> Memo<T> {
                 })),
                 disposed: Cell::new(false),
                 root: crate::context::current_context_root(),
+                // Inert: the marker closure only flips a flag and queues
+                // observers, so it allocates nothing to attribute. Set for
+                // uniformity with every other `EffectInner`.
+                owner: super::Owner::current(),
             }));
         });
 
@@ -116,6 +125,14 @@ impl<T: Clone + 'static> Memo<T> {
         // holds the second strong Rc to this same MemoInner.
         let (store_id, generation) =
             MEMO_STORE.with(|store| store.borrow_mut().alloc(inner as Rc<dyn Any>, id));
+
+        // Attribute this memo to the ambient owner, if any (issue #141). The
+        // marker effect is deliberately NOT recorded separately: `free_memo`
+        // releases the slot and the marker together, so one record covers both.
+        super::scope::record_memo(super::scope::MemoKey {
+            id: store_id,
+            generation,
+        });
 
         Self {
             id: store_id,
@@ -171,8 +188,14 @@ impl<T: Clone + 'static> Memo<T> {
         // one context but first read from another resolves the wrong stores
         // (issue #136 follow-up). Both guards are RAII so a panic in the user
         // computation cannot strand state (issue #141).
+        //
+        // The owner is restored for the same structural reason as the root: the
+        // computation runs in the *reader's* frame, so a memo created in one
+        // component but first read from another would otherwise attribute the
+        // resources it creates to whatever happened to be rendering.
         if inner.dirty.get() {
             let _root_guard = crate::context::push_context_root(inner.root);
+            let _owner_guard = inner.owner.push();
             let _observer_guard = super::effect::ObserverGuard::push(inner.id);
 
             let value = (inner.f.borrow())();
@@ -201,6 +224,25 @@ impl<T: 'static> Memo<T> {
     /// (issue #141).
     pub fn is_alive(&self) -> bool {
         MEMO_STORE.with(|store| store.borrow().get_inner(self.id, self.generation).is_some())
+    }
+
+    /// Detach this memo from its owning scope, giving it app lifetime.
+    ///
+    /// The memo counterpart of [`Signal::leak`](super::Signal::leak); the same
+    /// "call it in the same render that created it" rule applies.
+    #[track_caller]
+    pub fn leak(self) -> Self {
+        if !super::scope::forget_memo(super::scope::MemoKey {
+            id: self.id,
+            generation: self.generation,
+        }) {
+            tracing::debug!(
+                "Memo::leak() at {}: no ambient owner held this memo; it already had \
+                 app lifetime",
+                std::panic::Location::caller()
+            );
+        }
+        self
     }
 }
 

--- a/crates/rinch-core/src/reactive/mod.rs
+++ b/crates/rinch-core/src/reactive/mod.rs
@@ -83,7 +83,10 @@ pub use bounds::{
 pub use effect::Effect;
 pub use memo::Memo;
 pub use poll::{PollRate, drain_polls, poll_signal};
-pub use scope::Scope;
+/// Attribution hook for `crate::events`, which registers handlers on behalf of
+/// the scope currently rendering.
+pub(crate) use scope::record_handler;
+pub use scope::{OwnedCounts, Owner, OwnerGuard, Scope, current_owner, unowned};
 pub use signal::Signal;
 
 use std::any::Any;
@@ -129,6 +132,16 @@ pub(crate) struct Runtime {
     /// Counter for generating unique IDs
     next_id: usize,
 
+    /// Stack of scopes that own newly created resources.
+    ///
+    /// Deliberately separate from `observer_stack`: that one answers "who
+    /// subscribes to this read" and is suspended by [`untracked`]; this one
+    /// answers "who owns this allocation" and is suspended by [`unowned`].
+    ///
+    /// Entries are [`Weak`](std::rc::Weak), never `Rc` — see [`Owner`].
+    /// Module-private, so the private `scope::ScopeInner` can appear in its type.
+    owner_stack: Vec<std::rc::Weak<scope::ScopeInner>>,
+
     /// Callbacks invoked when any signal changes (for UI re-render / dirty
     /// tracking). Multi-subscriber: each entry is `(subscription id, callback)`;
     /// a [`SignalChangeSubscription`] removes only its own entry on drop, so
@@ -152,6 +165,7 @@ impl Runtime {
             pending_effects_set: HashSet::new(),
             batching: false,
             next_id: 0,
+            owner_stack: Vec::new(),
             on_signal_change: Vec::new(),
             next_signal_change_sub: 0,
             signals_changed: false,
@@ -643,6 +657,13 @@ pub fn derived<T: Clone + 'static>(f: impl Fn() -> T + 'static) -> Memo<T> {
 /// Run a function without tracking any signal reads.
 ///
 /// Useful for reading signals without creating subscriptions.
+///
+/// # See also
+///
+/// [`unowned`] suspends the *owner* stack instead of the *observer* stack —
+/// it changes who owns resources created inside `f`, not who subscribes to
+/// signals read inside it. The two are independent, and picking the wrong one
+/// fails silently.
 pub fn untracked<R>(f: impl FnOnce() -> R) -> R {
     // Temporarily remove the current observer
     let observer = RUNTIME.with(|rt| rt.borrow_mut().observer_stack.pop());
@@ -1143,6 +1164,125 @@ mod tests {
 
         // Cleanup should only run once
         assert_eq!(cleanup_count.get(), 1);
+    }
+
+    /// An effect re-runs under the scope that *created* it, not under whatever
+    /// happened to be rendering when the flush fired (issue #141).
+    ///
+    /// `flush_effects` is reached from arbitrary stacks — an event handler, a
+    /// timer, the cross-thread drain — so without the restore in `run_effect`
+    /// the third run below would attribute its signal to `b`.
+    #[test]
+    fn an_effect_reruns_under_its_creation_time_owner() {
+        let a = Scope::new();
+        let b = Scope::new();
+        let trigger = Signal::new(0);
+        let seen: Rc<RefCell<Vec<Option<Owner>>>> = Rc::new(RefCell::new(Vec::new()));
+
+        let log = seen.clone();
+        let effect = a.run(|| {
+            Effect::new(move || {
+                trigger.get();
+                Signal::new(0);
+                log.borrow_mut().push(current_owner());
+            })
+        });
+        a.add_effect(effect);
+
+        trigger.set(1); // re-run with an empty owner stack
+        b.run(|| trigger.set(2)); // re-run with an unrelated owner ambient
+
+        let seen = seen.borrow();
+        assert_eq!(seen.len(), 3, "creation run plus two re-runs");
+        for (i, owner) in seen.iter().enumerate() {
+            assert_eq!(
+                *owner,
+                Some(a.owner()),
+                "run {i} must observe the creation-time owner"
+            );
+        }
+        assert_eq!(
+            b.owned_counts().signals,
+            0,
+            "the ambient owner at flush time must not capture the effect's work"
+        );
+        assert_eq!(a.owned_counts().signals, 3);
+    }
+
+    /// A memo's user computation runs lazily, in the *reader's* frame, so it
+    /// must restore its creation-time owner too — the ownership analogue of the
+    /// context-root bug `MemoInner::root` exists to close.
+    #[test]
+    fn a_memo_recomputes_under_its_creation_time_owner() {
+        let a = Scope::new();
+        let b = Scope::new();
+        let source = Signal::new(1);
+
+        let memo = a.run(|| {
+            Memo::new(move || {
+                Signal::new(0);
+                source.get() * 2
+            })
+        });
+        assert_eq!(
+            a.owned_counts().signals,
+            0,
+            "a memo is lazy: nothing has computed yet"
+        );
+
+        // First read happens from inside a DIFFERENT scope.
+        assert_eq!(b.run(|| memo.get()), 2);
+
+        assert_eq!(
+            b.owned_counts().signals,
+            0,
+            "the reading scope must not capture the memo's computation"
+        );
+        assert_eq!(a.owned_counts().signals, 1);
+    }
+
+    /// The owner guard pops while unwinding, and — critically — does not abort
+    /// the process doing so. A panic raised inside a `Drop` during unwind is a
+    /// hard abort, which would take down the whole test binary rather than fail
+    /// one test.
+    #[test]
+    fn an_owner_guard_pops_while_unwinding() {
+        let scope = Scope::new();
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            scope.run(|| panic!("boom"));
+        }));
+        assert!(result.is_err(), "the body must have panicked");
+
+        assert!(
+            current_owner().is_none(),
+            "the guard must pop while unwinding"
+        );
+        Signal::new(0);
+        assert_eq!(
+            scope.owned_counts().signals,
+            0,
+            "a stranded owner would capture every later allocation"
+        );
+    }
+
+    /// Nested guards restore by depth, so an inner scope never clobbers the
+    /// outer one's entry.
+    #[test]
+    fn nested_owner_guards_restore_by_depth() {
+        let a = Scope::new();
+        let b = Scope::new();
+
+        a.run(|| {
+            let outer = current_owner().expect("a is ambient");
+            b.run(|| {
+                let inner = current_owner().expect("b is ambient");
+                assert_ne!(inner, outer, "the inner scope is a distinct owner");
+            });
+            assert_eq!(current_owner(), Some(outer), "the outer owner is restored");
+        });
+
+        assert!(current_owner().is_none(), "the stack drains completely");
     }
 
     #[test]

--- a/crates/rinch-core/src/reactive/scope.rs
+++ b/crates/rinch-core/src/reactive/scope.rs
@@ -1,13 +1,122 @@
 //! Scope: manages the lifetime of reactive primitives.
+//!
+//! # Ownership is ambient
+//!
+//! A [`Scope`] is both a disposal list (effects, cleanups, child scopes) and an
+//! **owner**: while a scope is pushed as the ambient owner, every [`Signal`],
+//! [`Memo`], [`Effect`] and event handler created is *attributed* to it.
+//!
+//! Attribution is recorded, not enforced — nothing is freed yet. Issue #141's
+//! later PRs turn these records into actual reclamation; this layer exists so
+//! that when they do, the answer to "who owns this?" is already there.
+//!
+//! **No ambient owner means app lifetime.** Resources created outside any
+//! render — in `main()`, in a startup routine, in a detached callback — are
+//! owned by nobody and live as long as the thread. That is what makes
+//! ownership non-breaking to add.
+//!
+//! Two independent stacks are in play, and they are easy to confuse:
+//!
+//! | stack | suspended by | answers |
+//! |---|---|---|
+//! | observer stack | [`untracked`](super::untracked) | *who subscribes to this read* |
+//! | owner stack | [`unowned`] | *who owns this allocation* |
+//!
+//! [`Signal`]: super::Signal
+//! [`Memo`]: super::Memo
 
 use std::cell::{Cell, RefCell};
+use std::marker::PhantomData;
+use std::rc::{Rc, Weak};
 
-use super::Effect;
+use super::{Effect, ObserverId, RUNTIME};
+use crate::events::EventHandlerId;
+
+// ============================================================================
+// Resource keys
+// ============================================================================
+
+/// Identifies a slot in `SIGNAL_STORE`.
+///
+/// A distinct newtype from [`MemoKey`] rather than a shared `(u32, u32)` alias:
+/// signals and memos are released by *different* functions (`SignalStore::free`
+/// versus `free_memo`), and calling the wrong one is silently catastrophic —
+/// `MemoStore::free` alone frees nothing and leaves the memo's dirty-marker
+/// subscribed, so the next write to a dependency panics its dependents. Making
+/// the two keys unmixable is the cheapest guard available.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(in crate::reactive) struct SignalKey {
+    pub id: u32,
+    pub generation: u32,
+}
+
+/// Identifies a slot in `MEMO_STORE`. See [`SignalKey`] for why this is a
+/// separate type.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(in crate::reactive) struct MemoKey {
+    pub id: u32,
+    pub generation: u32,
+}
+
+// ============================================================================
+// The owned-resource bucket
+// ============================================================================
+
+/// Resources created while a scope was the ambient owner.
+///
+/// Write-only bookkeeping today. Every field is plain data, so dropping an
+/// `Owned` runs no user code and cannot re-enter the disposal machinery.
+#[derive(Default)]
+pub(in crate::reactive) struct Owned {
+    signals: Vec<SignalKey>,
+    memos: Vec<MemoKey>,
+    handlers: Vec<EventHandlerId>,
+    /// Effects *created* under this owner.
+    ///
+    /// Deliberately distinct from [`ScopeInner::effects`], which holds effects
+    /// *adopted* via [`Scope::add_effect`] and is what `dispose` acts on. The
+    /// difference between the two counts is the number of fire-and-forget
+    /// effects nothing will ever dispose.
+    effects: Vec<ObserverId>,
+}
+
+/// A snapshot of what a scope owns.
+///
+/// Introspection for tests and diagnostics: because nothing is freed yet, these
+/// counts are the only observable evidence that ownership is being tracked.
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct OwnedCounts {
+    pub signals: usize,
+    pub memos: usize,
+    pub handlers: usize,
+    pub effects: usize,
+}
+
+impl Owned {
+    fn counts(&self) -> OwnedCounts {
+        OwnedCounts {
+            signals: self.signals.len(),
+            memos: self.memos.len(),
+            handlers: self.handlers.len(),
+            effects: self.effects.len(),
+        }
+    }
+}
+
+// ============================================================================
+// Scope
+// ============================================================================
 
 /// A scope that manages the lifetime of reactive primitives.
 ///
-/// When a scope is disposed, all effects created within it are cleaned up.
-/// Scopes can have child scopes for hierarchical cleanup.
+/// When a scope is disposed, all effects **adopted** into it (via
+/// [`add_effect`](Scope::add_effect)) are disposed, its cleanups run, and its
+/// child scopes are disposed too. Dropping the scope does the same thing.
+///
+/// Separately, a scope can be made the *ambient owner* — see
+/// [`run`](Scope::run) and the module docs. Ownership currently only records
+/// attribution; it does not free anything.
 ///
 /// # Example
 ///
@@ -15,85 +124,136 @@ use super::Effect;
 /// let scope = Scope::new();
 ///
 /// scope.run(|| {
-///     let signal = Signal::new(0);
-///     Effect::new(|| { /* ... */ });
-///     // signal and effect belong to this scope
+///     let signal = Signal::new(0);   // attributed to this scope
+///     // Effects are attributed too, but adoption is explicit:
+///     scope.add_effect(Effect::new(|| { /* ... */ }));
 /// });
 ///
-/// scope.dispose(); // Cleans up signal, effect, and all child scopes
+/// scope.dispose(); // Disposes adopted effects, runs cleanups, disposes children
 /// ```
-pub struct Scope {
+pub struct Scope(Rc<ScopeInner>);
+
+/// The reference-counted body of a [`Scope`].
+///
+/// Split out so that an [`Owner`] can hold a non-owning [`Weak`] reference to a
+/// live scope from inside the ambient owner stack, an `EffectInner`, a
+/// `MemoInner`, or an event-handler wrapper — all of which must observe a scope
+/// without keeping it alive.
+pub(in crate::reactive) struct ScopeInner {
     effects: RefCell<Vec<Effect>>,
     children: RefCell<Vec<Scope>>,
     cleanups: RefCell<Vec<Box<dyn FnOnce()>>>,
     disposed: Cell<bool>,
+    owned: RefCell<Owned>,
 }
 
 impl Scope {
     /// Create a new scope.
     pub fn new() -> Self {
-        Self {
+        Scope(Rc::new(ScopeInner {
             effects: RefCell::new(Vec::new()),
             children: RefCell::new(Vec::new()),
             cleanups: RefCell::new(Vec::new()),
             disposed: Cell::new(false),
-        }
+            owned: RefCell::new(Owned::default()),
+        }))
     }
 
     /// Check if this scope has been disposed.
     pub fn is_disposed(&self) -> bool {
-        self.disposed.get()
+        self.0.disposed.get()
     }
 
-    /// Run a function within this scope, capturing any effects created.
+    /// Make this scope the ambient owner for the duration of `f`.
+    ///
+    /// Signals, memos, effects and event handlers created inside `f` are
+    /// **attributed** to this scope. Effects are attributed but *not adopted* —
+    /// [`dispose`](Scope::dispose) only disposes effects handed to
+    /// [`add_effect`](Scope::add_effect).
+    ///
+    /// This takes `&self`, so it cannot be used where the surrounding code also
+    /// needs `&mut` access to a value the closure borrows. The DOM render sites
+    /// are exactly that shape and use the RAII `RenderScope::push_owner` guard
+    /// instead.
     pub fn run<R>(&self, f: impl FnOnce() -> R) -> R {
-        // TODO: Implement scope tracking so effects created within
-        // are automatically registered to this scope
+        let _owner = self.push_owner();
         f()
     }
 
-    /// Register an effect with this scope.
-    pub fn add_effect(&self, effect: Effect) {
-        self.effects.borrow_mut().push(effect);
+    /// Make this scope the ambient owner until the returned guard drops.
+    ///
+    /// The RAII form of [`run`](Scope::run), for callers that cannot wrap the
+    /// owned region in a closure.
+    pub(crate) fn push_owner(&self) -> OwnerGuard {
+        push_owner_weak(Rc::downgrade(&self.0))
     }
 
-    /// Create a child scope that will be disposed when this scope is disposed.
-    ///
-    /// Child scopes are useful for conditional or list rendering where nested
-    /// content needs independent lifecycle management.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// let parent = Scope::new();
-    /// let child = parent.child_scope();
-    ///
-    /// child.add_effect(Effect::new(|| { /* ... */ }));
-    ///
-    /// parent.dispose(); // Also disposes child and its effects
-    /// ```
-    pub fn child_scope(&self) -> Scope {
-        // We return the child and expect the caller to manage it
-        // The parent stores a reference for cleanup
-        Scope::new()
+    /// A non-owning reference to this scope, for comparison and diagnostics.
+    pub fn owner(&self) -> Owner {
+        Owner(Rc::downgrade(&self.0))
+    }
+
+    /// What this scope currently owns. See [`OwnedCounts`].
+    #[doc(hidden)]
+    pub fn owned_counts(&self) -> OwnedCounts {
+        self.0.owned.borrow().counts()
+    }
+
+    /// Register an effect with this scope, so `dispose` disposes it.
+    pub fn add_effect(&self, effect: Effect) {
+        self.0.effects.borrow_mut().push(effect);
     }
 
     /// Add a child scope to be disposed with this scope.
     pub fn add_child(&self, child: Scope) {
-        self.children.borrow_mut().push(child);
+        self.0.children.borrow_mut().push(child);
     }
 
     /// Register a cleanup function to run when this scope is disposed.
     ///
     /// Cleanup functions run after child scopes and effects are disposed.
     pub fn on_cleanup<F: FnOnce() + 'static>(&self, f: F) {
-        self.cleanups.borrow_mut().push(Box::new(f));
+        self.0.cleanups.borrow_mut().push(Box::new(f));
     }
 
     /// Dispose of all effects, child scopes, and run cleanup functions.
     ///
     /// After dispose, this scope should not be used.
     pub fn dispose(&self) {
+        self.0.dispose();
+    }
+
+    /// Clear all adopted effects without disposing them.
+    ///
+    /// # Warning
+    ///
+    /// This moves only the *adopted effect* list. The scope's owned-resource
+    /// records (signals, memos, handlers) stay behind, so the effects and the
+    /// resources they close over end up with different owners.
+    pub fn take_effects(&self) -> Vec<Effect> {
+        self.0.effects.borrow_mut().drain(..).collect()
+    }
+
+    /// Get the number of adopted effects in this scope.
+    pub fn effect_count(&self) -> usize {
+        self.0.effects.borrow().len()
+    }
+
+    /// Get the number of child scopes.
+    pub fn child_count(&self) -> usize {
+        self.0.children.borrow().len()
+    }
+
+    /// Strong reference count of the inner scope. Test-only: it is what
+    /// distinguishes a `Weak` owner stack from an `Rc` one.
+    #[cfg(test)]
+    pub(in crate::reactive) fn strong_count(&self) -> usize {
+        Rc::strong_count(&self.0)
+    }
+}
+
+impl ScopeInner {
+    fn dispose(&self) {
         if self.disposed.get() {
             return;
         }
@@ -169,45 +329,36 @@ impl Scope {
             cleanup();
         }
 
+        // #141 PR4: release `self.owned` here, in priority order
+        // (handlers -> effects -> cleanups -> memos -> signals -> value-drops).
+        // PR2 deliberately leaves the bucket intact so the attribution stays
+        // observable after disposal.
+
         // Process children iteratively
         let mut pending: Vec<Scope> = self.children.borrow_mut().drain(..).collect();
         while let Some(child) = pending.pop() {
-            if child.disposed.get() {
+            if child.0.disposed.get() {
                 // Drain to prevent recursive field drop
-                child.children.borrow_mut().drain(..);
-                child.effects.borrow_mut().drain(..);
+                child.0.children.borrow_mut().drain(..);
+                child.0.effects.borrow_mut().drain(..);
                 continue;
             }
-            child.disposed.set(true);
+            child.0.disposed.set(true);
 
-            pending.extend(child.children.borrow_mut().drain(..));
-            let child_effects: Vec<Effect> = child.effects.borrow_mut().drain(..).collect();
+            pending.extend(child.0.children.borrow_mut().drain(..));
+            let child_effects: Vec<Effect> = child.0.effects.borrow_mut().drain(..).collect();
             queue.with(|q| {
                 if let Some(ref mut vec) = *q.borrow_mut() {
                     vec.extend(child_effects);
                 }
             });
 
-            for cleanup in child.cleanups.borrow_mut().drain(..) {
+            for cleanup in child.0.cleanups.borrow_mut().drain(..) {
                 cleanup();
             }
+
+            // #141 PR4: release `child.0.owned` here too.
         }
-    }
-
-    /// Clear all effects without disposing them.
-    /// Used when transferring effects to another scope.
-    pub fn take_effects(&self) -> Vec<Effect> {
-        self.effects.borrow_mut().drain(..).collect()
-    }
-
-    /// Get the number of effects in this scope.
-    pub fn effect_count(&self) -> usize {
-        self.effects.borrow().len()
-    }
-
-    /// Get the number of child scopes.
-    pub fn child_count(&self) -> usize {
-        self.children.borrow().len()
     }
 }
 
@@ -217,22 +368,574 @@ impl Default for Scope {
     }
 }
 
-impl Drop for Scope {
+impl Drop for ScopeInner {
     fn drop(&mut self) {
         // Use the iterative dispose to avoid stack overflow.
         // Rust's default field drop would recursively drop children -> Scope -> Drop,
         // and Effect::dispose can drop closures that own RenderScopes -> more Scopes.
+        //
+        // This lives on `ScopeInner`, not `Scope`, so it fires when the last
+        // handle dies. `Scope` is deliberately not `Clone`, so that is the same
+        // instant the single handle drops.
         self.dispose();
     }
 }
 
 impl std::fmt::Debug for Scope {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let owned = self.0.owned.borrow();
         f.debug_struct("Scope")
-            .field("effects", &self.effects.borrow().len())
-            .field("children", &self.children.borrow().len())
-            .field("cleanups", &self.cleanups.borrow().len())
-            .field("disposed", &self.disposed.get())
+            .field("effects", &self.0.effects.borrow().len())
+            .field("children", &self.0.children.borrow().len())
+            .field("cleanups", &self.0.cleanups.borrow().len())
+            .field("disposed", &self.0.disposed.get())
+            .field("owned_signals", &owned.signals.len())
+            .field("owned_memos", &owned.memos.len())
+            .field("owned_handlers", &owned.handlers.len())
+            .field("owned_effects", &owned.effects.len())
             .finish()
+    }
+}
+
+// ============================================================================
+// Owner
+// ============================================================================
+
+/// A non-owning reference to a [`Scope`].
+///
+/// Holds a [`Weak`], never an `Rc`: an `Owner` is stored in long-lived places
+/// (the ambient owner stack, every effect, every memo, every event-handler
+/// wrapper), and a strong reference from any of them would keep the scope —
+/// and therefore everything it will eventually free — alive forever.
+#[derive(Clone)]
+pub struct Owner(Weak<ScopeInner>);
+
+impl Owner {
+    /// The "no owner" sentinel, which resolves to app lifetime.
+    pub(crate) fn none() -> Self {
+        Owner(Weak::new())
+    }
+
+    /// The ambient owner at this point, or the sentinel if there is none.
+    ///
+    /// Unlike [`current_owner`], this is total — it never returns `None` — so
+    /// callers can store and re-push it unconditionally. That matters: an
+    /// `Option<OwnerGuard>` routed through `Option::map` silently discards the
+    /// `#[must_use]`, which is exactly how an owner push gets lost.
+    pub(crate) fn current() -> Self {
+        RUNTIME.with(|rt| {
+            rt.borrow()
+                .owner_stack
+                .last()
+                .map(|w| Owner(w.clone()))
+                .unwrap_or_else(Owner::none)
+        })
+    }
+
+    /// Make this owner ambient until the returned guard drops.
+    ///
+    /// A dead or disposed owner pushes as "no owner" rather than falling
+    /// through to the caller's ambient owner. The owner stack is not an
+    /// ancestor chain — `run_effect` splices a creation-time owner on top of an
+    /// unrelated dispatch-time one — so falling through can attribute a
+    /// resource to a scope in a different component tree.
+    pub(crate) fn push(&self) -> OwnerGuard {
+        push_owner_weak(self.0.clone())
+    }
+
+    /// Whether the referenced scope still exists and has not been disposed.
+    pub fn is_alive(&self) -> bool {
+        self.0.upgrade().is_some_and(|inner| !inner.disposed.get())
+    }
+
+    /// Run `f` with this scope as the ambient owner.
+    ///
+    /// If the scope is already gone or disposed (see [`is_alive`](Owner::is_alive)),
+    /// resources created inside `f` get **app lifetime**. They are *not* handed
+    /// to the caller's ambient owner: the owner stack is not an ancestor chain —
+    /// `run_effect` splices a creation-time owner on top of an unrelated
+    /// dispatch-time one — so falling through could attribute a resource to a
+    /// scope in a different component tree.
+    ///
+    /// [`Signal::leak`](super::Signal::leak) is the one deliberate exception: it
+    /// *does* look past a dead entry, because it is searching for a record that
+    /// already exists rather than choosing where to put a new one.
+    pub fn run<R>(&self, f: impl FnOnce() -> R) -> R {
+        let _owner = self.push();
+        f()
+    }
+
+    /// What the referenced scope owns, or `None` if it is gone.
+    #[doc(hidden)]
+    pub fn owned_counts(&self) -> Option<OwnedCounts> {
+        self.0.upgrade().map(|inner| inner.owned.borrow().counts())
+    }
+}
+
+impl PartialEq for Owner {
+    fn eq(&self, other: &Self) -> bool {
+        Weak::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl Eq for Owner {}
+
+impl std::fmt::Debug for Owner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Owner")
+            .field("alive", &self.is_alive())
+            .finish()
+    }
+}
+
+// ============================================================================
+// The ambient owner stack
+// ============================================================================
+
+/// RAII guard for the ambient owner stack.
+///
+/// Restores the stack to its pre-push depth on drop, including while unwinding.
+#[must_use = "the ambient owner is popped the instant this guard drops — bind it to a named \
+              local (`let _owner = ...;`). `let _ = ...` drops it immediately and the push \
+              is lost"]
+pub struct OwnerGuard {
+    restore_len: usize,
+    /// The runtime is thread-local — keep the guard `!Send`/`!Sync`, or a guard
+    /// moved across threads would truncate the wrong stack.
+    _not_send: PhantomData<*const ()>,
+}
+
+pub(in crate::reactive) fn push_owner_weak(owner: Weak<ScopeInner>) -> OwnerGuard {
+    let restore_len = RUNTIME.with(|rt| {
+        let mut rt = rt.borrow_mut();
+        let depth = rt.owner_stack.len();
+        rt.owner_stack.push(owner);
+        depth
+    });
+    OwnerGuard {
+        restore_len,
+        _not_send: PhantomData,
+    }
+}
+
+impl Drop for OwnerGuard {
+    fn drop(&mut self) {
+        // `try_with`: TLS may already be torn down at thread exit, exactly as in
+        // `ObserverGuard::drop`. That case is legitimate and silent.
+        let in_order = RUNTIME.try_with(|rt| match rt.try_borrow_mut() {
+            Ok(mut rt) => {
+                let lifo = rt.owner_stack.len() == self.restore_len + 1;
+                // `truncate`, not `pop`: restores exactly the pre-push depth, so
+                // a lost inner guard is repaired rather than compounded, and it
+                // can never panic on an empty stack.
+                rt.owner_stack.truncate(self.restore_len);
+                lifo
+            }
+            Err(_) => false,
+        });
+
+        // A stranded owner is worse than a stranded observer — every later
+        // resource would be attributed to a corpse — so this does not silently
+        // swallow the failure. The assert is gated on `!panicking()` because a
+        // panic inside a `Drop` during unwind aborts the process, and this guard
+        // is live during exactly that unwind in the panic-safety tests.
+        if matches!(in_order, Ok(false)) {
+            tracing::error!("owner guard dropped out of LIFO order, or RUNTIME was borrowed");
+            if !std::thread::panicking() {
+                debug_assert!(false, "owner guards must drop in LIFO order (issue #141)");
+            }
+        }
+    }
+}
+
+/// The scope that currently owns newly created resources, if any.
+///
+/// Returns `None` when there is no ambient owner (app lifetime), and also when
+/// the ambient entry refers to a scope that has been dropped or disposed — a
+/// disposed scope owns nothing further, and the stack is not an ancestor chain,
+/// so there is no meaningful owner to fall back to.
+pub fn current_owner() -> Option<Owner> {
+    let owner = Owner::current();
+    owner.is_alive().then_some(owner)
+}
+
+/// Run `f` with no ambient owner, so resources created inside it live for the
+/// lifetime of the thread.
+///
+/// The owner-stack counterpart to [`untracked`](super::untracked), which
+/// suspends the *observer* stack instead. The two are independent and easy to
+/// confuse; picking the wrong one fails silently.
+///
+/// # Warning
+///
+/// `unowned` converts a lifetime bug into a leak. If a resource is being freed
+/// too early, prefer fixing the ownership — or reading it with
+/// [`Signal::try_get`](super::Signal::try_get) /
+/// [`Signal::is_alive`](super::Signal::is_alive) — over opting out of
+/// reclamation entirely.
+pub fn unowned<R>(f: impl FnOnce() -> R) -> R {
+    let _owner = Owner::none().push();
+    f()
+}
+
+/// Run `f` against the ambient owner's bucket, if there is a live one.
+fn with_ambient_owned<R>(f: impl FnOnce(&mut Owned) -> R) -> Option<R> {
+    let inner = RUNTIME.with(|rt| rt.borrow().owner_stack.last().and_then(|w| w.upgrade()))?;
+    if inner.disposed.get() {
+        return None;
+    }
+    // The borrow is released before returning, and `f` only touches plain data,
+    // so no user code runs under it.
+    let result = f(&mut inner.owned.borrow_mut());
+    Some(result)
+}
+
+/// Walk the owner stack top-down and run `f` against the first live bucket for
+/// which it returns `true`. Used by `leak` to detach a resource from whichever
+/// ancestor recorded it.
+fn with_owner_stack(mut f: impl FnMut(&mut Owned) -> bool) -> bool {
+    let stack: Vec<Weak<ScopeInner>> = RUNTIME.with(|rt| rt.borrow().owner_stack.clone());
+    for weak in stack.iter().rev() {
+        let Some(inner) = weak.upgrade() else {
+            continue;
+        };
+        if inner.disposed.get() {
+            continue;
+        }
+        if f(&mut inner.owned.borrow_mut()) {
+            return true;
+        }
+    }
+    false
+}
+
+pub(in crate::reactive) fn record_signal(key: SignalKey) {
+    with_ambient_owned(|owned| owned.signals.push(key));
+}
+
+pub(in crate::reactive) fn record_memo(key: MemoKey) {
+    with_ambient_owned(|owned| owned.memos.push(key));
+}
+
+pub(in crate::reactive) fn record_effect(id: ObserverId) {
+    with_ambient_owned(|owned| owned.effects.push(id));
+}
+
+/// Record an event handler against the ambient owner.
+///
+/// Called from [`crate::events`] at registration time.
+pub(crate) fn record_handler(id: EventHandlerId) {
+    with_ambient_owned(|owned| owned.handlers.push(id));
+}
+
+/// Detach a signal from whichever owner on the stack recorded it.
+///
+/// Searches the whole stack, not just the top: a `leak()` written inside a
+/// nested `if`/`for`/`match` branch runs with the branch's child scope ambient,
+/// while the entry sits in the enclosing scope's bucket. Removing the entry from
+/// an ancestor is safe because `(id, generation)` is globally unique per store —
+/// the entry found *is* this signal's entry.
+pub(in crate::reactive) fn forget_signal(key: SignalKey) -> bool {
+    with_owner_stack(|owned| {
+        if let Some(pos) = owned.signals.iter().position(|k| *k == key) {
+            owned.signals.remove(pos);
+            true
+        } else {
+            false
+        }
+    })
+}
+
+/// Detach a memo from whichever owner on the stack recorded it. See
+/// [`forget_signal`].
+pub(in crate::reactive) fn forget_memo(key: MemoKey) -> bool {
+    with_owner_stack(|owned| {
+        if let Some(pos) = owned.memos.iter().position(|k| *k == key) {
+            owned.memos.remove(pos);
+            true
+        } else {
+            false
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reactive::{Memo, Signal};
+    use std::cell::Cell;
+
+    /// The owner stack holds `Weak`, so dropping the last handle to the scope
+    /// that is *currently ambient* disposes it right then — not deferred to the
+    /// guard's epilogue.
+    ///
+    /// This is the only test that distinguishes a `Weak` owner stack from an
+    /// `Rc` one. With `Rc`, the strong count reads 2 while pushed and the log
+    /// comes back `["after-drop", "cleanup", "after-guard"]` — teardown having
+    /// silently migrated out of the drop and into the guard.
+    #[test]
+    fn a_scope_dropped_while_ambient_disposes_immediately() {
+        let log = Rc::new(RefCell::new(Vec::new()));
+        let scope = Scope::new();
+        let cleanup_log = log.clone();
+        scope.on_cleanup(move || cleanup_log.borrow_mut().push("cleanup"));
+
+        let mut holder = Some(scope);
+        {
+            let _owner = holder.as_ref().unwrap().push_owner();
+            assert_eq!(
+                holder.as_ref().unwrap().strong_count(),
+                1,
+                "the owner stack must not hold a strong reference"
+            );
+            holder.take(); // drops the only `Scope` handle
+            log.borrow_mut().push("after-drop");
+        }
+        log.borrow_mut().push("after-guard");
+
+        assert_eq!(
+            *log.borrow(),
+            ["cleanup", "after-drop", "after-guard"],
+            "disposal must happen when the handle drops, not when the guard pops"
+        );
+    }
+
+    /// Regression anchor for PR2's riskiest single edit: moving `Drop` from
+    /// `Scope` to `ScopeInner`. Every other scope test disposes explicitly and
+    /// would survive that impl being dropped on the floor.
+    #[test]
+    fn dropping_a_bare_scope_handle_runs_its_cleanup() {
+        let ran = Rc::new(Cell::new(false));
+        {
+            let scope = Scope::new();
+            let flag = ran.clone();
+            scope.on_cleanup(move || flag.set(true));
+            assert!(!ran.get(), "cleanup must not run early");
+        }
+        assert!(ran.get(), "dropping the last handle must dispose the scope");
+    }
+
+    /// `run` attributes signals, memos and effects — and adopts none of them.
+    /// Adoption stays explicit via `add_effect`, because that is what `dispose`
+    /// acts on.
+    #[test]
+    fn run_attributes_resources_but_adopts_nothing() {
+        let scope = Scope::new();
+
+        scope.run(|| {
+            Signal::new(0);
+            Memo::new(|| 1);
+            Effect::new(|| {});
+        });
+
+        assert_eq!(
+            scope.owned_counts(),
+            OwnedCounts {
+                signals: 1,
+                memos: 1,
+                handlers: 0,
+                effects: 1,
+            },
+            "everything created inside `run` is attributed to the scope"
+        );
+        assert_eq!(
+            scope.effect_count(),
+            0,
+            "`run` must not adopt effects — only `add_effect` does"
+        );
+
+        // The guard popped: later allocations are not attributed.
+        Signal::new(0);
+        assert_eq!(
+            scope.owned_counts().signals,
+            1,
+            "the guard must have popped"
+        );
+    }
+
+    /// The non-breaking-ness contract (#141 SD2): with no ambient owner, a
+    /// resource has app lifetime and no scope claims it.
+    #[test]
+    fn no_ambient_owner_means_app_lifetime() {
+        assert!(
+            current_owner().is_none(),
+            "tests start with an empty owner stack"
+        );
+
+        let orphan = Signal::new(7);
+
+        let scope = Scope::new();
+        assert_eq!(scope.owned_counts(), OwnedCounts::default());
+
+        scope.dispose();
+        assert!(orphan.is_alive(), "an unowned signal outlives any scope");
+        assert_eq!(orphan.get(), 7);
+    }
+
+    /// `unowned` suspends the owner stack, nests, and — unlike a naive
+    /// pop/run/push-back — restores the owner when the body panics.
+    #[test]
+    fn unowned_suspends_the_owner_and_is_panic_safe() {
+        let scope = Scope::new();
+
+        scope.run(|| {
+            let owner = current_owner().expect("scope is ambient");
+
+            unowned(|| {
+                assert!(current_owner().is_none(), "unowned clears the owner");
+                Signal::new(0);
+                unowned(|| assert!(current_owner().is_none(), "nesting is a no-op"));
+            });
+            assert_eq!(current_owner(), Some(owner.clone()), "owner is restored");
+
+            let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                unowned(|| panic!("boom"));
+            }));
+            assert!(panicked.is_err(), "the body must have panicked");
+            assert_eq!(
+                current_owner(),
+                Some(owner),
+                "a panic inside `unowned` must not strand the suspension"
+            );
+        });
+
+        assert_eq!(
+            scope.owned_counts().signals,
+            0,
+            "the signal created under `unowned` belongs to nobody"
+        );
+    }
+
+    /// A disposed scope owns nothing further, and ownership does **not** fall
+    /// through to the next entry down: the owner stack is not an ancestor chain
+    /// (`run_effect` splices a creation-time owner onto an unrelated
+    /// dispatch-time one), so falling through can cross component trees.
+    ///
+    /// Reachable in production: `dispose_into_queue` marks a child disposed
+    /// while `pending` still holds a strong reference, so the `Weak` upgrades
+    /// onto a corpse.
+    #[test]
+    fn a_disposed_scope_on_the_owner_stack_owns_nothing() {
+        let outer = Scope::new();
+        let inner = Scope::new();
+
+        let signal = outer.run(|| {
+            let _inner_owner = inner.push_owner();
+            inner.dispose(); // disposed while still ambient
+            assert!(current_owner().is_none(), "a disposed owner is no owner");
+            Signal::new(0)
+        });
+
+        assert_eq!(inner.owned_counts().signals, 0, "the corpse claims nothing");
+        assert_eq!(
+            outer.owned_counts().signals,
+            0,
+            "and ownership must not fall through to the next entry down"
+        );
+        assert!(signal.is_alive(), "the signal simply has app lifetime");
+    }
+
+    /// `leak` searches the whole owner stack, not just its top.
+    ///
+    /// A `leak()` written inside a nested branch runs with the branch's child
+    /// scope ambient while the entry sits in the enclosing scope's bucket. A
+    /// top-of-stack-only implementation leaves `outer` at 1 here — a silent
+    /// no-op whose PR4 failure mode is a use-after-free panic.
+    #[test]
+    fn leak_detaches_from_an_ancestor_owner_not_just_the_innermost() {
+        let outer = Scope::new();
+        let signal = outer.run(|| Signal::new(0));
+        assert_eq!(outer.owned_counts().signals, 1);
+
+        let inner = Scope::new();
+        outer.run(|| {
+            inner.run(|| {
+                // Decoy. Without it the innermost bucket is empty, so an
+                // implementation that removed "the first entry it found"
+                // instead of matching on `(id, generation)` would fall through
+                // to `outer` and pass by luck.
+                Signal::new(99);
+                let _ = signal.leak();
+            })
+        });
+
+        assert_eq!(
+            outer.owned_counts().signals,
+            0,
+            "leak must reach an owner further down the stack"
+        );
+        assert_eq!(
+            inner.owned_counts().signals,
+            1,
+            "and must match on the key rather than raiding the nearest bucket"
+        );
+        assert!(signal.is_alive());
+    }
+
+    /// `leak` with no ambient owner is a quiet no-op, and it works for memos.
+    #[test]
+    fn leak_is_quiet_without_an_owner_and_works_for_memos() {
+        // The defensive `Signal::new(x).leak()` idiom must stay noise-free:
+        // 30+ in-tree constructors run outside any render.
+        let orphan = Signal::new(5).leak();
+        assert_eq!(orphan.get(), 5);
+
+        let scope = Scope::new();
+        let source = Signal::new(2);
+
+        // A memo created under the scope and left alone is owned by it...
+        scope.run(|| Memo::new(move || source.get() * 2));
+        assert_eq!(scope.owned_counts().memos, 1);
+
+        // ...but `leak`, called in the same render, detaches it. Calling it
+        // later would be a no-op: `leak` searches the owner stack as it stands,
+        // and outside a render that stack is empty.
+        let doubled = scope.run(|| Memo::new(move || source.get() * 2).leak());
+        assert_eq!(
+            scope.owned_counts().memos,
+            1,
+            "the leaked memo is not added; only the first one is owned"
+        );
+
+        // Detaching must not disturb the memo itself — the marker effect is
+        // still subscribed, so invalidation still propagates.
+        assert_eq!(doubled.get(), 4);
+        source.set(10);
+        assert_eq!(doubled.get(), 20, "the dirty marker still fires");
+        assert!(doubled.is_alive());
+    }
+
+    /// PR2 is metrics-only: `dispose` must not free or drain anything.
+    #[test]
+    fn dispose_leaves_the_owned_bucket_intact() {
+        let scope = Scope::new();
+        let (signal, memo, handler) = scope.run(|| {
+            let s = Signal::new(1);
+            let m = Memo::new(|| 2);
+            Effect::new(|| {});
+            let h = crate::events::register_handler(std::rc::Rc::new(|| {}));
+            (s, m, h)
+        });
+        let before = scope.owned_counts();
+        assert_eq!(before.signals, 1);
+        assert_eq!(before.memos, 1);
+        assert_eq!(before.effects, 1);
+        assert_eq!(before.handlers, 1);
+
+        scope.dispose();
+
+        assert_eq!(
+            scope.owned_counts(),
+            before,
+            "PR2 records ownership; PR4 is what acts on it"
+        );
+        // The counts alone cannot detect a free, because PR2 does not drain the
+        // bucket on dispose — so probe the resources themselves.
+        assert!(signal.is_alive(), "nothing is freed yet");
+        assert!(memo.is_alive(), "nothing is freed yet");
+        assert!(
+            crate::events::dispatch_event(handler),
+            "the handler is still registered — PR4 is what unregisters it"
+        );
     }
 }

--- a/crates/rinch-core/src/reactive/signal.rs
+++ b/crates/rinch-core/src/reactive/signal.rs
@@ -147,11 +147,41 @@ impl<T: 'static> Signal<T> {
     /// Create a new signal with the given initial value.
     pub fn new(value: T) -> Self {
         let (id, generation) = SIGNAL_STORE.with(|store| store.borrow_mut().alloc(value));
+        // Attribute this signal to the ambient owner, if any. No ambient owner
+        // means app lifetime (issue #141).
+        super::scope::record_signal(super::scope::SignalKey { id, generation });
         Self {
             id,
             generation,
             _phantom: PhantomData,
         }
+    }
+
+    /// Detach this signal from its owning scope, giving it app lifetime.
+    ///
+    /// Signals created during a render are attributed to the scope being built,
+    /// and will be freed when that scope is disposed. `leak` opts out — for a
+    /// signal that is deliberately handed to something longer-lived than the
+    /// component that created it.
+    ///
+    /// Call it in the same render that created the signal: it searches the
+    /// owner stack as it stands *now*, so from a later callback (a timer, a
+    /// resumed continuation) the stack is empty and this is a no-op.
+    ///
+    /// Returns the signal, so it composes: `let s = Signal::new(0).leak();`
+    #[track_caller]
+    pub fn leak(self) -> Self {
+        if !super::scope::forget_signal(super::scope::SignalKey {
+            id: self.id,
+            generation: self.generation,
+        }) {
+            tracing::debug!(
+                "Signal::leak() at {}: no ambient owner held this signal; it already had \
+                 app lifetime",
+                std::panic::Location::caller()
+            );
+        }
+        self
     }
 
     /// Subscribe the current observer (if any) to this signal.

--- a/crates/rinch-core/src/show.rs
+++ b/crates/rinch-core/src/show.rs
@@ -127,7 +127,13 @@ where
     ) {
         if let Some(doc) = doc_weak.upgrade() {
             let mut child_scope = RenderScope::new(doc, parent_id);
-            let content = render_fn(&mut child_scope);
+            // Resources the branch creates belong to the branch's own scope, so
+            // flipping the condition takes them with it (issue #141). Covers
+            // both entry paths — initial render and the effect-driven swap.
+            let content = {
+                let _owner = child_scope.push_owner();
+                render_fn(&mut child_scope)
+            };
             marker.insert_after(&content);
             current_content.borrow_mut().push(content);
             *current_scope.borrow_mut() = Some(child_scope);
@@ -351,5 +357,77 @@ mod tests {
 
         // Cleanup ran
         assert!(cleanup_ran.get());
+    }
+
+    /// A branch body's resources are attributed to the branch's own child scope,
+    /// not to the parent that hosts the `show` (issue #141).
+    ///
+    /// Both entry paths are covered by the single push in
+    /// `insert_content_after_marker`: the initial render, and the effect-driven
+    /// swap when the condition flips.
+    #[test]
+    fn a_branch_body_is_attributed_to_its_own_child_scope() {
+        use crate::dom::traits::DomDocument;
+        use crate::dom::{RenderScope, mock::MockDomDocument};
+        use crate::reactive::{Owner, Signal, current_owner};
+        use std::cell::RefCell;
+
+        let doc = Rc::new(RefCell::new(MockDomDocument::new()));
+        let body = doc.borrow().body();
+        let mut scope = RenderScope::new(doc.clone(), body);
+        let parent = scope.parent();
+
+        let showing = Signal::new(true);
+        let owners: Rc<RefCell<Vec<Option<Owner>>>> = Rc::new(RefCell::new(Vec::new()));
+
+        let then_owners = owners.clone();
+        let else_owners = owners.clone();
+        let marker = crate::show::show_dom(
+            &mut scope,
+            &parent,
+            move || showing.get(),
+            move |s: &mut RenderScope| {
+                then_owners.borrow_mut().push(current_owner());
+                Signal::new(0);
+                s.create_element("div")
+            },
+            Some(move |s: &mut RenderScope| {
+                else_owners.borrow_mut().push(current_owner());
+                Signal::new(0);
+                s.create_element("span")
+            }),
+        );
+        let _ = marker;
+
+        showing.set(false); // flip: disposes the then-scope, builds the else-scope
+
+        let owners = owners.borrow();
+        assert_eq!(owners.len(), 2, "one initial render plus one swap");
+
+        let then_owner = owners[0].clone().expect("the branch runs under an owner");
+        let else_owner = owners[1].clone().expect("the branch runs under an owner");
+        assert_ne!(
+            then_owner, else_owner,
+            "each branch gets its own child scope"
+        );
+        assert_ne!(
+            else_owner,
+            scope.owner(),
+            "a branch is not attributed to the scope hosting the `show`"
+        );
+        assert!(
+            !then_owner.is_alive(),
+            "flipping the condition must have disposed the then-branch's scope"
+        );
+        assert_eq!(
+            else_owner.owned_counts().map(|c| c.signals),
+            Some(1),
+            "the live branch's signal belongs to that branch"
+        );
+        assert_eq!(
+            scope.owned_counts().signals,
+            0,
+            "and not to the parent render scope"
+        );
     }
 }

--- a/crates/rinch-core/src/virtual_list.rs
+++ b/crates/rinch-core/src/virtual_list.rs
@@ -207,7 +207,12 @@ where
                 && let Some(doc) = doc_weak.upgrade()
             {
                 let mut child_scope = RenderScope::new(doc, window_id);
-                let node = view(item_data.clone(), &mut child_scope);
+                // Each virtualized row owns what its view creates, so scrolling
+                // it out of the window takes them with it (issue #141).
+                let node = {
+                    let _owner = child_scope.push_owner();
+                    view(item_data.clone(), &mut child_scope)
+                };
                 state.insert(
                     k.clone(),
                     RenderedItem {
@@ -243,4 +248,64 @@ where
     scope.create_effect_from(effect);
 
     container
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::dom::traits::DomDocument;
+    use crate::dom::{RenderScope, mock::MockDomDocument};
+    use crate::reactive::{Owner, Signal, current_owner};
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    /// Each virtualized row is attributed to its own child scope, so scrolling a
+    /// row out of the window takes its resources with it (issue #141).
+    #[test]
+    fn a_virtualized_row_is_attributed_to_its_own_child_scope() {
+        let doc = Rc::new(RefCell::new(MockDomDocument::new()));
+        let body = doc.borrow().body();
+        let mut scope = RenderScope::new(doc.clone(), body);
+
+        let items = Signal::new(vec![1u32, 2, 3]);
+        let seen: Rc<RefCell<Vec<Option<Owner>>>> = Rc::new(RefCell::new(Vec::new()));
+
+        let log = seen.clone();
+        let list = super::virtual_list(
+            &mut scope,
+            20.0,
+            move || items.get(),
+            |item: &u32| *item,
+            1,
+            move |item: u32, s: &mut RenderScope| {
+                log.borrow_mut().push(current_owner());
+                Signal::new(item);
+                s.create_element("div")
+            },
+        );
+        let _ = list;
+
+        let seen = seen.borrow();
+        assert!(!seen.is_empty(), "at least one row rendered");
+
+        for (i, owner) in seen.iter().enumerate() {
+            let owner = owner
+                .clone()
+                .unwrap_or_else(|| panic!("row {i} had no owner"));
+            assert_ne!(
+                owner,
+                scope.owner(),
+                "row {i} must not be attributed to the list's own scope"
+            );
+            assert_eq!(
+                owner.owned_counts().map(|c| c.signals),
+                Some(1),
+                "row {i} owns the signal its view created"
+            );
+        }
+        assert_eq!(
+            scope.owned_counts().signals,
+            0,
+            "no row signal leaked into the parent scope"
+        );
+    }
 }

--- a/crates/rinch-web/src/lib.rs
+++ b/crates/rinch-web/src/lib.rs
@@ -206,7 +206,11 @@ where
     // Handler ids allocated during this build belong to this root (builds are
     // sequential, so the range is contiguous and exclusively ours).
     let handler_start = events::handler_id_watermark();
+    // The root scope owns everything this build creates (issue #141). Scoped to
+    // the build alone: theme injection, event delegation and root registration
+    // below are page-global setup with app lifetime.
     let root = {
+        let _owner = scope.borrow().push_owner();
         let mut scope_ref = scope.borrow_mut();
         build(&mut scope_ref)
     };

--- a/crates/rinch-web/tests/owner_scope.rs
+++ b/crates/rinch-web/tests/owner_scope.rs
@@ -1,0 +1,85 @@
+//! Browser-driven test for the root mount's ambient owner (#141 PR2).
+//!
+//! Run with a chromedriver matching the installed Chrome:
+//!
+//! ```text
+//! CHROMEDRIVER=/path/to/chromedriver \
+//!   cargo test -p rinch-web --target wasm32-unknown-unknown
+//! ```
+//!
+//! The invariant under test: `mount_into` builds the tree with the root
+//! `RenderScope` as the ambient owner, and pops that owner before returning.
+//! Everything after the build — theme injection, event delegation, root
+//! registration — is page-global setup with app lifetime, and must not be
+//! attributed to the root.
+//!
+//! This lives in `rinch-web` rather than `rinch-core` because the guard is at
+//! the web mount site, which `rinch-core` cannot reach.
+#![cfg(target_arch = "wasm32")]
+
+use rinch_core::element::ThemeProviderProps;
+use rinch_core::{Owner, Signal, current_owner, dom::RenderScope};
+use std::cell::RefCell;
+use std::rc::Rc;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn document() -> web_sys::Document {
+    web_sys::window().unwrap().document().unwrap()
+}
+
+/// A detached host element, so each test mounts into a clean subtree.
+fn host() -> web_sys::Element {
+    let el = document().create_element("div").unwrap();
+    document().body().unwrap().append_child(&el).unwrap();
+    el
+}
+
+#[wasm_bindgen_test]
+fn the_web_root_build_runs_under_an_owner_that_does_not_outlive_it() {
+    let seen: Rc<RefCell<Option<Owner>>> = Rc::new(RefCell::new(None));
+    let log = seen.clone();
+
+    let host = host();
+    let root = rinch_web::mount_into(
+        &host,
+        ThemeProviderProps::default(),
+        move |scope: &mut RenderScope| {
+            *log.borrow_mut() = current_owner();
+            Signal::new(0i32);
+            let div = scope.create_element("div");
+            let text = scope.create_text("owned");
+            div.append_child(&text);
+            div
+        },
+    );
+
+    assert!(
+        current_owner().is_none(),
+        "the mount guard must be popped before mount_into returns"
+    );
+
+    let owner = seen
+        .borrow()
+        .clone()
+        .expect("the build must run under an ambient owner");
+    assert!(owner.is_alive(), "the root scope outlives the mount");
+    assert_eq!(
+        owner.owned_counts().map(|c| c.signals),
+        Some(1),
+        "a signal created by the root build belongs to the root scope"
+    );
+
+    // Page-global setup that runs after the build is deliberately unowned.
+    let after = owner.owned_counts().expect("root scope is live");
+    Signal::new(0i32);
+    assert_eq!(
+        owner.owned_counts(),
+        Some(after),
+        "allocations after the build must not be attributed to the root"
+    );
+
+    root.unmount();
+    host.remove();
+}

--- a/crates/rinch/src/app/mod.rs
+++ b/crates/rinch/src/app/mod.rs
@@ -490,7 +490,12 @@ impl RinchApp {
 
         // Run the component
         let component = self.component.take().expect("component already consumed");
+        // The root scope owns everything the component tree builds (issue
+        // #141). Deliberately narrower than `_root_guard` above, which spans the
+        // whole function: the owner must not cover initial layout, caret
+        // updates or scroll-clamp dispatch, none of which belong to the tree.
         let root = {
+            let _owner = scope.borrow().push_owner();
             let mut scope_ref = scope.borrow_mut();
             component(&mut scope_ref)
         };

--- a/crates/rinch/src/lib.rs
+++ b/crates/rinch/src/lib.rs
@@ -211,7 +211,13 @@ pub mod prelude {
 pub use rinch_core::element::{
     Children, CloseRequestCallback, Element, ThemeProviderProps, WindowProps,
 };
-pub use rinch_core::{Effect, Memo, Scope, Signal, batch, derived, untracked};
+// `Owner` / `current_owner` / `unowned` sit at the crate root rather than in the
+// prelude, alongside `Effect`, for the same reason: they are advanced tools, and
+// `unowned` in particular is an attractive nuisance — it turns a lifetime bug
+// into a permanent leak. Reach for `Signal::try_get` / `is_alive` first.
+pub use rinch_core::{
+    Effect, Memo, Owner, Scope, Signal, batch, current_owner, derived, unowned, untracked,
+};
 pub use rinch_macros::{component, rsx};
 #[cfg(feature = "desktop")]
 #[allow(deprecated)]

--- a/crates/rinch/tests/multi_context.rs
+++ b/crates/rinch/tests/multi_context.rs
@@ -705,3 +705,56 @@ fn a_bounds_driven_effect_may_patch_the_dom() {
         drop(ctx);
     });
 }
+
+// ── the root mount owns the tree it builds (#141) ────────────────────────────
+
+/// The root component build runs under the root `RenderScope`'s ambient owner,
+/// and that owner is popped before mounting returns.
+///
+/// This pins the cross-crate half of #141 PR2: the guard lives in
+/// `RinchApp::mount_component`, so it cannot be exercised from `rinch-core`.
+/// It is deliberately narrower than the surrounding `_root_guard` — the owner
+/// must not cover initial layout, caret updates or scroll-clamp dispatch, none
+/// of which belong to the component tree.
+#[test]
+fn the_root_build_is_attributed_to_the_root_scope() {
+    on_ui_thread(|| {
+        assert!(
+            rinch::current_owner().is_none(),
+            "no ambient owner before mounting"
+        );
+
+        let seen: Rc<std::cell::RefCell<Option<rinch::Owner>>> =
+            Rc::new(std::cell::RefCell::new(None));
+        let log = seen.clone();
+
+        let mut ctx = RinchContext::new(cfg(), move |__scope: &mut RenderScope| {
+            *log.borrow_mut() = rinch::current_owner();
+            Signal::new(0i32);
+            rsx! { div { "owned" } }
+        });
+        ctx.update(&[]);
+
+        assert!(
+            rinch::current_owner().is_none(),
+            "the mount guard must not outlive the build"
+        );
+
+        let owner = seen
+            .borrow()
+            .clone()
+            .expect("the root component must build under an ambient owner");
+        assert!(owner.is_alive(), "the root scope outlives the mount");
+        assert_eq!(
+            owner.owned_counts().map(|c| c.signals),
+            Some(1),
+            "a signal created by the root component belongs to the root scope"
+        );
+
+        drop(ctx);
+        assert!(
+            !owner.is_alive(),
+            "dropping the context disposes the root scope"
+        );
+    });
+}

--- a/docs/src/architecture/reactive-system.md
+++ b/docs/src/architecture/reactive-system.md
@@ -154,7 +154,9 @@ fn my_component(__scope: &mut RenderScope) -> NodeHandle {
 // When __scope is disposed, all its effects are cleaned up
 ```
 
-> **Note:** `Scope::new()` and `Scope::run()` exist in the codebase but are currently placeholders. The active scope mechanism is `RenderScope`, which tracks effects and child scopes for automatic cleanup.
+> **Note:** `RenderScope` is what application code sees — it tracks effects and child scopes for automatic cleanup. Underneath, each `RenderScope` owns a reactive `Scope`, and `Scope::run(f)` makes that scope the **ambient owner** for `f`: signals, memos, effects and event handlers created inside are attributed to it. Attribution is currently recorded but not acted on — see [issue #141](https://github.com/joeleaver/rinch/issues/141), which turns these records into actual reclamation.
+>
+> Two independent stacks are in play, and they are easy to confuse: `untracked` suspends the *observer* stack (who subscribes to a read), while `unowned` suspends the *owner* stack (who owns an allocation). **With no ambient owner, a resource has app lifetime** — which is why signals created in `main()` or in startup code keep working untouched.
 
 ### Ownership
 


### PR DESCRIPTION
Third PR in the #141 sequence (after #170 = PR0 and #174 = PR1). Adds the **ambient owner** — the layer that answers "who owns this resource?" — and nothing else. **Nothing is freed.** PR4 is the first PR that reclaims anything; this one exists so that when it lands, the ownership question is already answered.

Implements the sequencing and every sub-decision ratified in the [#141 design comment](https://github.com/joeleaver/rinch/issues/141), including both maintainer calls that land here: **push the owner at handler dispatch** (decision 1) and **delete `Scope::child_scope`** (decision 5).

## The mechanism

`Scope` becomes an `Rc<ScopeInner>` handle carrying an `Owned` bucket, and a new thread-local **owner stack** makes "the scope currently being built" ambient. Every resource constructor records itself into it.

Two stacks now exist, and they are deliberately independent:

| stack | suspended by | answers |
|---|---|---|
| `observer_stack` (existing) | `untracked` | *who subscribes to this read* |
| `owner_stack` (new) | `unowned` | *who owns this allocation* |

That separation is load-bearing, not cosmetic: `for_loop.rs` already wraps two of its render sites in `untracked`, and those items must still be **owned** by their item scope.

**No ambient owner means app lifetime.** This is what makes the change non-breaking — signals created in `main()`, in startup routines, in menu callbacks and in the DevTools store are owned by nobody and keep working untouched.

## Every new reference edge is `Weak`

This is the part most worth reviewing. `EffectInner::owner`, `MemoInner::owner`, the four handler wrappers, the owner stack, and the public `Owner` are all `Weak<ScopeInner>`.

A strong edge in any of them would be actively harmful rather than merely wasteful. `EFFECTS` holds an `Rc<EffectInner>` and the only thing that clears a slot is `Effect::dispose`, whose only production caller is `Scope::dispose`. A strong `EffectInner -> ScopeInner` edge therefore closes the loop `EFFECTS -> EffectInner -> ScopeInner -> (never dropped) -> dispose never runs -> EFFECTS never cleared` — converting the leak this issue exists to fix into a permanent one.

The owner stack holds `Weak` for a subtler reason: `flush_effects` is re-entrant, so an effect body can transitively drop the last handle to the scope currently on the stack. With an `Rc` there, `ScopeInner::drop` — and therefore teardown — would be deferred to the guard's epilogue, an observable change from today. There is a test that fails if the stack is switched to `Rc`.

`Scope` is deliberately **not** `Clone`. That is a chosen invariant, and it discharges two proofs at once: disposal still happens exactly when the single handle drops, and the strong graph rooted at a `ScopeInner` stays a forest.

## Where the owner is pushed

All nine production render sites, `run_effect`, `Memo`'s lazy recompute, and all four `register_*` registrars.

The registrars mirror the existing #136 pattern exactly — capture at registration, re-push at dispatch — so a `Signal::new` inside an `onclick` belongs to the component that installed the handler, not to whatever was rendering when the event loop fired. `Memo`'s recompute needs the same treatment for the same structural reason `MemoInner::root` already does: the computation runs lazily in the *reader's* frame.

The render-site guards are narrow by rule — they cover exactly the user render call — so a dying scope's teardown is never attributed to the incoming one.

## New API

`Scope::run` (was a literal `// TODO` no-op), `Scope::push_owner`/`owner`/`owned_counts`, `Owner`, `OwnerGuard`, `OwnedCounts`, `current_owner`, `unowned`, `Signal::leak`, `Memo::leak`, `RenderScope::push_owner`/`owned_counts`/`owner`, and `events::unregister_handler` (uncalled — PR4 wires it).

`Owner`/`current_owner`/`unowned` sit at the `rinch` crate root rather than in the prelude, alongside `Effect` and for the same reason. `unowned` is an attractive nuisance in particular: once PR4 lands, a user hitting a read-after-free could "fix" it by wrapping the creation in `unowned`, turning a correctness bug into a permanent leak. Its docs say so and point at `try_get`/`is_alive`.

`leak` searches the **whole** owner stack rather than just its top. A `leak()` written inside a nested `if`/`for`/`match` branch runs with the branch's child scope ambient while the entry sits in the enclosing scope's bucket, so a top-only implementation would be a silent no-op whose PR4 failure mode is a use-after-free. Removing from an ancestor is safe because `(id, generation)` is globally unique per store — the entry found *is* this signal's entry.

## `Scope::child_scope` deleted

Broken as documented (it returned a detached scope and never linked it) and had zero callers — only its own doc comment and definition. `RenderScope::child_scope` is a different method and stays, now `#[doc(hidden)]` with a note that resources created through the returned `&mut` are attributed to the ambient parent. That is structurally unfixable, since the returned reference outlives any guard the method could return; its only caller is a test.

## Deliberate non-goals

- **Nothing is freed.** `Owned` is write-only. `free_memo`, `SignalStore::free`, `MemoStore::free` and the new `unregister_handler` keep `#[allow(dead_code)]` and stay uncalled.
- **`dispose` does not drain `owned`** — draining without freeing would destroy the only observable evidence the plumbing works. Two comments mark PR4's insertion points.
- The dispose fixpoint (PR4), store-entry cleanup (PR3), `focused_input_handler_id` invalidation (PR5), and `EFFECTS` → `HashMap` (PR6) are all untouched.
- Effects are **counted, not adopted**. Adoption stays explicit via `add_effect`, because that is what `dispose` acts on. The gap between `owned_counts().effects` and `effect_count()` is the number of fire-and-forget effects nothing will ever dispose — newly visible, deliberately not changed.

### How to check "nothing is freed"

`dispose`/`dispose_into_queue` moved to `impl ScopeInner` verbatim apart from the receiver and two PR4 marker comments — `owned` appears nowhere inside them. The diff adds no call to any free/unregister function. `dispose_leaves_the_owned_bucket_intact` asserts the counts and liveness are identical across a `dispose()`.

## Verification

- Full CI gate: `fmt`, `clippy --workspace --all-targets -D warnings`, `cargo test --workspace`, all three feature-gated combinations from #168, and all three `rinch` feature checks.
- wasm32 checks pass; `rinch-web` browser tests pass in real Chrome, including a new one for the web mount.
- `cargo test -p rinch-core --lib -- --test-threads=1` passes (129), so nothing depends on per-test thread-local isolation.
- Live `ui-zoo-desktop`: section swaps, drawer, input handlers, menu callbacks, dark-mode restyle, editor mount and typing.

**26 counterfactual mutations were applied one at a time, and all 26 were detected.** Because mechanism and tests share files here, `git stash` cannot separate them — each mechanism edit was reverted *in place*, the target test run, and confirmed failing, then restored. The mutations cover every `record_*`, every push site, `Scope::run`, `OwnerGuard::drop`, the disposed-owner gate, `leak`'s stack search and its key-matching, `Drop for ScopeInner`, a `dispose` that frees handlers, and the `Weak`→`Rc` owner-stack swap.

## Review

A 5-lens adversarial review (cycles/drop-order, attribution correctness, behavior preservation, test quality, API/docs) raised 22 findings; 6 survived independent refutation, all nit/low. **No contract violation was found**, and the three hard contracts were re-verified by hand: `dispose_into_queue` leaves `owned` untouched; exactly one site constructs an `Rc<ScopeInner>` and every other reference to it is a `Weak`, so no cycle is constructible; guard nesting is `push_context_root` → `owner.push()` → `ObserverGuard::push`, all RAII and LIFO, with `BTreeSet` subscriber sets and the `pop_front` drain intact.

Five findings are fixed here:

- `reactive/mod.rs` — `[Weak]` was an unresolved intra-doc link. Only visible under `--document-private-items`, which is exactly what `docs.yml` runs. `rinch-core` is back to its 2 pre-existing warnings.
- `scope.rs` — `Scope::run` linked to a `#[doc(hidden)]` target, rendering a dead anchor; now plain prose.
- `scope.rs` — `Owner::run` did not state the dead-owner rule, which lived on the `pub(crate)` `Owner::push` and was therefore invisible. Documented, including the deliberate asymmetry: attribution does *not* fall through to the next owner down, but `leak` does look past a dead entry, because it is finding an existing record rather than choosing where to put a new one.
- `scope.rs` — the `leak` ancestor test left the innermost bucket empty, so a key-blind "remove the first entry" implementation would have passed by luck. Added a decoy signal; verified the mutation is now caught.
- `scope.rs` — `dispose_leaves_the_owned_bucket_intact` never registered a handler, and the bucket counts alone cannot see a free (PR2 does not drain on dispose). It now dispatches a handler after `dispose()`; verified a `dispose`-frees-handlers mutation is caught.

## Notes for the next PR

- `reset_handler_ids` now documents an invariant PR4 depends on: rewinding a process-global counter aliases handler ids still recorded against a live scope. Safe today only because every production caller runs at startup.
- `unregister_handler` drops each removed callback *outside* its registry borrow. `remove_handlers_in_range`'s `retain` drops them inside — a latent re-entrancy bug PR4 must not inherit.
- `Memo::leak` drops the `MemoKey` from `Owned` but leaves `MemoInner::owner` holding its `Weak`, so PR4's fixpoint can never reach it — reset it to `Owner::none()` on dispose. `Signal::leak` is unaffected; signals store no `Owner`.
- `crates/rinch-video`'s `ACTIVE_PLAYERS` registry has no `on_cleanup`/`Drop` wiring (pre-existing, untouched here). Belongs on PR4's checklist beside the known `ACTIVE_DRAG` gotcha; the first read that would panic is `native/mpv_player.rs:219`.
- `docs/src/architecture/reactive-system.md:165` claims disposing a scope drops its primitives — false today, pre-existing, and true once PR4 lands. Fix it there. Note `docs/src/guide/reactivity.md` is orphaned from `SUMMARY.md`, so user-facing docs for `Owner`/`unowned`/`leak` belong in `hooks.md`/`signals.md`/`effects.md`.
- Two pre-existing `cargo doc` warnings remain in `rinch-core` (`context.rs:198`, `timer.rs:15`); both files are byte-identical to `main`. Likewise the pre-existing `unused_mut` at `rinch/src/lib.rs:296` under `--features theme`. Left alone to keep this diff to one concern.

Closes nothing on its own — #141 stays open until PR4 lands.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
