### PR TITLE
fix(rinch-core): #141 PR3 — store/context entries die with their creating scope

### DIFF
--- a/crates/rinch-core/src/context.rs
+++ b/crates/rinch-core/src/context.rs
@@ -13,6 +13,27 @@
 //! mount, and effects/event handlers capture the current root at creation
 //! time, so each context resolves its own namespace first and falls back to
 //! root `0` for anything it didn't create itself.
+//!
+//! # Entry lifetime (issue #141)
+//!
+//! An entry lives as long as the **scope that created it**. What that means in
+//! practice depends on where `create_store`/`create_context` was called:
+//!
+//! | called from | entry lives until |
+//! |---|---|
+//! | outside any render — startup, `main()`, a menu/tray callback, a timer | the thread ends (no ambient owner) |
+//! | a root component body | that mount is torn down |
+//! | a `match` arm, `for` body or `show` branch | that branch is swapped away |
+//! | a component re-rendered by `reactive_component_dom` | its next re-render |
+//! | an event handler or effect body | the scope that *registered* it dies |
+//!
+//! Only the **entry** is owned, never the signals inside it — the caller builds
+//! those before `create_store` is entered, so there is nothing to reparent. A
+//! store whose entry is gone reports the usual "Store not found" from
+//! [`use_store`], rather than handing back dangling handles.
+//!
+//! To opt out and keep an entry for the life of the thread, create it under
+//! [`unowned`](crate::reactive::unowned).
 
 use std::any::{Any, TypeId};
 use std::cell::{Cell, RefCell};
@@ -21,13 +42,67 @@ use std::collections::HashMap;
 /// The thread-global fallback root (see module docs).
 const GLOBAL_ROOT: u64 = 0;
 
+/// One insertion into the store.
+///
+/// The `epoch` exists for exactly one reason: a scope's cleanup runs *later*,
+/// and by then the slot may hold somebody else's entry (issue #141). Removing
+/// by key alone would let a dying scope delete a live scope's store.
+struct ContextEntry {
+    epoch: u64,
+    value: Box<dyn Any>,
+}
+
 // Thread-local context store for sharing state across components, keyed by
 // (root, TypeId) — each mounted root gets its own namespace (issue #136).
 thread_local! {
-    static CONTEXT_STORE: RefCell<HashMap<(u64, TypeId), Box<dyn Any>>> =
+    static CONTEXT_STORE: RefCell<HashMap<(u64, TypeId), ContextEntry>> =
         RefCell::new(HashMap::new());
     /// The root whose namespace create/use_context resolve right now.
     static CURRENT_ROOT: Cell<u64> = const { Cell::new(GLOBAL_ROOT) };
+    /// Monotonic insertion counter. Never reused, and deliberately **not** reset
+    /// by `clear_context`/`clear_context_for_root` — resetting it would recreate
+    /// the exact ABA the epoch exists to prevent.
+    static NEXT_EPOCH: Cell<u64> = const { Cell::new(1) };
+}
+
+fn next_epoch() -> u64 {
+    NEXT_EPOCH.with(|c| {
+        let epoch = c.get();
+        c.set(epoch + 1);
+        epoch
+    })
+}
+
+/// Remove `(root, tid)` **iff** it still carries `epoch`, returning the entry so
+/// the caller drops it outside the store borrow.
+///
+/// Total by construction: a missing or already-replaced entry is a no-op, never
+/// an assert. Both a scope cleanup and [`clear_context_for_root`] can target the
+/// same entry, in either order.
+#[must_use = "the removed value must be dropped outside the CONTEXT_STORE borrow"]
+fn take_context_entry(root: u64, tid: TypeId, epoch: u64) -> Option<ContextEntry> {
+    CONTEXT_STORE.with(|store| {
+        let mut store = store.borrow_mut();
+        match store.get(&(root, tid)) {
+            Some(entry) if entry.epoch == epoch => store.remove(&(root, tid)),
+            _ => None,
+        }
+    })
+}
+
+/// Remove every entry whose root satisfies `doomed`, dropping the values only
+/// after the store borrow is released.
+///
+/// `HashMap::retain` would drop them *inside* the borrow, and a removed value's
+/// `Drop` can now dispose a scope, whose cleanup re-enters this store
+/// (issue #141).
+fn clear_roots(doomed: impl Fn(u64) -> bool) {
+    let removed: Vec<ContextEntry> = CONTEXT_STORE.with(|store| {
+        let mut store = store.borrow_mut();
+        let keys: Vec<(u64, TypeId)> = store.keys().filter(|(r, _)| doomed(*r)).copied().collect();
+        keys.into_iter().filter_map(|k| store.remove(&k)).collect()
+    });
+    drop(removed);
 }
 
 /// The context root currently in effect on this thread (`0` = the
