### PR TITLE
feat(editor-view): expose the Automerge sync protocol on EditorHandle

### DIFF
--- a/crates/rinch-editor-view/src/handle.rs
+++ b/crates/rinch-editor-view/src/handle.rs
@@ -973,14 +973,96 @@ impl EditorHandle {
     /// peer: hand it to a new guest's [`Self::start_collaboration_guest`] so they
     /// adopt the current content (not just the host's original document). `None`
     /// when this editor isn't collaborating. Assumes a reliable, ordered delta
-    /// transport between existing peers — the full Automerge sync protocol (for
-    /// lossy / out-of-order reconciliation) is not yet exposed through the handle.
+    /// transport between existing peers; for lossy / out-of-order reconciliation use
+    /// the sync protocol ([`Self::collab_generate_sync_message`] /
+    /// [`Self::collab_receive_sync_message`]) instead.
     pub fn collab_snapshot(&self) -> Option<Vec<u8>> {
         self.inner
             .borrow_mut()
             .collab
             .as_mut()
             .map(|b| b.session.snapshot())
+    }
+
+    /// Generate the next Automerge **sync-protocol** message for the peer tracked by
+    /// `sync_state`, or `None` when that peer is up to date (or this editor isn't
+    /// collaborating).
+    ///
+    /// This is the state-negotiating alternative to the incremental-delta broadcast
+    /// (`outbound` + [`Self::collab_receive`]). Prefer it when the transport is not a
+    /// reliable ordered stream — an HTTP poll, a reconnecting socket, a peer that was
+    /// offline — because it reconciles from each side's actual heads instead of
+    /// assuming every delta arrived exactly once.
+    ///
+    /// The caller owns the [`SyncState`], one per peer. Generating a message mutates
+    /// protocol bookkeeping only; the document is untouched, so nothing needs saving
+    /// as a result of this call.
+    ///
+    /// Uses `try_borrow_mut` and yields `None` if the handle is already borrowed, for
+    /// the same reason [`Self::collab_receive`] does.
+    pub fn collab_generate_sync_message(
+        &self,
+        sync_state: &mut rinch_editor_collab::SyncState,
+    ) -> Option<rinch_editor_collab::SyncMessage> {
+        let mut core = self.inner.try_borrow_mut().ok()?;
+        core.collab
+            .as_mut()?
+            .session
+            .generate_sync_message(sync_state)
+    }
+
+    /// Integrate a peer's Automerge **sync-protocol** message: merge it into the CRDT,
+    /// rebuild the model from the *converged* CRDT, and re-project the view. Like
+    /// [`Self::collab_receive`], the change lands as a non-undoable, remote-origin
+    /// transaction and is **not** re-broadcast. Returns whether the document changed
+    /// (a message that only advances protocol state returns `false`).
+    ///
+    /// Must run on the main thread. A projection failure is recorded and readable via
+    /// [`Self::collab_take_error`].
+    pub fn collab_receive_sync_message(
+        &self,
+        sync_state: &mut rinch_editor_collab::SyncState,
+        message: rinch_editor_collab::SyncMessage,
+    ) -> bool {
+        let Ok(mut core) = self.inner.try_borrow_mut() else {
+            return false;
+        };
+        if core.collab.is_none() {
+            return false;
+        }
+        let prev = core.state.clone();
+        let result = core.collab.as_mut().unwrap().session.integrate_sync_message(
+            &prev,
+            sync_state,
+            message,
+        );
+        match result {
+            Ok(Some(next)) => {
+                core.state = next.clone();
+                if let Some(view) = core.view.as_mut() {
+                    view.update_dom(&prev, &next);
+                }
+                true
+            }
+            Ok(None) => false,
+            Err(e) => {
+                if let Some(bridge) = core.collab.as_mut() {
+                    bridge.last_error = Some(e);
+                }
+                false
+            }
+        }
+    }
+
+    /// The CRDT's current heads (its change frontier), or `None` when this editor
+    /// isn't collaborating. Useful for persisting "what this peer had" alongside a
+    /// snapshot, and for diffing against a later frontier.
+    pub fn collab_heads(&self) -> Option<Vec<rinch_editor_collab::ChangeHash>> {
+        self.inner
+            .borrow_mut()
+            .collab
+            .as_mut()
+            .map(|b| b.session.heads())
     }
 
     /// Detach the collaboration session (stop projecting and broadcasting). The
@@ -1932,6 +2014,105 @@ mod tests {
             assert!(
                 h.contains('H') && h.contains('G'),
                 "both edits survived: {h}"
+            );
+        }
+
+        /// Run the Automerge sync protocol between two handles until both go quiet,
+        /// each side keeping its own [`SyncState`] — the shape a networked caller uses.
+        fn sync_until_quiet(a: &EditorHandle, b: &EditorHandle) {
+            use rinch_editor_collab::SyncState;
+            let mut a_state = SyncState::new();
+            let mut b_state = SyncState::new();
+            for _ in 0..20 {
+                let a_to_b = a.collab_generate_sync_message(&mut a_state);
+                if let Some(m) = a_to_b.clone() {
+                    b.collab_receive_sync_message(&mut b_state, m);
+                }
+                let b_to_a = b.collab_generate_sync_message(&mut b_state);
+                if let Some(m) = b_to_a.clone() {
+                    a.collab_receive_sync_message(&mut a_state, m);
+                }
+                if a_to_b.is_none() && b_to_a.is_none() {
+                    return;
+                }
+            }
+            panic!("sync protocol did not settle");
+        }
+
+        #[test]
+        fn the_sync_protocol_converges_two_peers_whose_deltas_never_arrived() {
+            let s = schema();
+            let host = mount(doc_node(&s, vec![para(&s, "hello")])).handle;
+            let guest = mount(doc_node(&s, vec![para(&s, "")])).handle;
+
+            // Deltas go nowhere: this models the transport the sync protocol exists
+            // for — an HTTP poll, a dropped socket, a peer that was offline. The
+            // broadcast path alone would leave these two permanently diverged.
+            let snapshot = host.start_collaboration_host(|_d| {}).unwrap();
+            guest
+                .start_collaboration_guest(&snapshot, |_d| {})
+                .unwrap();
+
+            host.set_selection(Selection::cursor(Pos(6)));
+            assert!(host.insert_text(" world"));
+            guest.set_selection(Selection::cursor(Pos(1)));
+            assert!(guest.insert_text("G"));
+            assert_ne!(
+                doc_text(&host),
+                doc_text(&guest),
+                "precondition: no delta was delivered, so the peers diverged"
+            );
+
+            sync_until_quiet(&host, &guest);
+
+            let h = doc_text(&host);
+            assert_eq!(h, doc_text(&guest), "the sync protocol converged the peers");
+            assert!(
+                h.contains("world") && h.contains('G'),
+                "both offline edits survived: {h}"
+            );
+            assert_eq!(
+                host.collab_heads(),
+                guest.collab_heads(),
+                "converged peers share one change frontier"
+            );
+        }
+
+        #[test]
+        fn sync_methods_are_inert_without_a_session() {
+            use rinch_editor_collab::SyncState;
+            let s = schema();
+            let solo = mount(doc_node(&s, vec![para(&s, "local only")])).handle;
+            let mut state = SyncState::new();
+            assert!(solo.collab_generate_sync_message(&mut state).is_none());
+            assert!(solo.collab_heads().is_none());
+            assert_eq!(doc_text(&solo), "local only", "the document is untouched");
+        }
+
+        #[test]
+        fn integrating_a_sync_message_does_not_echo() {
+            let s = schema();
+            let host = mount(doc_node(&s, vec![para(&s, "ab")])).handle;
+            let guest = mount(doc_node(&s, vec![para(&s, "")])).handle;
+
+            let snapshot = host.start_collaboration_host(|_d| {}).unwrap();
+            // A sync-integrated change must not fire the broadcast sink either — a
+            // caller running both transports would otherwise loop.
+            let guest_emits = Rc::new(Cell::new(0usize));
+            let ge = guest_emits.clone();
+            guest
+                .start_collaboration_guest(&snapshot, move |_d| ge.set(ge.get() + 1))
+                .unwrap();
+
+            host.set_selection(Selection::cursor(Pos(3)));
+            assert!(host.insert_text("c"));
+            sync_until_quiet(&host, &guest);
+
+            assert_eq!(doc_text(&guest), "abc", "host edit reached the guest");
+            assert_eq!(
+                guest_emits.get(),
+                0,
+                "integrating a sync message must not broadcast a delta back"
             );
         }
 

--- a/crates/rinch-editor-view/src/handle.rs
+++ b/crates/rinch-editor-view/src/handle.rs
@@ -1031,11 +1031,12 @@ impl EditorHandle {
             return false;
         }
         let prev = core.state.clone();
-        let result = core.collab.as_mut().unwrap().session.integrate_sync_message(
-            &prev,
-            sync_state,
-            message,
-        );
+        let result = core
+            .collab
+            .as_mut()
+            .unwrap()
+            .session
+            .integrate_sync_message(&prev, sync_state, message);
         match result {
             Ok(Some(next)) => {
                 core.state = next.clone();
@@ -2049,9 +2050,7 @@ mod tests {
             // for — an HTTP poll, a dropped socket, a peer that was offline. The
             // broadcast path alone would leave these two permanently diverged.
             let snapshot = host.start_collaboration_host(|_d| {}).unwrap();
-            guest
-                .start_collaboration_guest(&snapshot, |_d| {})
-                .unwrap();
+            guest.start_collaboration_guest(&snapshot, |_d| {}).unwrap();
 
             host.set_selection(Selection::cursor(Pos(6)));
             assert!(host.insert_text(" world"));

--- a/crates/rinch-editor-view/src/lib.rs
+++ b/crates/rinch-editor-view/src/lib.rs
@@ -34,6 +34,11 @@ pub use registry::{
 /// the [`EditorHandle`] collaboration methods.
 #[cfg(feature = "collaboration")]
 pub use rinch_editor_collab::CollabError;
+/// Automerge sync-protocol types (re-exported from `rinch-editor-collab`), so a caller
+/// driving [`EditorHandle::collab_generate_sync_message`] /
+/// [`EditorHandle::collab_receive_sync_message`] needs no direct `automerge` dependency.
+#[cfg(feature = "collaboration")]
+pub use rinch_editor_collab::{ChangeHash, SyncMessage, SyncState};
 pub use view::RinchDomEditorView;
 
 use std::rc::Rc;

--- a/crates/rinch-web/src/lib.rs
+++ b/crates/rinch-web/src/lib.rs
@@ -66,6 +66,11 @@ pub use rinch_editor_view::{Editor, EditorHandle, create_editor};
 // (that is the desktop runtime's off-thread marshaller).
 #[cfg(feature = "collaboration")]
 pub use rinch_editor_view::{CollabError, collab_receive_for};
+// The Automerge sync-protocol types, for a caller driving
+// `EditorHandle::collab_generate_sync_message` / `collab_receive_sync_message` (the
+// reconciling alternative to delta broadcast, for poll/reconnect transports).
+#[cfg(feature = "collaboration")]
+pub use rinch_editor_view::{ChangeHash, SyncMessage, SyncState};
 
 // ============================================================================
 // Mounted-root registry + per-page guards

--- a/crates/rinch/src/lib.rs
+++ b/crates/rinch/src/lib.rs
@@ -180,6 +180,11 @@ pub mod prelude {
     #[cfg(feature = "collaboration")]
     pub use crate::editor::{CollabError, collab_receive_for, post_remote_delta};
 
+    // The Automerge sync-protocol types, for a caller driving
+    // `EditorHandle::collab_generate_sync_message` / `collab_receive_sync_message`.
+    #[cfg(feature = "collaboration")]
+    pub use crate::editor::{ChangeHash, SyncMessage, SyncState};
+
     // Desktop-only GPU types for render surfaces
     #[cfg(feature = "gpu")]
     pub use crate::render_surface::{GpuTextureRegistrar, TextureSource};


### PR DESCRIPTION
## Why

`CollabSession` has had `generate_sync_message` / `integrate_sync_message` / `heads` since the collab seam landed, but `EditorHandle` only exposed the incremental-delta broadcast (`outbound` + `collab_receive`).

That path assumes a reliable, ordered stream — every delta arrives exactly once. A caller whose transport is an **HTTP poll**, a **reconnecting socket**, or a **peer that was offline** has no way to reconcile: one dropped delta leaves the peers permanently diverged with no route back. The protocol that fixes this already exists one layer down; it just isn't reachable from the handle.

## What

Three pass-throughs onto the existing `CollabSession` methods, behind the existing `collaboration` feature:

- **`collab_generate_sync_message(&mut SyncState) -> Option<SyncMessage>`** — mutates protocol bookkeeping only; the document is untouched, so the caller has nothing to persist as a result.
- **`collab_receive_sync_message(&mut SyncState, SyncMessage) -> bool`** — merges, rebuilds the model from the converged CRDT, re-projects the view. Same contract as `collab_receive`: non-undoable, remote-origin, never re-broadcast. Projection failures land in `collab_take_error`.
- **`collab_heads() -> Option<Vec<ChangeHash>>`**.

`ChangeHash` / `SyncMessage` / `SyncState` are re-exported from `rinch-editor-view` and through both shells (`rinch::prelude`, `rinch-web`), so driving the protocol needs no direct `automerge` dependency. `collab_snapshot`'s doc comment no longer claims the sync protocol is unavailable through the handle.

`collab_generate_sync_message` uses `try_borrow_mut` and yields `None` when the handle is already borrowed — the same fail-soft treatment `collab_receive` gives a self-wired `outbound` sink.

## Tests

- **`the_sync_protocol_converges_two_peers_whose_deltas_never_arrived`** — the case that motivates the PR. Both peers edit with their `outbound` sinks wired to nothing (the offline/dropped-transport case broadcast cannot recover from); the test asserts they have genuinely diverged, then runs the protocol to convergence and checks both edits survived and the heads match.
- **`sync_methods_are_inert_without_a_session`** — no session: `None`, and the document is untouched.
- **`integrating_a_sync_message_does_not_echo`** — a sync-integrated change must not fire the broadcast sink, or a caller running both transports loops.

`cargo test -p rinch-editor-view --features collaboration` → 71 passed. Feature-off build clean. `rinch-editor-collab`, `rinch-editor-core`, `rinch-core`, `rinch-dom` green.

Two pre-existing failures in this environment, verified identical on unmodified `main` and untouched here: `audiopus_sys` needs an opus system dep (blocks a full `--workspace` run), and a standalone `rinch-web` wasm build fails on `uuid`'s js-randomness feature (consumers set it).

## Context

Written for PlotWeb's offline-first sync engine, where the server is a stateless HTTP endpoint that cannot push — exactly the transport the broadcast path can't serve. Structure docs (`user:` / `book:`) already sync there via plain `AutoCommit`; chapter and note bodies live behind this handle and are blocked on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NBUWjfUCLa29P4mqkAf7cr
