### PR TITLE
fix(rinch-core): #141 PR4 — the dispose fixpoint

### DIFF
--- a/crates/rinch-components/src/tabs.rs
+++ b/crates/rinch-components/src/tabs.rs
@@ -222,15 +222,24 @@ impl Component for Tabs {
         for (value, btn) in &tab_buttons {
             let val = value.clone();
             let active = active_tab;
-            // Preserve any user-provided onclick handler
-            let user_rid = btn
-                .get_attribute("data-user-rid")
-                .and_then(|s| s.parse::<usize>().ok())
-                .map(rinch_core::events::EventHandlerId);
+            // Preserve any user-provided onclick handler.
+            //
+            // The id is re-read from the button at *dispatch* time rather than
+            // captured here. `Tab` registers its handler under whichever scope
+            // built that button, which need not be the scope building this
+            // `Tabs` — a `for`-generated or conditional tab list makes them
+            // different — and disposing the inner one frees its handler while
+            // this wrapper survives (issue #141). A captured id would then
+            // silently stop firing; a re-read one simply resolves to nothing.
+            let button = btn.clone();
             let handler_id = __scope.register_handler(move || {
                 active.set(val.clone());
                 // Also fire user's onclick callback if present
-                if let Some(rid) = user_rid {
+                if let Some(rid) = button
+                    .get_attribute("data-user-rid")
+                    .and_then(|s| s.parse::<usize>().ok())
+                    .map(rinch_core::events::EventHandlerId)
+                {
                     rinch_core::events::dispatch_event(rid);
                 }
             });

--- a/crates/rinch-core/src/context.rs
+++ b/crates/rinch-core/src/context.rs
@@ -630,48 +630,48 @@ mod tests {
         clear_context();
     }
 
-    /// A `create_store` that reaches the *disposing* scope as its ambient owner
-    /// gets app lifetime rather than panicking on the borrowed cleanup list.
+    /// A `create_store` whose ambient owner is a **disposed** scope gets app
+    /// lifetime rather than attaching its cleanup to a corpse — where it would
+    /// silently never run.
     ///
-    /// Getting there takes a specific shape, because `dispose` itself pushes no
-    /// owner: a cleanup writes a signal, the synchronous flush re-runs an effect
-    /// that is enqueued-but-not-yet-disposed, and `run_effect` re-pushes *that
-    /// effect's* owner — which is the scope currently mid-drain.
-    ///
-    /// Two redundant guards make this safe: `with_ambient_scope` rejects a
-    /// disposed owner, and `on_cleanup_for_ambient_owner` uses `try_borrow_mut`.
-    /// Either alone suffices, so only removing **both** reproduces the panic.
+    /// This is reachable in production even though `dispose` pushes no owner of
+    /// its own. `record_effect` declines to record against a disposed ambient
+    /// owner while `Owner::current` still captures it, so such an effect is
+    /// disposed by nobody, and every later run re-pushes that dead owner —
+    /// which is exactly the stack `run_effect` installs here.
     #[test]
-    fn a_store_created_under_a_disposing_scope_gets_app_lifetime() {
+    fn a_store_created_under_a_disposed_owner_gets_app_lifetime() {
         use crate::reactive::{Effect, Signal};
 
         clear_context();
         let scope = Scope::new();
         scope.run(|| create_store(S("doomed")));
 
-        let trigger = Signal::new(0);
-        let effect = scope.run(|| {
+        let trigger = Signal::new(0).leak();
+        let effect = {
+            // Create the effect while the (already disposed) scope is ambient,
+            // reproducing the record/capture asymmetry described above.
+            let _owner = scope.push_owner();
+            scope.dispose();
             Effect::new(move || {
                 if trigger.get() > 0 {
-                    create_store(T2("born-during-dispose"));
+                    create_store(T2("born-under-a-corpse"));
                 }
             })
-        });
-        scope.add_effect(effect);
-
-        // Runs while `cleanups` is borrowed by the drain; the write flushes the
-        // effect above, which re-pushes this scope as the ambient owner.
-        scope.on_cleanup(move || trigger.set(1));
-
-        scope.dispose();
+        };
 
         assert_eq!(try_use_store::<S>(), None, "the owned entry is reclaimed");
+
+        trigger.set(1); // re-runs the effect with the dead owner ambient
+
         assert_eq!(
             try_use_store::<T2>(),
-            Some(T2("born-during-dispose")),
-            "a store whose only candidate owner is already disposing falls back \
-             to app lifetime instead of attaching to a corpse"
+            Some(T2("born-under-a-corpse")),
+            "a store whose only candidate owner is disposed falls back to app \
+             lifetime instead of attaching to a corpse"
         );
+
+        drop(effect);
         clear_context();
     }
 }

--- a/crates/rinch-core/src/dom/mod.rs
+++ b/crates/rinch-core/src/dom/mod.rs
@@ -720,8 +720,12 @@ where
     let m = marker.clone();
 
     let effect = crate::reactive::Effect::new(move || {
-        // Dispose old scope (cleans up nested effects)
-        if let Some(old) = cs.borrow_mut().take() {
+        // Dispose old scope (cleans up nested effects).
+        //
+        // `take()` on its own line so the `RefMut` is not held across the
+        // dispose — see the matching note in `show_dom` (issue #141).
+        let old = cs.borrow_mut().take();
+        if let Some(old) = old {
             old.dispose();
         }
         // Remove old nodes

--- a/crates/rinch-core/src/dom/render_scope.rs
+++ b/crates/rinch-core/src/dom/render_scope.rs
@@ -317,10 +317,26 @@ impl RenderScope {
     ///
     /// Equivalent to dropping it: cleanups and effects both live on
     /// `reactive_scope`, whose own `Drop` disposes it. This exists for callers
-    /// that want teardown to happen at a definite point.
+    /// that want teardown to happen at a definite point — which matters more
+    /// than it looks, because disposal now *frees* the scope's signals, memos
+    /// and event handlers rather than merely stopping its effects (issue #141),
+    /// so doing it before the surrounding DOM is torn down rather than after is
+    /// the difference between cleanups patching live nodes and patching a
+    /// corpse.
     pub fn dispose(mut self) {
-        // Dispose child scopes first
-        for child in self.children.drain(..) {
+        self.dispose_in_place();
+    }
+
+    /// [`dispose`](RenderScope::dispose) for callers that hold only `&mut` —
+    /// notably a `RenderScope` living inside a shared `Rc<RefCell<_>>`, where the
+    /// by-value form is unreachable.
+    ///
+    /// Prefer the by-value form: it proves at the type level that nothing else
+    /// can observe the scope while its cleanups run.
+    pub fn dispose_in_place(&mut self) {
+        // Emptied before any child is disposed, so a child's teardown cannot
+        // observe (or re-enter) a half-drained list.
+        for child in std::mem::take(&mut self.children) {
             child.dispose();
         }
 

--- a/crates/rinch-core/src/events/drag.rs
+++ b/crates/rinch-core/src/events/drag.rs
@@ -63,6 +63,54 @@ struct ActiveDrag {
     last_pos: Option<(f32, f32)>,
     /// Whether to continue dispatching surface events during this drag.
     forward_surface_events: bool,
+    /// The scope that was rendering when `start()` was called, if any.
+    ///
+    /// A drag lives in a process-lifetime global, so it can outlive the
+    /// component that armed it: an `on_move` that writes a signal can flip a
+    /// branch, switch a tab, or reconcile the very list item the drag belongs
+    /// to. Disposing that scope frees the signals these callbacks close over
+    /// (issue #141), and the fixpoint cannot reach the callbacks themselves —
+    /// they sit in no scope's owned bucket and are reachable from no effect. So
+    /// the drag carries its owner and checks it before every dispatch.
+    ///
+    /// `Option`, not the `Owner::none()` sentinel: a *dangling* `Weak` is what a
+    /// dropped scope also looks like, and the two must not be confused. `None`
+    /// means the drag was armed outside any render and has app lifetime; `Some`
+    /// that died means stop.
+    ///
+    /// Identity, not a flag: `ACTIVE_DRAG` is a single global slot, so a bool
+    /// could not say *whose* drag was abandoned. `Owner` is a `Weak`, so this
+    /// does not keep the scope — or anything it will free — alive.
+    owner: Option<crate::reactive::Owner>,
+}
+
+impl ActiveDrag {
+    /// Whether the scope that armed this drag has since been disposed.
+    fn is_abandoned(&self) -> bool {
+        self.owner.as_ref().is_some_and(|o| !o.is_alive())
+    }
+}
+
+/// Drop the active drag if the scope that armed it is gone.
+///
+/// Returns `true` if a drag was discarded. Deliberately silent: `on_cancel` is
+/// not fired, because it belongs to the same dead component and would be the
+/// next thing to read a freed signal. There is nothing left to restore.
+fn discard_if_abandoned() -> bool {
+    let abandoned = ACTIVE_DRAG.with(|drag| {
+        let mut slot = drag.borrow_mut();
+        match slot.as_ref() {
+            Some(state) if state.is_abandoned() => slot.take(),
+            _ => None,
+        }
+    });
+    // Dropped out here: the callbacks it owns are arbitrary user closures.
+    if abandoned.is_some() {
+        tracing::debug!("dropping an in-flight drag whose owning scope was disposed");
+        drop(abandoned);
+        return true;
+    }
+    false
 }
 
 thread_local! {
@@ -175,8 +223,13 @@ impl Drag {
             None => Rc::new(|_, _| {}),
         };
         let start_context = get_click_context();
-        ACTIVE_DRAG.with(|drag| {
-            *drag.borrow_mut() = Some(ActiveDrag {
+        // Captured here rather than at dispatch: `start()` runs inside the
+        // handler that armed the drag, so the registering scope is ambient
+        // (`register_handler` re-enters it on dispatch). By the time `on_move`
+        // fires, the owner stack is unrelated.
+        let owner = crate::reactive::current_owner();
+        let previous = ACTIVE_DRAG.with(|drag| {
+            drag.borrow_mut().replace(ActiveDrag {
                 mode: self.mode,
                 on_move,
                 on_end: self.on_end,
@@ -184,8 +237,12 @@ impl Drag {
                 start_context,
                 last_pos: None,
                 forward_surface_events: self.forward_surface_events,
-            });
+                owner,
+            })
         });
+        // Dropped outside the borrow: a superseded drag's callbacks are
+        // arbitrary user closures, and their `Drop` may query the drag state.
+        drop(previous);
     }
 
     /// Cancel the active drag, firing `on_cancel` (but **not** `on_end` — a
@@ -212,7 +269,12 @@ impl Drag {
     }
 
     /// Check if a drag is currently active.
+    ///
+    /// A drag whose owning scope has been disposed is discarded here rather
+    /// than reported as active — the runtime gates hover, surface events and
+    /// text selection on this, and a stale `true` would wedge all three.
     pub fn is_active() -> bool {
+        discard_if_abandoned();
         ACTIVE_DRAG.with(|drag| drag.borrow().is_some())
     }
 
@@ -239,6 +301,11 @@ impl Drag {
 /// - `handled`: true if a drag callback was invoked
 /// - `forward_surface_events`: true if surface events should still be dispatched
 pub fn update_drag(mouse_x: f32, mouse_y: f32) -> (bool, bool) {
+    // A drag whose component was unmounted mid-gesture is dropped rather than
+    // driven: its callbacks close over signals the dispose fixpoint has freed
+    // (issue #141), so `on_move` would panic on the first read.
+    discard_if_abandoned();
+
     // Map coords + record last_pos under a short borrow, then release it
     // before invoking `on_move` (which may itself query or cancel the drag).
     let pending = ACTIVE_DRAG.with(|drag| {
@@ -257,7 +324,13 @@ pub fn update_drag(mouse_x: f32, mouse_y: f32) -> (bool, bool) {
 }
 
 /// Finish the drag, firing `on_end` if set. Called by the runtime on mouseup.
+///
+/// A drag whose owning scope was disposed mid-gesture does not commit: `on_end`
+/// is the *commit* callback, and there is nothing left to commit to.
 pub fn finish_drag(mouse_x: f32, mouse_y: f32) {
+    if discard_if_abandoned() {
+        return;
+    }
     let on_end = ACTIVE_DRAG.with(|drag| drag.borrow_mut().take().and_then(|s| s.on_end));
     if let Some(cb) = on_end {
         cb(mouse_x, mouse_y);
@@ -371,5 +444,72 @@ mod tests {
         Drag::cancel();
 
         assert!(saw_inactive.get());
+    }
+
+    /// A drag armed inside a component that is then unmounted mid-gesture is
+    /// dropped rather than driven (issue #141).
+    ///
+    /// The callbacks close over the component's signals, which disposal has
+    /// freed, so `on_move` would panic on the first read — and `ACTIVE_DRAG` is
+    /// a process-lifetime global the dispose fixpoint cannot reach into.
+    #[test]
+    fn a_drag_whose_scope_was_disposed_stops_being_driven() {
+        use crate::reactive::{Scope, Signal};
+
+        let moves = Rc::new(Cell::new(0));
+        let ends = Rc::new(Cell::new(0));
+
+        let scope = Scope::new();
+        let m = moves.clone();
+        let e = ends.clone();
+        scope.run(|| {
+            let owned = Signal::new(0);
+            Drag::absolute()
+                .on_move(move |x, _| {
+                    // Reads freed state if this is allowed to run post-dispose.
+                    let _ = owned.get();
+                    m.set(m.get() + 1);
+                    owned.set(x as i32);
+                })
+                .on_end(move |_, _| e.set(e.get() + 1))
+                .start();
+        });
+
+        assert!(Drag::is_active(), "the drag is armed");
+        update_drag(10.0, 10.0);
+        assert_eq!(moves.get(), 1, "and driven normally while mounted");
+
+        scope.dispose();
+
+        assert!(
+            !Drag::is_active(),
+            "an abandoned drag is not reported active"
+        );
+        update_drag(20.0, 20.0);
+        finish_drag(20.0, 20.0);
+
+        assert_eq!(moves.get(), 1, "no further on_move after the scope died");
+        assert_eq!(ends.get(), 0, "and an abandoned drag must not commit");
+    }
+
+    /// The other half: a drag armed outside any render keeps app lifetime, so
+    /// an unrelated scope being disposed must not disturb it.
+    #[test]
+    fn a_drag_armed_outside_a_render_is_never_abandoned() {
+        use crate::reactive::Scope;
+
+        let moves = Rc::new(Cell::new(0));
+        let m = moves.clone();
+        Drag::absolute()
+            .on_move(move |_, _| m.set(m.get() + 1))
+            .start();
+
+        // An unrelated component unmounts.
+        Scope::new().dispose();
+
+        assert!(Drag::is_active(), "an ownerless drag survives");
+        update_drag(5.0, 5.0);
+        assert_eq!(moves.get(), 1, "and is still driven");
+        Drag::cancel();
     }
 }

--- a/crates/rinch-core/src/events/handlers.rs
+++ b/crates/rinch-core/src/events/handlers.rs
@@ -176,38 +176,19 @@ pub fn reset_handler_ids() {
     NEXT_HANDLER_ID.store(0, Ordering::SeqCst);
 }
 
-/// The id the *next* `register_*` call will allocate. Capture this before and
-/// after building a component subtree to record which handler ids that subtree
-/// created (used by `rinch-web` to tear down a root on unmount).
-pub fn handler_id_watermark() -> EventHandlerId {
-    EventHandlerId(NEXT_HANDLER_ID.load(Ordering::SeqCst))
-}
-
-/// Remove every handler whose id is in `[start, end)` from all registries.
-///
-/// Used to deregister the handlers a single root created at build time when it
-/// is unmounted, without disturbing handlers belonging to other roots.
-pub fn remove_handlers_in_range(start: EventHandlerId, end: EventHandlerId) {
-    let range = start.0..end.0;
-    EVENT_REGISTRY.with(|r| r.borrow_mut().handlers.retain(|k, _| !range.contains(&k.0)));
-    INPUT_REGISTRY.with(|r| r.borrow_mut().handlers.retain(|k, _| !range.contains(&k.0)));
-    FILE_DROP_REGISTRY.with(|r| r.borrow_mut().handlers.retain(|k, _| !range.contains(&k.0)));
-    SCROLL_REGISTRY.with(|r| r.borrow_mut().handlers.retain(|k, _| !range.contains(&k.0)));
-}
-
 /// Remove a single handler, by id, from whichever registry holds it.
 ///
-/// The per-id counterpart of [`remove_handlers_in_range`], which #141's dispose
-/// fixpoint (PR4) needs: id *ranges* do not nest correctly once several roots
-/// interleave registrations, but a scope's recorded ids always do.
+/// This is how scope disposal reclaims the handlers a scope owns (issue #141).
+/// It replaced a `handler_id_watermark`/`remove_handlers_in_range` pair that
+/// deleted a contiguous *range* of ids, which was both incomplete and unsound:
+/// a range recorded around a synchronous build misses every handler a later
+/// effect run registers, and a synchronous effect flush *inside* that build lets
+/// an unrelated root allocate an id within the window, which the range would
+/// then delete out from under it. A scope's own record has neither problem.
 ///
 /// Each removed callback is moved into a local and dropped **after** its
-/// registry borrow is released. The callbacks are `Rc<dyn Fn(..)>` closing over
-/// arbitrary user state whose `Drop` may touch these same registries, and
-/// `remove_handlers_in_range`'s `retain` drops them *inside* the borrow.
-///
-/// Not yet reachable from production code — PR4 wires it in.
-#[allow(dead_code)]
+/// registry borrow is released: the callbacks are `Rc<dyn Fn(..)>` closing over
+/// arbitrary user state whose `Drop` may touch these same registries.
 pub fn unregister_handler(id: EventHandlerId) {
     let click = EVENT_REGISTRY.with(|r| r.borrow_mut().handlers.remove(&id));
     drop(click);
@@ -217,6 +198,32 @@ pub fn unregister_handler(id: EventHandlerId) {
     drop(file_drop);
     let scroll = SCROLL_REGISTRY.with(|r| r.borrow_mut().handlers.remove(&id));
     drop(scroll);
+}
+
+/// Whether a click handler is still registered under this id.
+///
+/// Scope disposal frees the handlers a scope owns (issue #141), so an id read
+/// back out of a `data-rid` attribute can outlive its callback: nothing removes
+/// the attribute when the handler goes. Dispatchers that walk an ancestor chain
+/// use this to *skip* a dead node and keep walking, rather than consuming the
+/// event on its behalf.
+pub fn has_click_handler(id: EventHandlerId) -> bool {
+    EVENT_REGISTRY.with(|registry| registry.borrow().handlers.contains_key(&id))
+}
+
+/// Whether an input handler is still registered under this id.
+///
+/// The counterpart to [`has_click_handler`] for callers that cache an id across
+/// frames (the desktop shell's focused-input state) and must notice when the
+/// element it belongs to has been torn down.
+pub fn has_input_handler(id: EventHandlerId) -> bool {
+    INPUT_REGISTRY.with(|registry| registry.borrow().handlers.contains_key(&id))
+}
+
+/// Whether a file-drop handler is still registered under this id.
+/// See [`has_click_handler`].
+pub fn has_file_drop_handler(id: EventHandlerId) -> bool {
+    FILE_DROP_REGISTRY.with(|registry| registry.borrow().handlers.contains_key(&id))
 }
 
 // Thread-local event handler registry.
@@ -376,6 +383,12 @@ pub fn get_click_context() -> ClickContext {
 /// Dispatch an event to the handler with the given ID.
 ///
 /// Returns `true` if a handler was found and called, `false` otherwise.
+///
+/// A `false` is **not** by itself a bug: disposing a scope frees the handlers it
+/// owns while their `data-rid` attributes stay on any node that outlives them
+/// (issue #141), so a miss is the routine outcome of a teardown race. Callers
+/// that walk an ancestor chain should treat it as "keep walking" — see
+/// [`has_click_handler`] for probing without dispatching.
 pub fn dispatch_event(id: EventHandlerId) -> bool {
     // Clone the handler out of the registry so we can release the borrow
     // before calling it. This allows handlers to register new handlers
@@ -391,17 +404,10 @@ pub fn dispatch_event(id: EventHandlerId) -> bool {
         tracing::info!("dispatch_event: Handler {:?} completed", id);
         true
     } else {
-        let (count, handler_ids) = EVENT_REGISTRY.with(|registry| {
-            let reg = registry.borrow();
-            let ids: Vec<_> = reg.handlers.keys().cloned().collect();
-            (ids.len(), ids)
-        });
-        tracing::error!(
-            "dispatch_event: handler {:?} NOT FOUND. Registry has {} handlers: {:?}",
-            id,
-            count,
-            handler_ids
-        );
+        // `debug!`, and no registry dump: since #141 a miss is an expected
+        // teardown outcome rather than a bug, and this runs on every stale
+        // hover/drag-move, where formatting the whole registry would dominate.
+        tracing::debug!("dispatch_event: no handler registered for {:?}", id);
         false
     }
 }

--- a/crates/rinch-core/src/for_loop.rs
+++ b/crates/rinch-core/src/for_loop.rs
@@ -160,6 +160,9 @@ where
 
         // Track inserted nodes to chain insert_after calls
         let mut initial_nodes: Vec<NodeHandle> = Vec::new();
+        // Item states displaced by a duplicate key, dropped after `state` is
+        // released — see the note on `state.insert` below.
+        let mut displaced: Vec<ItemState> = Vec::new();
 
         for item in initial_items {
             if let Some(doc) = doc_weak.upgrade() {
@@ -180,7 +183,10 @@ where
 
                 keys.push(item.key.clone());
                 initial_nodes.push(node.clone());
-                state.insert(
+                // A duplicate key displaces a live `ItemState`, and dropping it
+                // here would dispose its scope — running user code under
+                // `state`'s `RefMut` (issue #141). Park it instead.
+                let clobbered = state.insert(
                     item.key.clone(),
                     ItemState {
                         node,
@@ -188,8 +194,20 @@ where
                         scope: Some(child_scope),
                     },
                 );
+                if let Some(clobbered) = clobbered {
+                    tracing::warn!(
+                        "duplicate `for` key {:?}: the earlier item's state is discarded while \
+                         its DOM node stays mounted. Give each item a unique `key:`.",
+                        keys.last()
+                    );
+                    displaced.push(clobbered);
+                }
             }
         }
+
+        drop(state);
+        drop(keys);
+        drop(displaced);
     }
 
     // Create Effect that reconciles list when it changes
@@ -214,6 +232,18 @@ where
         // Always use diff_keyed to compute minimal operations
         let ops = diff_keyed(&old_keys, &new_keys);
 
+        // Scopes displaced by this reconcile, torn down at the very end of the
+        // closure once `state` and `keys` are no longer borrowed.
+        //
+        // Disposal runs user code — cleanups, handler-closure drops, signal
+        // value drops (issue #141) — and any of it that writes a signal flushes
+        // effects synchronously, re-entering this very closure. Disposing under
+        // the `RefMut`s below would make that a `BorrowMutError` rather than a
+        // reconcile. The cost is that a removed item's effects stay live for the
+        // remainder of this pass; they have no signal to wake them in that
+        // window, since nothing re-enters the flush before the drop.
+        let mut doomed: Vec<RenderScope> = Vec::new();
+
         // Apply operations
         let mut state = items_state_clone.borrow_mut();
         let mut keys = keys_order_clone.borrow_mut();
@@ -226,9 +256,7 @@ where
                 ListOp::Remove { key, .. } => {
                     // Remove the item's DOM node
                     if let Some(item_state) = state.remove(&key) {
-                        if let Some(old_scope) = item_state.scope {
-                            old_scope.dispose();
-                        }
+                        doomed.extend(item_state.scope);
                         item_state.node.clear_animations();
                         item_state.node.remove();
                     }
@@ -285,17 +313,25 @@ where
                             }
                         }
 
-                        // Update state
+                        // Update state. A duplicate key displaces a live
+                        // `ItemState`; park it rather than letting it drop —
+                        // and so dispose — under the `state` borrow (#141).
                         let insert_pos = new_index.min(keys.len());
                         keys.insert(insert_pos, key.clone());
-                        state.insert(
+                        if let Some(clobbered) = state.insert(
                             key,
                             ItemState {
                                 node,
                                 item: item.clone(),
                                 scope: Some(child_scope),
                             },
-                        );
+                        ) {
+                            tracing::warn!(
+                                "duplicate `for` key: the earlier item's state is discarded \
+                                 while its DOM node stays mounted. Give each item a unique `key:`."
+                            );
+                            doomed.extend(clobbered.scope);
+                        }
                     }
                 }
                 ListOp::Move { key, new_index, .. } => {
@@ -362,9 +398,7 @@ where
                     if !eq_fn(&old_state.item, item) {
                         // Data changed — re-render this item
                         if let Some(doc) = doc_weak_clone.upgrade() {
-                            if let Some(old_scope) = old_state.scope.take() {
-                                old_scope.dispose();
-                            }
+                            doomed.extend(old_state.scope.take());
                             let mut child_scope = RenderScope::new(doc, parent_id);
                             // The re-rendered item owns its new resources
                             // (issue #141); the old scope was disposed above,
@@ -386,6 +420,13 @@ where
 
         // Update keys to match new order
         *keys = new_keys;
+
+        // Borrows released before the parked scopes are torn down.
+        drop(state);
+        drop(keys);
+        for scope in doomed {
+            scope.dispose();
+        }
     });
 
     // Attach effect to parent scope
@@ -793,5 +834,66 @@ mod tests {
         // Verify data is preserved
         let item_data = items[0].downcast::<TestItem>().unwrap();
         assert_eq!(item_data.name, "One");
+    }
+
+    /// Removing an item whose teardown writes a signal must not deadlock the
+    /// reconcile on its own `RefCell`s (issue #141).
+    ///
+    /// Disposal now runs user code — cleanups, handler-closure drops, signal
+    /// value drops — and a write from any of it flushes effects synchronously,
+    /// re-entering this very reconcile closure. Disposing under the
+    /// `items_state`/`keys_order` borrows makes that a `BorrowMutError`; parking
+    /// the doomed scopes until both are released makes it a no-op re-entry.
+    ///
+    /// Counterfactual: replace the `doomed` vec at the `ListOp::Remove` arm with
+    /// an inline `old_scope.dispose()` and this panics with
+    /// "already mutably borrowed".
+    #[test]
+    fn removing_an_item_whose_cleanup_writes_a_signal_does_not_panic() {
+        use crate::dom::traits::DomDocument;
+        use crate::dom::{RenderScope, mock::MockDomDocument};
+        use crate::reactive::Signal;
+        use std::cell::RefCell;
+
+        let doc = Rc::new(RefCell::new(MockDomDocument::new()));
+        let body = doc.borrow().body();
+        let mut scope = RenderScope::new(doc.clone(), body);
+        let parent = scope.parent();
+
+        let items = Signal::new(vec![
+            TestItem {
+                id: "a".into(),
+                name: "A".into(),
+            },
+            TestItem {
+                id: "b".into(),
+                name: "B".into(),
+            },
+        ]);
+        // Written from each item's cleanup, and read by the list itself — so the
+        // write re-enters the reconcile effect rather than merely waking a
+        // bystander.
+        let churn = Signal::new(0);
+
+        let marker = super::for_each_dom_typed(
+            &mut scope,
+            &parent,
+            move || {
+                churn.get();
+                items.get()
+            },
+            |item: &TestItem| item.id.clone(),
+            move |_item: TestItem, s: &mut RenderScope| {
+                s.on_cleanup(move || churn.update(|n| *n += 1));
+                s.create_element("div")
+            },
+        );
+        let _ = marker;
+
+        // Drops item "a": its cleanup writes `churn`, whose flush re-enters this
+        // reconcile.
+        items.update(|v| v.retain(|i| i.id == "b"));
+
+        assert_eq!(churn.get(), 1, "exactly the removed item's cleanup ran");
     }
 }

--- a/crates/rinch-core/src/main_thread.rs
+++ b/crates/rinch-core/src/main_thread.rs
@@ -30,13 +30,25 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::reactive::is_main_thread;
 
+/// A parked continuation, plus the scope that parked it.
+struct Parked {
+    /// The scope being rendered when this callback was parked, if any.
+    ///
+    /// `None` means it was parked outside any render — from `main`, a timer, a
+    /// detached callback — and has app lifetime. `Some` that has since been
+    /// disposed means the component is gone and the callback must not run.
+    /// `Owner` is a `Weak`, so this keeps nothing alive.
+    owner: Option<crate::reactive::Owner>,
+    /// Type-erased `Box<dyn FnOnce(T)>` for the caller's own payload type `T`,
+    /// downcast back on resume.
+    callback: Box<dyn Any>,
+}
+
 thread_local! {
     /// Callbacks parked by [`park_main_callback`], keyed by id, on the thread that
-    /// parked them (the main/UI thread). Type-erased: each entry holds a
-    /// `Box<dyn FnOnce(T)>` for the caller's own payload type `T`, downcast back on
-    /// resume. Keeping them thread-local (not global) is what lets the callback be
-    /// `!Send`.
-    static PARKED: RefCell<HashMap<u64, Box<dyn Any>>> = RefCell::new(HashMap::new());
+    /// parked them (the main/UI thread). Keeping them thread-local (not global) is
+    /// what lets the callback be `!Send`.
+    static PARKED: RefCell<HashMap<u64, Parked>> = RefCell::new(HashMap::new());
 }
 
 static NEXT_ID: AtomicU64 = AtomicU64::new(1);
@@ -73,6 +85,32 @@ impl MainCallbackId {
 /// Must be called on the main thread: [`resume_main_callback`] looks the callback
 /// up in *its* thread's registry, so a callback parked off-main could never be
 /// resumed (debug-asserted).
+///
+/// # Cancelled when the component that parked it unmounts
+///
+/// A callback parked **during a render** is tied to the scope being built: if
+/// that scope is disposed before the callback resumes, [`resume_main_callback`]
+/// drops it unrun.
+///
+/// That is the flip side of the `!Send` capture this whole module exists for —
+/// the continuation holds UI state, and disposing a scope frees the signals it
+/// holds (issue #141), so resuming afterwards would panic on the first read.
+/// Cancelling is also what the caller almost always means: there is no UI left
+/// to update.
+///
+/// The check happens at resume rather than through a cleanup registered on the
+/// scope, deliberately: a debounce parks a fresh callback on *every keystroke*,
+/// and one cleanup per park would grow without bound for as long as the
+/// component lives. Pruning at resume costs nothing and matches how the poll and
+/// bounds registries already derive their lifetime from what they drive.
+///
+/// Park outside any render — or wrap in [`unowned`](crate::reactive::unowned) —
+/// for a continuation that must survive its component, such as a save-on-close
+/// flush:
+///
+/// ```ignore
+/// rinch_core::reactive::unowned(|| set_timeout(500, move || flush_to_disk()));
+/// ```
 pub fn park_main_callback<T: 'static>(cb: impl FnOnce(T) + 'static) -> MainCallbackId {
     debug_assert!(
         is_main_thread(),
@@ -81,7 +119,11 @@ pub fn park_main_callback<T: 'static>(cb: impl FnOnce(T) + 'static) -> MainCallb
     );
     let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
     let boxed: Box<dyn FnOnce(T)> = Box::new(cb);
-    PARKED.with(|p| p.borrow_mut().insert(id, Box::new(boxed)));
+    let parked = Parked {
+        owner: crate::reactive::current_owner(),
+        callback: Box::new(boxed),
+    };
+    PARKED.with(|p| p.borrow_mut().insert(id, parked));
     MainCallbackId(id)
 }
 
@@ -92,17 +134,37 @@ pub fn park_main_callback<T: 'static>(cb: impl FnOnce(T) + 'static) -> MainCallb
 /// The callback is removed from the registry *before* it runs, so it may re-park a
 /// fresh callback without re-entrancy trouble.
 ///
+/// Also a no-op if the component that parked the callback has since been
+/// unmounted — see [`park_main_callback`]. The callback runs with that component
+/// as the ambient owner, so anything it allocates belongs to the component
+/// rather than to whatever the event loop happened to be doing.
+///
 /// Call on the main thread. `T` must match the type used at [`park_main_callback`];
 /// a mismatch is a programming error (debug-asserted, ignored in release).
 pub fn resume_main_callback<T: 'static>(id: MainCallbackId, payload: T) {
     let entry = PARKED.with(|p| p.borrow_mut().remove(&id.0));
     let Some(entry) = entry else { return };
-    match entry.downcast::<Box<dyn FnOnce(T)>>() {
-        Ok(cb) => (*cb)(payload),
-        Err(_) => debug_assert!(
+
+    if entry.owner.as_ref().is_some_and(|owner| !owner.is_alive()) {
+        tracing::debug!(
+            "dropping parked callback {}: the component that parked it was unmounted",
+            id.0
+        );
+        // Dropped here, outside the registry borrow above.
+        drop(entry);
+        return;
+    }
+
+    let Ok(cb) = entry.callback.downcast::<Box<dyn FnOnce(T)>>() else {
+        debug_assert!(
             false,
             "resume_main_callback: payload type does not match the parked callback"
-        ),
+        );
+        return;
+    };
+    match entry.owner {
+        Some(owner) => owner.run(move || (*cb)(payload)),
+        None => (*cb)(payload),
     }
 }
 
@@ -111,9 +173,11 @@ pub fn resume_main_callback<T: 'static>(id: MainCallbackId, payload: T) {
 /// Idempotent, and harmless after the callback has already run (or was never
 /// parked).
 pub fn cancel_main_callback(id: MainCallbackId) {
-    PARKED.with(|p| {
-        p.borrow_mut().remove(&id.0);
-    });
+    // Taken out first: the callback closes over arbitrary user state whose
+    // `Drop` may itself park or cancel a callback, and dropping it inside the
+    // `borrow_mut` would make that a `BorrowMutError`.
+    let entry = PARKED.with(|p| p.borrow_mut().remove(&id.0));
+    drop(entry);
 }
 
 #[cfg(test)]
@@ -150,6 +214,66 @@ mod tests {
 
         // Cancelling again (or after a run) is a harmless no-op.
         cancel_main_callback(id);
+    }
+
+    /// A continuation parked during a render is dropped unrun once the
+    /// component that parked it is unmounted (issue #141).
+    ///
+    /// Without this, the idiomatic `set_timeout(500, move || label.set(fmt(count.get())))`
+    /// panics on the read when the component unmounts before the deadline —
+    /// disposal has freed `count` by then.
+    #[test]
+    fn a_callback_parked_during_a_render_is_dropped_when_its_scope_is_disposed() {
+        use crate::reactive::{Scope, Signal};
+
+        let ran = Rc::new(Cell::new(false));
+        let scope = Scope::new();
+
+        let r = ran.clone();
+        let id = scope.run(|| {
+            let owned = Signal::new(7);
+            park_main_callback::<()>(move |()| {
+                // Would panic on a freed signal if this were allowed to run.
+                let _ = owned.get();
+                r.set(true);
+            })
+        });
+
+        scope.dispose();
+        resume_main_callback(id, ());
+
+        assert!(
+            !ran.get(),
+            "a parked continuation must not outlive the component that parked it"
+        );
+    }
+
+    /// The escape hatch, and the non-breaking half: parked outside any render —
+    /// or under `unowned` — the callback keeps app lifetime.
+    #[test]
+    fn a_callback_parked_outside_a_render_still_resumes() {
+        use crate::reactive::{Scope, unowned};
+
+        // No ambient owner at all.
+        let ran = Rc::new(Cell::new(false));
+        let r = ran.clone();
+        let id = park_main_callback::<()>(move |()| r.set(true));
+        resume_main_callback(id, ());
+        assert!(ran.get(), "an ownerless callback resumes normally");
+
+        // Explicitly opted out from inside a render.
+        let escaped = Rc::new(Cell::new(false));
+        let scope = Scope::new();
+        let e = escaped.clone();
+        let id = scope.run(|| unowned(|| park_main_callback::<()>(move |()| e.set(true))));
+
+        scope.dispose();
+        resume_main_callback(id, ());
+
+        assert!(
+            escaped.get(),
+            "`unowned` must detach the callback from the render that parked it"
+        );
     }
 
     #[test]

--- a/crates/rinch-core/src/match_dom.rs
+++ b/crates/rinch-core/src/match_dom.rs
@@ -120,8 +120,12 @@ where
         if new_idx != old_idx {
             *idx_clone.borrow_mut() = new_idx;
 
-            // Dispose old scope BEFORE removing DOM nodes
-            if let Some(old_scope) = scope_clone.borrow_mut().take() {
+            // Dispose old scope BEFORE removing DOM nodes.
+            //
+            // `take()` on its own line so the `RefMut` is not held across the
+            // dispose — see the matching note in `show_dom` (issue #141).
+            let old_scope = scope_clone.borrow_mut().take();
+            if let Some(old_scope) = old_scope {
                 old_scope.dispose();
             }
 

--- a/crates/rinch-core/src/reactive/effect.rs
+++ b/crates/rinch-core/src/reactive/effect.rs
@@ -119,22 +119,42 @@ impl Effect {
         run_effect(self.id);
     }
 
+    /// This effect's observer id, for the disposal fixpoint — which works from
+    /// the ids a scope recorded rather than from `Effect` handles (issue #141).
+    pub(super) fn id(&self) -> ObserverId {
+        self.id
+    }
+
     /// Dispose of this effect, preventing it from running again.
     ///
     /// Also clears the slot in the global EFFECTS vec, allowing the
     /// `Rc<EffectInner>` to be reclaimed.
     pub fn dispose(&self) {
-        EFFECTS.with(|effects| {
-            let mut effects = effects.borrow_mut();
-            if let Some(slot) = effects.get_mut(self.id.0) {
-                if let Some(inner) = slot.as_ref() {
-                    inner.disposed.set(true);
-                }
-                // Release the Rc to reclaim memory
-                *slot = None;
-            }
-        });
+        dispose_effect(self.id);
     }
+}
+
+/// Dispose the effect with this id, if it is still registered.
+///
+/// The by-id counterpart of [`Effect::dispose`], and its implementation.
+///
+/// The `Rc<EffectInner>` is moved out and dropped **after** the registry borrow
+/// is released. That is load-bearing, not tidiness: the `Rc` owns the effect's
+/// closure, which captures arbitrary user state — very often the only handle to
+/// a child `RenderScope`. Dropping it in place (`*slot = None`) runs that state's
+/// `Drop` while `EFFECTS` is mutably borrowed, so a `Drop` that writes a signal
+/// flushes effects synchronously into `run_effect`, whose `EFFECTS.borrow()`
+/// then panics with a `BorrowMutError` (issue #141).
+pub(super) fn dispose_effect(id: ObserverId) {
+    let inner = EFFECTS.with(|effects| {
+        let mut effects = effects.borrow_mut();
+        let slot = effects.get_mut(id.0)?;
+        if let Some(inner) = slot.as_ref() {
+            inner.disposed.set(true);
+        }
+        slot.take()
+    });
+    drop(inner);
 }
 
 impl Drop for Effect {
@@ -197,8 +217,30 @@ pub(super) fn run_effect(id: ObserverId) {
         // effect body cannot strand it on the stack (issue #141).
         let _observer_guard = ObserverGuard::push(id);
 
-        // Run the effect
-        (inner.f.borrow_mut())();
+        // An effect never re-enters itself.
+        //
+        // `f` is borrowed for the whole body, so a *synchronous* re-entry would
+        // be a `BorrowMutError` — and re-entry is reachable: a write inside the
+        // body flushes effects immediately (outside `batch`), and if the effect
+        // observes that signal it is queued and run right there, one frame down
+        // its own stack. Since #141 this has a routine trigger — an effect that
+        // disposes a scope (every control-flow swap does) runs that scope's
+        // cleanups, and a cleanup that writes a signal the effect reads lands
+        // exactly here.
+        //
+        // Skipping is deliberate over re-queuing: re-queuing an effect that is
+        // still running turns a self-triggering body into a hang, which is
+        // strictly harder to debug than a stale value. The effect re-runs on the
+        // next genuine change.
+        let Ok(mut body) = inner.f.try_borrow_mut() else {
+            tracing::debug!(
+                "run_effect({}): SKIPPED - re-entered while already running",
+                id.0
+            );
+            return;
+        };
+        body();
+        drop(body);
 
         tracing::debug!("run_effect({}): done", id.0);
     } else {
@@ -231,5 +273,85 @@ pub(super) fn flush_effects() {
             Some(id) => run_effect(id),
             None => break,
         }
+    }
+}
+
+#[cfg(test)]
+mod dispose_tests {
+    use super::*;
+    use crate::reactive::Signal;
+    use std::cell::Cell;
+
+    /// Disposing an effect drops its closure **after** the `EFFECTS` borrow is
+    /// released.
+    ///
+    /// The closure captures arbitrary user state. If that state's `Drop` writes
+    /// a signal, the write flushes effects synchronously into `run_effect`,
+    /// whose `EFFECTS.borrow()` conflicts with a `borrow_mut` still held by the
+    /// dispose — a `BorrowMutError`, not a leak. Rare before #141, routine now
+    /// that disposal drops every closure a scope owns.
+    #[test]
+    fn disposing_an_effect_drops_its_closure_outside_the_registry_borrow() {
+        struct Noisy(Signal<i32>);
+        impl Drop for Noisy {
+            fn drop(&mut self) {
+                // Wakes `_observer` below, re-entering `run_effect`.
+                self.0.set(1);
+            }
+        }
+
+        let signal = Signal::new(0);
+        let woken = Rc::new(Cell::new(0));
+
+        let hits = woken.clone();
+        let _observer = Effect::new(move || {
+            signal.get();
+            hits.set(hits.get() + 1);
+        });
+        assert_eq!(woken.get(), 1);
+
+        let noisy = Noisy(signal);
+        let effect = Effect::new(move || {
+            let _held = &noisy;
+        });
+
+        effect.dispose(); // must not panic
+
+        assert_eq!(
+            woken.get(),
+            2,
+            "the drop's write reached the surviving observer"
+        );
+    }
+
+    /// An effect that writes a signal it observes does not re-enter itself.
+    ///
+    /// `EffectInner::f` is borrowed for the whole body, and a write outside
+    /// `batch` flushes synchronously — so a self-observing write lands back in
+    /// `run_effect` one frame down its own stack. Unguarded that is a
+    /// `BorrowMutError`, and since #141 it has a routine trigger: an effect that
+    /// disposes a scope runs that scope's cleanups, and a cleanup that writes a
+    /// signal the effect reads arrives exactly here.
+    #[test]
+    fn an_effect_that_writes_a_signal_it_observes_does_not_re_enter_itself() {
+        let signal = Signal::new(0);
+        let runs = Rc::new(Cell::new(0));
+
+        let hits = runs.clone();
+        let _effect = Effect::new(move || {
+            let seen = signal.get();
+            hits.set(hits.get() + 1);
+            if seen == 0 {
+                // Flushes synchronously and re-enters this very effect.
+                signal.set(1);
+            }
+        });
+
+        assert_eq!(runs.get(), 1, "the re-entrant run is skipped, not panicked");
+        assert_eq!(signal.get(), 1, "and the write itself still landed");
+
+        // The effect is not wedged: a later genuine change still runs it.
+        signal.set(2);
+        assert_eq!(runs.get(), 2);
     }
 }

--- a/crates/rinch-core/src/reactive/memo.rs
+++ b/crates/rinch-core/src/reactive/memo.rs
@@ -61,7 +61,12 @@ struct MemoInner<T> {
     /// The scope that owned this memo at creation, re-entered around the lazy
     /// recompute for the same reason `root` is (issue #141). Weak by
     /// construction — see [`Owner`](super::Owner).
-    owner: super::Owner,
+    ///
+    /// Mutable so that [`Memo::leak`] can clear it. Detaching the memo from its
+    /// owner's bucket is only half of leaking: the recompute still re-enters
+    /// this owner, so a `Signal` the computation creates would be attributed to
+    /// — and freed with — the very scope the memo was leaked out of.
+    owner: RefCell<super::Owner>,
     /// Observers to notify, ordered — same contract (and same reason) as
     /// `SignalSlot::subscribers`: a memo's dependents run in registration order.
     subscribers: RefCell<BTreeSet<ObserverId>>,
@@ -81,7 +86,7 @@ impl<T: Clone + 'static> Memo<T> {
             f: RefCell::new(Box::new(f)),
             dirty: Cell::new(true),
             root: crate::context::current_context_root(),
-            owner: super::Owner::current(),
+            owner: RefCell::new(super::Owner::current()),
             subscribers: RefCell::new(BTreeSet::new()),
         });
 
@@ -194,8 +199,11 @@ impl<T: Clone + 'static> Memo<T> {
         // component but first read from another would otherwise attribute the
         // resources it creates to whatever happened to be rendering.
         if inner.dirty.get() {
+            // Clone the owner out before pushing: the user computation below can
+            // reach `Memo::leak` on this same memo, which takes `owner` mutably.
+            let owner = inner.owner.borrow().clone();
             let _root_guard = crate::context::push_context_root(inner.root);
-            let _owner_guard = inner.owner.push();
+            let _owner_guard = owner.push();
             let _observer_guard = super::effect::ObserverGuard::push(inner.id);
 
             let value = (inner.f.borrow())();
@@ -218,10 +226,6 @@ impl<T: 'static> Memo<T> {
     ///
     /// A memo is freed when the scope that owns it is disposed, after which
     /// [`get`](Memo::get) panics. Does **not** subscribe the current observer.
-    ///
-    /// Nothing frees memos yet — this returns `true` for every memo that was
-    /// ever created. It becomes meaningful when scope-driven disposal lands
-    /// (issue #141).
     pub fn is_alive(&self) -> bool {
         MEMO_STORE.with(|store| store.borrow().get_inner(self.id, self.generation).is_some())
     }
@@ -230,6 +234,13 @@ impl<T: 'static> Memo<T> {
     ///
     /// The memo counterpart of [`Signal::leak`](super::Signal::leak); the same
     /// "call it in the same render that created it" rule applies.
+    ///
+    /// Detaching is two-sided for a memo, where it is one-sided for a signal.
+    /// Dropping the `MemoKey` from the owner's bucket stops the memo itself
+    /// being freed, but the *recompute* also re-enters that owner (see
+    /// [`MemoInner::owner`]), so anything the computation allocates would still
+    /// be attributed to the scope this memo was just leaked out of, and die with
+    /// it. Clearing the owner closes that half.
     #[track_caller]
     pub fn leak(self) -> Self {
         if !super::scope::forget_memo(super::scope::MemoKey {
@@ -241,6 +252,17 @@ impl<T: 'static> Memo<T> {
                  app lifetime",
                 std::panic::Location::caller()
             );
+        }
+        // `try_borrow_mut` rather than `borrow_mut`: `try_get` clones the owner
+        // out before pushing it precisely so this cannot conflict, and that
+        // pairing is easy to break from a distance. Degrading to "owner left in
+        // place" beats taking the app down over a `leak`.
+        let inner_any = MEMO_STORE.with(|store| store.borrow().get_inner(self.id, self.generation));
+        if let Some(inner_any) = inner_any
+            && let Ok(inner) = inner_any.downcast::<MemoInner<T>>()
+            && let Ok(mut owner) = inner.owner.try_borrow_mut()
+        {
+            *owner = super::Owner::none();
         }
         self
     }
@@ -318,6 +340,55 @@ mod liveness_tests {
             1,
             "the marker effect must be cleared too, or the memo leaks"
         );
+    }
+
+    /// `leak` detaches a memo from its owner on **both** sides.
+    ///
+    /// Dropping the `MemoKey` from the bucket is the obvious half. The other is
+    /// `MemoInner::owner`: the computation runs lazily, in the reader's frame,
+    /// re-entering the creation-time owner — so without clearing it a `Signal`
+    /// the computation allocates is still attributed to, and freed with, the
+    /// scope the memo was leaked out of. The leak would then hold a handle to
+    /// dead state, which is worse than not leaking at all.
+    #[test]
+    fn leak_detaches_a_memos_recompute_from_its_owner_too() {
+        use crate::reactive::Scope;
+
+        let source = Signal::new(1).leak();
+        let scope = Scope::new();
+
+        // Leaked in the same render that created it, per the documented rule.
+        let inner_signal: Rc<Cell<Option<Signal<i32>>>> = Rc::new(Cell::new(None));
+        let sink = inner_signal.clone();
+        let memo = scope.run(|| {
+            Memo::new(move || {
+                sink.set(Some(Signal::new(7)));
+                source.get() * 2
+            })
+            .leak()
+        });
+
+        assert_eq!(memo.get(), 2, "the computation ran");
+        let created = inner_signal
+            .get()
+            .expect("the computation created a signal");
+        assert_eq!(
+            scope.owned_counts().signals,
+            0,
+            "a leaked memo must not attribute its computation to the scope"
+        );
+
+        scope.dispose();
+
+        assert!(
+            memo.is_alive(),
+            "the memo itself survives, as leak promises"
+        );
+        assert!(
+            created.is_alive(),
+            "and so does what its computation allocated"
+        );
+        assert_eq!(memo.get(), 2);
     }
 
     #[test]

--- a/crates/rinch-core/src/reactive/mod.rs
+++ b/crates/rinch-core/src/reactive/mod.rs
@@ -83,7 +83,7 @@ pub use bounds::{
 pub use effect::Effect;
 pub use memo::Memo;
 pub use poll::{PollRate, drain_polls, poll_signal};
-pub use scope::{OwnedCounts, Owner, OwnerGuard, Scope, current_owner, unowned};
+pub use scope::{OwnedCounts, Owner, OwnerGuard, Scope, current_owner, on_cleanup, unowned};
 /// Ambient-owner hooks for the rest of the crate: `crate::events` attributes
 /// handlers to the scope currently rendering, and `crate::context` ties a
 /// store/context entry to the scope that created it (issue #141).
@@ -467,9 +467,6 @@ impl SignalStore {
     /// a value whose `Drop` touches a signal would otherwise `BorrowMutError`
     /// (issue #141, SD4). Returns `None` if the slot was already freed or the
     /// generation does not match.
-    ///
-    /// Not yet reachable from production code — #141's dispose fixpoint wires it.
-    #[allow(dead_code)]
     fn free(&mut self, id: u32, generation: u32) -> Option<Box<dyn Any>> {
         let slot = self.slots.get_mut(id as usize)?;
         if !slot.as_ref().is_some_and(|s| s.generation == generation) {
@@ -481,13 +478,22 @@ impl SignalStore {
     }
 }
 
-/// Free a signal slot directly, simulating the scope disposal that #141's
-/// dispose fixpoint will perform. Test-only: nothing frees signals yet, so
-/// without this the liveness API could not be exercised at all.
+/// Free a signal slot, **returning** its value for the caller to drop once every
+/// borrow is released. See [`SignalStore::free`].
+///
+/// The disposal fixpoint parks the returned value and drops it at the very end,
+/// so that a value's `Drop` sees a deterministic world rather than an arbitrary
+/// prefix of its siblings.
+pub(crate) fn free_signal(id: u32, generation: u32) -> Option<Box<dyn Any>> {
+    SIGNAL_STORE.with(|store| store.borrow_mut().free(id, generation))
+}
+
+/// Free a signal slot and drop its value, standing in for scope disposal.
+/// Test-only convenience over [`free_signal`].
 #[cfg(test)]
 pub(crate) fn free_signal_for_tests(id: u32, generation: u32) {
     // Dropped out here, after the store borrow is released.
-    let _value = SIGNAL_STORE.with(|store| store.borrow_mut().free(id, generation));
+    let _value = free_signal(id, generation);
 }
 
 // ============================================================================
@@ -561,7 +567,6 @@ impl MemoStore {
     ///
     /// Freeing the slot alone does **not** release the memo. Use
     /// [`free_memo`], which also clears the marker effect.
-    #[allow(dead_code)]
     pub(crate) fn free(&mut self, id: u32, generation: u32) -> Option<(Rc<dyn Any>, ObserverId)> {
         let slot = self.slots.get_mut(id as usize)?;
         if !slot.as_ref().is_some_and(|s| s.generation == generation) {
@@ -585,10 +590,6 @@ impl MemoStore {
 ///
 /// Both `Rc`s are dropped after every borrow is released, since the cached value
 /// is arbitrary user data whose `Drop` may touch the reactive stores.
-///
-/// Not yet reachable from production code — #141 PR4 wires it into the dispose
-/// fixpoint.
-#[allow(dead_code)]
 pub(crate) fn free_memo(id: u32, generation: u32) {
     let Some((inner, observer)) = MEMO_STORE.with(|store| store.borrow_mut().free(id, generation))
     else {

--- a/crates/rinch-core/src/reactive/scope.rs
+++ b/crates/rinch-core/src/reactive/scope.rs
@@ -6,9 +6,10 @@
 //! **owner**: while a scope is pushed as the ambient owner, every [`Signal`],
 //! [`Memo`], [`Effect`] and event handler created is *attributed* to it.
 //!
-//! Attribution is recorded, not enforced — nothing is freed yet. Issue #141's
-//! later PRs turn these records into actual reclamation; this layer exists so
-//! that when they do, the answer to "who owns this?" is already there.
+//! Disposing a scope **frees** everything attributed to it. Reads of a freed
+//! [`Signal`]/[`Memo`] panic and writes become warn-once no-ops (see the
+//! [`reactive`](super) module's "Liveness" section); a freed event handler
+//! simply stops being found by dispatch.
 //!
 //! **No ambient owner means app lifetime.** Resources created outside any
 //! render — in `main()`, in a startup routine, in a detached callback — are
@@ -25,6 +26,7 @@
 //! [`Signal`]: super::Signal
 //! [`Memo`]: super::Memo
 
+use std::any::Any;
 use std::cell::{Cell, RefCell};
 use std::marker::PhantomData;
 use std::rc::{Rc, Weak};
@@ -64,8 +66,10 @@ pub(in crate::reactive) struct MemoKey {
 
 /// Resources created while a scope was the ambient owner.
 ///
-/// Write-only bookkeeping today. Every field is plain data, so dropping an
-/// `Owned` runs no user code and cannot re-enter the disposal machinery.
+/// Every field is plain data — ids and keys, never the resource itself — so
+/// taking an `Owned` apart runs no user code and cannot re-enter the disposal
+/// machinery. The actual release happens later, in
+/// [`run_dispose_fixpoint`], from the batches harvested here.
 #[derive(Default)]
 pub(in crate::reactive) struct Owned {
     signals: Vec<SignalKey>,
@@ -74,16 +78,16 @@ pub(in crate::reactive) struct Owned {
     /// Effects *created* under this owner.
     ///
     /// Deliberately distinct from [`ScopeInner::effects`], which holds effects
-    /// *adopted* via [`Scope::add_effect`] and is what `dispose` acts on. The
-    /// difference between the two counts is the number of fire-and-forget
-    /// effects nothing will ever dispose.
+    /// *adopted* via [`Scope::add_effect`]. Disposal releases both: the
+    /// difference between the two counts is the fire-and-forget effects nothing
+    /// ever adopted, which is precisely the leak #141 was filed for.
     effects: Vec<ObserverId>,
 }
 
 /// A snapshot of what a scope owns.
 ///
-/// Introspection for tests and diagnostics: because nothing is freed yet, these
-/// counts are the only observable evidence that ownership is being tracked.
+/// Introspection for tests and diagnostics. Disposal empties the bucket, so
+/// after `dispose` every count reads zero.
 #[doc(hidden)]
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct OwnedCounts {
@@ -110,13 +114,16 @@ impl Owned {
 
 /// A scope that manages the lifetime of reactive primitives.
 ///
-/// When a scope is disposed, all effects **adopted** into it (via
-/// [`add_effect`](Scope::add_effect)) are disposed, its cleanups run, and its
-/// child scopes are disposed too. Dropping the scope does the same thing.
+/// Disposing a scope releases everything it owns and everything its child
+/// scopes own — event handlers, effects, cleanups, memos, signals — and
+/// dropping the scope does the same thing. See [`run_dispose_fixpoint`] for the
+/// order and why it is a fixpoint.
 ///
-/// Separately, a scope can be made the *ambient owner* — see
-/// [`run`](Scope::run) and the module docs. Ownership currently only records
-/// attribution; it does not free anything.
+/// A scope owns a resource if it was the *ambient owner* when that resource was
+/// created — see [`run`](Scope::run) and the module docs. Effects are the one
+/// thing that can also be **adopted** explicitly, via
+/// [`add_effect`](Scope::add_effect), which is how an effect created elsewhere
+/// is made to die here.
 ///
 /// # Example
 ///
@@ -124,12 +131,12 @@ impl Owned {
 /// let scope = Scope::new();
 ///
 /// scope.run(|| {
-///     let signal = Signal::new(0);   // attributed to this scope
-///     // Effects are attributed too, but adoption is explicit:
+///     let signal = Signal::new(0);   // owned by this scope; freed on dispose
 ///     scope.add_effect(Effect::new(|| { /* ... */ }));
 /// });
 ///
-/// scope.dispose(); // Disposes adopted effects, runs cleanups, disposes children
+/// scope.dispose();
+/// assert!(!signal.is_alive());
 /// ```
 pub struct Scope(Rc<ScopeInner>);
 
@@ -211,14 +218,15 @@ impl Scope {
 
     /// Register a cleanup function to run when this scope is disposed.
     ///
-    /// Today cleanups run *before* this scope's child scopes are processed, and
-    /// before its effects are actually disposed — disposal only enqueues them.
-    /// **Do not depend on either**: issue #141's PR4 reorders disposal to
-    /// handlers → effects → cleanups so that a cleanup cannot resurrect a
-    /// disposed effect.
+    /// Cleanups run **after** every effect this scope owns has been disposed,
+    /// and after the whole subtree beneath it has been marked disposed — so a
+    /// cleanup cannot resurrect a disposed effect, and writing a signal from one
+    /// wakes only observers outside the tree coming down. They run **before**
+    /// the scope's memos and signals are freed, so a cleanup may still read
+    /// them. See [`run_dispose_fixpoint`].
     ///
-    /// A cleanup must not register another cleanup on the *same* scope: the
-    /// cleanup list is borrowed for the duration of the drain that runs it.
+    /// A cleanup registered by another cleanup on the same scope still runs:
+    /// the fixpoint takes the list out before running any of it, then loops.
     pub fn on_cleanup<F: FnOnce() + 'static>(&self, f: F) {
         self.0.cleanups.borrow_mut().push(Box::new(f));
     }
@@ -230,16 +238,12 @@ impl Scope {
         self.0.dispose();
     }
 
-    /// Clear all adopted effects without disposing them.
-    ///
-    /// # Warning
-    ///
-    /// This moves only the *adopted effect* list. The scope's owned-resource
-    /// records (signals, memos, handlers) stay behind, so the effects and the
-    /// resources they close over end up with different owners.
-    pub fn take_effects(&self) -> Vec<Effect> {
-        self.0.effects.borrow_mut().drain(..).collect()
-    }
+    // NOTE: there was a `take_effects()` here that moved the adopted-effect list
+    // out without disposing it. It had no callers, and it is unsound now that
+    // disposal frees resources: it left the scope's signal/memo/handler records
+    // behind, so the taken effects kept running against state the next dispose
+    // freed — a use-after-free by construction (issue #141). If detaching
+    // effects is ever needed, it has to move the matching `Owned` entries too.
 
     /// Get the number of adopted effects in this scope.
     pub fn effect_count(&self) -> usize {
@@ -260,112 +264,266 @@ impl Scope {
 }
 
 impl ScopeInner {
+    /// Dispose this scope and everything beneath it.
+    ///
+    /// Two phases, and the split is what keeps teardown iterative:
+    ///
+    /// 1. **Collect** — mark this scope and its whole subtree disposed and move
+    ///    their work into the thread-local [`DisposeCtx`]. Runs no user code.
+    /// 2. **Drain** — the *outermost* call runs [`run_dispose_fixpoint`].
+    ///
+    /// Every nested `dispose()` — and there are many, because an effect closure
+    /// commonly owns the only handle to a child `RenderScope`, so dropping it
+    /// disposes that scope — finds the context already installed, contributes to
+    /// it, and returns. Only the outermost frame drains, so the recursion depth
+    /// stays at "one collect walk" instead of growing with the component tree.
     fn dispose(&self) {
         if self.disposed.get() {
             return;
         }
 
-        // Use a thread-local disposal queue to avoid stack overflow.
-        //
-        // The problem: Effect closures may capture Rc<RefCell<RenderScope>>,
-        // so Effect::dispose() -> drops closure -> drops RenderScope -> Scope::drop
-        // -> dispose() -> more Effect::dispose() -- creating unbounded recursion.
-        //
-        // The solution: The outermost dispose() call runs an iterative loop.
-        // Nested dispose() calls (triggered by closure drops) just push their
-        // effects onto the queue instead of processing them immediately.
-        thread_local! {
-            static DISPOSE_QUEUE: RefCell<Option<Vec<Effect>>> = const { RefCell::new(None) };
-        }
-
-        let is_root = DISPOSE_QUEUE.with(|q| {
-            let mut q = q.borrow_mut();
-            if q.is_none() {
-                *q = Some(Vec::new());
+        let is_root = DISPOSE_CTX.with(|ctx| {
+            let mut ctx = ctx.borrow_mut();
+            if ctx.is_none() {
+                *ctx = Some(DisposeCtx::default());
                 true
             } else {
                 false
             }
         });
 
-        // Mark this scope and collect its effects into the queue
-        self.dispose_into_queue(&DISPOSE_QUEUE);
+        self.collect();
 
         if is_root {
-            // We are the outermost dispose call. Process the queue iteratively.
-            loop {
-                let batch: Vec<Effect> =
-                    DISPOSE_QUEUE.with(|q| std::mem::take(q.borrow_mut().as_mut().unwrap()));
-                if batch.is_empty() {
-                    break;
-                }
-                // Disposing effects may drop closures that own RenderScopes,
-                // triggering more Scope::drop -> dispose() calls. Those nested
-                // calls will push onto the queue (not recurse) because
-                // DISPOSE_QUEUE is Some.
-                for effect in batch {
-                    effect.dispose();
-                }
-            }
-            // Clean up the queue
-            DISPOSE_QUEUE.with(|q| *q.borrow_mut() = None);
+            run_dispose_fixpoint();
+            DISPOSE_CTX.with(|ctx| *ctx.borrow_mut() = None);
         }
     }
 
-    /// Mark this scope as disposed and push its effects onto the disposal queue.
-    /// Also iteratively processes all child scopes.
-    fn dispose_into_queue(
-        &self,
-        queue: &'static std::thread::LocalKey<RefCell<Option<Vec<Effect>>>>,
-    ) {
+    /// Mark this scope and its whole subtree disposed, moving their work into
+    /// the in-flight [`DisposeCtx`].
+    ///
+    /// Iterative rather than recursive: the subtree can be as deep as the
+    /// component tree, and `Scope` is not `Clone`, so popping a handle off the
+    /// worklist is the last reference to it.
+    fn collect(&self) {
+        let mut pending: Vec<Scope> = Vec::new();
+        self.collect_one(&mut pending);
+        while let Some(child) = pending.pop() {
+            child.0.collect_one(&mut pending);
+            // `child` drops here. Its `disposed` flag is already set, so the
+            // `Drop for ScopeInner` that fires is an immediate no-op rather
+            // than a second, recursive teardown.
+        }
+    }
+
+    /// Move one scope's work into the context. Allocation-only — no user code
+    /// runs here, so no borrow taken below can be observed re-entrantly.
+    fn collect_one(&self, pending: &mut Vec<Scope>) {
+        // Children are harvested even from an already-disposed scope: Rust's
+        // default field drop would otherwise walk them recursively when the last
+        // handle dies, which is exactly the stack overflow the worklist exists
+        // to prevent. (A live scope's list is normally empty by then.)
+        pending.extend(self.children.borrow_mut().drain(..));
+
         if self.disposed.get() {
             return;
         }
         self.disposed.set(true);
 
-        // Collect effects into the queue
-        let effects: Vec<Effect> = self.effects.borrow_mut().drain(..).collect();
-        queue.with(|q| {
-            if let Some(ref mut vec) = *q.borrow_mut() {
-                vec.extend(effects);
-            }
-        });
+        // Adopted effects and *owned* effects are both released. The two lists
+        // overlap for the common case (created and adopted under the same
+        // scope); the difference is the fire-and-forget effects that nothing
+        // ever adopted, which before #141 leaked for the life of the thread.
+        // Disposing an id twice is a no-op, so the overlap needs no dedup.
+        let effects: Vec<ObserverId> = self
+            .effects
+            .borrow_mut()
+            .drain(..)
+            .map(|effect| effect.id())
+            .collect();
+        let cleanups: Vec<Box<dyn FnOnce()>> = self.cleanups.borrow_mut().drain(..).collect();
+        let owned = std::mem::take(&mut *self.owned.borrow_mut());
 
-        // Run cleanups
-        for cleanup in self.cleanups.borrow_mut().drain(..) {
-            cleanup();
+        with_dispose_ctx(|ctx| {
+            ctx.effects.extend(effects);
+            ctx.effects.extend(owned.effects);
+            ctx.cleanups.extend(cleanups);
+            ctx.handlers.extend(owned.handlers);
+            ctx.memos.extend(owned.memos);
+            ctx.signals.extend(owned.signals);
+        });
+    }
+}
+
+// ============================================================================
+// The disposal fixpoint
+// ============================================================================
+
+/// Work harvested from scopes that have been marked disposed, drained in
+/// priority order by [`run_dispose_fixpoint`].
+///
+/// Every field is plain data or a boxed closure — pushing to and taking from a
+/// `DisposeCtx` never runs user code, which is what lets the whole struct be
+/// touched under a `RefCell` borrow safely.
+#[derive(Default)]
+struct DisposeCtx {
+    handlers: Vec<EventHandlerId>,
+    effects: Vec<ObserverId>,
+    cleanups: Vec<Box<dyn FnOnce()>>,
+    memos: Vec<MemoKey>,
+    signals: Vec<SignalKey>,
+    /// Values taken out of freed signal slots, dropped at the lowest priority.
+    values: Vec<Box<dyn Any>>,
+}
+
+thread_local! {
+    /// The in-flight disposal, or `None` when nothing is being disposed.
+    ///
+    /// `Some` also *means* "a fixpoint is already draining above me", which is
+    /// how [`ScopeInner::dispose`] tells an outermost call from a nested one.
+    static DISPOSE_CTX: RefCell<Option<DisposeCtx>> = const { RefCell::new(None) };
+}
+
+/// Run `f` against the in-flight disposal context, if there is one.
+///
+/// Holds the context borrow across `f`, so `f` must be allocation-only: pushing
+/// work on, or taking a batch off. Never user code.
+fn with_dispose_ctx<R>(f: impl FnOnce(&mut DisposeCtx) -> R) -> Option<R> {
+    DISPOSE_CTX.with(|ctx| ctx.borrow_mut().as_mut().map(f))
+}
+
+/// Take one batch off the context, leaving it empty.
+fn take_batch<T>(f: impl FnOnce(&mut DisposeCtx) -> &mut Vec<T>) -> Vec<T> {
+    with_dispose_ctx(|ctx| std::mem::take(f(ctx))).unwrap_or_default()
+}
+
+/// Release everything collected into the [`DisposeCtx`], to a fixpoint.
+///
+/// # Why a fixpoint and not a pipeline
+///
+/// A scope's subtree is not enumerable up front. Child `RenderScope`s live
+/// *inside* their parent effect's closure, so a subtree only becomes reachable
+/// once the parent effect is disposed and its closure dropped. Every level below
+/// therefore runs code that can mark more scopes disposed — dropping a closure,
+/// running a cleanup, dropping a user value — and each of those pushes fresh
+/// work onto the context. Draining the levels once, in order, would leave that
+/// late-arriving work stranded.
+///
+/// So each level, after doing any work at all, **restarts from the top**. The
+/// loop exits only when a full sweep finds every level empty.
+///
+/// # Why this order
+///
+/// Strictly: handlers → effects → cleanups → memos → signals → value drops.
+///
+/// - **Handlers first.** Unregistering them is the only step that runs no user
+///   code at all, and doing it first means a re-entrant dispatch arriving during
+///   teardown (a cleanup that pumps the event loop, a `Drop` that fires a
+///   callback) finds nothing to call, instead of calling into a component whose
+///   signals are about to be freed.
+/// - **Cleanups after effects**, so a cleanup cannot resurrect an effect that
+///   was already disposed (issue #141, maintainer decision).
+/// - **Memos before signals**, because a memo recompute *reads* signals; a memo
+///   still reachable after its sources were freed would panic on the next read.
+/// - **Signals second to last**, because everything above — effect closures,
+///   cleanups — legitimately reads them while running.
+///
+/// # Termination
+///
+/// Every level either does nothing or permanently consumes at least one item:
+/// handler ids are removed from the registries and never re-added, effect slots
+/// are emptied, cleanups are `FnOnce`, memo and signal slots are generation
+/// guarded so a second free is a no-op, and values are dropped. New work only
+/// arrives by marking a not-yet-disposed scope disposed, and `disposed` is
+/// one-way. The loop is therefore bounded by the number of live scopes, plus
+/// whatever user code creates *and* disposes while unwinding — which is
+/// unbounded only in the same sense that any user `Drop` is.
+///
+/// # Completeness is per invocation, not per instant
+///
+/// One case defers to a *later* fixpoint rather than joining this one: a scope
+/// disposed from inside a **running effect**. `run_effect` holds a strong
+/// `Rc<EffectInner>` across the whole body, so `dispose_effect` can only empty
+/// the registry slot — the closure, and any child `RenderScope` it captures, is
+/// not dropped until that body returns, by which point this fixpoint has exited
+/// and the drop starts a fresh one.
+///
+/// Nothing is missed; it just happens one turn later. The practical consequence
+/// is for tests: after a dispose triggered from inside an effect, assert
+/// liveness once the flush has settled, not on the line after `dispose()`.
+fn run_dispose_fixpoint() {
+    loop {
+        // 1. Handlers.
+        let handlers = take_batch(|ctx| &mut ctx.handlers);
+        if !handlers.is_empty() {
+            for id in handlers {
+                crate::events::unregister_handler(id);
+            }
+            continue;
         }
 
-        // #141 PR4: release `self.owned` here, in priority order
-        // (handlers -> effects -> cleanups -> memos -> signals -> value-drops).
-        // PR2 deliberately leaves the bucket intact so the attribution stays
-        // observable after disposal.
-
-        // Process children iteratively
-        let mut pending: Vec<Scope> = self.children.borrow_mut().drain(..).collect();
-        while let Some(child) = pending.pop() {
-            if child.0.disposed.get() {
-                // Drain to prevent recursive field drop
-                child.0.children.borrow_mut().drain(..);
-                child.0.effects.borrow_mut().drain(..);
-                continue;
+        // 2. Effects. Dropping an effect's closure is the step that reaches
+        //    child scopes, so this is where the subtree grows.
+        let effects = take_batch(|ctx| &mut ctx.effects);
+        if !effects.is_empty() {
+            for id in effects {
+                super::effect::dispose_effect(id);
             }
-            child.0.disposed.set(true);
+            continue;
+        }
 
-            pending.extend(child.0.children.borrow_mut().drain(..));
-            let child_effects: Vec<Effect> = child.0.effects.borrow_mut().drain(..).collect();
-            queue.with(|q| {
-                if let Some(ref mut vec) = *q.borrow_mut() {
-                    vec.extend(child_effects);
-                }
-            });
-
-            for cleanup in child.0.cleanups.borrow_mut().drain(..) {
+        // 3. Cleanups.
+        let cleanups = take_batch(|ctx| &mut ctx.cleanups);
+        if !cleanups.is_empty() {
+            for cleanup in cleanups {
                 cleanup();
             }
-
-            // #141 PR4: release `child.0.owned` here too.
+            continue;
         }
+
+        // 4. Memos. `free_memo`, never `MemoStore::free`: a memo holds two
+        //    strong `Rc<MemoInner>`, one in the store and one captured by its
+        //    dirty-marker effect, and releasing only the store slot frees
+        //    nothing *and* leaves the marker subscribed — so the next write to a
+        //    source re-queues the memo's dependents, whose `get()` then panics
+        //    on the empty slot. `free_memo` drops the cached value here, while
+        //    signals are still live, which is strictly friendlier than deferring
+        //    it: a derived value's `Drop` may still read the state it derives
+        //    from.
+        let memos = take_batch(|ctx| &mut ctx.memos);
+        if !memos.is_empty() {
+            for key in memos {
+                super::free_memo(key.id, key.generation);
+            }
+            continue;
+        }
+
+        // 5. Signals. The value comes back out rather than dropping under the
+        //    store borrow, and is parked for level 6 rather than dropped here:
+        //    dropping in place would let one value's `Drop` observe an arbitrary
+        //    prefix of its siblings already freed. Deferring makes the state a
+        //    value's `Drop` sees deterministic — *everything* this scope owned
+        //    is gone — which matches the documented contract for reading a
+        //    handle after its scope was disposed.
+        let signals = take_batch(|ctx| &mut ctx.signals);
+        if !signals.is_empty() {
+            let values: Vec<Box<dyn Any>> = signals
+                .into_iter()
+                .filter_map(|key| super::free_signal(key.id, key.generation))
+                .collect();
+            with_dispose_ctx(|ctx| ctx.values.extend(values));
+            continue;
+        }
+
+        // 6. Value drops.
+        let values = take_batch(|ctx| &mut ctx.values);
+        if !values.is_empty() {
+            drop(values);
+            continue;
+        }
+
+        break;
     }
 }
 
@@ -644,33 +802,50 @@ pub(crate) fn record_handler(id: EventHandlerId) {
     with_ambient_owned(|owned| owned.handlers.push(id));
 }
 
-/// Register a cleanup to run when the ambient owner is disposed.
+/// Register a cleanup to run when the scope currently rendering is disposed.
 ///
-/// Returns `false` when there is no live ambient owner, in which case the
-/// caller's resource keeps **app lifetime** — the #141 SD2 default. Like
-/// [`with_ambient_owned`], a dead or disposed top entry counts as *no owner*
-/// and does not fall through to the next entry down: the owner stack is not an
-/// ancestor chain.
+/// This is the escape hatch for a **process-lifetime registry that holds a
+/// handle to scope-owned state** — a list of active players, a subscription
+/// table, anything polled from the event loop. Disposal frees the signals such a
+/// handle points at, so the registry has to be told to let go; registering that
+/// here ties it to the same lifetime automatically, rather than depending on the
+/// component author to remember.
 ///
-/// Called from [`crate::context`] to tie a store/context entry to the scope
-/// that created it.
+/// Cleanups run *before* the scope's signals and memos are freed (see
+/// [`run_dispose_fixpoint`]), so a cleanup may still read them.
+///
+/// Returns `false` when there is no live ambient owner — outside any render, or
+/// under [`unowned`] — in which case the caller's resource keeps **app
+/// lifetime**, the #141 SD2 default. A dead or disposed top entry also counts as
+/// *no owner* and does not fall through to the next entry down: the owner stack
+/// is not an ancestor chain (see [`Owner::push`]).
+///
+/// ```ignore
+/// let player = VideoPlayer::new(backend);
+/// REGISTRY.with(|r| r.borrow_mut().push(player.clone()));
+/// let doomed = player.clone();
+/// on_cleanup(move || REGISTRY.with(|r| r.borrow_mut().retain(|p| p != &doomed)));
+/// ```
+pub fn on_cleanup(f: impl FnOnce() + 'static) -> bool {
+    on_cleanup_for_ambient_owner(f)
+}
+
+/// Crate-internal spelling of [`on_cleanup`], used by [`crate::context`] to tie a
+/// store/context entry to the scope that created it.
 pub(crate) fn on_cleanup_for_ambient_owner(f: impl FnOnce() + 'static) -> bool {
     with_ambient_scope(|inner| {
-        // `try_borrow_mut`, not `borrow_mut`: `dispose_into_queue` drains this
-        // vec with the borrow held across every cleanup it runs, so reaching a
-        // mid-drain scope here would panic.
+        // The load-bearing guard is `with_ambient_scope` rejecting a *disposed*
+        // owner, and that is reachable: `record_effect` declines to record
+        // against a disposed ambient owner while `Owner::current` still captures
+        // it, so such an effect is never disposed by anyone, and every later run
+        // re-pushes its dead owner. A cleanup registered there would never run.
         //
-        // Reaching one is not easy — `dispose` pushes no owner, so the stack is
-        // normally empty by then — but it is possible: a cleanup writes a
-        // signal, the synchronous flush re-runs an effect that is
-        // enqueued-but-not-yet-disposed, and `run_effect` re-pushes that
-        // effect's owner, which is the disposing scope.
-        //
-        // Two guards cover it and either alone suffices: `with_ambient_scope`
-        // rejects a disposed owner (`disposed` is set before the drain begins),
-        // and this `try_borrow_mut`. Kept redundant deliberately — degrading to
-        // "not registered" beats taking the app down, matching the lenient-write
-        // stance PR1 established.
+        // `try_borrow_mut` is the belt to that suspenders. It used to be
+        // essential — disposal drained this vec with the borrow held across
+        // every cleanup — but the fixpoint now moves cleanups out and releases
+        // the borrow before running any of them. Kept anyway: degrading to "not
+        // registered" beats taking the app down if that pairing is ever broken,
+        // matching the lenient-write stance PR1 established.
         match inner.cleanups.try_borrow_mut() {
             Ok(mut cleanups) => {
                 cleanups.push(Box::new(f));
@@ -1011,9 +1186,10 @@ mod tests {
         assert!(doubled.is_alive());
     }
 
-    /// PR2 is metrics-only: `dispose` must not free or drain anything.
+    /// The headline of #141: disposing a scope releases every kind of resource
+    /// attributed to it, not just the effects explicitly adopted into it.
     #[test]
-    fn dispose_leaves_the_owned_bucket_intact() {
+    fn dispose_frees_everything_the_scope_owns() {
         let scope = Scope::new();
         let (signal, memo, handler) = scope.run(|| {
             let s = Signal::new(1);
@@ -1022,26 +1198,290 @@ mod tests {
             let h = crate::events::register_handler(std::rc::Rc::new(|| {}));
             (s, m, h)
         });
-        let before = scope.owned_counts();
-        assert_eq!(before.signals, 1);
-        assert_eq!(before.memos, 1);
-        assert_eq!(before.effects, 1);
-        assert_eq!(before.handlers, 1);
+        assert_eq!(
+            scope.owned_counts(),
+            OwnedCounts {
+                signals: 1,
+                memos: 1,
+                handlers: 1,
+                effects: 1,
+            }
+        );
+        assert!(signal.is_alive());
+        assert!(memo.is_alive());
+        assert!(crate::events::dispatch_event(handler));
 
         scope.dispose();
 
         assert_eq!(
             scope.owned_counts(),
-            before,
-            "PR2 records ownership; PR4 is what acts on it"
+            OwnedCounts::default(),
+            "the bucket is emptied as it is released"
         );
-        // The counts alone cannot detect a free, because PR2 does not drain the
-        // bucket on dispose — so probe the resources themselves.
-        assert!(signal.is_alive(), "nothing is freed yet");
-        assert!(memo.is_alive(), "nothing is freed yet");
+        assert!(!signal.is_alive(), "the signal slot is freed");
+        assert!(!memo.is_alive(), "the memo slot is freed");
         assert!(
-            crate::events::dispatch_event(handler),
-            "the handler is still registered — PR4 is what unregisters it"
+            !crate::events::dispatch_event(handler),
+            "the handler is deregistered"
         );
+    }
+
+    /// The leak #141 was filed for: an effect created during a render but never
+    /// handed to [`Scope::add_effect`] used to run for the life of the thread.
+    ///
+    /// Ownership catches it even though adoption did not.
+    #[test]
+    fn an_effect_nobody_adopted_still_dies_with_its_owner() {
+        let trigger = Signal::new(0);
+        let runs = Rc::new(Cell::new(0));
+
+        let scope = Scope::new();
+        let hits = runs.clone();
+        scope.run(|| {
+            // Deliberately dropped on the floor — no `add_effect`.
+            Effect::new(move || {
+                trigger.get();
+                hits.set(hits.get() + 1);
+            });
+        });
+        assert_eq!(runs.get(), 1, "ran once at creation");
+        assert_eq!(scope.effect_count(), 0, "and was never adopted");
+
+        trigger.set(1);
+        assert_eq!(runs.get(), 2);
+
+        scope.dispose();
+
+        trigger.set(2);
+        assert_eq!(
+            runs.get(),
+            2,
+            "a fire-and-forget effect must not outlive the scope that created it"
+        );
+    }
+
+    /// Why disposal has to be a **fixpoint** rather than one pass down the
+    /// priority list.
+    ///
+    /// A scope's subtree is not enumerable up front: `child` here is reachable
+    /// only through the cleanup closure, so it is not marked disposed until
+    /// cleanups run — which is *after* the handler level. A single pass would
+    /// leave its handler registered forever; the fixpoint loops back to the top
+    /// and catches it.
+    #[test]
+    fn a_scope_reached_only_by_a_cleanup_still_has_its_handlers_freed() {
+        let outer = Scope::new();
+
+        let child = Scope::new();
+        let handler = child.run(|| crate::events::register_handler(std::rc::Rc::new(|| {})));
+        assert!(crate::events::dispatch_event(handler));
+
+        // The only handle to `child` lives inside the cleanup closure, so the
+        // handler cannot be discovered before cleanups run.
+        let mut held = Some(child);
+        outer.on_cleanup(move || drop(held.take()));
+
+        outer.dispose();
+
+        assert!(
+            !crate::events::dispatch_event(handler),
+            "the fixpoint must revisit the handler level after cleanups ran"
+        );
+    }
+
+    /// A grandchild scope reachable *only* through an effect closure is still
+    /// fully released.
+    ///
+    /// This is the shape every control-flow construct produces: `show_dom`,
+    /// `match_dom`, `for_each_dom` and `reactive_component_dom` all keep their
+    /// child scope inside the closure of the effect that swaps it. So the child
+    /// is not enumerable when the parent is collected — it only becomes
+    /// reachable once that effect is disposed and its closure dropped, one level
+    /// down the fixpoint.
+    ///
+    /// Without this, `dispose_frees_everything_the_scope_owns` is trivially
+    /// satisfiable by a single flat pass and proves nothing about the fixpoint.
+    #[test]
+    fn a_grandchild_reachable_only_through_an_effect_closure_is_released() {
+        let outer = Scope::new();
+
+        // Two levels down, each hidden inside the closure above it.
+        let child = Scope::new();
+        let grandchild = Scope::new();
+        let deep_signal = grandchild.run(|| Signal::new(41));
+        let deep_handler = grandchild.run(|| crate::events::register_handler(Rc::new(|| {})));
+
+        // The grandchild handle lives *inside* an effect closure owned by
+        // `child`; nothing else references it. Same for `child` one level up.
+        let holder = child.run(|| {
+            let held = grandchild;
+            Effect::new(move || {
+                let _ = &held;
+            })
+        });
+        child.add_effect(holder);
+
+        let outer_holder = outer.run(|| {
+            let held = child;
+            Effect::new(move || {
+                let _ = &held;
+            })
+        });
+        outer.add_effect(outer_holder);
+
+        assert!(deep_signal.is_alive());
+        assert!(crate::events::dispatch_event(deep_handler));
+
+        outer.dispose();
+
+        assert!(
+            !deep_signal.is_alive(),
+            "the fixpoint must reach two levels of effect-closure indirection"
+        );
+        assert!(
+            !crate::events::dispatch_event(deep_handler),
+            "including levels above the one that discovered the scope"
+        );
+    }
+
+    /// A cleanup runs after the scope's effects are disposed, so it cannot
+    /// resurrect one — the ordering ratified for #141 (SD4).
+    #[test]
+    fn a_cleanup_cannot_resurrect_a_disposed_effect() {
+        let trigger = Signal::new(0);
+        let runs = Rc::new(Cell::new(0));
+
+        let scope = Scope::new();
+        let hits = runs.clone();
+        let effect = scope.run(|| {
+            Effect::new(move || {
+                trigger.get();
+                hits.set(hits.get() + 1);
+            })
+        });
+        scope.add_effect(effect);
+        assert_eq!(runs.get(), 1);
+
+        // Writing a signal from a cleanup flushes effects synchronously.
+        scope.on_cleanup(move || trigger.set(1));
+        scope.dispose();
+
+        assert_eq!(
+            runs.get(),
+            1,
+            "the effect was already disposed when the cleanup wrote its dependency"
+        );
+    }
+
+    /// Cleanups run *before* the scope's signals and memos are freed, so a
+    /// cleanup can still read the state it is tearing down.
+    ///
+    /// This is what makes "save my draft on unmount" expressible at all.
+    #[test]
+    fn a_cleanup_can_still_read_the_signals_it_is_tearing_down() {
+        let saved = Rc::new(RefCell::new(String::new()));
+
+        let scope = Scope::new();
+        let draft = scope.run(|| Signal::new(String::from("unsent")));
+
+        let sink = saved.clone();
+        scope.on_cleanup(move || *sink.borrow_mut() = draft.get());
+
+        scope.dispose();
+
+        assert_eq!(*saved.borrow(), "unsent", "the read must not have panicked");
+        assert!(!draft.is_alive(), "and the signal is freed afterwards");
+    }
+
+    /// A signal's value is dropped with no store borrow held, and only once
+    /// every sibling has been freed — so a `Drop` that touches the reactive
+    /// stores neither panics nor observes a half-torn-down scope.
+    #[test]
+    fn freed_values_drop_outside_the_store_borrow_and_after_their_siblings() {
+        struct Probe {
+            sibling: Signal<i32>,
+            sibling_was_alive: Rc<Cell<bool>>,
+        }
+        impl Drop for Probe {
+            fn drop(&mut self) {
+                // Touching SIGNAL_STORE here is a BorrowMutError if the value
+                // is dropped in place inside `SignalStore::free`.
+                self.sibling_was_alive.set(self.sibling.is_alive());
+            }
+        }
+
+        let sibling_was_alive = Rc::new(Cell::new(true));
+        let scope = Scope::new();
+        let flag = sibling_was_alive.clone();
+        scope.run(|| {
+            let sibling = Signal::new(0);
+            Signal::new(Probe {
+                sibling,
+                sibling_was_alive: flag,
+            });
+        });
+
+        scope.dispose(); // must not panic
+
+        assert!(
+            !sibling_was_alive.get(),
+            "value drops are deferred until every signal the scope owned is gone"
+        );
+    }
+
+    /// Disposal is re-entrant: a cleanup may dispose another scope, and that
+    /// scope's own work joins the fixpoint already in flight instead of
+    /// starting a nested one.
+    #[test]
+    fn a_cleanup_may_dispose_another_scope() {
+        let log = Rc::new(RefCell::new(Vec::new()));
+
+        let inner = Scope::new();
+        let inner_signal = inner.run(|| Signal::new(0));
+        let inner_log = log.clone();
+        inner.on_cleanup(move || inner_log.borrow_mut().push("inner"));
+
+        let outer = Scope::new();
+        let outer_log = log.clone();
+        outer.on_cleanup(move || {
+            outer_log.borrow_mut().push("outer");
+            inner.dispose();
+        });
+
+        outer.dispose();
+
+        assert_eq!(*log.borrow(), ["outer", "inner"]);
+        assert!(
+            !inner_signal.is_alive(),
+            "the nested scope was fully released"
+        );
+    }
+
+    /// Freeing a memo releases its dirty-marker effect too, so writing a source
+    /// afterwards neither resurrects its dependents nor panics.
+    ///
+    /// The distinction between `free_memo` and `MemoStore::free`, pinned at the
+    /// level that actually calls it.
+    #[test]
+    fn disposing_a_scope_releases_a_memos_marker_effect_as_well() {
+        let source = Signal::new(1);
+        let scope = Scope::new();
+        let memo = scope.run(|| Memo::new(move || source.get() * 2));
+        assert_eq!(memo.get(), 2);
+
+        let runs = Rc::new(Cell::new(0));
+        let hits = runs.clone();
+        // Lives outside the scope, so it survives the dispose below.
+        let _dependent = Effect::new(move || {
+            source.get();
+            hits.set(hits.get() + 1);
+        });
+        assert_eq!(runs.get(), 1);
+
+        scope.dispose();
+        source.set(5); // must not panic
+
+        assert!(!memo.is_alive());
+        assert_eq!(runs.get(), 2, "the surviving observer still runs");
     }
 }

--- a/crates/rinch-core/src/reactive/scope.rs
+++ b/crates/rinch-core/src/reactive/scope.rs
@@ -295,8 +295,10 @@ impl ScopeInner {
         self.collect();
 
         if is_root {
+            // RAII, because the fixpoint runs arbitrary user code and it can
+            // panic — see [`DisposeCtxGuard`].
+            let _ctx_guard = DisposeCtxGuard;
             run_dispose_fixpoint();
-            DISPOSE_CTX.with(|ctx| *ctx.borrow_mut() = None);
         }
     }
 
@@ -383,6 +385,31 @@ thread_local! {
     /// `Some` also *means* "a fixpoint is already draining above me", which is
     /// how [`ScopeInner::dispose`] tells an outermost call from a nested one.
     static DISPOSE_CTX: RefCell<Option<DisposeCtx>> = const { RefCell::new(None) };
+}
+
+/// Clears the in-flight [`DisposeCtx`] on drop, including while unwinding.
+///
+/// The fixpoint runs arbitrary user code — cleanups, closure drops, value drops
+/// — and any of it can panic. Clearing the context on the normal path only would
+/// leave it installed for the rest of the thread's life, and then every later
+/// `dispose()` would see it, conclude it was *nested*, collect into it and never
+/// drain. One panicking cleanup would silently and permanently disable disposal
+/// process-wide, which is a far worse failure than the panic itself.
+struct DisposeCtxGuard;
+
+impl Drop for DisposeCtxGuard {
+    fn drop(&mut self) {
+        // `try_with`: TLS may already be torn down at thread exit, exactly as in
+        // `ObserverGuard::drop`. `try_borrow_mut` guards the (pathological) case
+        // of unwinding out of `with_dispose_ctx` itself.
+        let leftover = DISPOSE_CTX
+            .try_with(|ctx| ctx.try_borrow_mut().ok().and_then(|mut ctx| ctx.take()))
+            .ok()
+            .flatten();
+        // Dropped out here with no borrow held: an abandoned batch still holds
+        // un-run cleanups and freed values, i.e. more arbitrary user `Drop`s.
+        drop(leftover);
+    }
 }
 
 /// Run `f` against the in-flight disposal context, if there is one.
@@ -1341,6 +1368,36 @@ mod tests {
         assert!(
             !crate::events::dispatch_event(deep_handler),
             "including levels above the one that discovered the scope"
+        );
+    }
+
+    /// A panicking cleanup must not disable disposal for the rest of the
+    /// thread's life.
+    ///
+    /// The fixpoint installs a thread-local context and uses "is it installed?"
+    /// to tell an outermost `dispose` from a nested one. Clearing it only on the
+    /// normal path would leave it stranded after a panic, and every later
+    /// `dispose()` would then collect into it and never drain — silently, and
+    /// for every scope in the process, not just this one.
+    #[test]
+    fn a_panicking_cleanup_does_not_strand_the_disposal_context() {
+        let scope = Scope::new();
+        scope.on_cleanup(|| panic!("boom"));
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| scope.dispose()));
+        assert!(result.is_err(), "the cleanup must have panicked");
+
+        // The positive control: a completely unrelated scope disposed
+        // afterwards still frees what it owns.
+        let later = Scope::new();
+        let signal = later.run(|| Signal::new(0));
+        assert!(signal.is_alive());
+
+        later.dispose();
+
+        assert!(
+            !signal.is_alive(),
+            "disposal must still work after a cleanup panicked in an earlier scope"
         );
     }
 

--- a/crates/rinch-core/src/reactive/signal.rs
+++ b/crates/rinch-core/src/reactive/signal.rs
@@ -305,10 +305,6 @@ impl<T: 'static> Signal<T> {
     /// to make from a long-lived callback or a background worker holding a
     /// `Copy` handle.
     ///
-    /// Nothing frees signals yet — this returns `true` for every signal that was
-    /// ever created. It becomes meaningful when scope-driven disposal lands
-    /// (issue #141).
-    ///
     /// Does **not** subscribe the current observer — liveness is not reactive,
     /// and tracking it would resurrect the dependency you are trying to drop.
     pub fn is_alive(&self) -> bool {

--- a/crates/rinch-core/src/show.rs
+++ b/crates/rinch-core/src/show.rs
@@ -182,8 +182,18 @@ where
             *showing_clone.borrow_mut() = new_showing;
 
             // DISPOSE old scope BEFORE removing DOM nodes
-            // This ensures all nested effects are cleaned up properly
-            if let Some(old_scope) = current_scope_clone.borrow_mut().take() {
+            // This ensures all nested effects are cleaned up properly.
+            //
+            // The `take()` is deliberately a separate statement: an `if let`
+            // scrutinee's temporaries live through the then-block, so the
+            // obvious one-liner holds `current_scope`'s `RefMut` across the
+            // dispose. That used to be harmless, but disposal now runs user code
+            // — cleanups, handler-closure drops, signal value drops (issue
+            // #141) — and any of it that writes a signal flushes effects
+            // synchronously, re-entering this very closure and panicking on the
+            // outstanding borrow.
+            let old_scope = current_scope_clone.borrow_mut().take();
+            if let Some(old_scope) = old_scope {
                 old_scope.dispose();
             }
 

--- a/crates/rinch-core/src/timer.rs
+++ b/crates/rinch-core/src/timer.rs
@@ -20,6 +20,9 @@
 //! let t = rinch_core::set_timeout(300, move || save(editor.doc()));
 //! rinch_core::clear_timeout(t); // debounce: cancel and re-arm
 //! ```
+//!
+//! A timeout armed during a render is also cancelled if that component unmounts
+//! before it fires — see [`set_timeout`].
 
 use std::sync::Mutex;
 
@@ -50,6 +53,21 @@ pub fn set_timer_backend(backend: TimerBackend) {
 /// and invoked there, so it needn't be `Send` and may capture `Rc`-based UI state.
 /// The native scheduler additionally requires the runtime's cross-thread
 /// dispatcher to be registered (it hops the fired id back onto the main thread).
+///
+/// # Unmounting cancels it
+///
+/// A timeout armed **during a render** does not fire if the component that armed
+/// it is unmounted first — its captured signals are freed with that component
+/// (issue #141), so firing would read dead state. This is what you want for the
+/// usual cases (debounce, toast auto-dismiss, retry): there is no UI left to
+/// update.
+///
+/// For work that must outlive the component — flushing to disk, releasing an
+/// external resource — arm it outside any render, or opt out explicitly:
+///
+/// ```ignore
+/// rinch_core::reactive::unowned(|| set_timeout(500, move || flush_to_disk()));
+/// ```
 pub fn set_timeout(delay_ms: u32, cb: impl FnOnce() + 'static) -> TimeoutHandle {
     let id = park_main_callback::<()>(move |()| cb());
     schedule(id.raw(), delay_ms);

--- a/crates/rinch-core/src/virtual_list.rs
+++ b/crates/rinch-core/src/virtual_list.rs
@@ -181,12 +181,18 @@ where
             .cloned()
             .collect();
 
-        // Remove out-of-range items
+        // Remove out-of-range items.
+        //
+        // Their scopes are parked and disposed at the very end of this closure,
+        // once `state` and `old_keys` are no longer borrowed. Disposal runs user
+        // code — cleanups, handler-closure drops, signal value drops (issue
+        // #141) — and any of it that writes a signal flushes effects
+        // synchronously, re-entering this closure and panicking on the
+        // outstanding `RefMut`s.
+        let mut doomed: Vec<RenderScope> = Vec::new();
         for k in &to_remove {
             if let Some(item_state) = state.remove(k) {
-                if let Some(s) = item_state.scope {
-                    s.dispose();
-                }
+                doomed.extend(item_state.scope);
                 item_state.node.remove();
             }
         }
@@ -243,6 +249,13 @@ where
 
         // Update keys order
         *old_keys = new_keys;
+
+        // Borrows released before the parked scopes are torn down.
+        drop(state);
+        drop(old_keys);
+        for scope in doomed {
+            scope.dispose();
+        }
     });
 
     scope.create_effect_from(effect);

--- a/crates/rinch-macros/src/dom_codegen/control_flow.rs
+++ b/crates/rinch-macros/src/dom_codegen/control_flow.rs
@@ -467,6 +467,141 @@ fn generate_children_body(children: &[RsxNode], ctx: &mut DomCodegenContext) -> 
 
 /// Generate DOM code for a native `for` loop in RSX.
 ///
+/// The leading `let` statements of a `for` body that the key expression
+/// actually depends on, in source order.
+///
+/// The key closure runs once per item on **every** reconcile pass, and is a
+/// separate closure from the view. Copying the whole leading-`let` prologue into
+/// it therefore re-executes each statement per item per pass — and the
+/// documented per-item-state idiom puts a `Signal::new(..)` in exactly that
+/// prologue:
+///
+/// ```ignore
+/// for todo in todos.get() {
+///     let editing = Signal::new(false);   // per-item state, for the *view*
+///     div { key: todo.id, /* ... */ }     // the key needs `todo`, not `editing`
+/// }
+/// ```
+///
+/// Unfiltered, that mints a throwaway signal per item per reconcile, attributed
+/// to the scope *enclosing* the `for` (the reconcile effect re-enters its
+/// creation-time owner), so they accumulate until the whole component dies —
+/// an invisible leak before #141, and an unbounded `Owned::signals` for the
+/// dispose fixpoint to walk after it. Keeping only what the key reads removes
+/// the allocation rather than re-homing it.
+///
+/// Traced backwards so a chain survives intact: if the key needs `b` and `b`'s
+/// initialiser reads `a`, both are kept. Non-`let` statements are kept
+/// unconditionally — they bind nothing to trace and may carry side effects the
+/// key relies on.
+fn key_relevant_leading_stmts(for_loop: &RsxForLoop, key_fn: &TokenStream2) -> Vec<TokenStream2> {
+    let leading: Vec<&syn::Stmt> = for_loop
+        .children
+        .iter()
+        .take_while(|c| matches!(c, RsxNode::Statement(_)))
+        .filter_map(|c| match c {
+            RsxNode::Statement(stmt) => Some(stmt),
+            _ => None,
+        })
+        .collect();
+
+    let mut needed = token_idents(key_fn);
+
+    let mut keep = vec![false; leading.len()];
+    for (i, stmt) in leading.iter().enumerate().rev() {
+        let syn::Stmt::Local(local) = stmt else {
+            keep[i] = true;
+            continue;
+        };
+        let mut bound = HashSet::new();
+        collect_pat_idents(&local.pat, &mut bound);
+        if bound.iter().any(|name| needed.contains(name)) {
+            keep[i] = true;
+            if let Some(init) = &local.init {
+                let expr = &init.expr;
+                needed.extend(token_idents(&quote! { #expr }));
+                // `let x = a else { ... }` — the divergent block can reference
+                // bindings too.
+                if let Some((_, diverge)) = &init.diverge {
+                    needed.extend(token_idents(&quote! { #diverge }));
+                }
+            }
+        }
+    }
+
+    leading
+        .into_iter()
+        .zip(keep)
+        .filter(|&(_, keep)| keep)
+        .map(|(stmt, _)| quote! { #stmt })
+        .collect()
+}
+
+/// Every identifier that *might* be referenced by `tokens`.
+///
+/// Deliberately a token-level over-approximation rather than the scope-aware
+/// [`collect_capture_idents`]: this drives a decision about what to **discard**,
+/// so the only acceptable error is keeping too much. Two things a `syn::Expr`
+/// walk misses outright, both of which would silently drop a binding the key
+/// needs and turn it into a compile error in user code:
+///
+/// - **Macro arguments.** `syn` models a macro invocation's body as an opaque
+///   `TokenStream`, so `key: format!("{}-{}", a, b)` yields no identifiers at all.
+/// - **Inline format args.** In `format!("{prefix}-{}", id)`, `prefix` lives
+///   inside a string *literal* and is not a token anywhere.
+///
+/// Field names and method names are collected too. Harmless: at worst a `let`
+/// whose binding happens to share a name with a field is kept unnecessarily.
+fn token_idents(tokens: &TokenStream2) -> HashSet<String> {
+    use proc_macro2::TokenTree;
+
+    let mut out = HashSet::new();
+    let mut stack: Vec<TokenStream2> = vec![tokens.clone()];
+    while let Some(stream) = stack.pop() {
+        for tree in stream {
+            match tree {
+                TokenTree::Ident(id) => {
+                    out.insert(id.to_string());
+                }
+                TokenTree::Group(g) => stack.push(g.stream()),
+                TokenTree::Literal(lit) => collect_inline_format_args(&lit.to_string(), &mut out),
+                TokenTree::Punct(_) => {}
+            }
+        }
+    }
+    out
+}
+
+/// Pull identifiers out of a string literal's `{...}` placeholders, so an inline
+/// format arg such as the `prefix` in `format!("{prefix}-{}", id)` is seen.
+///
+/// Takes the leading identifier of each placeholder, stopping at `:` (the format
+/// spec) — `{width$}`/`{0}`/`{}` contribute nothing. `{{` is an escaped brace and
+/// is skipped. Over-collecting from an unrelated string literal is harmless.
+fn collect_inline_format_args(literal: &str, out: &mut HashSet<String>) {
+    let bytes: Vec<char> = literal.chars().collect();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != '{' {
+            i += 1;
+            continue;
+        }
+        if bytes.get(i + 1) == Some(&'{') {
+            i += 2; // escaped `{{`
+            continue;
+        }
+        let start = i + 1;
+        let mut end = start;
+        while end < bytes.len() && (bytes[end].is_alphanumeric() || bytes[end] == '_') {
+            end += 1;
+        }
+        if end > start && !bytes[start].is_ascii_digit() {
+            out.insert(bytes[start..end].iter().collect());
+        }
+        i = end.max(start + 1);
+    }
+}
+
 /// Desugars to `for_each_dom_typed()`. The iterator expression is auto-wrapped
 /// in a `move ||` closure. If a `key:` prop is found on the first child element,
 /// it's extracted as the key function.
@@ -481,19 +616,9 @@ pub fn generate_for_loop(
     // Try to extract key from first child element's `key:` prop
     let key_fn = extract_key_expr(for_loop);
 
-    // Collect leading let statements so they can be included in the key closure too
-    let leading_stmts: Vec<TokenStream2> = for_loop
-        .children
-        .iter()
-        .take_while(|c| matches!(c, RsxNode::Statement(_)))
-        .filter_map(|c| {
-            if let RsxNode::Statement(stmt) = c {
-                Some(quote! { #stmt })
-            } else {
-                None
-            }
-        })
-        .collect();
+    // Leading `let`s the key expression depends on, so `key:` can reference a
+    // let-bound value. Deliberately filtered — see `key_relevant_leading_stmts`.
+    let leading_stmts = key_relevant_leading_stmts(for_loop, &key_fn);
 
     // Build the view closure body from children
     let body = generate_children_body(&for_loop.children, ctx);
@@ -636,6 +761,126 @@ pub fn generate_match_block(
                 vec![#(#branch_closures),*]
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod key_prologue_tests {
+    use super::key_relevant_leading_stmts;
+    use crate::node::RsxForLoop;
+    use quote::quote;
+
+    /// Render the statements `key_relevant_leading_stmts` would copy into the
+    /// key closure, as one whitespace-free string.
+    fn prologue(for_body: proc_macro2::TokenStream, key: proc_macro2::TokenStream) -> String {
+        let for_loop: RsxForLoop = syn::parse2(for_body).expect("parse for loop");
+        key_relevant_leading_stmts(&for_loop, &key)
+            .iter()
+            .map(|ts| ts.to_string())
+            .collect::<String>()
+            .replace(' ', "")
+    }
+
+    /// The documented per-item-state idiom must not be re-executed by the key
+    /// closure: `Signal::new` there mints a throwaway signal per item per
+    /// reconcile pass, attributed to the scope enclosing the `for` (issue #141).
+    #[test]
+    fn per_item_state_is_not_copied_into_the_key_closure() {
+        let copied = prologue(
+            quote! {
+                for todo in todos.get() {
+                    let editing = Signal::new(false);
+                    div { key: todo.id, "x" }
+                }
+            },
+            quote! { todo.id },
+        );
+        assert_eq!(
+            copied, "",
+            "the key reads only `todo`, so nothing needs re-running"
+        );
+    }
+
+    /// The reason the prologue is copied at all still works: a key that reads a
+    /// let-bound value keeps the binding that produced it.
+    #[test]
+    fn a_binding_the_key_reads_is_kept() {
+        let copied = prologue(
+            quote! {
+                for todo in todos.get() {
+                    let composite = format!("{}-{}", todo.id, todo.rev);
+                    div { key: composite, "x" }
+                }
+            },
+            quote! { composite },
+        );
+        assert!(
+            copied.contains("letcomposite"),
+            "the key depends on `composite`, so its binding must survive: {copied}"
+        );
+    }
+
+    /// A key built with a macro keeps its dependencies.
+    ///
+    /// This is why the analysis is token-level: `syn` models a macro body as an
+    /// opaque `TokenStream`, so an expression walk sees *no* identifiers in
+    /// `format!("{}", part)` at all and would drop `part` — turning the filter
+    /// from an optimisation into a compile error in user code.
+    #[test]
+    fn a_key_built_by_a_macro_keeps_its_dependencies() {
+        let positional = prologue(
+            quote! {
+                for todo in todos.get() {
+                    let part = todo.id.to_string();
+                    let editing = Signal::new(false);
+                    div { key: format!("{}-x", part), "x" }
+                }
+            },
+            quote! { format!("{}-x", part) },
+        );
+        assert!(positional.contains("letpart"), "{positional}");
+        assert!(!positional.contains("letediting"), "{positional}");
+
+        // The same, with an inline format arg — the identifier lives inside a
+        // string literal and is not a token anywhere.
+        let inline = prologue(
+            quote! {
+                for todo in todos.get() {
+                    let part = todo.id.to_string();
+                    let editing = Signal::new(false);
+                    div { key: format!("{part}-x"), "x" }
+                }
+            },
+            quote! { format!("{part}-x") },
+        );
+        assert!(inline.contains("letpart"), "{inline}");
+        assert!(!inline.contains("letediting"), "{inline}");
+    }
+
+    /// Dependencies are traced backwards through a chain, and unrelated
+    /// bindings interleaved with it are still dropped.
+    #[test]
+    fn a_dependency_chain_is_kept_and_unrelated_bindings_are_not() {
+        let copied = prologue(
+            quote! {
+                for todo in todos.get() {
+                    let prefix = todo.group.clone();
+                    let editing = Signal::new(false);
+                    let composite = format!("{prefix}-{}", todo.id);
+                    div { key: composite, "x" }
+                }
+            },
+            quote! { composite },
+        );
+        assert!(copied.contains("letcomposite"), "{copied}");
+        assert!(
+            copied.contains("letprefix"),
+            "`composite` reads `prefix`, so the chain must survive: {copied}"
+        );
+        assert!(
+            !copied.contains("letediting"),
+            "`editing` is not on the chain and must be dropped: {copied}"
+        );
     }
 }
 

--- a/crates/rinch-video/src/hooks.rs
+++ b/crates/rinch-video/src/hooks.rs
@@ -41,7 +41,24 @@ pub fn use_video_player_paused(src: &str) -> VideoPlayer {
 
 fn use_video_player_impl(src: &str, start_paused: bool) -> VideoPlayer {
     // Component functions run once, so just create the player directly.
-    create_platform_player(src, start_paused)
+    let player = create_platform_player(src, start_paused);
+
+    // Unregister the player when the component that created it is unmounted
+    // (issue #141).
+    //
+    // The player's seven `Signal`s are minted right here, so they belong to the
+    // component's scope and are freed when it is disposed — while `play()` has
+    // handed a clone to the process-lifetime `ACTIVE_PLAYERS` list that the
+    // event loop polls every frame. Without this the very next frame reads a
+    // freed signal and panics, and because nothing else ever removes the entry
+    // it panics again on every frame after that.
+    //
+    // `cleanup` reads no signals itself, and cleanups run before the scope's
+    // signals are freed, so this is safe in both directions.
+    let doomed = player.clone();
+    rinch_core::reactive::on_cleanup(move || doomed.cleanup());
+
+    player
 }
 
 /// Create a platform-appropriate video player.

--- a/crates/rinch-video/src/lib.rs
+++ b/crates/rinch-video/src/lib.rs
@@ -168,6 +168,18 @@ pub(crate) fn unregister_active_player(player: &VideoPlayer) {
 /// mpv property-change events into reactive Signals.
 /// Also unregisters players that have ended (EOF).
 pub fn poll_active_players() {
+    // Drop players whose signals have been freed, before anything reads one.
+    //
+    // A player's signals belong to the component that created it, so unmounting
+    // that component frees them (issue #141) while this process-lifetime list
+    // still holds a clone. `use_video_player` registers a cleanup that
+    // unregisters here, which is the primary mechanism; this sweep is the
+    // backstop for a player built some other way, and it mirrors how the poll
+    // and bounds registries in rinch-core already derive their own lifetime from
+    // the signal they drive. Without it the first read below panics, every
+    // frame, forever.
+    ACTIVE_PLAYERS.with(|list| list.borrow_mut().retain(|p| p.state.is_alive()));
+
     // Clone the list so we don't hold a borrow during poll().
     // poll() updates signals (e.g. duration) which can trigger Effects
     // that call play() → register_active_player() → borrow_mut().
@@ -175,9 +187,11 @@ pub fn poll_active_players() {
     for player in &players {
         player.poll();
     }
-    // Remove players that have ended (EOF)
+    // Remove players that have ended (EOF), and any whose signals a `poll()`
+    // above tore down (a state change can flush an effect that unmounts the
+    // component showing the video).
     ACTIVE_PLAYERS.with(|list| {
         let mut list = list.borrow_mut();
-        list.retain(|p| p.state.get() != PlaybackState::Ended);
+        list.retain(|p| p.state.try_get().is_some_and(|s| s != PlaybackState::Ended));
     });
 }

--- a/crates/rinch-video/src/native/mpv_player.rs
+++ b/crates/rinch-video/src/native/mpv_player.rs
@@ -151,7 +151,10 @@ impl VideoPlayerBackend for MpvPlayer {
                 MpvUpdate::PausedForCache(stalled) => {
                     if stalled {
                         self.signals.state.set(PlaybackState::Loading);
-                    } else if self.signals.playing.get() {
+                    } else if self.signals.playing.try_get() == Some(true) {
+                        // `try_get`, for the same reason as the render gate
+                        // below: a freed signal here would panic the poll loop
+                        // rather than skip a torn-down player (issue #141).
                         self.signals.state.set(PlaybackState::Playing);
                     }
                 }
@@ -216,7 +219,14 @@ impl VideoPlayerBackend for MpvPlayer {
         // non-blocking snapshot of the current audio-clock position — safe to call
         // at display refresh rate without causing fast-forward.
         if !self.render_ctx.is_null() {
-            let state = self.signals.state.get();
+            // `try_get`: this runs from the per-frame poll, and the component
+            // that owns these signals may have been unmounted since the last
+            // one — `poll_active_players` sweeps the registry, but an effect
+            // flushed by the property updates above can unmount it mid-poll
+            // (issue #141). Nothing to render for a torn-down player.
+            let Some(state) = self.signals.state.try_get() else {
+                return;
+            };
             let should_render = matches!(state, PlaybackState::Playing | PlaybackState::Loading);
             if should_render && self.needs_render.swap(false, Ordering::AcqRel) {
                 self.render_sw_frame();

--- a/crates/rinch-video/src/player.rs
+++ b/crates/rinch-video/src/player.rs
@@ -179,7 +179,11 @@ impl VideoPlayer {
         self.inner.borrow().poll_updates();
     }
 
-    /// Clean up resources. Called automatically on drop via the hook.
+    /// Clean up resources and unregister this player from the active list.
+    ///
+    /// `use_video_player` wires this to the creating component's scope, so a
+    /// player stops being polled when the component showing it is unmounted
+    /// (issue #141). Call it directly only for a player built outside a render.
     pub fn cleanup(&self) {
         self.inner.borrow().cleanup();
         crate::unregister_active_player(self);

--- a/crates/rinch-web/src/event_delegation.rs
+++ b/crates/rinch-web/src/event_delegation.rs
@@ -916,9 +916,19 @@ fn dispatch_click_at(
         events::set_click_ancestors(ancestors);
 
         // Prevent browser default behavior (e.g. text selection during slider
-        // drag, <label> synthesizing extra events).
-        event.prevent_default();
-        events::dispatch_event(events::EventHandlerId(rid));
+        // drag, <label> synthesizing extra events) — but only if a handler
+        // actually ran.
+        //
+        // Order matters here in a way it does not on desktop. Disposing a scope
+        // frees its handlers while the `data-rid` attribute stays on any node
+        // that outlives them (issue #141), and a detached element still
+        // satisfies `closest()` within its own detached subtree. Suppressing the
+        // default unconditionally would then be strictly worse than doing
+        // nothing: text selection, `<label>` activation, native form submit and
+        // the context menu are all cancelled while nothing is dispatched.
+        if events::dispatch_event(events::EventHandlerId(rid)) {
+            event.prevent_default();
+        }
     }
 }
 

--- a/crates/rinch-web/src/lib.rs
+++ b/crates/rinch-web/src/lib.rs
@@ -75,11 +75,10 @@ pub use rinch_editor_view::{CollabError, collab_receive_for};
 struct MountedRoot {
     web_doc: Rc<RefCell<WebDocument>>,
     /// Held so the render scope (and the effects that reference it) stay alive.
-    #[allow(dead_code)]
+    /// It also *owns* everything the build created — handlers included — so
+    /// dropping it is what reclaims the root (issue #141).
     scope: Rc<RefCell<RenderScope>>,
     root: NodeHandle,
-    handler_start: events::EventHandlerId,
-    handler_end: events::EventHandlerId,
 }
 
 thread_local! {
@@ -113,9 +112,26 @@ impl RootHandle {
     pub fn unmount(self) {
         let root = MOUNTED_ROOTS.with(|m| m.borrow_mut().remove(&self.id));
         if let Some(r) = root {
+            // Dispose the scope *first*, while the DOM it was built against is
+            // still standing: disposal runs this root's cleanups and drops its
+            // effect closures, and those legitimately touch their own nodes.
+            // Tearing the tree down first left them patching a corpse.
+            //
+            // Disposal is also what deregisters this root's event handlers now,
+            // replacing the old `handler_id_watermark` range. The range was both
+            // incomplete and unsound: it only covered ids allocated during the
+            // synchronous build (missing every handler a later effect run
+            // registers), and a synchronous effect flush inside the build lets
+            // an *unrelated* root allocate an id inside the recorded window,
+            // which unmounting this root would then delete. A scope's own record
+            // has neither problem (issue #141).
+            match Rc::try_unwrap(r.scope) {
+                // The expected path: nothing else can reach the scope, so its
+                // cleanups run with no borrow outstanding anywhere.
+                Ok(cell) => cell.into_inner().dispose(),
+                Err(shared) => shared.borrow_mut().dispose_in_place(),
+            }
             r.web_doc.borrow_mut().remove_node(r.root.node_id());
-            events::remove_handlers_in_range(r.handler_start, r.handler_end);
-            // Dropping `r` releases the WebDocument and RenderScope for this root.
         }
     }
 }
@@ -203,18 +219,15 @@ where
 
     set_render_scope(scope.clone());
 
-    // Handler ids allocated during this build belong to this root (builds are
-    // sequential, so the range is contiguous and exclusively ours).
-    let handler_start = events::handler_id_watermark();
-    // The root scope owns everything this build creates (issue #141). Scoped to
-    // the build alone: theme injection, event delegation and root registration
-    // below are page-global setup with app lifetime.
+    // The root scope owns everything this build creates — signals, memos,
+    // effects and event handlers — and `unmount` releases them by disposing it
+    // (issue #141). Scoped to the build alone: theme injection, event delegation
+    // and root registration below are page-global setup with app lifetime.
     let root = {
         let _owner = scope.borrow().push_owner();
         let mut scope_ref = scope.borrow_mut();
         build(&mut scope_ref)
     };
-    let handler_end = events::handler_id_watermark();
 
     web_doc.borrow_mut().append_child(body_id, root.node_id());
 
@@ -240,8 +253,6 @@ where
                 web_doc,
                 scope,
                 root,
-                handler_start,
-                handler_end,
             },
         );
     });

--- a/crates/rinch/src/app/click_handling.rs
+++ b/crates/rinch/src/app/click_handling.rs
@@ -292,9 +292,18 @@ impl RinchApp {
         let mut current = Some(hit_id);
         while let Some(node_id) = current {
             if let Some(node) = d.tree.get(node_id) {
-                // Check for click handler
+                // Check for click handler.
+                //
+                // The liveness probe is what keeps a *stale* `data-rid` from
+                // swallowing the click. Disposing a scope frees its handlers
+                // (issue #141) but nothing strips the attribute from a node that
+                // outlives them, and this walk commits to the first node
+                // carrying one — so without the probe a dead button would
+                // consume clicks that belong to the row, backdrop or modal
+                // wrapping it, silently and permanently.
                 if let Some(rid_str) = node.attributes.get("data-rid")
                     && let Ok(handler_id) = rid_str.parse::<usize>()
+                    && events::has_click_handler(events::EventHandlerId(handler_id))
                 {
                     let text_hit = Self::compute_text_hit_info(&d.tree, hit_id, x, y);
 

--- a/crates/rinch/src/app/event_dispatch.rs
+++ b/crates/rinch/src/app/event_dispatch.rs
@@ -1186,10 +1186,17 @@ impl RinchApp {
             let mut found = None;
             while let Some(nid) = current {
                 if let Some(node) = d.tree.get(nid) {
-                    if let Some(val) = node.attributes.get("data-onenter") {
-                        if let Ok(id) = val.parse::<usize>() {
-                            found = Some(id);
-                        }
+                    // A stale attribute must not stop the walk: disposing a
+                    // scope frees its handlers (issue #141) while nothing strips
+                    // the attribute from a node that outlives them, and this
+                    // walk commits to the first node carrying one.
+                    if let Some(id) = node
+                        .attributes
+                        .get("data-onenter")
+                        .and_then(|v| v.parse::<usize>().ok())
+                        .filter(|&id| events::has_click_handler(events::EventHandlerId(id)))
+                    {
+                        found = Some(id);
                         break;
                     }
                     current = node.parent;
@@ -1215,10 +1222,17 @@ impl RinchApp {
             let mut found = None;
             while let Some(nid) = current {
                 if let Some(node) = d.tree.get(nid) {
-                    if let Some(val) = node.attributes.get("data-onleave") {
-                        if let Ok(id) = val.parse::<usize>() {
-                            found = Some(id);
-                        }
+                    // A stale attribute must not stop the walk: disposing a
+                    // scope frees its handlers (issue #141) while nothing strips
+                    // the attribute from a node that outlives them, and this
+                    // walk commits to the first node carrying one.
+                    if let Some(id) = node
+                        .attributes
+                        .get("data-onleave")
+                        .and_then(|v| v.parse::<usize>().ok())
+                        .filter(|&id| events::has_click_handler(events::EventHandlerId(id)))
+                    {
+                        found = Some(id);
                         break;
                     }
                     current = node.parent;
@@ -1254,8 +1268,14 @@ impl RinchApp {
             let mut found = None;
             while let Some(nid) = current {
                 if let Some(node) = d.tree.get(nid) {
+                    // A stale attribute must not stop the walk — see the note
+                    // on the `data-onenter` walk (issue #141).
                     if let Some(val) = node.attributes.get("data-oncontextmenu") {
-                        if let Ok(id) = val.parse::<usize>() {
+                        if let Some(id) = val
+                            .parse::<usize>()
+                            .ok()
+                            .filter(|&id| events::has_click_handler(events::EventHandlerId(id)))
+                        {
                             // Compute element absolute position
                             let mut ax = node.layout.x;
                             let mut ay = node.layout.y;
@@ -1408,8 +1428,14 @@ impl RinchApp {
             let mut found = None;
             while let Some(nid) = current {
                 if let Some(node) = d.tree.get(nid) {
+                    // A stale attribute must not stop the walk — see the note
+                    // on the `data-onenter` walk (issue #141).
                     if let Some(val) = node.attributes.get(attr) {
-                        if let Ok(id) = val.parse::<usize>() {
+                        if let Some(id) = val
+                            .parse::<usize>()
+                            .ok()
+                            .filter(|&id| events::has_click_handler(events::EventHandlerId(id)))
+                        {
                             // Compute element absolute position
                             let mut ax = node.layout.x;
                             let mut ay = node.layout.y;
@@ -1463,10 +1489,15 @@ impl RinchApp {
             let mut found = None;
             while let Some(nid) = current {
                 if let Some(node) = d.tree.get(nid) {
-                    if let Some(val) = node.attributes.get(attr) {
-                        if let Ok(id) = val.parse::<usize>() {
-                            found = Some(id);
-                        }
+                    // A stale attribute must not stop the walk — see the note
+                    // on the `data-onenter` walk (issue #141).
+                    if let Some(id) = node
+                        .attributes
+                        .get(attr)
+                        .and_then(|v| v.parse::<usize>().ok())
+                        .filter(|&id| events::has_click_handler(events::EventHandlerId(id)))
+                    {
+                        found = Some(id);
                         break;
                     }
                     current = node.parent;
@@ -1528,8 +1559,14 @@ impl RinchApp {
             let mut found = None;
             while let Some(nid) = current {
                 if let Some(node) = d.tree.get(nid) {
+                    // A stale attribute must not stop the walk — see the note
+                    // on the `data-onenter` walk (issue #141).
                     if let Some(val) = node.attributes.get(attr) {
-                        if let Ok(id) = val.parse::<usize>() {
+                        if let Some(id) = val
+                            .parse::<usize>()
+                            .ok()
+                            .filter(|&id| events::has_click_handler(events::EventHandlerId(id)))
+                        {
                             // Compute element absolute position
                             let mut ax = node.layout.x;
                             let mut ay = node.layout.y;
@@ -1607,10 +1644,17 @@ impl RinchApp {
             let mut found = None;
             while let Some(nid) = current {
                 if let Some(node) = d.tree.get(nid) {
-                    if let Some(val) = node.attributes.get("data-onfiledrop") {
-                        if let Ok(id) = val.parse::<usize>() {
-                            found = Some(id);
-                        }
+                    // A stale attribute must not stop the walk: disposing a
+                    // scope frees its handlers (issue #141) while nothing strips
+                    // the attribute from a node that outlives them, and this
+                    // walk commits to the first node carrying one.
+                    if let Some(id) = node
+                        .attributes
+                        .get("data-onfiledrop")
+                        .and_then(|v| v.parse::<usize>().ok())
+                        .filter(|&id| events::has_file_drop_handler(events::EventHandlerId(id)))
+                    {
+                        found = Some(id);
                         break;
                     }
                     current = node.parent;

--- a/crates/rinch/src/app/mod.rs
+++ b/crates/rinch/src/app/mod.rs
@@ -1292,9 +1292,39 @@ impl RinchApp {
     // Routes editing commands through EditableState<StringDocument> for
     // proper cursor tracking, selection, and undo support.
 
+    /// The focused input's handler id, **if its handler is still registered**.
+    ///
+    /// Disposing a scope frees the event handlers it owns (issue #141), so this
+    /// cached id dangles the instant the focused `<input>`'s branch is torn down
+    /// — a modal closing, an `if` flipping, a `for` item being removed. Every
+    /// consumer below then fails silently: `dispatch_input_event` returns a
+    /// `false` nobody reads, `update_focused_input_dom_value` matches no node so
+    /// the DOM stops tracking `focused_input_value`, and the window keeps IME
+    /// enabled for an element that no longer exists.
+    ///
+    /// So a miss self-heals by dropping focus entirely, mirroring what
+    /// `FocusTarget::Editor` already does when its container is unmounted. That
+    /// also clears `focused_input_node_id`, which matters: it is a slab index,
+    /// and a recycled one would aim the caret/value attribute writes at an
+    /// unrelated element.
+    ///
+    /// Must be called with no outstanding borrow of `self.doc` — `set_focus_target`
+    /// writes DOM attributes.
+    fn live_focused_input_handler(&mut self) -> Option<usize> {
+        let handler_id = self.focused_input_handler_id?;
+        if events::has_input_handler(events::EventHandlerId(handler_id)) {
+            return Some(handler_id);
+        }
+        tracing::debug!(
+            "focused input handler {handler_id} was freed with its scope; dropping focus"
+        );
+        self.set_focus_target(FocusTarget::None);
+        None
+    }
+
     /// Central dispatch: execute an EditCommand on the focused input's EditableState.
     fn handle_input_edit_command(&mut self, cmd: EditCommand) {
-        let Some(handler_id) = self.focused_input_handler_id else {
+        let Some(handler_id) = self.live_focused_input_handler() else {
             return;
         };
         let Some(state) = self.focused_input_state.as_mut() else {
@@ -1327,7 +1357,7 @@ impl RinchApp {
     fn handle_text_input(&mut self, text: &str) {
         if self.focused_input_state.is_some() {
             self.handle_input_edit_command(EditCommand::InsertText(text.to_string()));
-        } else if let Some(handler_id) = self.focused_input_handler_id {
+        } else if let Some(handler_id) = self.live_focused_input_handler() {
             // Fallback for inputs without EditableState (shouldn't happen)
             self.focused_input_value.push_str(text);
             let value = self.focused_input_value.clone();
@@ -1338,7 +1368,7 @@ impl RinchApp {
     fn handle_backspace(&mut self) {
         if self.focused_input_state.is_some() {
             self.handle_input_edit_command(EditCommand::DeleteBackward);
-        } else if let Some(handler_id) = self.focused_input_handler_id {
+        } else if let Some(handler_id) = self.live_focused_input_handler() {
             self.focused_input_value.pop();
             let value = self.focused_input_value.clone();
             self.update_focused_input_dom_value(handler_id, &value);
@@ -1367,8 +1397,11 @@ impl RinchApp {
         self.handle_input_edit_command(cmd);
     }
     fn handle_enter(&mut self) {
-        // Check if a text input is focused and has an onsubmit handler
-        if self.focused_input_handler_id.is_some() {
+        // Check if a text input is focused and has an onsubmit handler.
+        // Probe liveness first: with a freed id the block below still runs, the
+        // node lookups match nothing, and Enter is swallowed rather than falling
+        // through to the global handlers (issue #141).
+        if self.live_focused_input_handler().is_some() {
             // Use stored node_id if available, else linear scan
             let submit_handler_id = if let Some(node_id) = self.focused_input_node_id {
                 if let Some(doc) = &self.doc {

--- a/crates/rinch/src/shell/types.rs
+++ b/crates/rinch/src/shell/types.rs
@@ -2,8 +2,6 @@
 
 /// Events used internally by rinch.
 #[cfg(feature = "desktop")]
-use rinch_core::events::{ClickContext, EventHandlerId};
-#[cfg(feature = "desktop")]
 #[derive(Debug, Clone)]
 pub enum RinchEvent {
     /// Poll a window for document updates.
@@ -18,12 +16,12 @@ pub enum RinchEvent {
     /// Fine-grained reactive text update - directly update the DOM Document.
     /// This is the fastest path: no app() re-execution, no HTML regeneration.
     UpdateReactiveText { reactive_id: usize, text: String },
-    /// An element was clicked (with handler ID, source window, and click context).
-    ElementClicked {
-        handler_id: EventHandlerId,
-        window_id: winit::window::WindowId,
-        click_context: ClickContext,
-    },
+    // NOTE: there was an `ElementClicked { handler_id, .. }` variant here. It was
+    // dead, and it is the one shape scope-owned handlers forbid: an id queued for
+    // *later* delivery can have its handler freed before the queue is drained
+    // (issue #141). If deferred click delivery is ever needed, carry the
+    // `Callback`/`Rc<dyn Fn()>` itself, or re-probe liveness at drain time with
+    // `events::has_click_handler`.
     /// Toggle the DevTools window.
     ToggleDevTools {
         source_window: winit::window::WindowId,


### PR DESCRIPTION
PR4 of the 8-PR sequence for #141. Disposing a scope now **frees** everything attributed to it — event handlers, effects, cleanups, memos, signals — instead of only stopping its adopted effects. PR0–PR3 built the ownership records; this is the PR that acts on them.

Follows #170, #174, #179, #181.

## The algorithm

`ScopeInner::dispose` splits in two. **Collect** marks the scope and its whole subtree disposed and moves their work into a thread-local `DisposeCtx` — allocation only, no user code. **Drain** — in the outermost call only — runs `run_dispose_fixpoint`.

Six strictly-prioritised levels: **handlers → effects → cleanups → memos → signals → value drops.** Any level that does work *restarts from the top*; the loop exits only when a full sweep finds every level empty.

It has to be a fixpoint rather than one pass because **a scope's subtree is not enumerable up front**: every child `RenderScope` lives inside its parent effect's closure, so it only becomes reachable once that effect is disposed. A cleanup that drops the last handle to a child scope owning an event handler would otherwise leave that handler registered forever — pinned by `a_scope_reached_only_by_a_cleanup_still_has_its_handlers_freed`.

Order rationale:

- **Handlers first** — the only step that runs no user code, so a re-entrant dispatch arriving mid-teardown finds nothing to call rather than calling into a component whose signals are about to go.
- **Cleanups after effects**, so a cleanup cannot resurrect a disposed effect (the ratified SD4 decision).
- **Memos before signals**, because a memo recompute reads signals.
- **Signals second-to-last**, because effect closures and cleanups legitimately read them — "save my draft on unmount" has to work.
- **Values last, parked rather than dropped in place**, so a value's `Drop` sees a deterministic world (everything the scope owned is gone) instead of an arbitrary prefix of its siblings.

No `DisposeCtx` borrow is ever held while user code runs. `take_batch` is the only way work leaves the context and it releases the borrow before the caller iterates.

**Termination:** every level permanently consumes ≥1 item; new work arrives only by marking a not-yet-disposed scope disposed, and `disposed` is one-way. Documented caveat: completeness is *per invocation* — a scope disposed from inside a running effect has its closure pinned by `run_effect`'s strong `Rc`, so it tears down one turn later.

## Bugs this exposed

Four latent crashes that only became reachable once disposal started doing real work:

- **`Effect::dispose` dropped the closure inside the `EFFECTS` borrow.** A captured value whose `Drop` writes a signal flushes synchronously into `run_effect`, whose `EFFECTS.borrow()` then panics. Extracted as `dispose_effect`, which moves the `Rc` out first.
- **An effect could be re-entered while running.** `EffectInner::f` is borrowed for the whole body, and a write inside it flushes immediately — so an effect that disposes a scope whose cleanup writes a signal it observes re-entered itself and hit a `BorrowMutError`. `run_effect` now skips. Skip rather than re-queue deliberately: re-queuing a still-running effect turns a self-triggering body into a hang, which is harder to debug than a stale value.
- **All five reconciliation sites disposed under a `RefCell` borrow.** `show_dom`, `match_dom`, `reactive_component_dom`, `for_each_dom` and `virtual_list` each held their state borrow across `dispose()`. The doomed scopes are now parked and torn down once the borrows are released. (`if let Some(x) = cell.borrow_mut().take()` keeps the `RefMut` alive through the then-block — that shape appears at four of the five.)
- **`Memo::leak` only detached half the memo.** The recompute still re-entered the leaked-from owner, so signals the computation allocated died with that scope. `MemoInner::owner` is cleared too.

## Consumers of a handler id that would have dangled silently

- `RinchApp::focused_input_handler_id` self-heals via `live_focused_input_handler`, mirroring what `FocusTarget::Editor` already did. Without it, typing into an input whose branch was torn down was silently swallowed and IME stayed enabled forever.
- Every desktop attribute walk-up (`data-rid`, `data-onenter`, `data-onleave`, `data-oncontextmenu`, drag and mouse attrs, `data-onfiledrop`) probes liveness first, so a stale attribute on a surviving node no longer *consumes* the event on its ancestors' behalf.
- rinch-web calls `prevent_default()` only if a handler actually ran — a dead `data-rid` there was strictly worse than doing nothing (it cancelled text selection, `<label>` activation and native form submit while dispatching nothing).
- `Tabs` re-reads `data-user-rid` at dispatch instead of capturing it.
- Deleted the dead `RinchEvent::ElementClicked` — an id queued for *later* delivery is exactly the shape scope-owned handlers forbid.
- Deleted `handler_id_watermark` / `remove_handlers_in_range`. The range was both incomplete (missed every handler a later effect run registers) and unsound (a synchronous flush inside a build lets another root allocate an id inside the recorded window). `RootHandle::unmount` now disposes the root scope *first*, while the document it was built against is still standing.
- Deleted `Scope::take_effects` — zero callers, and unsound once disposal frees: it left the owned records behind, so taken effects outlived the state they read.

## Registries holding handles to scope-owned state

- **rinch-video was a guaranteed crash.** `ACTIVE_PLAYERS` holds a clone of every playing player and nothing removed it — `VideoPlayer::cleanup` had *no callers* despite a doc comment claiming a drop hook. Unmounting a video component freed its seven signals while the per-frame poll kept reading them: an unrecoverable panic in the event loop on an ordinary tab switch. `use_video_player` now registers a cleanup, and the poll self-prunes as a backstop.
- **`Drag`** carries the owner that armed it and drops an in-flight drag whose scope was disposed. `on_cancel` is deliberately *not* fired: it belongs to the same dead component and would be the next thing to read a freed signal.
- **Parked main-thread continuations** (`set_timeout`, `fetch`) parked during a render are dropped unrun if their component unmounts first, and otherwise resume under it as ambient owner. Checked at resume rather than via a registered cleanup: a debounce parks per keystroke, and one cleanup per park would grow without bound. `unowned` is the documented opt-out. **This is a semantic change to `set_timeout` — chosen deliberately over doc-only.**

## Also

- New public `rinch_core::reactive::on_cleanup` — the hook a process-lifetime registry needs to let go of scope-owned state.
- The `for` codegen no longer copies the whole leading-`let` prologue into the key closure, only the bindings the key actually reads. The documented per-item `Signal::new(false)` idiom sits in that prologue, and the key closure runs per item per reconcile pass, so it was minting a throwaway signal each time — attributed to the *enclosing* scope and released only when the whole component died. The dependency analysis is deliberately token-level: `syn` models a macro body as an opaque `TokenStream`, so an expression walk sees no identifiers in `format!("{}", part)` at all and would have dropped a binding the key needs (caught by its own test).

## Verification

- Full workspace suite green (523 tests + doctests); clippy and fmt clean; pre-commit gate passed.
- 20 new tests. The ones that matter, each with a stated counterfactual: the nested-fixpoint case (a grandchild reachable only through two levels of effect closure), the cleanup-only-reachable handler, cleanup ordering in both directions, deferred value drops, the `EFFECTS`-borrow drop, effect self-re-entry, the `for_each_dom` borrow regression, `Memo::leak`'s second half, and timer cancellation with its `unowned` escape hatch.
- Live pass on `ui-zoo-desktop --release --features video`: mounted and unmounted the Video section (the guaranteed-crash path), typed into a `TextInput` then navigated away **while focused** and typed again (focus self-heals, no swallowed keys), mounted/unmounted Audio/Video (whose uncancellable 50ms worker keeps writing a freed signal — lenient writes hold), and exercised the virtual list. No panics.

## Spun off rather than absorbed

#183 (unscoped global callback registries — menu, keyboard interceptor, selection, ws, android), #184 (rinch-web `NODE_REGISTRY` never pruned), #185 (duplicate `for` key leaves a live DOM node with a dead scope), #186 (`VideoViewport` punches a transparent hole even when no frame is ever produced — spotted during the live pass, pre-existing paint-path bug).

Refs #141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