@@ -69,6 +144,13 @@ pub fn push_context_root(root: u64) -> ContextRootGuard {
 /// built, or the thread-global root when called outside any root (see module
 /// docs).
 ///
+/// # Lifetime
+///
+/// The entry is owned by the scope that created it and is removed when that
+/// scope is disposed; created outside any render it lives for the life of the
+/// thread. See the "Entry lifetime" section of the [module docs](self) for the
+/// full table, and [`unowned`](crate::reactive::unowned) to opt out.
+///
 /// # Example
 ///
 /// ```ignore
@@ -108,12 +190,39 @@ pub fn push_context_root(root: u64) -> ContextRootGuard {
 /// }
 /// ```
 pub fn create_context<T: Clone + 'static>(value: T) -> T {
+    // Captured HERE rather than read back in the cleanup: the cleanup runs at
+    // dispose time with no root guard pushed, so `current_context_root()` would
+    // report the thread-global root 0 — a *different* namespace. Same reasoning
+    // as the handler wrappers in `crate::events` (issue #136).
     let root = current_context_root();
-    CONTEXT_STORE.with(|store| {
-        store
-            .borrow_mut()
-            .insert((root, TypeId::of::<T>()), Box::new(value.clone()));
+    let tid = TypeId::of::<T>();
+    let epoch = next_epoch();
+
+    // Cloned and boxed BEFORE taking the borrow. `store.borrow_mut().insert(k,
+    // Box::new(value.clone()))` evaluates the receiver first, so `T::clone` —
+    // arbitrary user code — would run while the store is mutably borrowed.
+    let boxed: Box<dyn Any> = Box::new(value.clone());
+    let displaced = CONTEXT_STORE.with(|store| {
+        store.borrow_mut().insert(
+            (root, tid),
+            ContextEntry {
+                epoch,
+                value: boxed,
+            },
+        )
     });
+    // Any value this replaced is dropped out here, after the borrow is released.
+    drop(displaced);
+
+    // Tie the ENTRY to the scope that created it (issue #141). Not the signals
+    // inside it: the caller built those before this function was entered, so
+    // there is nothing to reparent. With no ambient owner — startup code, a menu
+    // callback, a timer — nothing is registered and the entry keeps the app
+    // lifetime it has always had.
+    let _registered = crate::reactive::on_cleanup_for_ambient_owner(move || {
+        drop(take_context_entry(root, tid, epoch));
+    });
+
     value
 }
 
@@ -187,7 +296,7 @@ pub fn try_use_context<T: Clone + 'static>() -> Option<T> {
                     .then(|| store.get(&(GLOBAL_ROOT, tid)))
                     .flatten()
             })
-            .and_then(|b| b.downcast_ref::<T>())
+            .and_then(|entry| entry.value.downcast_ref::<T>())
             .cloned()
     })
 }
@@ -195,10 +304,14 @@ pub fn try_use_context<T: Clone + 'static>() -> Option<T> {
 /// Create a store — a shared state container accessible from any component.
 ///
 /// Stores are the recommended way to manage application state in rinch.
-/// A store is a struct with [`Signal`] fields and action methods that
-/// encapsulate state mutations and side effects.
+/// A store is a struct with [`Signal`](crate::reactive::Signal) fields and
+/// action methods that encapsulate state mutations and side effects.
 ///
 /// This is an alias for [`create_context`] with store-oriented naming.
+///
+/// The store entry is owned by the scope that created it — see the "Entry
+/// lifetime" section of the [module docs](self). Calling this from a root
+/// component body (the usual place) gives it that mount's lifetime.
 ///
 /// # Example
 ///
@@ -266,7 +379,7 @@ pub fn try_use_store<T: Clone + 'static>() -> Option<T> {
 /// Per-root namespaces are untouched — they are cleared by
 /// [`clear_context_for_root`] when their root is dropped.
 pub fn clear_context() {
-    CONTEXT_STORE.with(|store| store.borrow_mut().retain(|(r, _), _| *r != GLOBAL_ROOT));
+    clear_roots(|r| r == GLOBAL_ROOT);
 }
 
 /// Clear one root's context namespace.
@@ -274,5 +387,291 @@ pub fn clear_context() {
 /// Called when a mounted root (e.g. an embed `RinchContext`) is dropped, so
 /// its stores/contexts do not outlive it (issue #136).
 pub fn clear_context_for_root(root: u64) {
-    CONTEXT_STORE.with(|store| store.borrow_mut().retain(|(r, _), _| *r != root));
+    clear_roots(move |r| r == root);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reactive::{Scope, unowned};
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct S(&'static str);
+    #[derive(Clone, Debug, PartialEq)]
+    struct T2(&'static str);
+
+    /// The core of PR3: an entry created under a scope dies with it.
+    #[test]
+    fn a_store_created_under_a_scope_dies_with_it() {
+        let scope = Scope::new();
+        scope.run(|| create_store(S("owned")));
+        assert_eq!(try_use_store::<S>(), Some(S("owned")));
+
+        scope.dispose();
+        assert_eq!(
+            try_use_store::<S>(),
+            None,
+            "the entry must not outlive the scope that created it"
+        );
+    }
+
+    /// The other direction, and the reason this is non-breaking: with no ambient
+    /// owner an entry keeps app lifetime. This is what keeps the DevTools store
+    /// alive across F12 open/close cycles.
+    #[test]
+    fn a_store_created_with_no_owner_survives_a_scope_dispose() {
+        clear_context();
+        create_store(S("global"));
+
+        let scope = Scope::new();
+        scope.run(|| create_store(T2("scoped")));
+        scope.dispose();
+
+        assert_eq!(
+            try_use_store::<S>(),
+            Some(S("global")),
+            "an unowned entry must survive an unrelated scope's disposal"
+        );
+        assert_eq!(try_use_store::<T2>(), None, "the scoped one is reclaimed");
+        clear_context();
+    }
+
+    /// The ABA case the epoch exists for: two sibling scopes create the same
+    /// type, then the *earlier* one dies. It must not delete the live entry.
+    ///
+    /// Reachable for real — two `for` items rendering the same component. The
+    /// self-replacement case (one component re-rendering) is safe without an
+    /// epoch, because every re-render site disposes the old scope before
+    /// building the new one; siblings have no such ordering.
+    #[test]
+    fn a_later_scopes_entry_survives_the_earlier_scopes_dispose() {
+        clear_context();
+        let a = Scope::new();
+        let b = Scope::new();
+
+        a.run(|| create_store(S("a")));
+        b.run(|| create_store(S("b")));
+        assert_eq!(try_use_store::<S>(), Some(S("b")), "last write wins");
+
+        a.dispose();
+        assert_eq!(
+            try_use_store::<S>(),
+            Some(S("b")),
+            "a stale cleanup must not remove an entry it no longer owns"
+        );
+
+        b.dispose();
+        assert_eq!(try_use_store::<S>(), None, "the live owner still reclaims");
+        clear_context();
+    }
+
+    /// Creating the same type twice in one scope leaves two cleanups; the epoch
+    /// makes the stale one inert, so no de-duplication is needed.
+    #[test]
+    fn duplicate_creates_in_one_scope_remove_exactly_the_live_entry() {
+        clear_context();
+        let a = Scope::new();
+        let b = Scope::new();
+
+        a.run(|| {
+            create_store(S("first"));
+            create_store(S("second"));
+        });
+        b.run(|| create_store(S("third")));
+
+        a.dispose();
+        assert_eq!(
+            try_use_store::<S>(),
+            Some(S("third")),
+            "both of A's cleanups must no-op against B's entry"
+        );
+
+        b.dispose();
+        assert_eq!(try_use_store::<S>(), None);
+        clear_context();
+    }
+
+    /// The cleanup must target the root that was current at *creation*. At
+    /// dispose time no root guard is pushed, so reading it back would resolve
+    /// the thread-global root 0 and delete the wrong namespace.
+    #[test]
+    fn a_cleanup_removes_only_its_creation_root() {
+        clear_context();
+        create_store(S("root-zero"));
+
+        let scope = Scope::new();
+        {
+            let _root = push_context_root(7);
+            scope.run(|| create_store(S("root-seven")));
+        }
+
+        // Dispose with CURRENT_ROOT back at 0.
+        scope.dispose();
+
+        assert_eq!(
+            try_use_store::<S>(),
+            Some(S("root-zero")),
+            "the root-0 entry belongs to nobody and must be untouched"
+        );
+        {
+            let _root = push_context_root(7);
+            assert_eq!(
+                try_use_store::<S>(),
+                Some(S("root-zero")),
+                "root 7's own entry is gone, so the lookup falls back to root 0"
+            );
+        }
+        clear_context();
+    }
+
+    /// A scope cleanup and `clear_context_for_root` can both target one entry,
+    /// in either order, without panicking or removing a later re-creation.
+    #[test]
+    fn clear_context_for_root_then_dispose_is_idempotent() {
+        clear_context();
+        let a = Scope::new();
+        {
+            let _root = push_context_root(9);
+            a.run(|| create_store(S("first")));
+        }
+
+        clear_context_for_root(9);
+        {
+            let _root = push_context_root(9);
+            unowned(|| create_store(S("recreated")));
+        }
+
+        a.dispose(); // A's cleanup is now stale
+        {
+            let _root = push_context_root(9);
+            assert_eq!(
+                try_use_store::<S>(),
+                Some(S("recreated")),
+                "a cleanup whose entry was already cleared must not remove its successor"
+            );
+        }
+        clear_context_for_root(9);
+        clear_context();
+    }
+
+    /// A store value whose `Drop` re-enters the context store must not
+    /// `BorrowMutError`. Pins that removed values are dropped outside the borrow.
+    #[test]
+    fn a_store_drop_that_re_enters_the_context_store_does_not_panic() {
+        clear_context();
+        #[derive(Clone)]
+        struct Probe(Rc<RefCell<Vec<&'static str>>>);
+        impl Drop for Probe {
+            fn drop(&mut self) {
+                // Re-entrant read while the store is being mutated elsewhere.
+                let _ = try_use_context::<S>();
+                self.0.borrow_mut().push("dropped");
+            }
+        }
+
+        let log = Rc::new(RefCell::new(Vec::new()));
+        let scope = Scope::new();
+        scope.run(|| drop(create_context(Probe(log.clone()))));
+
+        scope.dispose();
+        assert!(
+            log.borrow().contains(&"dropped"),
+            "the removed value's Drop must have run"
+        );
+        assert!(
+            try_use_context::<Probe>().is_none(),
+            "and the entry must be gone"
+        );
+        clear_context();
+    }
+
+    /// Replacing an entry drops the displaced value outside the store borrow.
+    /// Pre-PR3 this panicked: `insert` dropped it while the `RefMut` was live.
+    #[test]
+    fn replacing_an_entry_drops_the_old_value_outside_the_borrow() {
+        clear_context();
+        #[derive(Clone)]
+        struct Probe;
+        impl Drop for Probe {
+            fn drop(&mut self) {
+                // Would panic "already mutably borrowed" if this ran under the
+                // insert's borrow.
+                let _ = try_use_context::<S>();
+            }
+        }
+
+        unowned(|| {
+            drop(create_context(Probe));
+            drop(create_context(Probe)); // displaces the first
+        });
+        clear_context();
+    }
+
+    /// `clear_context_for_root` drops removed values outside the borrow too.
+    /// This is the path `RinchContext::drop` takes on every embed teardown.
+    #[test]
+    fn clear_context_for_root_drops_values_outside_the_borrow() {
+        clear_context();
+        #[derive(Clone)]
+        struct Probe;
+        impl Drop for Probe {
+            fn drop(&mut self) {
+                let _ = try_use_context::<S>();
+            }
+        }
+
+        {
+            let _root = push_context_root(5);
+            unowned(|| drop(create_context(Probe)));
+        }
+        clear_context_for_root(5); // must not panic
+        clear_context();
+    }
+
+    /// A `create_store` that reaches the *disposing* scope as its ambient owner
+    /// gets app lifetime rather than panicking on the borrowed cleanup list.
+    ///
+    /// Getting there takes a specific shape, because `dispose` itself pushes no
+    /// owner: a cleanup writes a signal, the synchronous flush re-runs an effect
+    /// that is enqueued-but-not-yet-disposed, and `run_effect` re-pushes *that
+    /// effect's* owner — which is the scope currently mid-drain.
+    ///
+    /// Two redundant guards make this safe: `with_ambient_scope` rejects a
+    /// disposed owner, and `on_cleanup_for_ambient_owner` uses `try_borrow_mut`.
+    /// Either alone suffices, so only removing **both** reproduces the panic.
+    #[test]
+    fn a_store_created_under_a_disposing_scope_gets_app_lifetime() {
+        use crate::reactive::{Effect, Signal};
+
+        clear_context();
+        let scope = Scope::new();
+        scope.run(|| create_store(S("doomed")));
+
+        let trigger = Signal::new(0);
+        let effect = scope.run(|| {
+            Effect::new(move || {
+                if trigger.get() > 0 {
+                    create_store(T2("born-during-dispose"));
+                }
+            })
+        });
+        scope.add_effect(effect);
+
+        // Runs while `cleanups` is borrowed by the drain; the write flushes the
+        // effect above, which re-pushes this scope as the ambient owner.
+        scope.on_cleanup(move || trigger.set(1));
+
+        scope.dispose();
+
+        assert_eq!(try_use_store::<S>(), None, "the owned entry is reclaimed");
+        assert_eq!(
+            try_use_store::<T2>(),
+            Some(T2("born-during-dispose")),
+            "a store whose only candidate owner is already disposing falls back \
+             to app lifetime instead of attaching to a corpse"
+        );
+        clear_context();
+    }
 }

--- a/crates/rinch-core/src/reactive/mod.rs
+++ b/crates/rinch-core/src/reactive/mod.rs
@@ -83,10 +83,11 @@ pub use bounds::{
 pub use effect::Effect;
 pub use memo::Memo;
 pub use poll::{PollRate, drain_polls, poll_signal};
-/// Attribution hook for `crate::events`, which registers handlers on behalf of
-/// the scope currently rendering.
-pub(crate) use scope::record_handler;
 pub use scope::{OwnedCounts, Owner, OwnerGuard, Scope, current_owner, unowned};
+/// Ambient-owner hooks for the rest of the crate: `crate::events` attributes
+/// handlers to the scope currently rendering, and `crate::context` ties a
+/// store/context entry to the scope that created it (issue #141).
+pub(crate) use scope::{on_cleanup_for_ambient_owner, record_handler};
 pub use signal::Signal;
 
 use std::any::Any;

--- a/crates/rinch-core/src/reactive/scope.rs
+++ b/crates/rinch-core/src/reactive/scope.rs
@@ -211,7 +211,14 @@ impl Scope {
 
     /// Register a cleanup function to run when this scope is disposed.
     ///
-    /// Cleanup functions run after child scopes and effects are disposed.
+    /// Today cleanups run *before* this scope's child scopes are processed, and
+    /// before its effects are actually disposed — disposal only enqueues them.
+    /// **Do not depend on either**: issue #141's PR4 reorders disposal to
+    /// handlers → effects → cleanups so that a cleanup cannot resurrect a
+    /// disposed effect.
+    ///
+    /// A cleanup must not register another cleanup on the *same* scope: the
+    /// cleanup list is borrowed for the duration of the drain that runs it.
     pub fn on_cleanup<F: FnOnce() + 'static>(&self, f: F) {
         self.0.cleanups.borrow_mut().push(Box::new(f));
     }
@@ -578,16 +585,25 @@ pub fn unowned<R>(f: impl FnOnce() -> R) -> R {
     f()
 }
 
-/// Run `f` against the ambient owner's bucket, if there is a live one.
-fn with_ambient_owned<R>(f: impl FnOnce(&mut Owned) -> R) -> Option<R> {
+/// Run `f` against the live ambient owner's scope, if there is one.
+///
+/// "Live" is load-bearing in both directions: a dead **or disposed** top entry
+/// resolves to *no owner*, and the stack is deliberately not walked down past it
+/// — it is not an ancestor chain (see [`Owner::push`]).
+///
+/// Holds a strong `Rc<ScopeInner>` across `f`, so `f` must stay allocation-only.
+/// No user code may run inside it.
+fn with_ambient_scope<R>(f: impl FnOnce(&ScopeInner) -> R) -> Option<R> {
     let inner = RUNTIME.with(|rt| rt.borrow().owner_stack.last().and_then(|w| w.upgrade()))?;
     if inner.disposed.get() {
         return None;
     }
-    // The borrow is released before returning, and `f` only touches plain data,
-    // so no user code runs under it.
-    let result = f(&mut inner.owned.borrow_mut());
-    Some(result)
+    Some(f(&inner))
+}
+
+/// Run `f` against the ambient owner's bucket, if there is a live one.
+fn with_ambient_owned<R>(f: impl FnOnce(&mut Owned) -> R) -> Option<R> {
+    with_ambient_scope(|inner| f(&mut inner.owned.borrow_mut()))
 }
 
 /// Walk the owner stack top-down and run `f` against the first live bucket for
@@ -626,6 +642,50 @@ pub(in crate::reactive) fn record_effect(id: ObserverId) {
 /// Called from [`crate::events`] at registration time.
 pub(crate) fn record_handler(id: EventHandlerId) {
     with_ambient_owned(|owned| owned.handlers.push(id));
+}
+
+/// Register a cleanup to run when the ambient owner is disposed.
+///
+/// Returns `false` when there is no live ambient owner, in which case the
+/// caller's resource keeps **app lifetime** — the #141 SD2 default. Like
+/// [`with_ambient_owned`], a dead or disposed top entry counts as *no owner*
+/// and does not fall through to the next entry down: the owner stack is not an
+/// ancestor chain.
+///
+/// Called from [`crate::context`] to tie a store/context entry to the scope
+/// that created it.
+pub(crate) fn on_cleanup_for_ambient_owner(f: impl FnOnce() + 'static) -> bool {
+    with_ambient_scope(|inner| {
+        // `try_borrow_mut`, not `borrow_mut`: `dispose_into_queue` drains this
+        // vec with the borrow held across every cleanup it runs, so reaching a
+        // mid-drain scope here would panic.
+        //
+        // Reaching one is not easy — `dispose` pushes no owner, so the stack is
+        // normally empty by then — but it is possible: a cleanup writes a
+        // signal, the synchronous flush re-runs an effect that is
+        // enqueued-but-not-yet-disposed, and `run_effect` re-pushes that
+        // effect's owner, which is the disposing scope.
+        //
+        // Two guards cover it and either alone suffices: `with_ambient_scope`
+        // rejects a disposed owner (`disposed` is set before the drain begins),
+        // and this `try_borrow_mut`. Kept redundant deliberately — degrading to
+        // "not registered" beats taking the app down, matching the lenient-write
+        // stance PR1 established.
+        match inner.cleanups.try_borrow_mut() {
+            Ok(mut cleanups) => {
+                cleanups.push(Box::new(f));
+                true
+            }
+            Err(_) => {
+                tracing::warn!(
+                    "a cleanup was registered while its owning scope was already disposing; \
+                     it will not run"
+                );
+                false
+            }
+        }
+    })
+    .unwrap_or(false)
 }
 
 /// Detach a signal from whichever owner on the stack recorded it.
@@ -833,6 +893,52 @@ mod tests {
             "and ownership must not fall through to the next entry down"
         );
         assert!(signal.is_alive(), "the signal simply has app lifetime");
+    }
+
+    /// The cleanup hook `crate::context` uses to tie a store entry to its
+    /// creating scope registers against a **live ambient** owner only.
+    #[test]
+    fn on_cleanup_for_ambient_owner_registers_only_against_a_live_ambient_owner() {
+        let fired = Rc::new(Cell::new(0));
+
+        // No ambient owner => not registered (the resource keeps app lifetime).
+        assert!(
+            !on_cleanup_for_ambient_owner(|| {}),
+            "an empty owner stack must not accept a cleanup"
+        );
+
+        let scope = Scope::new();
+        let hits = fired.clone();
+        scope.run(|| {
+            assert!(
+                on_cleanup_for_ambient_owner(move || hits.set(hits.get() + 1)),
+                "a live ambient owner accepts the cleanup"
+            );
+            // `unowned` suspends the owner stack, so nothing to register against.
+            unowned(|| {
+                assert!(
+                    !on_cleanup_for_ambient_owner(|| {}),
+                    "`unowned` must hide the ambient owner from the cleanup hook too"
+                );
+            });
+        });
+
+        assert_eq!(fired.get(), 0, "cleanups do not run before disposal");
+        scope.dispose();
+        assert_eq!(fired.get(), 1, "the registered cleanup ran on dispose");
+
+        // A disposed top entry counts as no owner, and is NOT walked past.
+        let outer = Scope::new();
+        let inner = Scope::new();
+        outer.run(|| {
+            let _inner = inner.push_owner();
+            inner.dispose();
+            assert!(
+                !on_cleanup_for_ambient_owner(|| {}),
+                "a disposed ambient owner must not accept a cleanup, and must not \
+                 fall through to the live scope beneath it"
+            );
+        });
     }
 
     /// `leak` searches the whole owner stack, not just its top.

--- a/crates/rinch-core/src/show.rs
+++ b/crates/rinch-core/src/show.rs
@@ -430,4 +430,55 @@ mod tests {
             "and not to the parent render scope"
         );
     }
+
+    /// A store created inside a branch dies with that branch (issue #141 PR3).
+    ///
+    /// This is the claim SD2 rests on — "a `create_store` inside a `match` arm
+    /// removes its entry when the arm flips" — exercised on a real render path
+    /// rather than a bare `Scope`.
+    #[test]
+    fn a_store_created_in_a_branch_dies_with_the_branch() {
+        use crate::context::{clear_context, create_store, try_use_store};
+        use crate::dom::traits::DomDocument;
+        use crate::dom::{RenderScope, mock::MockDomDocument};
+        use crate::reactive::Signal;
+        use std::cell::RefCell;
+
+        #[derive(Clone, Debug, PartialEq)]
+        struct BranchStore(&'static str);
+
+        clear_context();
+        let doc = Rc::new(RefCell::new(MockDomDocument::new()));
+        let body = doc.borrow().body();
+        let mut scope = RenderScope::new(doc.clone(), body);
+        let parent = scope.parent();
+
+        let showing = Signal::new(true);
+        let marker = crate::show::show_dom(
+            &mut scope,
+            &parent,
+            move || showing.get(),
+            move |s: &mut RenderScope| {
+                create_store(BranchStore("in-branch"));
+                s.create_element("div")
+            },
+            Some(move |s: &mut RenderScope| s.create_element("span")),
+        );
+        let _ = marker;
+
+        assert_eq!(
+            try_use_store::<BranchStore>(),
+            Some(BranchStore("in-branch")),
+            "the store resolves while its branch is mounted"
+        );
+
+        showing.set(false); // flip: the then-branch's scope is disposed
+
+        assert_eq!(
+            try_use_store::<BranchStore>(),
+            None,
+            "flipping the branch must reclaim the store it created"
+        );
+        clear_context();
+    }
 }


### PR DESCRIPTION
Fourth PR in the #141 sequence (after #170 = PR0, #174 = PR1, #179 = PR2). **The first one that actually reclaims something**, so the blast radius gets more attention below than the mechanism does.

Implements sub-decision SD2 part 3 from the [#141 design comment](https://github.com/joeleaver/rinch/issues/141).

## The mechanism

`create_store` / `create_context` now register a cleanup on the ambient owner (PR2's owner stack) that removes the `(root, TypeId)` entry when that scope is disposed.

**Only the entry is owned, never the signals inside it.** The caller builds those before `create_store` is entered — `create_store(TodoStore::new())` — so there is nothing to reparent without magic. A store whose entry is gone reports the existing `"Store not found: … Did you forget to call create_store()"` from `use_store`, rather than handing back dangling handles.

**No ambient owner still means app lifetime**, so nothing created at startup, in a menu/tray callback, or in a timer changes at all.

## The epoch, and why it earns its keep

Each insertion carries a monotonic epoch; a cleanup removes its entry only if the epoch still matches.

I checked whether removal-by-key would have been enough, and it is *almost* enough: all four re-render sites (`show.rs`, `match_dom.rs`, `for_loop.rs`, `reactive_component_dom`) dispose the old scope **before** building the new one, so a component replacing its own store is safe on ordering alone. The gap is **siblings** — two `for` items rendering a component that creates the same store type have no such ordering, and the earlier one's teardown would delete the later one's live entry. Today that shape is harmless last-wins; without the epoch, PR3 would turn it into a regression.

The epoch is deliberately never reset by `clear_context`/`clear_context_for_root` — resetting it would recreate exactly the ABA it exists to prevent.

## Two latent borrow bugs fixed in passing

Both pre-existing on `main`, both found while writing this:

- `store.borrow_mut().insert(k, Box::new(value.clone()))` evaluates the **receiver first**, so `T::clone` — arbitrary user code — ran while the store was mutably borrowed. The displaced value was dropped under the same borrow.
- `clear_context` / `clear_context_for_root` used `HashMap::retain`, which drops removed values **inside** the borrow. That is the path `RinchContext::drop` takes on *every* embed teardown, and PR3 widens the hazard class from "a `Drop` that touches context directly" to "a `Drop` that disposes any scope".

Values are now dropped outside every borrow, and both have regression tests that panic against the old code.

## Blast radius

Every in-tree `create_store`/`create_context` site, classified:

| site | ambient owner | changes? |
|---|---|---|
| DevTools store + `MainDocRef` (`rinch_runtime.rs:333,359`) | **none** — reached from the event loop, after `handle_event` returned | no. Load-bearing: F12 close/reopen would break otherwise |
| `MenuBarContext` (`shell/mod.rs:258,280`) | root scope (runs just before `component(scope)`) | now freed at shutdown. Its only reader is `borderless_window.rs:182`, during the same root build |
| 8 × ui-zoo section stores via `init_all_sections()` | root scope — called inside `build_app` / `fn app()` on both platforms | now freed at shutdown |
| `todo-app`, `video-call` | root component body | now freed at shutdown |
| `multi_context.rs` tests | each `RinchContext`'s root scope | freed on `drop(ctx)` |

**No in-tree site sits inside a `match` arm, `for` body, `show` branch, a `reactive_component_dom` re-render, or an event handler.** `rinch-macros` emits no context calls.

Out-of-tree, a `create_store` in one of those nested positions now dies with that scope — which is the intent, and is documented. `unowned(|| create_store(…))` is the escape hatch.

## Also closes the web hole

`RootHandle::unmount` never cleared context, and since rinch-web never pushes a context root, every web root writes to root 0 — so `clear_context_for_root` could never have fixed it. Dropping `MountedRoot` disposes the root scope, which now runs these cleanups, so the generic mechanism closes it.

## Verification

- Full gate: `fmt`, `clippy --workspace --all-targets -D warnings`, `cargo test --workspace`, all three feature-gated combinations from #168, wasm32, and `rinch-web` browser tests in real Chrome.
- **6 counterfactual mutations, all 6 detected**: no cleanup registered; removal by key instead of epoch; root read at dispose time instead of captured; displaced value dropped inside the insert borrow; `clear_roots` reverted to `retain`; and both re-entrancy guards removed.
- Live `ui-zoo-desktop`: section stores across arm swaps (Inputs → Overlays → modal → back), the inline titlebar `MenuBarContext`, and three F12 DevTools cycles.

One test is worth calling out. `a_store_created_under_a_disposing_scope_gets_app_lifetime` reaches a genuinely awkward path: `dispose` pushes no owner, so the naive version of this test never exercised the re-entrancy it claimed to. Getting there needs a cleanup to write a signal, whose synchronous flush re-runs an effect that is enqueued-but-not-yet-disposed, so `run_effect` re-pushes *that effect's* owner — the scope currently mid-drain. Two redundant guards cover it (`with_ambient_scope` rejects a disposed owner; `on_cleanup_for_ambient_owner` uses `try_borrow_mut`), and only removing **both** reproduces the `RefCell already borrowed` panic — verified.

## Notes

- `Scope::on_cleanup`'s doc claimed cleanups run "after child scopes and effects are disposed". False on both counts today — corrected, with a pointer that PR4 reorders it.
- Cleared one pre-existing `cargo doc` warning in a file this PR already rewrites (`[Signal]` in `create_store`'s doc). `rinch-core` is down to one, in an untouched file.
- PR4 (the dispose fixpoint) is next; #141 stays open until it lands.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
