### PR TITLE
feat(rinch-editor-collab): #190 PR1 — replace Automerge with yrs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,11 +128,12 @@ jobs:
   # was never linted. Two real lints and a batch of `unexpected_cfgs` warnings hid
   # there; a green clippy meant less than it looked.
   #
-  # Per-crate, not `--workspace`: a workspace-wide wasm build pulls
-  # rinch-editor-collab -> automerge -> uuid -> getrandom, which refuses to build
-  # for wasm32 unless a *consuming app* enables its `js` feature. That layering is
-  # deliberate (see the collaboration notes in CLAUDE.md), so the crates that are
-  # meant to stand alone on wasm are listed explicitly instead.
+  # Per-crate, not `--workspace`: the workspace still contains crates that only make
+  # sense natively (rinch-dom, the shell, the debug server), so the crates that are
+  # meant to stand alone on wasm are listed explicitly. rinch-editor-collab is one of
+  # them since #190 — under automerge it could not be listed here at all, because
+  # automerge -> uuid -> getrandom refused to build for wasm32 unless a *consuming app*
+  # turned on a randomness feature. yrs needs no such shim.
   clippy-wasm:
     runs-on: ubuntu-latest
     steps:
@@ -157,8 +158,8 @@ jobs:
 
       - name: Run clippy (wasm32)
         run: |
-          for crate in rinch-core rinch-editor-core rinch-editor-view \
-                       rinch-http rinch-ws rinch-web; do
+          for crate in rinch-core rinch-editor-core rinch-editor-collab \
+                       rinch-editor-view rinch-http rinch-ws rinch-web; do
             echo "::group::clippy $crate (wasm32)"
             cargo clippy -p "$crate" --target wasm32-unknown-unknown \
               --all-targets -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,29 +605,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "automerge"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0dae93622d3c6850d196503480004576249e0e391bddb3f54600974d92a790"
-dependencies = [
- "cfg-if 1.0.4",
- "flate2",
- "fxhash",
- "hex",
- "im",
- "itertools 0.13.0",
- "leb128",
- "serde",
- "sha2",
- "smol_str 0.2.2",
- "thiserror 1.0.69",
- "tinyvec",
- "tracing",
- "unicode-segmentation",
- "uuid",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,15 +700,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
 ]
 
 [[package]]
@@ -1474,6 +1451,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if 1.0.4",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,6 +1744,9 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "fdeflate"
@@ -2456,6 +2450,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -2733,20 +2733,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "im"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
-dependencies = [
- "bitmaps",
- "rand_core 0.6.4",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "image"
 version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2946,12 +2932,6 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
-name = "leb128"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
 name = "libappindicator"
@@ -3895,9 +3875,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -4010,7 +3990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4576,15 +4556,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "range-alloc"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4933,11 +4904,10 @@ version = "0.1.0"
 name = "rinch-editor-collab"
 version = "0.1.0"
 dependencies = [
- "automerge",
  "pretty_assertions",
  "rinch-editor-core",
- "serde_json",
  "thiserror 1.0.69",
+ "yrs",
 ]
 
 [[package]]
@@ -5522,17 +5492,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if 1.0.4",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5568,16 +5527,6 @@ name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
 
 [[package]]
 name = "skrifa"
@@ -5621,6 +5570,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d31d263dd118560e1a492922182ab6ca6dc1d03a3bf54e7699993f31a4150e3f"
 
 [[package]]
+name = "smallstr"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862077b1e764f04c251fe82a2ef562fd78d7cadaeb072ca7c2bcaf7217b1ff3b"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5651,15 +5609,6 @@ dependencies = [
  "wayland-protocols-wlr",
  "wayland-scanner",
  "xkeysym",
-]
-
-[[package]]
-name = "smol_str"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -6204,21 +6153,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "to_shmem"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6665,7 +6599,6 @@ version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
- "getrandom 0.3.4",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -7744,7 +7677,7 @@ dependencies = [
  "libc",
  "raw-window-handle",
  "rustix 1.1.3",
- "smol_str 0.3.6",
+ "smol_str",
  "tracing",
  "winit-android",
  "winit-appkit",
@@ -7768,7 +7701,7 @@ dependencies = [
  "dpi",
  "ndk 0.9.0",
  "raw-window-handle",
- "smol_str 0.3.6",
+ "smol_str",
  "tracing",
  "winit-core",
 ]
@@ -7789,7 +7722,7 @@ dependencies = [
  "objc2-core-video",
  "objc2-foundation 0.3.2",
  "raw-window-handle",
- "smol_str 0.3.6",
+ "smol_str",
  "tracing",
  "winit-common",
  "winit-core",
@@ -7803,7 +7736,7 @@ dependencies = [
  "memmap2",
  "objc2 0.6.3",
  "objc2-core-foundation",
- "smol_str 0.3.6",
+ "smol_str",
  "tracing",
  "winit-core",
  "x11-dl",
@@ -7820,7 +7753,7 @@ dependencies = [
  "dpi",
  "keyboard-types 0.8.3",
  "raw-window-handle",
- "smol_str 0.3.6",
+ "smol_str",
  "web-time",
 ]
 
@@ -7834,7 +7767,7 @@ dependencies = [
  "orbclient",
  "raw-window-handle",
  "redox_syscall 0.5.18",
- "smol_str 0.3.6",
+ "smol_str",
  "tracing",
  "winit-core",
 ]
@@ -7853,7 +7786,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "objc2-ui-kit",
  "raw-window-handle",
- "smol_str 0.3.6",
+ "smol_str",
  "tracing",
  "winit-common",
  "winit-core",
@@ -7875,7 +7808,7 @@ dependencies = [
  "rustix 1.1.3",
  "sctk-adwaita",
  "smithay-client-toolkit",
- "smol_str 0.3.6",
+ "smol_str",
  "tracing",
  "wayland-backend",
  "wayland-client",
@@ -7898,7 +7831,7 @@ dependencies = [
  "js-sys",
  "pin-project",
  "raw-window-handle",
- "smol_str 0.3.6",
+ "smol_str",
  "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -7916,7 +7849,7 @@ dependencies = [
  "cursor-icon",
  "dpi",
  "raw-window-handle",
- "smol_str 0.3.6",
+ "smol_str",
  "tracing",
  "unicode-segmentation",
  "windows-sys 0.59.0",
@@ -7937,7 +7870,7 @@ dependencies = [
  "percent-encoding",
  "raw-window-handle",
  "rustix 1.1.3",
- "smol_str 0.3.6",
+ "smol_str",
  "tracing",
  "winit-common",
  "winit-core",
@@ -8130,6 +8063,24 @@ dependencies = [
  "quote",
  "syn 2.0.114",
  "synstructure",
+]
+
+[[package]]
+name = "yrs"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d3a728b1abffeca5b9e5319c5b81e04b73790cbdc1e342da8d91b440b3026cb"
+dependencies = [
+ "arc-swap",
+ "async-lock",
+ "async-trait",
+ "dashmap",
+ "fastrand",
+ "serde",
+ "serde_json",
+ "smallstr",
+ "smallvec",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/crates/rinch-editor-collab/Cargo.toml
+++ b/crates/rinch-editor-collab/Cargo.toml
@@ -13,8 +13,15 @@ rinch-editor-core = { workspace = true }
 # reuse this adapter as-is.
 #
 # The document is always built with `OffsetKind::Utf16` — never `Doc::new()`, whose
-# default is `OffsetKind::Bytes`. See `projection::CollabDoc::empty_doc`.
-yrs = "0.27"
+# default is `OffsetKind::Bytes`. See `projection::CollabDoc::blank`.
+#
+# `sync` is a marker feature (`sync = []` — it pulls in no dependencies, so it cannot
+# affect the wasm build) and it does NOT gate the `yrs::sync` module, which is always
+# there. What it does is make `Subscription` `Send`/`Sync` and tighten observer closures
+# to match. We need that: `CollabDoc` holds the update subscription that feeds the
+# broadcast outbox, and `CollabSession` must stay `Send` because a server holds one
+# across an `.await`. The `Send` bound is pinned by a static assertion in `lib.rs`.
+yrs = { version = "0.27", features = ["sync"] }
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/rinch-editor-collab/Cargo.toml
+++ b/crates/rinch-editor-collab/Cargo.toml
@@ -3,18 +3,18 @@ name = "rinch-editor-collab"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "Optional collaborative-editing adapter for the Rinch editor: projects the pure rinch-editor-core model onto an Automerge CRDT, translates remote patches back into Steps, and salvages the Automerge sync transport. The ONLY first-party home of automerge in the workspace. Opt-in (off by default); wasm-compatible so the desktop and a future web view can share one adapter."
+description = "Optional collaborative-editing adapter for the Rinch editor: projects the pure rinch-editor-core model onto a yrs (Yjs) CRDT and rebuilds remote changes back into Steps. The ONLY first-party CRDT dependency in the workspace. Opt-in (off by default); wasm-compatible with no shims, so the desktop and a future web view can share one adapter."
 
 [dependencies]
 rinch-editor-core = { workspace = true }
-# The ONLY first-party automerge dependency in the workspace (design §2). Pinned to
-# the line the salvaged sync transport was written against. Pure model↔CRDT logic with
-# no platform deps — wasm-compatible (a wasm app supplies a randomness source for the
-# transitive automerge→uuid), so a future Rust web editor view can reuse this adapter.
-automerge = "0.5"
-# Compact, deterministic encoding of mark/attr values into the CRDT (mark values are
-# a single scalar; attr-bearing marks ride as a JSON object string). Non-wasm.
-serde_json = "1"
+# The ONLY first-party CRDT dependency in the workspace (design §2, issue #190).
+# Pure model↔CRDT logic with no platform deps, and wasm-compatible with **no**
+# consumer shims (yrs carries `fastrand/js` itself), so a Rust web editor view can
+# reuse this adapter as-is.
+#
+# The document is always built with `OffsetKind::Utf16` — never `Doc::new()`, whose
+# default is `OffsetKind::Bytes`. See `projection::CollabDoc::empty_doc`.
+yrs = "0.27"
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/crates/rinch-editor-collab/src/error.rs
+++ b/crates/rinch-editor-collab/src/error.rs
@@ -13,9 +13,10 @@ use thiserror::Error;
 /// Why a collab projection / sync step failed.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum CollabError {
-    /// An underlying automerge operation failed (I/O, decode, sync-protocol error).
-    #[error("automerge error: {0}")]
-    Automerge(String),
+    /// An underlying CRDT-engine operation failed (decoding an update or a state
+    /// vector, integrating an update).
+    #[error("crdt engine error: {0}")]
+    Engine(String),
 
     /// The model shape is outside the staged first-milestone scope (nested blocks,
     /// inline atoms, deep nesting). **Fail-loud, never a silent drop** (design A22).
@@ -40,9 +41,15 @@ impl CollabError {
     }
 }
 
-impl From<automerge::AutomergeError> for CollabError {
-    fn from(e: automerge::AutomergeError) -> CollabError {
-        CollabError::Automerge(e.to_string())
+impl From<yrs::encoding::read::Error> for CollabError {
+    fn from(e: yrs::encoding::read::Error) -> CollabError {
+        CollabError::Engine(format!("decode failed: {e}"))
+    }
+}
+
+impl From<yrs::error::UpdateError> for CollabError {
+    fn from(e: yrs::error::UpdateError) -> CollabError {
+        CollabError::Engine(format!("update failed: {e}"))
     }
 }
 

--- a/crates/rinch-editor-collab/src/lib.rs
+++ b/crates/rinch-editor-collab/src/lib.rs
@@ -56,6 +56,21 @@ pub mod sync;
 // here as an inherent-impl module.
 mod project;
 
+/// `CollabSession` and `CollabDoc` must stay **`Send`**: a server holds a session across
+/// an `.await`, so losing the bound breaks downstream consumers at their next upgrade —
+/// as a compile error in *their* tree, which is the worst place to find out.
+///
+/// It has been lost once already. Moving the broadcast delta to an observer-fed outbox
+/// (#190) introduced both an `Rc<RefCell<_>>` queue and yrs's `Subscription`, which is
+/// only `Send` with yrs's `sync` feature. Hence the queue is an `Arc<Mutex<_>>` and that
+/// feature is on — and hence this assertion, which stops the crate compiling if either
+/// ever regresses.
+const _: fn() = || {
+    fn assert_send<T: Send>() {}
+    assert_send::<CollabDoc>();
+    assert_send::<CollabSession>();
+};
+
 pub use error::{CollabError, Result};
 pub use plugin::{COLLAB_KEY, CollabPlugin, CollabState};
 pub use projection::CollabDoc;

--- a/crates/rinch-editor-collab/src/lib.rs
+++ b/crates/rinch-editor-collab/src/lib.rs
@@ -1,22 +1,22 @@
 //! # rinch-editor-collab
 //!
 //! Optional, **opt-in** collaborative-editing adapter for the Rinch editor, and the
-//! **only** first-party home of `automerge` in the workspace (design §2/§8). Gated
-//! behind the facade's `collaboration` feature so default builds — desktop *and* web —
-//! link zero automerge. The crate itself is pure model↔CRDT logic with no platform
-//! deps and is **wasm-compatible** (a wasm app just supplies a randomness source for
-//! the transitive `automerge → uuid`), so a future Rust web editor view can reuse this
-//! *same* adapter rather than bridging to a separate JS CRDT.
+//! **only** first-party home of a CRDT engine — [`yrs`] (Yjs) — in the workspace
+//! (design §2/§8, issue #190). Gated behind the facade's `collaboration` feature so
+//! default builds — desktop *and* web — link zero CRDT code. The crate itself is pure
+//! model↔CRDT logic with no platform deps and is **wasm-compatible with no shims**, so
+//! a Rust web editor view can reuse this *same* adapter rather than bridging to a
+//! separate JS CRDT.
 //!
-//! Automerge is *not* the document model — `rinch-editor-core` is. This crate projects
-//! that pure model onto an Automerge CRDT so concurrent edits converge, and translates
-//! remote CRDT changes back into editor [`Step`](rinch_editor_core::Step)s. The whole
-//! design rests on one invariant:
+//! The CRDT is *not* the document model — `rinch-editor-core` is. This crate projects
+//! that pure model onto a yrs CRDT so concurrent edits converge, and rebuilds remote
+//! CRDT changes back into editor [`Step`](rinch_editor_core::Step)s. The whole design
+//! rests on one invariant:
 //!
 //! > **`model ≡ project(model)`** — every local step is projected onto the CRDT
 //! > ([`CollabDoc::project_change`]); every remote CRDT change is rebuilt into the model
-//! > ([`CollabSession::integrate_incremental`]). Convergence then follows from
-//! > Automerge's own convergence.
+//! > ([`CollabSession::integrate_incremental`]). Convergence then follows from yrs's own
+//! > convergence.
 //!
 //! ## Staged scope (design A22)
 //!
@@ -39,9 +39,9 @@
 //! let state = EditorState::create(schema.clone(), doc, default_plugins());
 //!
 //! // Peer A starts a session and shares a snapshot.
-//! let mut a = CollabSession::new(&state).unwrap();
-//! let mut b = CollabSession::from_bytes(&a.snapshot()).unwrap();
-//! # let _ = (&mut a, &mut b, &state);
+//! let a = CollabSession::new(&state).unwrap();
+//! let b = CollabSession::from_bytes(&a.snapshot()).unwrap();
+//! # let _ = (&a, &b, &state);
 //! ```
 
 pub mod error;
@@ -60,6 +60,5 @@ pub use error::{CollabError, Result};
 pub use plugin::{COLLAB_KEY, CollabPlugin, CollabState};
 pub use projection::CollabDoc;
 pub use rebase::rebase_steps;
-pub use remote::{ORIGIN_REMOTE, RemoteOp, build_remote_transaction};
+pub use remote::{ORIGIN_REMOTE, build_remote_transaction};
 pub use session::CollabSession;
-pub use sync::{ChangeHash, SyncMessage, SyncState};

--- a/crates/rinch-editor-collab/src/project.rs
+++ b/crates/rinch-editor-collab/src/project.rs
@@ -87,8 +87,13 @@ impl CollabDoc {
             read_node(before.child(idx))?;
         }
 
-        // Writes — one transaction for the whole change. Past here only a corrupt-CRDT
-        // read-back can fail, not a content-scope check.
+        // Writes — one transaction for the whole change.
+        //
+        // The all-or-nothing guarantee the pre-pass buys covers the **content-scope**
+        // class only: no out-of-scope node can reach a write. An error raised from here on
+        // — a corrupt-CRDT read-back, a bounds check — still commits whatever this
+        // transaction wrote before it, because yrs has no rollback. Extending the pre-pass
+        // to cover that class too is tracked separately.
         let content = self.content.clone();
         let mut txn = self.doc.transact_mut();
         // Reconcile the overlapping changed blocks in place (keeps identity). A changed

--- a/crates/rinch-editor-collab/src/project.rs
+++ b/crates/rinch-editor-collab/src/project.rs
@@ -7,8 +7,7 @@
 //! 1. The unchanged leading/trailing blocks are skipped by **`Rc` identity**
 //!    ([`Node::same_ref`]) — the persistent model shares every untouched block, so
 //!    typing one character reads and re-splices exactly one block.
-//! 2. Each changed block is reconciled in place
-//!    ([`reconcile_node`](crate::projection::reconcile_node)) with a minimal
+//! 2. Each changed block is reconciled in place (`reconcile_node`) with a minimal
 //!    common-prefix/suffix text splice, so the per-character CRDT identity of
 //!    unchanged text survives and concurrent edits merge.
 //! 3. The net block-count difference is inserted/deleted at the boundary, preserving

--- a/crates/rinch-editor-collab/src/project.rs
+++ b/crates/rinch-editor-collab/src/project.rs
@@ -1,4 +1,4 @@
-//! Local projection: fold a model [`Transaction`] into the Automerge CRDT.
+//! Local projection: fold a model [`Transaction`] into the CRDT.
 //!
 //! This is the **local** half of the `model ≡ project(model)` invariant. Rather than
 //! pattern-matching each `Step`'s geometry (brittle for split/join), we project the
@@ -7,8 +7,9 @@
 //! 1. The unchanged leading/trailing blocks are skipped by **`Rc` identity**
 //!    ([`Node::same_ref`]) — the persistent model shares every untouched block, so
 //!    typing one character reads and re-splices exactly one block.
-//! 2. Each changed block is reconciled in place ([`CollabDoc::reconcile_node`]) with a
-//!    minimal common-prefix/suffix text splice, so the per-character CRDT identity of
+//! 2. Each changed block is reconciled in place
+//!    ([`reconcile_node`](crate::projection::reconcile_node)) with a minimal
+//!    common-prefix/suffix text splice, so the per-character CRDT identity of
 //!    unchanged text survives and concurrent edits merge.
 //! 3. The net block-count difference is inserted/deleted at the boundary, preserving
 //!    the identity of the leading reconciled blocks (so a split keeps block N's text
@@ -19,10 +20,12 @@
 //! outside the supported scope (a non-list nested block, an inline atom) anywhere in
 //! `before` or `after` fails loud ([`CollabError::Unsupported`], design A22).
 
+use yrs::{Array, Transact};
+
 use rinch_editor_core::{Node, Transaction};
 
 use crate::error::Result;
-use crate::projection::{CollabDoc, read_node};
+use crate::projection::{CollabDoc, check_index, insert_node, read_node, reconcile_node};
 
 impl CollabDoc {
     /// Project a freshly-applied local transaction onto the CRDT. A no-op for a
@@ -39,7 +42,7 @@ impl CollabDoc {
     }
 
     /// Project an arbitrary `before → after` document change (also the building block
-    /// for loading content). Both must be flat documents.
+    /// for loading content). Both must be within the projected scope.
     pub fn project_change(&mut self, before: &Node, after: &Node) -> Result<()> {
         let bn = before.child_count();
         let an = after.child_count();
@@ -67,38 +70,46 @@ impl CollabDoc {
         // Validation pre-pass (design A22 fail-loud must be all-or-nothing): read and
         // validate EVERY block this change will touch — the `after` blocks to
         // reconcile/insert, and the `before` blocks to delete — BEFORE issuing any
-        // CRDT write. A mixed flat/non-flat change (e.g. pasting or loading a list
-        // while collaborating) then leaves the CRDT *exactly* at the prior converged
-        // state and returns `Unsupported`, instead of partially mutating it and
-        // wedging the session in a half-projected state.
+        // CRDT write, and before the write transaction is even opened. A mixed
+        // in-scope/out-of-scope change (e.g. pasting or loading a table while
+        // collaborating) then leaves the CRDT *exactly* at the prior converged state
+        // and returns `Unsupported`, instead of partially mutating it and wedging the
+        // session in a half-projected state.
+        //
+        // Under yrs this ordering also buys **panic safety**, not just atomicity: a
+        // yrs text/array index out of range panics where automerge returned an error,
+        // so no write may be attempted until the whole change is known projectable.
         let mut targets = Vec::with_capacity(post_mid);
         for k in 0..post_mid {
             targets.push(read_node(after.child(prefix + k))?);
         }
         for idx in prefix + common..prefix + pre_mid {
-            // Validate (and discard) each block being deleted — fail loud if non-flat.
+            // Validate (and discard) each block being deleted — fail loud if out of scope.
             read_node(before.child(idx))?;
         }
 
-        // Writes — past here only an automerge I/O error can fail, not a content one.
+        // Writes — one transaction for the whole change. Past here only a corrupt-CRDT
+        // read-back can fail, not a content-scope check.
+        let content = self.content.clone();
+        let mut txn = self.doc.transact_mut();
         // Reconcile the overlapping changed blocks in place (keeps identity). A changed
         // top-level list reconciles recursively, touching only the edited descendant.
-        let content = self.content.clone();
         for (k, target) in targets.iter().take(common).enumerate() {
-            self.reconcile_node(&content, prefix + k, target)?;
+            reconcile_node(&mut txn, &content, (prefix + k) as u32, target)?;
         }
         // Insert the extra post blocks (e.g. the tail of a split). `targets` has
         // exactly `post_mid` entries, so skipping `common` yields indices
         // `common..post_mid`.
         for (k, target) in targets.iter().enumerate().skip(common) {
-            self.insert_node(&content, prefix + k, target)?;
+            insert_node(&mut txn, &content, (prefix + k) as u32, target)?;
         }
         // Delete the extra pre blocks (e.g. a join, or a block deletion). `common` is
         // the min, so at most one of insert/delete runs; when this runs the CRDT
         // indices still match `before`'s. Delete from the end so earlier indices stay
         // valid.
         for idx in (prefix + common..prefix + pre_mid).rev() {
-            self.delete_block(idx)?;
+            check_index(&txn, &content, idx as u32, false)?;
+            content.remove(&mut txn, idx as u32);
         }
         Ok(())
     }

--- a/crates/rinch-editor-collab/src/projection.rs
+++ b/crates/rinch-editor-collab/src/projection.rs
@@ -58,7 +58,7 @@
 //! Every committed transaction hands its *own* update to an `observe_update_v1`
 //! subscription, which parks it in [`CollabDoc`]'s outbox for
 //! [`CollabSession::save_incremental`](crate::CollabSession::save_incremental) to drain.
-//! A transaction applying *foreign* bytes is tagged `REMOTE_ORIGIN` and skipped:
+//! A transaction applying *foreign* bytes is tagged `ENGINE_APPLY_ORIGIN` and skipped:
 //! those changes are already shared, so re-broadcasting them would echo. Locally
 //! projected writes are therefore exactly the broadcasts.
 //!
@@ -83,10 +83,8 @@
 //! `task_list`/`task_item`) and every inline atom (`hard_break`, `image`,
 //! `horizontal_rule`).
 
-use std::cell::RefCell;
 use std::collections::HashMap;
-use std::rc::Rc;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use yrs::types::Attrs as YAttrs;
 use yrs::types::text::YChange;
@@ -107,16 +105,36 @@ const TYPE: &str = "type";
 const ATTRS: &str = "attrs";
 const TEXT: &str = "text";
 
-/// Origin tag for a transaction that applies bytes received from a peer, as opposed to one
-/// that projects a local edit. The update observer skips these: they are already shared,
-/// so putting them in the outbox would echo them back.
-pub(crate) const REMOTE_ORIGIN: &str = "collabRemoteOrigin";
+/// Origin tag for a yrs transaction that applies bytes received from a peer, as opposed to
+/// one that projects a local edit. The update observer skips these: they are already
+/// shared, so putting them in the outbox would echo them back.
+///
+/// Not to be confused with [`ORIGIN_REMOTE`](crate::ORIGIN_REMOTE), which is a *model*
+/// `Transaction` meta key marking the editor-side transaction as remote-originated. Two
+/// different mechanisms at two different layers.
+pub(crate) const ENGINE_APPLY_ORIGIN: &str = "collabEngineApply";
 
-/// Updates produced by locally-projected transactions, waiting to be broadcast. Shared
-/// with the update observer, which is why it is behind `Rc<RefCell<_>>`: without the
-/// `sync` cargo feature yrs asks nothing of the closure but `'static`, and the whole
-/// adapter is single-threaded.
-pub(crate) type Outbox = Rc<RefCell<Vec<Vec<u8>>>>;
+/// Updates produced by locally-projected transactions, waiting to be broadcast.
+///
+/// `Arc<Mutex<_>>` rather than `Rc<RefCell<_>>` even though the adapter is single-threaded:
+/// the outbox is captured by the update observer, which is held by [`CollabDoc`], so an
+/// `Rc` here would make `CollabDoc` — and therefore `CollabSession` — `!Send`. A server
+/// holds a session across an `.await`, so that must not happen; the bound is pinned by a
+/// static assertion in `lib.rs`.
+pub(crate) type Outbox = Arc<Mutex<Vec<Vec<u8>>>>;
+
+/// Lock the outbox, recovering from a poisoned mutex rather than failing on it.
+///
+/// The guarded value is a plain queue of encoded updates with no invariant spanning it, so
+/// a panic elsewhere while the lock was held cannot have left it inconsistent. Both
+/// alternatives are worse: the update observer's signature cannot return an error, so it
+/// would have to either drop a broadcast silently — the divergence class this adapter
+/// exists to prevent — or panic in the middle of a yrs commit.
+pub(crate) fn lock_outbox(outbox: &Outbox) -> std::sync::MutexGuard<'_, Vec<Vec<u8>>> {
+    outbox
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
 
 /// One coalesced run of a single mark over a block's text (char offsets).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -206,7 +224,7 @@ impl std::fmt::Debug for CollabDoc {
         f.debug_struct("CollabDoc")
             .field("client_id", &self.doc.client_id())
             .field("blocks", &self.content.len(&self.doc.transact()))
-            .field("pending_updates", &self.outbox.borrow().len())
+            .field("pending_updates", &lock_outbox(&self.outbox).len())
             .finish()
     }
 }
@@ -227,16 +245,16 @@ impl CollabDoc {
             offset_kind: OffsetKind::Utf16,
             ..Default::default()
         });
-        let outbox: Outbox = Rc::new(RefCell::new(Vec::new()));
+        let outbox: Outbox = Arc::new(Mutex::new(Vec::new()));
         let sink = outbox.clone();
-        let remote = Origin::from(REMOTE_ORIGIN);
+        let remote = Origin::from(ENGINE_APPLY_ORIGIN);
         // yrs does not fire this for a transaction that changed nothing, so the outbox
         // never collects an empty update and "outbox is empty" really does mean "nothing
         // to send".
         let updates = doc
             .observe_update_v1(move |txn, e| {
                 if txn.origin() != Some(&remote) {
-                    sink.borrow_mut().push(e.update.clone());
+                    lock_outbox(&sink).push(e.update.clone());
                 }
             })
             .expect("a freshly built document has no live transaction to conflict with");
@@ -290,7 +308,7 @@ impl CollabDoc {
         let update = Update::decode_v1(bytes)?;
         let (ydoc, outbox, updates) = CollabDoc::blank();
         {
-            let mut txn = ydoc.transact_mut_with(Origin::from(REMOTE_ORIGIN));
+            let mut txn = ydoc.transact_mut_with(Origin::from(ENGINE_APPLY_ORIGIN));
             txn.apply_update(update)?;
         }
         let content = ydoc.get_or_insert_array(CONTENT);
@@ -1230,14 +1248,14 @@ mod tests {
 
         let mut a = CollabDoc::from_doc(&doc).unwrap();
         assert_eq!(
-            a.outbox.borrow().len(),
+            lock_outbox(&a.outbox).len(),
             1,
             "the initial projection is a local write and is broadcast"
         );
 
         let mut b = CollabDoc::load(&a.save()).unwrap();
         assert!(
-            b.outbox.borrow().is_empty(),
+            lock_outbox(&b.outbox).is_empty(),
             "joining from a snapshot must not queue the host's document for re-broadcast"
         );
 
@@ -1258,7 +1276,7 @@ mod tests {
 
         b.apply_update(&delta).unwrap();
         assert!(
-            b.outbox.borrow().is_empty(),
+            lock_outbox(&b.outbox).is_empty(),
             "an applied peer delta must not be queued for re-broadcast"
         );
     }
@@ -1302,7 +1320,7 @@ mod tests {
         a.project_change(&d1, &d2).unwrap();
         a.project_change(&d2, &d3).unwrap();
         assert_eq!(
-            a.outbox.borrow().len(),
+            lock_outbox(&a.outbox).len(),
             3,
             "each local transaction parks its own update, so the merge branch is what runs"
         );

--- a/crates/rinch-editor-collab/src/projection.rs
+++ b/crates/rinch-editor-collab/src/projection.rs
@@ -53,6 +53,24 @@
 //! helpers below are free functions taking `&T: ReadTxn` or `&mut TransactionMut`
 //! rather than methods that reach for a transaction of their own.
 //!
+//! ## The broadcast outbox
+//!
+//! Every committed transaction hands its *own* update to an `observe_update_v1`
+//! subscription, which parks it in [`CollabDoc`]'s outbox for
+//! [`CollabSession::save_incremental`](crate::CollabSession::save_incremental) to drain.
+//! A transaction applying *foreign* bytes is tagged `REMOTE_ORIGIN` and skipped:
+//! those changes are already shared, so re-broadcasting them would echo. Locally
+//! projected writes are therefore exactly the broadcasts.
+//!
+//! Relaying a peer's content onward is the **transport's** job, not the adapter's: a mesh
+//! delivers to everyone directly, and a star hub forwards the raw delta bytes it received.
+//!
+//! The outbox exists because the obvious alternative — diffing against the state vector
+//! of the last broadcast — cannot work here. `encode_diff_v1` writes the *complete*
+//! delete set regardless of the target state vector, so once a document has seen any
+//! deletion every delta re-carries the whole deletion history (growing without bound) and
+//! a "nothing new" diff is no longer empty. A transaction's own update is constant-size.
+//!
 //! ## Scope (design A22)
 //!
 //! Supported: **flat text-blocks + marks** (`paragraph`/`heading`/`code_block` whose own
@@ -65,15 +83,18 @@
 //! `task_list`/`task_item`) and every inline atom (`hard_break`, `image`,
 //! `horizontal_rule`).
 
+use std::cell::RefCell;
 use std::collections::HashMap;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use yrs::types::Attrs as YAttrs;
 use yrs::types::text::YChange;
 use yrs::updates::decoder::Decode;
 use yrs::{
-    Any, Array, ArrayPrelim, ArrayRef, Doc, Map, MapPrelim, MapRef, OffsetKind, Options, Out,
-    ReadTxn, StateVector, Text, TextPrelim, TextRef, Transact, TransactionMut, Update,
+    Any, Array, ArrayPrelim, ArrayRef, Doc, Map, MapPrelim, MapRef, OffsetKind, Options, Origin,
+    Out, ReadTxn, StateVector, Subscription, Text, TextPrelim, TextRef, Transact, TransactionMut,
+    Update,
 };
 
 use rinch_editor_core::{AttrValue, Attrs, Fragment, Mark, Node, Schema};
@@ -85,6 +106,17 @@ const CONTENT: &str = "content";
 const TYPE: &str = "type";
 const ATTRS: &str = "attrs";
 const TEXT: &str = "text";
+
+/// Origin tag for a transaction that applies bytes received from a peer, as opposed to one
+/// that projects a local edit. The update observer skips these: they are already shared,
+/// so putting them in the outbox would echo them back.
+pub(crate) const REMOTE_ORIGIN: &str = "collabRemoteOrigin";
+
+/// Updates produced by locally-projected transactions, waiting to be broadcast. Shared
+/// with the update observer, which is why it is behind `Rc<RefCell<_>>`: without the
+/// `sync` cargo feature yrs asks nothing of the closure but `'static`, and the whole
+/// adapter is single-threaded.
+pub(crate) type Outbox = Rc<RefCell<Vec<Vec<u8>>>>;
 
 /// One coalesced run of a single mark over a block's text (char offsets).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -149,7 +181,6 @@ fn is_supported_container(type_name: &str) -> bool {
 }
 
 /// A yrs document projecting an editor document.
-#[derive(Debug)]
 pub struct CollabDoc {
     /// The yrs document. `pub(crate)` so [`crate::sync`] can drive the transport.
     pub(crate) doc: Doc,
@@ -157,19 +188,55 @@ pub struct CollabDoc {
     /// type opens its own transaction, so doing it lazily inside a live one would
     /// deadlock.
     pub(crate) content: ArrayRef,
+    /// Updates from locally-projected transactions, awaiting broadcast.
+    pub(crate) outbox: Outbox,
+    /// Keeps the update observer alive — dropping the subscription unsubscribes it, and
+    /// the outbox would silently stop filling.
+    _updates: Subscription,
+}
+
+// `Subscription` is not `Debug`, and neither is the observer closure behind it, so the
+// derive is replaced by a summary of what a reader actually wants to see.
+impl std::fmt::Debug for CollabDoc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CollabDoc")
+            .field("client_id", &self.doc.client_id())
+            .field("blocks", &self.content.len(&self.doc.transact()))
+            .field("pending_updates", &self.outbox.borrow().len())
+            .finish()
+    }
 }
 
 impl CollabDoc {
-    /// A fresh, empty CRDT document.
+    /// A fresh, empty CRDT document with its broadcast outbox wired up, and no root type
+    /// resolved yet.
     ///
     /// **Never `Doc::new()`** — `Options::default()` is [`OffsetKind::Bytes`], which
     /// would make every text index a byte offset and quietly corrupt any block holding
     /// a non-ASCII character.
-    fn empty_doc() -> Doc {
-        Doc::with_options(Options {
+    ///
+    /// The root is deliberately left unresolved: [`CollabDoc::load`] has to inspect what
+    /// arrived *before* declaring a type for it, because declaring one reinterprets
+    /// whatever is there (see the shape guard in `load`).
+    fn blank() -> (Doc, Outbox, Subscription) {
+        let doc = Doc::with_options(Options {
             offset_kind: OffsetKind::Utf16,
             ..Default::default()
-        })
+        });
+        let outbox: Outbox = Rc::new(RefCell::new(Vec::new()));
+        let sink = outbox.clone();
+        let remote = Origin::from(REMOTE_ORIGIN);
+        // yrs does not fire this for a transaction that changed nothing, so the outbox
+        // never collects an empty update and "outbox is empty" really does mean "nothing
+        // to send".
+        let updates = doc
+            .observe_update_v1(move |txn, e| {
+                if txn.origin() != Some(&remote) {
+                    sink.borrow_mut().push(e.update.clone());
+                }
+            })
+            .expect("a freshly built document has no live transaction to conflict with");
+        (doc, outbox, updates)
     }
 
     /// Build a fresh projection from a model document. Fails loud
@@ -182,42 +249,65 @@ impl CollabDoc {
             nodes.push(read_node(doc.child(i))?);
         }
 
-        let ydoc = CollabDoc::empty_doc();
+        let (ydoc, outbox, updates) = CollabDoc::blank();
         let content = ydoc.get_or_insert_array(CONTENT);
+        // A plain local transaction, so the initial projection lands in the outbox and is
+        // broadcast like any other local change. A peer that joined from a snapshot
+        // already has it and applies it as a no-op (updates are idempotent).
         {
             let mut txn = ydoc.transact_mut();
             for (i, node) in nodes.iter().enumerate() {
                 insert_node(&mut txn, &content, i as u32, node)?;
             }
         }
-        Ok(CollabDoc { doc: ydoc, content })
+        Ok(CollabDoc {
+            doc: ydoc,
+            content,
+            outbox,
+            _updates: updates,
+        })
     }
 
     /// Load a projection from a peer's saved CRDT bytes (see [`CollabDoc::save`]).
+    ///
+    /// Fails loud on bytes that decode as a yrs update but are not one of *our*
+    /// projections, rather than silently adopting an empty document and collaborating on
+    /// content no peer shares.
+    ///
+    /// The guard validates **content, not the root's type**, because a root type carries
+    /// no type tag on the wire: a root arriving from a peer reads as `Out::UndefinedRef`
+    /// whatever it really is, and asking for it as an array *reinterprets* whatever is
+    /// there (a foreign `Map` root named `content` then reads as a zero-length array, a
+    /// `Text` root as an array of single characters). So the check is that the array is
+    /// non-empty and that every entry reads back as a projected node — which is strictly
+    /// stronger than the type check this replaced, since a `content` list full of junk
+    /// would have passed that.
     pub fn load(bytes: &[u8]) -> Result<CollabDoc> {
         let update = Update::decode_v1(bytes)?;
-        let doc = CollabDoc::empty_doc();
-        doc.transact_mut().apply_update(update)?;
-        // Fail loud on bytes that are decodable but are not one of *our* snapshots,
-        // instead of silently adopting an empty document and collaborating on content
-        // no peer shares. yrs does not transmit a root type holding nothing, so an
-        // absent `content` root means the update carried no blocks — and a projection of
-        // an editor document always carries at least one, because an editor document
-        // always has at least one block.
-        //
-        // The check runs in its own scope: `get_or_insert_array` opens a transaction of
-        // its own, and a second acquisition while one is live deadlocks.
-        let has_content = {
-            let txn = doc.transact();
-            txn.get_array(CONTENT).is_some()
-        };
-        if !has_content {
-            return Err(CollabError::schema(
-                "these CRDT bytes carry no `content` blocks — not a rinch editor projection",
-            ));
+        let (ydoc, outbox, updates) = CollabDoc::blank();
+        {
+            let mut txn = ydoc.transact_mut_with(Origin::from(REMOTE_ORIGIN));
+            txn.apply_update(update)?;
         }
-        let content = doc.get_or_insert_array(CONTENT);
-        Ok(CollabDoc { doc, content })
+        let content = ydoc.get_or_insert_array(CONTENT);
+        {
+            let txn = ydoc.transact();
+            let n = content.len(&txn);
+            if n == 0 {
+                return Err(CollabError::schema(
+                    "these CRDT bytes carry no `content` blocks — not a rinch editor projection",
+                ));
+            }
+            for i in 0..n {
+                read_node_data(&txn, &content, i)?;
+            }
+        }
+        Ok(CollabDoc {
+            doc: ydoc,
+            content,
+            outbox,
+            _updates: updates,
+        })
     }
 
     /// Save the whole projection (for forking a peer): the complete document state as
@@ -1045,20 +1135,72 @@ mod tests {
         assert!(decode_mark_value(&Any::BigInt(5)).is_err()); // wrong kind
     }
 
+    /// Encode a whole foreign document as an update, for the `load` guard cases.
+    fn foreign_update(build: impl FnOnce(&Doc)) -> Vec<u8> {
+        let (doc, _outbox, _sub) = CollabDoc::blank();
+        build(&doc);
+        doc.transact()
+            .encode_state_as_update_v1(&StateVector::default())
+    }
+
     #[test]
     fn load_fails_loud_on_bytes_that_are_not_a_projection() {
-        // A decodable yrs update that is not one of our snapshots must not be silently
+        // A decodable yrs update that is not one of our projections must not be silently
         // adopted as an empty document — a guest joining on it would then collaborate on
         // content no peer shares, which is the silent-divergence class A22 exists to kill.
-        let foreign = CollabDoc::empty_doc();
-        let other = foreign.get_or_insert_map("something_else");
-        other.insert(&mut foreign.transact_mut(), "k", Any::Bool(true));
-        let bytes = foreign
-            .transact()
-            .encode_state_as_update_v1(&StateVector::default());
+        //
+        // The guard cannot key off the root's *type*: a root arriving from a peer reads as
+        // `UndefinedRef` whatever it is, and asking for it as an array reinterprets
+        // whatever is there. Each case below is a different way that reinterpretation can
+        // succeed, which is why the guard validates the blocks instead.
+
+        // (a) a differently-named root: `content` is absent, so it reinterprets as empty.
+        let elsewhere = foreign_update(|d| {
+            let m = d.get_or_insert_map("something_else");
+            m.insert(&mut d.transact_mut(), "k", Any::Bool(true));
+        });
         assert!(matches!(
-            CollabDoc::load(&bytes).unwrap_err(),
+            CollabDoc::load(&elsewhere).unwrap_err(),
             CollabError::Schema(_)
+        ));
+
+        // (b) a MAP root that happens to be named `content`: reinterprets as a
+        // zero-length array, so a type-blind `get_array(..).is_some()` check would let it
+        // through and `to_doc` would invent a paragraph.
+        let map_root = foreign_update(|d| {
+            let m = d.get_or_insert_map(CONTENT);
+            m.insert(&mut d.transact_mut(), "k", Any::Bool(true));
+        });
+        assert!(matches!(
+            CollabDoc::load(&map_root).unwrap_err(),
+            CollabError::Schema(_)
+        ));
+
+        // (c) a TEXT root named `content`: reinterprets as a *non-empty* array of single
+        // characters, so an emptiness check alone would let it through too.
+        let text_root = foreign_update(|d| {
+            let t = d.get_or_insert_text(CONTENT);
+            t.insert(&mut d.transact_mut(), 0, "hello");
+        });
+        assert!(matches!(
+            CollabDoc::load(&text_root).unwrap_err(),
+            CollabError::Schema(_)
+        ));
+
+        // (d) an array root named `content` holding junk rather than block maps.
+        let junk_array = foreign_update(|d| {
+            let a = d.get_or_insert_array(CONTENT);
+            a.insert(&mut d.transact_mut(), 0, Any::String("junk".into()));
+        });
+        assert!(matches!(
+            CollabDoc::load(&junk_array).unwrap_err(),
+            CollabError::Schema(_)
+        ));
+
+        // Undecodable bytes are an engine error, not a schema one.
+        assert!(matches!(
+            CollabDoc::load(&[0xff, 0xff, 0xff, 0xff]).unwrap_err(),
+            CollabError::Engine(_)
         ));
 
         // A real projection loads and rebuilds identically.
@@ -1070,6 +1212,111 @@ mod tests {
         let cdoc = CollabDoc::from_doc(&doc).unwrap();
         let loaded = CollabDoc::load(&cdoc.save()).unwrap();
         assert_eq!(loaded.to_doc(&s).unwrap(), doc);
+    }
+
+    #[test]
+    fn the_outbox_collects_local_writes_and_skips_applied_bytes() {
+        // The broadcast contract: a locally-projected transaction is a broadcast, an
+        // applied peer update is not (re-broadcasting it would echo).
+        let s = schema();
+        let para = s
+            .branch("paragraph", Fragment::from_node(s.text("hi").unwrap()))
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(para)).unwrap();
+
+        let mut a = CollabDoc::from_doc(&doc).unwrap();
+        assert_eq!(
+            a.outbox.borrow().len(),
+            1,
+            "the initial projection is a local write and is broadcast"
+        );
+
+        let mut b = CollabDoc::load(&a.save()).unwrap();
+        assert!(
+            b.outbox.borrow().is_empty(),
+            "joining from a snapshot must not queue the host's document for re-broadcast"
+        );
+
+        // A local edit on A fills A's outbox; applying it on B leaves B's empty.
+        let edited = {
+            let p = s
+                .branch("paragraph", Fragment::from_node(s.text("hi!").unwrap()))
+                .unwrap();
+            s.branch("doc", Fragment::from_node(p)).unwrap()
+        };
+        a.project_change(&doc, &edited).unwrap();
+        let delta = a.take_outbox().unwrap();
+        assert!(!delta.is_empty(), "a local edit produces a delta");
+        assert!(
+            a.take_outbox().unwrap().is_empty(),
+            "a drained outbox is empty, so a second save sends nothing"
+        );
+
+        b.apply_update(&delta).unwrap();
+        assert!(
+            b.outbox.borrow().is_empty(),
+            "an applied peer delta must not be queued for re-broadcast"
+        );
+    }
+
+    #[test]
+    fn a_broadcast_delta_does_not_regrow_with_deletion_history() {
+        // The regression the outbox exists to prevent. `encode_diff_v1` writes the whole
+        // delete set whatever state vector it is given, so a diff-based delta re-carries
+        // every past deletion on every keystroke and a "nothing new" diff is never empty.
+        // A transaction's own update carries only its own change.
+        let s = schema();
+        let text = |t: &str| {
+            let p = s
+                .branch("paragraph", Fragment::from_node(s.text(t).unwrap()))
+                .unwrap();
+            s.branch("doc", Fragment::from_node(p)).unwrap()
+        };
+
+        let long: String = std::iter::repeat_n("abcdefghij", 20).collect();
+        let start = text(&long);
+        let mut cdoc = CollabDoc::from_doc(&start).unwrap();
+        let _ = cdoc.take_outbox().unwrap(); // drop the initial projection
+
+        // Delete a lot, in many separate transactions, to build up deletion history.
+        let mut current = start;
+        for _ in 0..20 {
+            let shorter: String = current
+                .child(0)
+                .child(0)
+                .text()
+                .unwrap()
+                .chars()
+                .skip(5)
+                .collect();
+            let next = text(&shorter);
+            cdoc.project_change(&current, &next).unwrap();
+            let _ = cdoc.take_outbox().unwrap();
+            current = next;
+        }
+
+        // With history accumulated: nothing new must mean literally nothing.
+        assert!(
+            cdoc.take_outbox().unwrap().is_empty(),
+            "a save with no local edit since the last one must be empty even after deletions"
+        );
+        // And a one-character insert must cost about one character, not the history.
+        let with_char: String =
+            format!("{}Z", current.child(0).child(0).text().unwrap_or_default());
+        let next = text(&with_char);
+        cdoc.project_change(&current, &next).unwrap();
+        let one_char = cdoc.take_outbox().unwrap();
+        let history_diff = cdoc.diff_since(&cdoc.state_vector());
+        assert!(
+            one_char.len() < 40,
+            "a 1-char edit's delta should be small, got {} bytes",
+            one_char.len()
+        );
+        assert!(
+            !history_diff.is_empty(),
+            "precondition: the state-vector diff is NOT empty even with nothing new — \
+             which is exactly why it cannot be the broadcast mechanism"
+        );
     }
 
     #[test]

--- a/crates/rinch-editor-collab/src/projection.rs
+++ b/crates/rinch-editor-collab/src/projection.rs
@@ -38,7 +38,7 @@
 //! `rinch-editor-core` positions are **Unicode scalars** (chars); yrs offers only
 //! `OffsetKind::Bytes` and `OffsetKind::Utf16`, so the document is built with
 //! [`OffsetKind::Utf16`] and every index crossing a `Text` boundary is converted
-//! ([`u16_offset`]). Blocks are small, so the linear walk is cheaper than maintaining a
+//! (`u16_offset`). Blocks are small, so the linear walk is cheaper than maintaining a
 //! rope mirror. Getting this wrong is silent: yrs snaps an index that lands mid
 //! surrogate pair to the nearest boundary rather than erroring, which is why the offset
 //! tests use **two** astral characters (one cannot distinguish a correct conversion

--- a/crates/rinch-editor-collab/src/projection.rs
+++ b/crates/rinch-editor-collab/src/projection.rs
@@ -197,6 +197,10 @@ pub struct CollabDoc {
 
 // `Subscription` is not `Debug`, and neither is the observer closure behind it, so the
 // derive is replaced by a summary of what a reader actually wants to see.
+//
+// CAUTION: this takes a **read transaction** to report the block count, so formatting a
+// `CollabDoc` while a transaction is live (a `dbg!` in the middle of a projection write,
+// say) deadlocks on native and panics on wasm — yrs cannot nest transaction acquisitions.
 impl std::fmt::Debug for CollabDoc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("CollabDoc")
@@ -1256,6 +1260,68 @@ mod tests {
         assert!(
             b.outbox.borrow().is_empty(),
             "an applied peer delta must not be queued for re-broadcast"
+        );
+    }
+
+    #[test]
+    fn several_parked_updates_merge_into_one_delta_that_converges_a_peer() {
+        // The multi-update branch of `take_outbox`. More than one local transaction can
+        // pile up before a single save (the initial projection plus a first edit is the
+        // everyday case), and those updates must be *merged* into one valid update —
+        // concatenating them would produce bytes that are not an update at all — which a
+        // peer then applies in one go.
+        let s = schema();
+        let doc = |texts: &[&str]| {
+            let blocks: Vec<Node> = texts
+                .iter()
+                .map(|t| {
+                    let content = if t.is_empty() {
+                        Fragment::empty()
+                    } else {
+                        Fragment::from_node(s.text(t).unwrap())
+                    };
+                    s.branch("paragraph", content).unwrap()
+                })
+                .collect();
+            s.branch("doc", Fragment::from_children(blocks)).unwrap()
+        };
+
+        let d0 = doc(&["one", "two"]);
+        let mut a = CollabDoc::from_doc(&d0).unwrap();
+        let mut b = CollabDoc::load(&a.save()).unwrap();
+        // Drop the initial projection: the peer already has it from the snapshot, so what
+        // follows is a merge of edits only.
+        let _ = a.take_outbox().unwrap();
+
+        // Three separate transactions, touching different blocks and adding a mark, so the
+        // merge has to carry insertions in two text objects plus formatting.
+        let d1 = doc(&["oneA", "two"]);
+        let d2 = doc(&["oneA", "twoB"]);
+        let d3 = doc(&["oneA", "twoB!"]);
+        a.project_change(&d0, &d1).unwrap();
+        a.project_change(&d1, &d2).unwrap();
+        a.project_change(&d2, &d3).unwrap();
+        assert_eq!(
+            a.outbox.borrow().len(),
+            3,
+            "each local transaction parks its own update, so the merge branch is what runs"
+        );
+
+        let merged = a.take_outbox().unwrap();
+        b.apply_update(&merged).unwrap();
+        assert_eq!(
+            b.to_doc(&s).unwrap(),
+            a.to_doc(&s).unwrap(),
+            "one apply of the merged delta converges the peer"
+        );
+        assert_eq!(
+            b.to_doc(&s).unwrap(),
+            d3,
+            "and lands exactly on the document the three edits produced"
+        );
+        assert!(
+            a.take_outbox().unwrap().is_empty(),
+            "the merge drained the outbox"
         );
     }
 

--- a/crates/rinch-editor-collab/src/projection.rs
+++ b/crates/rinch-editor-collab/src/projection.rs
@@ -190,20 +190,33 @@ impl CollabDoc {
                 insert_node(&mut txn, &content, i as u32, node)?;
             }
         }
-        Ok(CollabDoc {
-            doc: ydoc,
-            content,
-        })
+        Ok(CollabDoc { doc: ydoc, content })
     }
 
     /// Load a projection from a peer's saved CRDT bytes (see [`CollabDoc::save`]).
     pub fn load(bytes: &[u8]) -> Result<CollabDoc> {
         let update = Update::decode_v1(bytes)?;
         let doc = CollabDoc::empty_doc();
-        // The root handle is resolved before the update is applied — a named root type
-        // is identified by name, so the incoming blocks land in this very array.
-        let content = doc.get_or_insert_array(CONTENT);
         doc.transact_mut().apply_update(update)?;
+        // Fail loud on bytes that are decodable but are not one of *our* snapshots,
+        // instead of silently adopting an empty document and collaborating on content
+        // no peer shares. yrs does not transmit a root type holding nothing, so an
+        // absent `content` root means the update carried no blocks — and a projection of
+        // an editor document always carries at least one, because an editor document
+        // always has at least one block.
+        //
+        // The check runs in its own scope: `get_or_insert_array` opens a transaction of
+        // its own, and a second acquisition while one is live deadlocks.
+        let has_content = {
+            let txn = doc.transact();
+            txn.get_array(CONTENT).is_some()
+        };
+        if !has_content {
+            return Err(CollabError::schema(
+                "these CRDT bytes carry no `content` blocks — not a rinch editor projection",
+            ));
+        }
+        let content = doc.get_or_insert_array(CONTENT);
         Ok(CollabDoc { doc, content })
     }
 
@@ -309,7 +322,12 @@ fn node_attrs<T: ReadTxn>(txn: &T, node: &MapRef) -> Attrs {
 /// index the projection writes comes from a model/CRDT pair it believes are in step, so
 /// a mismatch is a projection bug — and it must surface as a loud [`CollabError`], not
 /// as a panic that kills the host application.
-pub(crate) fn check_index<T: ReadTxn>(txn: &T, list: &ArrayRef, index: u32, allow_end: bool) -> Result<()> {
+pub(crate) fn check_index<T: ReadTxn>(
+    txn: &T,
+    list: &ArrayRef,
+    index: u32,
+    allow_end: bool,
+) -> Result<()> {
     let len = list.len(txn);
     if if allow_end { index <= len } else { index < len } {
         Ok(())
@@ -606,8 +624,7 @@ fn read_text_data<T: ReadTxn>(txn: &T, text: &TextRef) -> Result<(String, Vec<Sp
 fn read_node_data<T: ReadTxn>(txn: &T, list: &ArrayRef, index: u32) -> Result<NodeData> {
     let node = child_map(txn, list, index)
         .ok_or_else(|| CollabError::schema("read_node_data: missing node"))?;
-    let type_name =
-        node_type(txn, &node).ok_or_else(|| CollabError::schema("node has no type"))?;
+    let type_name = node_type(txn, &node).ok_or_else(|| CollabError::schema("node has no type"))?;
     let attrs = node_attrs(txn, &node);
     if let Some(text_obj) = block_text(txn, &node) {
         let (text, marks) = read_text_data(txn, &text_obj)?;
@@ -710,13 +727,7 @@ fn push_span(marks: &mut Vec<SpanMark>, m: &Mark, start: usize, end: usize) {
 
 /// The coalescing half of [`push_span`], shared with the CRDT read-back so both sides
 /// produce the same canonical span list for the same logical formatting.
-fn push_mark_span(
-    marks: &mut Vec<SpanMark>,
-    name: &str,
-    attrs: Attrs,
-    start: usize,
-    end: usize,
-) {
+fn push_mark_span(marks: &mut Vec<SpanMark>, name: &str, attrs: Attrs, start: usize, end: usize) {
     if let Some(prev) = marks
         .iter_mut()
         .find(|s| s.end == start && s.name == name && s.attrs == attrs)
@@ -838,13 +849,11 @@ fn same_mark_set(a: &[Mark], b: &[Mark]) -> bool {
 /// integer, not a stringified one.
 fn write_attrs(txn: &mut TransactionMut, obj: &MapRef, attrs: &Attrs) {
     for (k, v) in attrs.iter() {
-        match attr_to_any(v) {
-            Some(any) => {
-                obj.insert(txn, k.to_string(), any);
-            }
-            // `Null` means "explicitly absent"; storing it would be indistinguishable
-            // from a cleared key on read-back.
-            None => {}
+        // `attr_to_any` yields `None` for `AttrValue::Null`, which means "explicitly
+        // absent" — storing it would be indistinguishable from a cleared key on
+        // read-back.
+        if let Some(any) = attr_to_any(v) {
+            obj.insert(txn, k.to_string(), any);
         }
     }
 }
@@ -1034,6 +1043,33 @@ mod tests {
             .is_err()
         ); // non-integer
         assert!(decode_mark_value(&Any::BigInt(5)).is_err()); // wrong kind
+    }
+
+    #[test]
+    fn load_fails_loud_on_bytes_that_are_not_a_projection() {
+        // A decodable yrs update that is not one of our snapshots must not be silently
+        // adopted as an empty document — a guest joining on it would then collaborate on
+        // content no peer shares, which is the silent-divergence class A22 exists to kill.
+        let foreign = CollabDoc::empty_doc();
+        let other = foreign.get_or_insert_map("something_else");
+        other.insert(&mut foreign.transact_mut(), "k", Any::Bool(true));
+        let bytes = foreign
+            .transact()
+            .encode_state_as_update_v1(&StateVector::default());
+        assert!(matches!(
+            CollabDoc::load(&bytes).unwrap_err(),
+            CollabError::Schema(_)
+        ));
+
+        // A real projection loads and rebuilds identically.
+        let s = schema();
+        let para = s
+            .branch("paragraph", Fragment::from_node(s.text("hi").unwrap()))
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(para)).unwrap();
+        let cdoc = CollabDoc::from_doc(&doc).unwrap();
+        let loaded = CollabDoc::load(&cdoc.save()).unwrap();
+        assert_eq!(loaded.to_doc(&s).unwrap(), doc);
     }
 
     #[test]

--- a/crates/rinch-editor-collab/src/projection.rs
+++ b/crates/rinch-editor-collab/src/projection.rs
@@ -1,38 +1,57 @@
-//! [`CollabDoc`] — the Automerge projection of a flat editor document.
+//! [`CollabDoc`] — the yrs (Yjs) projection of an editor document.
 //!
-//! Automerge is **not** the model (design §8). The model lives in `rinch-editor-core`;
+//! The CRDT is **not** the model (design §8). The model lives in `rinch-editor-core`;
 //! this is a *projection* of it onto a CRDT so concurrent edits converge. The two are
 //! kept byte-for-byte equivalent by the invariant **`model ≡ project(model)`**: every
 //! local step is projected onto the CRDT ([`crate::project`]), every remote CRDT change
-//! is translated back into steps ([`crate::remote`]). Convergence then follows from
-//! Automerge's own convergence.
+//! is rebuilt back into the model ([`crate::remote`]). Convergence then follows from
+//! yrs's own convergence.
 //!
 //! ## Wire shape (rich-text projection)
 //!
-//! Every model node — at any depth — projects onto the **same** Automerge `Map` shape;
+//! Every model node — at any depth — projects onto the **same** yrs `Map` shape;
 //! nesting is just recursion on it. A node is *either* a textblock (carries a `text`)
-//! *or* a container (carries a `content` list of child nodes):
+//! *or* a container (carries a `content` array of child nodes):
 //!
 //! ```text
-//! ROOT (Map)
-//!   "content" -> List<Node>
-//!     Node (Map):
-//!       "type"  -> Str             // "paragraph" | "heading" | "bullet_list" | …
-//!       "attrs" -> Map<Str,scalar> // e.g. heading {"level": 2}, ordered_list {"start": 3}
-//!       and then EXACTLY ONE of:
-//!         "text"    -> Text        // a textblock's plain text, codepoint-indexed
-//!           (marks applied to "text" via doc.mark(): name = mark type;
-//!            value = Bool(true) for an attr-less mark, or Str(json) carrying its attrs)
-//!         "content" -> List<Node>  // a container block's child nodes, recursively
+//! root Array "content"            // a named root type, holding the top-level blocks
+//!   Node (Map):
+//!     "type"  -> string           // "paragraph" | "heading" | "bullet_list" | …
+//!     "attrs" -> Map<str, Any>    // e.g. heading {"level": 2}, ordered_list {"start": 3}
+//!     and then EXACTLY ONE of:
+//!       "text"    -> Text         // a textblock's plain text
+//!         (marks are the Text's own *formatting attributes*: the attribute key is
+//!          the mark type name; its value is `true` for an attr-less mark or a
+//!          `Map` of the mark's attrs. Per the Yjs convention a `null` value
+//!          *removes* the format over a range.)
+//!       "content" -> Array<Node>  // a container block's child nodes, recursively
 //! ```
 //!
-//! One `Text` per textblock with Automerge marks over it is the *rich-text* model — text
-//! and formatting merge independently, which is exactly the "concurrent insert/format"
-//! convergence the milestone requires. Automerge `Text` is **codepoint-indexed**, which
-//! matches `rinch-editor-core`'s char-based positions exactly — no UTF conversion. A
-//! textblock keeps its own `Text` object however deeply it is nested, so concurrent edits
-//! to *different* list items are edits to *different* `Text` objects and merge without
-//! loss.
+//! One `Text` per textblock with native formatting attributes over it is the
+//! *rich-text* model — text and formatting merge independently, which is exactly the
+//! "concurrent insert/format" convergence the milestone requires. A textblock keeps its
+//! own `Text` object however deeply it is nested, so concurrent edits to *different*
+//! list items are edits to *different* `Text` objects and merge without loss.
+//!
+//! ## Offsets: char in the model, UTF-16 in the CRDT
+//!
+//! `rinch-editor-core` positions are **Unicode scalars** (chars); yrs offers only
+//! `OffsetKind::Bytes` and `OffsetKind::Utf16`, so the document is built with
+//! [`OffsetKind::Utf16`] and every index crossing a `Text` boundary is converted
+//! ([`u16_offset`]). Blocks are small, so the linear walk is cheaper than maintaining a
+//! rope mirror. Getting this wrong is silent: yrs snaps an index that lands mid
+//! surrogate pair to the nearest boundary rather than erroring, which is why the offset
+//! tests use **two** astral characters (one cannot distinguish a correct conversion
+//! from a snapped one).
+//!
+//! ## One transaction per entry point
+//!
+//! yrs cannot nest transaction acquisitions — a second `transact()`/`transact_mut()`
+//! taken while one is live blocks on native and panics on wasm. So the root handle is
+//! resolved once at construction (`get_or_insert_array` opens its own transaction) and
+//! every public entry point opens **exactly one** transaction and threads it down; the
+//! helpers below are free functions taking `&T: ReadTxn` or `&mut TransactionMut`
+//! rather than methods that reach for a transaction of their own.
 //!
 //! ## Scope (design A22)
 //!
@@ -46,15 +65,22 @@
 //! `task_list`/`task_item`) and every inline atom (`hard_break`, `image`,
 //! `horizontal_rule`).
 
-use automerge::marks::{ExpandMark, Mark as AmMark};
-use automerge::transaction::Transactable;
-use automerge::{AutoCommit, ObjId, ObjType, ReadDoc, ScalarValue, Value};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use yrs::types::Attrs as YAttrs;
+use yrs::types::text::YChange;
+use yrs::updates::decoder::Decode;
+use yrs::{
+    Any, Array, ArrayPrelim, ArrayRef, Doc, Map, MapPrelim, MapRef, OffsetKind, Options, Out,
+    ReadTxn, StateVector, Text, TextPrelim, TextRef, Transact, TransactionMut, Update,
+};
 
 use rinch_editor_core::{AttrValue, Attrs, Fragment, Mark, Node, Schema};
 
 use crate::error::{CollabError, Result};
 
-/// Automerge key/value names used by the projection.
+/// yrs key/root names used by the projection.
 const CONTENT: &str = "content";
 const TYPE: &str = "type";
 const ATTRS: &str = "attrs";
@@ -80,9 +106,9 @@ pub(crate) struct BlockData {
 
 /// One projectable model node: either a flat text-block ([`BlockData`]) or a container
 /// block (a list / list item) holding child nodes recursively. Structural equality is
-/// canonical (marks are sorted in [`read_block`] / [`CollabDoc::read_text_marks`]), so
-/// comparing two `NodeData` trees is the same as comparing the model nodes they came
-/// from — the child-list diff in [`CollabDoc::reconcile_child_list`] relies on that.
+/// canonical (marks are sorted in [`read_block`] / [`read_text_data`]), so comparing two
+/// `NodeData` trees is the same as comparing the model nodes they came from — the
+/// child-list diff in [`reconcile_child_list`] relies on that.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum NodeData {
     /// A flat text-block (`paragraph`/`heading`/`code_block`): its `text` + marks.
@@ -114,7 +140,7 @@ impl NodeData {
 }
 
 /// The container block types the projection nests (design A22). A container carries a
-/// `content` list of child nodes instead of a `text`. Deliberately a whitelist: every
+/// `content` array of child nodes instead of a `text`. Deliberately a whitelist: every
 /// other non-text-block node (`blockquote`, tables, `task_list`/`task_item`, atoms)
 /// stays [`CollabError::Unsupported`] so an unsupported shape fails loud rather than
 /// being silently mangled.
@@ -122,366 +148,86 @@ fn is_supported_container(type_name: &str) -> bool {
     matches!(type_name, "bullet_list" | "ordered_list" | "list_item")
 }
 
-/// An Automerge document projecting a flat editor document.
+/// A yrs document projecting an editor document.
 #[derive(Debug)]
 pub struct CollabDoc {
-    /// The Automerge document. `pub(crate)` so [`crate::sync`] can drive the transport.
-    pub(crate) doc: AutoCommit,
-    /// The root `content` list object id.
-    pub(crate) content: ObjId,
+    /// The yrs document. `pub(crate)` so [`crate::sync`] can drive the transport.
+    pub(crate) doc: Doc,
+    /// The root `content` array handle. Resolved once at construction: obtaining a root
+    /// type opens its own transaction, so doing it lazily inside a live one would
+    /// deadlock.
+    pub(crate) content: ArrayRef,
 }
 
 impl CollabDoc {
+    /// A fresh, empty CRDT document.
+    ///
+    /// **Never `Doc::new()`** — `Options::default()` is [`OffsetKind::Bytes`], which
+    /// would make every text index a byte offset and quietly corrupt any block holding
+    /// a non-ASCII character.
+    fn empty_doc() -> Doc {
+        Doc::with_options(Options {
+            offset_kind: OffsetKind::Utf16,
+            ..Default::default()
+        })
+    }
+
     /// Build a fresh projection from a model document. Fails loud
     /// ([`CollabError::Unsupported`]) on any node outside the staged scope.
     pub fn from_doc(doc: &Node) -> Result<CollabDoc> {
-        let mut am = AutoCommit::new();
-        let content = am.put_object(automerge::ROOT, CONTENT, ObjType::List)?;
-        let mut cdoc = CollabDoc {
-            doc: am,
-            content: content.clone(),
-        };
+        // Validate the whole document before opening the write transaction, so an
+        // out-of-scope node leaves no half-built CRDT behind (design A22).
+        let mut nodes = Vec::with_capacity(doc.child_count());
         for i in 0..doc.child_count() {
-            let node = read_node(doc.child(i))?;
-            cdoc.insert_node(&content, i, &node)?;
-        }
-        Ok(cdoc)
-    }
-
-    /// Load a projection from saved Automerge bytes (a peer's document).
-    pub fn load(bytes: &[u8]) -> Result<CollabDoc> {
-        let am = AutoCommit::load(bytes)?;
-        let content = match am.get(automerge::ROOT, CONTENT)? {
-            Some((Value::Object(ObjType::List), id)) => id,
-            _ => {
-                return Err(CollabError::schema(
-                    "loaded automerge doc has no `content` list",
-                ));
-            }
-        };
-        Ok(CollabDoc { doc: am, content })
-    }
-
-    /// Save the whole projection (for forking a peer).
-    pub fn save(&mut self) -> Vec<u8> {
-        self.doc.save()
-    }
-
-    /// The number of blocks.
-    pub(crate) fn block_count(&self) -> usize {
-        self.doc.length(&self.content)
-    }
-
-    /// The map object of the child at `index` of a content list (top-level `content` or
-    /// a container's nested `content`).
-    pub(crate) fn child_map(&self, list: &ObjId, index: usize) -> Option<ObjId> {
-        match self.doc.get(list, index) {
-            Ok(Some((Value::Object(ObjType::Map), id))) => Some(id),
-            _ => None,
-        }
-    }
-
-    /// The object id of the top-level block at `index`.
-    pub(crate) fn block_obj(&self, index: usize) -> Option<ObjId> {
-        self.child_map(&self.content, index)
-    }
-
-    /// The `text` Text object of a text-block node.
-    pub(crate) fn block_text_obj(&self, block: &ObjId) -> Option<ObjId> {
-        match self.doc.get(block, TEXT) {
-            Ok(Some((Value::Object(ObjType::Text), id))) => Some(id),
-            _ => None,
-        }
-    }
-
-    /// The `content` List object of a container node.
-    pub(crate) fn node_content_obj(&self, node: &ObjId) -> Option<ObjId> {
-        match self.doc.get(node, CONTENT) {
-            Ok(Some((Value::Object(ObjType::List), id))) => Some(id),
-            _ => None,
-        }
-    }
-
-    /// Insert a new node (text-block or container) at `index` of `list`.
-    pub(crate) fn insert_node(&mut self, list: &ObjId, index: usize, nd: &NodeData) -> Result<()> {
-        let node = self.doc.insert_object(list, index, ObjType::Map)?;
-        self.write_node(&node, nd)
-    }
-
-    /// Write a node's contents into its (already-inserted) map object. Recurses into a
-    /// container's children.
-    fn write_node(&mut self, node: &ObjId, nd: &NodeData) -> Result<()> {
-        self.doc.put(node, TYPE, nd.type_name())?;
-        let attrs_obj = self.doc.put_object(node, ATTRS, ObjType::Map)?;
-        write_attrs(&mut self.doc, &attrs_obj, nd.attrs())?;
-        match nd {
-            NodeData::Block(b) => {
-                let text = self.doc.put_object(node, TEXT, ObjType::Text)?;
-                if !b.text.is_empty() {
-                    self.doc.splice_text(&text, 0, 0, &b.text)?;
-                }
-                for m in &b.marks {
-                    self.apply_mark(&text, m)?;
-                }
-            }
-            NodeData::Container { children, .. } => {
-                let content = self.doc.put_object(node, CONTENT, ObjType::List)?;
-                for (i, child) in children.iter().enumerate() {
-                    self.insert_node(&content, i, child)?;
-                }
-            }
-        }
-        Ok(())
-    }
-
-    /// Delete the top-level block at `index`.
-    pub(crate) fn delete_block(&mut self, index: usize) -> Result<()> {
-        self.doc.delete(&self.content, index)?;
-        Ok(())
-    }
-
-    /// Reconcile the node at `index` of `list` to `target`: update type/attrs if they
-    /// changed, then reconcile its body — a text-block's text + marks, or a container's
-    /// child list — recursively. Unchanged descendants keep their CRDT identity, so a
-    /// concurrent edit to a *different* text-block (even in a different list item) merges.
-    pub(crate) fn reconcile_node(
-        &mut self,
-        list: &ObjId,
-        index: usize,
-        target: &NodeData,
-    ) -> Result<()> {
-        let node = self
-            .child_map(list, index)
-            .ok_or_else(|| CollabError::schema("reconcile_node: missing node"))?;
-
-        // A node changing *kind* (text-block <-> container — e.g. a paragraph wrapped
-        // into a list) can't be reconciled in place; replace it wholesale. Rare, so the
-        // coarse-grained replace is fine.
-        let crdt_is_block = self.block_text_obj(&node).is_some();
-        let target_is_block = matches!(target, NodeData::Block(_));
-        if crdt_is_block != target_is_block {
-            self.doc.delete(list, index)?;
-            self.insert_node(list, index, target)?;
-            return Ok(());
+            nodes.push(read_node(doc.child(i))?);
         }
 
-        // type — only write when it changed
-        if self.scalar_str(&node, TYPE).as_deref() != Some(target.type_name()) {
-            self.doc.put(&node, TYPE, target.type_name())?;
-        }
-        // attrs — only rebuild when they changed. Replacing the attrs object on every
-        // keystroke would churn the CRDT and clobber a concurrent remote attr edit on
-        // the same node.
-        let current_attrs = match self.doc.get(&node, ATTRS) {
-            Ok(Some((Value::Object(ObjType::Map), id))) => read_attrs(&self.doc, &id),
-            _ => Attrs::new(),
-        };
-        if current_attrs != *target.attrs() {
-            let attrs_obj = self.doc.put_object(&node, ATTRS, ObjType::Map)?;
-            write_attrs(&mut self.doc, &attrs_obj, target.attrs())?;
-        }
-
-        match target {
-            NodeData::Block(b) => {
-                let text = self
-                    .block_text_obj(&node)
-                    .ok_or_else(|| CollabError::schema("reconcile_node: missing text"))?;
-                self.reconcile_text(&text, b)?;
-            }
-            NodeData::Container { children, .. } => {
-                let content = self
-                    .node_content_obj(&node)
-                    .ok_or_else(|| CollabError::schema("reconcile_node: missing content"))?;
-                self.reconcile_child_list(&content, children)?;
-            }
-        }
-        Ok(())
-    }
-
-    /// Reconcile a text-block's `text` Text object to `b`: a minimal common-prefix/suffix
-    /// splice (so the per-char CRDT identity of unchanged text survives) plus a mark
-    /// resync only when the marks actually changed.
-    fn reconcile_text(&mut self, text: &ObjId, b: &BlockData) -> Result<()> {
-        let old = self.doc.text(text)?;
-        if old != b.text {
-            splice_min(&mut self.doc, text, &old, &b.text)?;
-        }
-        // marks — only clear-and-reapply when they actually changed (after the splice,
-        // Automerge has already shifted existing mark ranges with the text). Skipping
-        // the resync on a pure text edit avoids clobbering a concurrent remote mark.
-        let mut target_marks = b.marks.clone();
-        target_marks.sort_by(|a, b| (a.start, a.end, &a.name).cmp(&(b.start, b.end, &b.name)));
-        if self.read_text_marks(text)? != target_marks {
-            self.resync_marks(text, &b.marks)?;
-        }
-        Ok(())
-    }
-
-    /// Reconcile a container's `content` list to `target`. Diffs the CRDT's current
-    /// children against `target` by *structural* equality (a common leading/trailing run
-    /// is left untouched, keeping the CRDT identity — and merge behaviour — of every
-    /// node in it), reconciles the overlapping middle in place, and inserts/deletes the
-    /// count difference. This is the same block-list diff as [`Self::project_change`],
-    /// one level down; recursion carries it to any depth.
-    fn reconcile_child_list(&mut self, content: &ObjId, target: &[NodeData]) -> Result<()> {
-        let cn = self.doc.length(content);
-        let mut cur = Vec::with_capacity(cn);
-        for i in 0..cn {
-            cur.push(self.read_node_data(content, i)?);
-        }
-        let tn = target.len();
-
-        let mut prefix = 0;
-        while prefix < cn && prefix < tn && cur[prefix] == target[prefix] {
-            prefix += 1;
-        }
-        let mut suffix = 0;
-        while suffix < cn - prefix
-            && suffix < tn - prefix
-            && cur[cn - 1 - suffix] == target[tn - 1 - suffix]
+        let ydoc = CollabDoc::empty_doc();
+        let content = ydoc.get_or_insert_array(CONTENT);
         {
-            suffix += 1;
-        }
-
-        let cur_mid = cn - prefix - suffix;
-        let tgt_mid = tn - prefix - suffix;
-        let common = cur_mid.min(tgt_mid);
-
-        // Reconcile the overlapping changed children in place (keeps identity).
-        for k in 0..common {
-            self.reconcile_node(content, prefix + k, &target[prefix + k])?;
-        }
-        // Insert the extra target children.
-        for k in common..tgt_mid {
-            self.insert_node(content, prefix + k, &target[prefix + k])?;
-        }
-        // Delete the extra current children (from the end so earlier indices stay valid).
-        for idx in (prefix + common..prefix + cur_mid).rev() {
-            self.doc.delete(content, idx)?;
-        }
-        Ok(())
-    }
-
-    /// Read a Text object's active marks back as canonical (sorted) [`SpanMark`]s.
-    fn read_text_marks(&self, text: &ObjId) -> Result<Vec<SpanMark>> {
-        let mut marks: Vec<SpanMark> = self
-            .doc
-            .marks(text)?
-            .into_iter()
-            .filter(|m| m.value() != &ScalarValue::Null)
-            .map(|m| {
-                Ok(SpanMark {
-                    name: m.name().to_string(),
-                    attrs: decode_mark_value(m.value())?,
-                    start: m.start,
-                    end: m.end,
-                })
-            })
-            .collect::<Result<Vec<_>>>()?;
-        marks.sort_by(|a, b| (a.start, a.end, &a.name).cmp(&(b.start, b.end, &b.name)));
-        Ok(marks)
-    }
-
-    /// Clear and reapply a Text object's marks to match `target` exactly.
-    pub(crate) fn resync_marks(&mut self, text: &ObjId, target: &[SpanMark]) -> Result<()> {
-        // Clear every currently-active mark (set its name to Null over its range).
-        // Collect owned data first so the read borrow ends before we mutate.
-        let existing: Vec<(String, usize, usize)> = self
-            .doc
-            .marks(text)?
-            .iter()
-            .map(|m| (m.name().to_string(), m.start, m.end))
-            .collect();
-        for (name, start, end) in existing {
-            self.doc.mark(
-                text,
-                AmMark::new(name, ScalarValue::Null, start, end),
-                ExpandMark::None,
-            )?;
-        }
-        for m in target {
-            self.apply_mark(text, m)?;
-        }
-        Ok(())
-    }
-
-    /// Apply one mark span to a Text object, encoding its attrs into the mark value.
-    fn apply_mark(&mut self, text: &ObjId, m: &SpanMark) -> Result<()> {
-        let value = if m.attrs.is_empty() {
-            ScalarValue::Boolean(true)
-        } else {
-            ScalarValue::Str(encode_attrs(&m.attrs).into())
-        };
-        self.doc.mark(
-            text,
-            AmMark::new(m.name.clone(), value, m.start, m.end),
-            ExpandMark::None,
-        )?;
-        Ok(())
-    }
-
-    /// Read a scalar string attribute of an object.
-    fn scalar_str(&self, obj: &ObjId, key: &str) -> Option<String> {
-        match self.doc.get(obj, key) {
-            Ok(Some((Value::Scalar(s), _))) => match s.as_ref() {
-                ScalarValue::Str(smol) => Some(smol.to_string()),
-                _ => None,
-            },
-            _ => None,
-        }
-    }
-
-    /// Read the node at `index` of `list` back out of the CRDT as [`NodeData`]. A node
-    /// carrying a `text` Text is a text-block; a node carrying a `content` List is a
-    /// container, read recursively. Fails loud on a node that is neither (a corrupt
-    /// projection), rather than materializing a broken shape.
-    pub(crate) fn read_node_data(&self, list: &ObjId, index: usize) -> Result<NodeData> {
-        let node = self
-            .child_map(list, index)
-            .ok_or_else(|| CollabError::schema("read_node_data: missing node"))?;
-        let type_name = self
-            .scalar_str(&node, TYPE)
-            .ok_or_else(|| CollabError::schema("node has no type"))?;
-        let attrs = match self.doc.get(&node, ATTRS) {
-            Ok(Some((Value::Object(ObjType::Map), id))) => read_attrs(&self.doc, &id),
-            _ => Attrs::new(),
-        };
-        if let Some(text_obj) = self.block_text_obj(&node) {
-            let text = self.doc.text(&text_obj)?;
-            let marks = self.read_text_marks(&text_obj)?;
-            Ok(NodeData::Block(BlockData {
-                type_name,
-                attrs,
-                text,
-                marks,
-            }))
-        } else if let Some(content) = self.node_content_obj(&node) {
-            let len = self.doc.length(&content);
-            let mut children = Vec::with_capacity(len);
-            for i in 0..len {
-                children.push(self.read_node_data(&content, i)?);
+            let mut txn = ydoc.transact_mut();
+            for (i, node) in nodes.iter().enumerate() {
+                insert_node(&mut txn, &content, i as u32, node)?;
             }
-            Ok(NodeData::Container {
-                type_name,
-                attrs,
-                children,
-            })
-        } else {
-            Err(CollabError::schema(format!(
-                "node `{type_name}` has neither a `text` nor a `content` object"
-            )))
         }
+        Ok(CollabDoc {
+            doc: ydoc,
+            content,
+        })
+    }
+
+    /// Load a projection from a peer's saved CRDT bytes (see [`CollabDoc::save`]).
+    pub fn load(bytes: &[u8]) -> Result<CollabDoc> {
+        let update = Update::decode_v1(bytes)?;
+        let doc = CollabDoc::empty_doc();
+        // The root handle is resolved before the update is applied — a named root type
+        // is identified by name, so the incoming blocks land in this very array.
+        let content = doc.get_or_insert_array(CONTENT);
+        doc.transact_mut().apply_update(update)?;
+        Ok(CollabDoc { doc, content })
+    }
+
+    /// Save the whole projection (for forking a peer): the complete document state as
+    /// a v1 update, which [`CollabDoc::load`] reads back.
+    pub fn save(&self) -> Vec<u8> {
+        self.doc
+            .transact()
+            .encode_state_as_update_v1(&StateVector::default())
     }
 
     /// Rebuild the whole model document from the projection (the canonical, total
     /// read-back; both peers reconstruct identically, so equal CRDTs give equal docs).
     pub fn to_doc(&self, schema: &Schema) -> Result<Node> {
-        let n = self.block_count();
-        let mut blocks = Vec::with_capacity(n);
-        for i in 0..n {
-            let nd = self.read_node_data(&self.content, i)?;
-            blocks.push(build_node(schema, &nd)?);
-        }
+        let mut blocks = {
+            let txn = self.doc.transact();
+            let n = self.content.len(&txn);
+            let mut blocks = Vec::with_capacity(n as usize);
+            for i in 0..n {
+                let nd = read_node_data(&txn, &self.content, i)?;
+                blocks.push(build_node(schema, &nd)?);
+            }
+            blocks
+        };
         if blocks.is_empty() {
             // An editor doc is never empty; mirror the starter empty paragraph.
             let para = schema
@@ -494,6 +240,402 @@ impl CollabDoc {
             .map_err(CollabError::from)
     }
 }
+
+// --- offset conversion ----------------------------------------------------------
+
+/// The UTF-16 code-unit offset of char offset `chars` inside `s`.
+///
+/// The model counts chars, yrs counts UTF-16 code units ([`OffsetKind::Utf16`]), so
+/// every index handed to a `Text` goes through here. A char offset past the end clamps
+/// to the end: [`Text::remove_range`] **panics** on an out-of-range index (automerge
+/// returned an error), and a panic here would take the whole app down.
+fn u16_offset(s: &str, chars: usize) -> u32 {
+    s.chars().take(chars).map(|c| c.len_utf16() as u32).sum()
+}
+
+/// A char range as a UTF-16 `(index, len)` pair inside `s`.
+fn u16_span(s: &str, start: usize, end: usize) -> (u32, u32) {
+    let at = u16_offset(s, start);
+    let to = u16_offset(s, end.max(start));
+    (at, to - at)
+}
+
+// --- structural read helpers (any transaction) ----------------------------------
+
+/// The map object of the child at `index` of a content array (the root `content` or a
+/// container's nested `content`).
+fn child_map<T: ReadTxn>(txn: &T, list: &ArrayRef, index: u32) -> Option<MapRef> {
+    match list.get(txn, index) {
+        Some(Out::YMap(m)) => Some(m),
+        _ => None,
+    }
+}
+
+/// The `text` Text object of a text-block node.
+fn block_text<T: ReadTxn>(txn: &T, node: &MapRef) -> Option<TextRef> {
+    match node.get(txn, TEXT) {
+        Some(Out::YText(t)) => Some(t),
+        _ => None,
+    }
+}
+
+/// The `content` Array object of a container node.
+fn node_content<T: ReadTxn>(txn: &T, node: &MapRef) -> Option<ArrayRef> {
+    match node.get(txn, CONTENT) {
+        Some(Out::YArray(a)) => Some(a),
+        _ => None,
+    }
+}
+
+/// A node's `type` string.
+fn node_type<T: ReadTxn>(txn: &T, node: &MapRef) -> Option<String> {
+    match node.get(txn, TYPE) {
+        Some(Out::Any(Any::String(s))) => Some(s.to_string()),
+        _ => None,
+    }
+}
+
+/// A node's `attrs` map read back into a model attr set (empty when absent).
+fn node_attrs<T: ReadTxn>(txn: &T, node: &MapRef) -> Attrs {
+    match node.get(txn, ATTRS) {
+        Some(Out::YMap(m)) => read_attrs(txn, &m),
+        _ => Attrs::new(),
+    }
+}
+
+/// Bounds-check a content-array index before a write.
+///
+/// yrs **panics** on an out-of-range array index where automerge returned `Err`. Every
+/// index the projection writes comes from a model/CRDT pair it believes are in step, so
+/// a mismatch is a projection bug — and it must surface as a loud [`CollabError`], not
+/// as a panic that kills the host application.
+pub(crate) fn check_index<T: ReadTxn>(txn: &T, list: &ArrayRef, index: u32, allow_end: bool) -> Result<()> {
+    let len = list.len(txn);
+    if if allow_end { index <= len } else { index < len } {
+        Ok(())
+    } else {
+        Err(CollabError::schema(format!(
+            "content index {index} out of range (length {len})"
+        )))
+    }
+}
+
+// --- writes --------------------------------------------------------------------
+
+/// Insert a new node (text-block or container) at `index` of `list`.
+pub(crate) fn insert_node(
+    txn: &mut TransactionMut,
+    list: &ArrayRef,
+    index: u32,
+    nd: &NodeData,
+) -> Result<()> {
+    check_index(txn, list, index, true)?;
+    let node = list.insert(txn, index, MapPrelim::default());
+    write_node(txn, &node, nd)
+}
+
+/// Write a node's contents into its (already-inserted) map object. Recurses into a
+/// container's children.
+fn write_node(txn: &mut TransactionMut, node: &MapRef, nd: &NodeData) -> Result<()> {
+    node.insert(txn, TYPE, Any::String(nd.type_name().into()));
+    let attrs_obj = node.insert(txn, ATTRS, MapPrelim::default());
+    write_attrs(txn, &attrs_obj, nd.attrs());
+    match nd {
+        NodeData::Block(b) => {
+            let text = node.insert(txn, TEXT, TextPrelim::new(b.text.as_str()));
+            for m in &b.marks {
+                apply_mark(txn, &text, &b.text, m);
+            }
+        }
+        NodeData::Container { children, .. } => {
+            let content = node.insert(txn, CONTENT, ArrayPrelim::default());
+            for (i, child) in children.iter().enumerate() {
+                insert_node(txn, &content, i as u32, child)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Reconcile the node at `index` of `list` to `target`: update type/attrs if they
+/// changed, then reconcile its body — a text-block's text + marks, or a container's
+/// child list — recursively. Unchanged descendants keep their CRDT identity, so a
+/// concurrent edit to a *different* text-block (even in a different list item) merges.
+pub(crate) fn reconcile_node(
+    txn: &mut TransactionMut,
+    list: &ArrayRef,
+    index: u32,
+    target: &NodeData,
+) -> Result<()> {
+    let node = child_map(txn, list, index)
+        .ok_or_else(|| CollabError::schema("reconcile_node: missing node"))?;
+
+    // A node changing *kind* (text-block <-> container — e.g. a paragraph wrapped
+    // into a list) can't be reconciled in place; replace it wholesale. Rare, so the
+    // coarse-grained replace is fine.
+    let crdt_is_block = block_text(txn, &node).is_some();
+    let target_is_block = matches!(target, NodeData::Block(_));
+    if crdt_is_block != target_is_block {
+        check_index(txn, list, index, false)?;
+        list.remove(txn, index);
+        return insert_node(txn, list, index, target);
+    }
+
+    // type — only write when it changed
+    if node_type(txn, &node).as_deref() != Some(target.type_name()) {
+        node.insert(txn, TYPE, Any::String(target.type_name().into()));
+    }
+    // attrs — only rebuild when they changed. Replacing the attrs object on every
+    // keystroke would churn the CRDT and clobber a concurrent remote attr edit on
+    // the same node.
+    if node_attrs(txn, &node) != *target.attrs() {
+        let attrs_obj = node.insert(txn, ATTRS, MapPrelim::default());
+        write_attrs(txn, &attrs_obj, target.attrs());
+    }
+
+    match target {
+        NodeData::Block(b) => {
+            let text = block_text(txn, &node)
+                .ok_or_else(|| CollabError::schema("reconcile_node: missing text"))?;
+            reconcile_text(txn, &text, b)
+        }
+        NodeData::Container { children, .. } => {
+            let content = node_content(txn, &node)
+                .ok_or_else(|| CollabError::schema("reconcile_node: missing content"))?;
+            reconcile_child_list(txn, &content, children)
+        }
+    }
+}
+
+/// Reconcile a text-block's `text` object to `b`: a minimal common-prefix/suffix splice
+/// (so the per-char CRDT identity of unchanged text survives) plus a mark resync only
+/// when the marks actually changed.
+fn reconcile_text(txn: &mut TransactionMut, text: &TextRef, b: &BlockData) -> Result<()> {
+    let (old, old_marks) = read_text_data(txn, text)?;
+    let spliced = old != b.text;
+    if spliced {
+        splice_min(txn, text, &old, &b.text);
+    }
+
+    let mut target_marks = b.marks.clone();
+    target_marks.sort_by(|a, b| (a.start, a.end, &a.name).cmp(&(b.start, b.end, &b.name)));
+
+    // Marks must be compared *after* the splice: yrs has already shifted existing
+    // formatting ranges with the text, and text inserted **inside** a formatted run
+    // inherits that run's attributes (which usually matches the editor's own stored-mark
+    // behaviour, but not always). Re-reading is what keeps the two in step. Skipping the
+    // resync when the marks already agree avoids clobbering a concurrent remote mark on
+    // a pure text edit.
+    let (current, current_marks) = if spliced {
+        read_text_data(txn, text)?
+    } else {
+        (old, old_marks)
+    };
+    if current_marks != target_marks {
+        resync_marks(txn, text, &current, &current_marks, &target_marks);
+    }
+    Ok(())
+}
+
+/// Reconcile a container's `content` array to `target`. Diffs the CRDT's current
+/// children against `target` by *structural* equality (a common leading/trailing run
+/// is left untouched, keeping the CRDT identity — and merge behaviour — of every
+/// node in it), reconciles the overlapping middle in place, and inserts/deletes the
+/// count difference. This is the same block-list diff as
+/// [`project_change`](CollabDoc::project_change), one level down; recursion carries it
+/// to any depth.
+fn reconcile_child_list(
+    txn: &mut TransactionMut,
+    content: &ArrayRef,
+    target: &[NodeData],
+) -> Result<()> {
+    let cn = content.len(txn) as usize;
+    let mut cur = Vec::with_capacity(cn);
+    for i in 0..cn {
+        cur.push(read_node_data(txn, content, i as u32)?);
+    }
+    let tn = target.len();
+
+    let mut prefix = 0;
+    while prefix < cn && prefix < tn && cur[prefix] == target[prefix] {
+        prefix += 1;
+    }
+    let mut suffix = 0;
+    while suffix < cn - prefix
+        && suffix < tn - prefix
+        && cur[cn - 1 - suffix] == target[tn - 1 - suffix]
+    {
+        suffix += 1;
+    }
+
+    let cur_mid = cn - prefix - suffix;
+    let tgt_mid = tn - prefix - suffix;
+    let common = cur_mid.min(tgt_mid);
+
+    // Reconcile the overlapping changed children in place (keeps identity).
+    for k in 0..common {
+        reconcile_node(txn, content, (prefix + k) as u32, &target[prefix + k])?;
+    }
+    // Insert the extra target children.
+    for k in common..tgt_mid {
+        insert_node(txn, content, (prefix + k) as u32, &target[prefix + k])?;
+    }
+    // Delete the extra current children (from the end so earlier indices stay valid).
+    for idx in (prefix + common..prefix + cur_mid).rev() {
+        check_index(txn, content, idx as u32, false)?;
+        content.remove(txn, idx as u32);
+    }
+    Ok(())
+}
+
+/// Minimal common-prefix/suffix splice: replace only the changed middle so unchanged
+/// characters keep their CRDT identity (and merge across peers). yrs has no
+/// `update_text` equivalent, so the diff is computed here and applied as a
+/// remove-then-insert pair, converted from char offsets into UTF-16 code units.
+pub(crate) fn splice_min(txn: &mut TransactionMut, text: &TextRef, old: &str, new: &str) {
+    let o: Vec<char> = old.chars().collect();
+    let n: Vec<char> = new.chars().collect();
+    let mut prefix = 0;
+    while prefix < o.len() && prefix < n.len() && o[prefix] == n[prefix] {
+        prefix += 1;
+    }
+    let mut suffix = 0;
+    while suffix < o.len() - prefix
+        && suffix < n.len() - prefix
+        && o[o.len() - 1 - suffix] == n[n.len() - 1 - suffix]
+    {
+        suffix += 1;
+    }
+    let del = o.len() - prefix - suffix;
+    let ins: String = n[prefix..n.len() - suffix].iter().collect();
+
+    let at: u32 = o[..prefix].iter().map(|c| c.len_utf16() as u32).sum();
+    let del_u16: u32 = o[prefix..prefix + del]
+        .iter()
+        .map(|c| c.len_utf16() as u32)
+        .sum();
+    if del_u16 > 0 {
+        text.remove_range(txn, at, del_u16);
+    }
+    if !ins.is_empty() {
+        text.insert(txn, at, &ins);
+    }
+}
+
+/// Apply one mark span as a formatting attribute over a `Text` range. A zero-length
+/// span is skipped — there is nothing to format, and the model never produces one.
+fn apply_mark(txn: &mut TransactionMut, text: &TextRef, s: &str, m: &SpanMark) {
+    let (at, len) = u16_span(s, m.start, m.end);
+    if len == 0 {
+        return;
+    }
+    let attrs = YAttrs::from([(m.name.as_str().into(), encode_mark_value(&m.attrs))]);
+    text.format(txn, at, len, attrs);
+}
+
+/// Clear and reapply a `Text`'s formatting attributes to match `target` exactly.
+/// `current` is the text's present string and `current_marks` the spans read out of it
+/// (both **after** any splice), so the ranges being cleared are the live ones.
+fn resync_marks(
+    txn: &mut TransactionMut,
+    text: &TextRef,
+    current: &str,
+    current_marks: &[SpanMark],
+    target: &[SpanMark],
+) {
+    // Clear every currently-active mark over its range. Per the Yjs convention a
+    // `null` attribute value removes that format.
+    for m in current_marks {
+        let (at, len) = u16_span(current, m.start, m.end);
+        if len == 0 {
+            continue;
+        }
+        text.format(
+            txn,
+            at,
+            len,
+            YAttrs::from([(m.name.as_str().into(), Any::Null)]),
+        );
+    }
+    for m in target {
+        apply_mark(txn, text, current, m);
+    }
+}
+
+// --- CRDT → NodeData -----------------------------------------------------------
+
+/// Read a `Text` back as its plain string plus the canonical (sorted, coalesced) mark
+/// spans over it, in **char** offsets.
+///
+/// `Text::diff` hands back the text already split into runs at every formatting change,
+/// each carrying the full attribute set active over it — so the string and the spans are
+/// read in one pass and cannot disagree. A chunk that is not a string is an embedded
+/// value, which is outside the staged scope (A22) and fails loud rather than being
+/// dropped.
+fn read_text_data<T: ReadTxn>(txn: &T, text: &TextRef) -> Result<(String, Vec<SpanMark>)> {
+    let mut s = String::new();
+    let mut marks: Vec<SpanMark> = Vec::new();
+    for chunk in text.diff(txn, YChange::identity) {
+        let Out::Any(Any::String(part)) = &chunk.insert else {
+            return Err(CollabError::unsupported(
+                "an embedded value inside a block's text is not supported (inline atoms \
+                 such as image/hard_break are not yet projected)",
+            ));
+        };
+        let start = s.chars().count();
+        s.push_str(part);
+        let end = s.chars().count();
+        if let Some(attrs) = &chunk.attributes {
+            for (name, value) in attrs.iter() {
+                // A cleared format can linger as an explicit null; it is not a mark.
+                if matches!(value, Any::Null | Any::Undefined) {
+                    continue;
+                }
+                push_mark_span(&mut marks, name, decode_mark_value(value)?, start, end);
+            }
+        }
+    }
+    marks.sort_by(|a, b| (a.start, a.end, &a.name).cmp(&(b.start, b.end, &b.name)));
+    Ok((s, marks))
+}
+
+/// Read the node at `index` of `list` back out of the CRDT as [`NodeData`]. A node
+/// carrying a `text` object is a text-block; a node carrying a `content` array is a
+/// container, read recursively. Fails loud on a node that is neither (a corrupt
+/// projection), rather than materializing a broken shape.
+fn read_node_data<T: ReadTxn>(txn: &T, list: &ArrayRef, index: u32) -> Result<NodeData> {
+    let node = child_map(txn, list, index)
+        .ok_or_else(|| CollabError::schema("read_node_data: missing node"))?;
+    let type_name =
+        node_type(txn, &node).ok_or_else(|| CollabError::schema("node has no type"))?;
+    let attrs = node_attrs(txn, &node);
+    if let Some(text_obj) = block_text(txn, &node) {
+        let (text, marks) = read_text_data(txn, &text_obj)?;
+        Ok(NodeData::Block(BlockData {
+            type_name,
+            attrs,
+            text,
+            marks,
+        }))
+    } else if let Some(content) = node_content(txn, &node) {
+        let len = content.len(txn);
+        let mut children = Vec::with_capacity(len as usize);
+        for i in 0..len {
+            children.push(read_node_data(txn, &content, i)?);
+        }
+        Ok(NodeData::Container {
+            type_name,
+            attrs,
+            children,
+        })
+    } else {
+        Err(CollabError::schema(format!(
+            "node `{type_name}` has neither a `text` nor a `content` object"
+        )))
+    }
+}
+
+// --- model → NodeData ----------------------------------------------------------
 
 /// Validate a model node is projectable and extract its [`NodeData`], recursing into
 /// list containers. A flat text-block becomes [`NodeData::Block`]; a supported list
@@ -524,9 +666,9 @@ pub(crate) fn read_node(node: &Node) -> Result<NodeData> {
 }
 
 /// Validate a model block is a flat textblock and extract its projectable data. Marks
-/// are returned in canonical `(start, end, name)` order — matching
-/// [`CollabDoc::read_text_marks`] — so a [`NodeData`] read from the model compares equal
-/// to the same node read back from the CRDT.
+/// are returned in canonical `(start, end, name)` order — matching [`read_text_data`] —
+/// so a [`NodeData`] read from the model compares equal to the same node read back from
+/// the CRDT.
 pub(crate) fn read_block(block: &Node) -> Result<BlockData> {
     if !block.is_textblock() {
         return Err(CollabError::unsupported(format!(
@@ -563,21 +705,34 @@ pub(crate) fn read_block(block: &Node) -> Result<BlockData> {
 /// Append a mark over `start..end`, coalescing with an immediately-preceding span of
 /// the same (type, attrs).
 fn push_span(marks: &mut Vec<SpanMark>, m: &Mark, start: usize, end: usize) {
-    let name = m.type_name().to_string();
+    push_mark_span(marks, m.type_name(), m.attrs.clone(), start, end);
+}
+
+/// The coalescing half of [`push_span`], shared with the CRDT read-back so both sides
+/// produce the same canonical span list for the same logical formatting.
+fn push_mark_span(
+    marks: &mut Vec<SpanMark>,
+    name: &str,
+    attrs: Attrs,
+    start: usize,
+    end: usize,
+) {
     if let Some(prev) = marks
         .iter_mut()
-        .find(|s| s.end == start && s.name == name && s.attrs == m.attrs)
+        .find(|s| s.end == start && s.name == name && s.attrs == attrs)
     {
         prev.end = end;
         return;
     }
     marks.push(SpanMark {
-        name,
-        attrs: m.attrs.clone(),
+        name: name.to_string(),
+        attrs,
         start,
         end,
     });
 }
+
+// --- NodeData → model ----------------------------------------------------------
 
 /// Rebuild a model node from projected [`NodeData`], recursing into list containers.
 /// The inbound scope guard (A22) is shared with the outbound [`read_node`]: a container
@@ -679,113 +834,118 @@ fn same_mark_set(a: &[Mark], b: &[Mark]) -> bool {
 
 // --- attr / mark-value encoding ------------------------------------------------
 
-/// Write a model attr set into an Automerge map (scalar values only).
-fn write_attrs(doc: &mut AutoCommit, obj: &ObjId, attrs: &Attrs) -> Result<()> {
+/// Write a model attr set into a yrs map. Values stay **typed** — an integer is an
+/// integer, not a stringified one.
+fn write_attrs(txn: &mut TransactionMut, obj: &MapRef, attrs: &Attrs) {
     for (k, v) in attrs.iter() {
-        match v {
-            AttrValue::Str(s) => doc.put(obj, k, s.as_ref())?,
-            AttrValue::Int(i) => doc.put(obj, k, *i)?,
-            AttrValue::Bool(b) => doc.put(obj, k, *b)?,
-            AttrValue::Null => {}
+        match attr_to_any(v) {
+            Some(any) => {
+                obj.insert(txn, k.to_string(), any);
+            }
+            // `Null` means "explicitly absent"; storing it would be indistinguishable
+            // from a cleared key on read-back.
+            None => {}
         }
     }
-    Ok(())
 }
 
-/// Read an Automerge map back into a model attr set.
-fn read_attrs(doc: &AutoCommit, obj: &ObjId) -> Attrs {
+/// Read a yrs map back into a model attr set. Values yrs cannot have come from
+/// [`write_attrs`] (a nested shared type, a buffer) are skipped rather than guessed at.
+fn read_attrs<T: ReadTxn>(txn: &T, obj: &MapRef) -> Attrs {
     let mut out = Attrs::new();
-    for key in doc.keys(obj) {
-        if let Ok(Some((Value::Scalar(s), _))) = doc.get(obj, &key) {
-            let v = match s.as_ref() {
-                ScalarValue::Str(smol) => AttrValue::from(smol.to_string()),
-                ScalarValue::Int(i) => AttrValue::Int(*i),
-                // Clamp rather than wrap a foreign-impl Uint past i64::MAX.
-                ScalarValue::Uint(u) => AttrValue::Int(i64::try_from(*u).unwrap_or(i64::MAX)),
-                ScalarValue::Boolean(b) => AttrValue::Bool(*b),
-                _ => continue,
-            };
+    for (key, value) in obj.iter(txn) {
+        if let Out::Any(any) = value
+            && let Some(v) = any_to_attr(&any)
+        {
             out = out.with(key, v);
         }
     }
     out
 }
 
-/// Encode mark attrs as a compact deterministic JSON object string.
-fn encode_attrs(attrs: &Attrs) -> String {
-    let mut map = serde_json::Map::new();
-    for (k, v) in attrs.iter() {
-        let jv = match v {
-            AttrValue::Str(s) => serde_json::Value::String(s.to_string()),
-            AttrValue::Int(i) => serde_json::Value::from(*i),
-            AttrValue::Bool(b) => serde_json::Value::Bool(*b),
-            AttrValue::Null => serde_json::Value::Null,
-        };
-        map.insert(k.to_string(), jv);
+/// One model attr value as a yrs [`Any`]. `None` for [`AttrValue::Null`], which is not
+/// stored at all.
+fn attr_to_any(v: &AttrValue) -> Option<Any> {
+    match v {
+        AttrValue::Str(s) => Some(Any::String(s.as_ref().into())),
+        // Written explicitly as a `BigInt` so the encoding does not depend on the
+        // value's magnitude; `any_to_attr` accepts both encodings regardless.
+        AttrValue::Int(i) => Some(Any::BigInt(*i)),
+        AttrValue::Bool(b) => Some(Any::Bool(*b)),
+        AttrValue::Null => None,
     }
-    serde_json::Value::Object(map).to_string()
 }
 
-/// Decode a mark's Automerge scalar value back into model attrs. The two valid
-/// encodings ([`CollabDoc::apply_mark`]) are `Boolean(true)` for an attr-less mark
-/// (→ empty attrs) and `Str(json-object)` for an attr-bearing mark. Fails loud on
-/// anything else — a wrong scalar kind, invalid JSON, a non-object, or a non-integer
-/// number — rather than silently dropping a peer's corrupted mark attrs (A22).
-fn decode_mark_value(value: &ScalarValue) -> Result<Attrs> {
-    let smol = match value {
+/// One yrs [`Any`] as a model attr value, or `None` for a shape the projection never
+/// writes.
+///
+/// Integers are accepted in **both** encodings: yrs picks between `BigInt` and
+/// `Number` by magnitude, so matching only the arm we write would silently drop
+/// attributes that came from another writer (or a future yrs).
+fn any_to_attr(v: &Any) -> Option<AttrValue> {
+    match v {
+        Any::String(s) => Some(AttrValue::from(s.to_string())),
+        Any::BigInt(i) => Some(AttrValue::Int(*i)),
+        Any::Number(n) if n.fract() == 0.0 => Some(AttrValue::Int(*n as i64)),
+        Any::Bool(b) => Some(AttrValue::Bool(*b)),
+        _ => None,
+    }
+}
+
+/// Encode a mark's attrs as its yrs formatting-attribute **value**.
+///
+/// Two encodings, mirrored by [`decode_mark_value`]: `true` for an attr-less mark
+/// (bold, italic) and a `Map` of typed values for an attr-bearing one (a link's
+/// `href`). yrs formatting attributes carry structured values, so — unlike automerge,
+/// whose marks held a single scalar — no JSON-string indirection is needed.
+fn encode_mark_value(attrs: &Attrs) -> Any {
+    if attrs.is_empty() {
+        return Any::Bool(true);
+    }
+    let mut map: HashMap<String, Any> = HashMap::new();
+    for (k, v) in attrs.iter() {
+        map.insert(k.to_string(), attr_to_any(v).unwrap_or(Any::Null));
+    }
+    Any::Map(Arc::new(map))
+}
+
+/// Decode a mark's yrs formatting value back into model attrs. Fails loud on anything
+/// [`encode_mark_value`] could not have produced — a wrong value kind, a non-integer
+/// number, a nested collection — rather than silently dropping a peer's corrupted mark
+/// attrs (A22).
+fn decode_mark_value(value: &Any) -> Result<Attrs> {
+    let map = match value {
         // The attr-less encoding — no attributes to decode.
-        ScalarValue::Boolean(_) => return Ok(Attrs::new()),
-        ScalarValue::Str(smol) => smol,
+        Any::Bool(_) => return Ok(Attrs::new()),
+        Any::Map(map) => map,
         other => {
             return Err(CollabError::schema(format!(
-                "mark value must be Boolean(true) or a JSON-object string, got {other:?}"
+                "mark value must be `true` or a map of attributes, got {other:?}"
             )));
         }
     };
-    let serde_json::Value::Object(map) = serde_json::from_str(smol)
-        .map_err(|e| CollabError::schema(format!("mark attr json invalid: {e}")))?
-    else {
-        return Err(CollabError::schema("mark attr json must be an object"));
-    };
     let mut out = Attrs::new();
-    for (k, v) in map {
+    for (k, v) in map.iter() {
         let av = match v {
-            serde_json::Value::String(s) => AttrValue::from(s),
-            serde_json::Value::Bool(b) => AttrValue::Bool(b),
-            serde_json::Value::Number(n) if n.is_i64() => AttrValue::Int(n.as_i64().unwrap()),
-            serde_json::Value::Number(n) => {
+            Any::String(s) => AttrValue::from(s.to_string()),
+            Any::Bool(b) => AttrValue::Bool(*b),
+            Any::BigInt(i) => AttrValue::Int(*i),
+            Any::Number(n) if n.fract() == 0.0 => AttrValue::Int(*n as i64),
+            Any::Number(n) => {
                 return Err(CollabError::schema(format!(
-                    "non-integer JSON number in mark attr `{k}`: {n}"
+                    "non-integer number in mark attr `{k}`: {n}"
                 )));
             }
-            serde_json::Value::Null => AttrValue::Null,
-            _ => continue,
+            Any::Null | Any::Undefined => AttrValue::Null,
+            other => {
+                return Err(CollabError::schema(format!(
+                    "unsupported value in mark attr `{k}`: {other:?}"
+                )));
+            }
         };
-        out = out.with(k, av);
+        out = out.with(k.as_str(), av);
     }
     Ok(out)
-}
-
-/// Minimal common-prefix/suffix splice: replace only the changed middle so unchanged
-/// characters keep their CRDT identity (and merge across peers).
-pub(crate) fn splice_min(doc: &mut AutoCommit, text: &ObjId, old: &str, new: &str) -> Result<()> {
-    let o: Vec<char> = old.chars().collect();
-    let n: Vec<char> = new.chars().collect();
-    let mut prefix = 0;
-    while prefix < o.len() && prefix < n.len() && o[prefix] == n[prefix] {
-        prefix += 1;
-    }
-    let mut suffix = 0;
-    while suffix < o.len() - prefix
-        && suffix < n.len() - prefix
-        && o[o.len() - 1 - suffix] == n[n.len() - 1 - suffix]
-    {
-        suffix += 1;
-    }
-    let del = o.len() - prefix - suffix;
-    let ins: String = n[prefix..n.len() - suffix].iter().collect();
-    doc.splice_text(text, prefix, del as isize, &ins)?;
-    Ok(())
 }
 
 #[cfg(test)]
@@ -841,9 +1001,12 @@ mod tests {
             .branch("paragraph", Fragment::from_node(s.text("hi").unwrap()))
             .unwrap();
         let doc = s.branch("doc", Fragment::from_node(para)).unwrap();
-        let mut cdoc = CollabDoc::from_doc(&doc).unwrap();
-        let block = cdoc.block_obj(0).unwrap();
-        cdoc.doc.put(&block, TYPE, "blockquote").unwrap();
+        let cdoc = CollabDoc::from_doc(&doc).unwrap();
+        {
+            let mut txn = cdoc.doc.transact_mut();
+            let block = child_map(&txn, &cdoc.content, 0).unwrap();
+            block.insert(&mut txn, TYPE, Any::String("blockquote".into()));
+        }
         assert!(matches!(
             cdoc.to_doc(&s).unwrap_err(),
             CollabError::Unsupported(_)
@@ -853,18 +1016,40 @@ mod tests {
     #[test]
     fn decode_mark_value_fails_loud_on_corruption() {
         // attr-less encoding decodes to empty attrs
-        assert!(
-            decode_mark_value(&ScalarValue::Boolean(true))
-                .unwrap()
-                .is_empty()
-        );
-        // valid attr json decodes
-        let attrs = decode_mark_value(&ScalarValue::Str(r#"{"href":"x"}"#.into())).unwrap();
+        assert!(decode_mark_value(&Any::Bool(true)).unwrap().is_empty());
+        // valid attr map decodes
+        let attrs = decode_mark_value(&encode_mark_value(
+            &Attrs::new().with("href", AttrValue::from("x")),
+        ))
+        .unwrap();
         assert_eq!(attrs.get_str("href"), Some("x"));
         // malformed values fail loud rather than silently dropping the attrs
-        assert!(decode_mark_value(&ScalarValue::Str("not json".into())).is_err());
-        assert!(decode_mark_value(&ScalarValue::Str(r#"["a"]"#.into())).is_err()); // not an object
-        assert!(decode_mark_value(&ScalarValue::Str(r#"{"n":1.5}"#.into())).is_err()); // non-integer
-        assert!(decode_mark_value(&ScalarValue::Int(5)).is_err()); // wrong scalar kind
+        assert!(decode_mark_value(&Any::String("not a map".into())).is_err()); // wrong kind
+        assert!(decode_mark_value(&Any::Array(Arc::from([Any::Bool(true)]))).is_err()); // not a map
+        assert!(
+            decode_mark_value(&Any::Map(Arc::new(HashMap::from([(
+                "n".to_string(),
+                Any::Number(1.5)
+            )]))))
+            .is_err()
+        ); // non-integer
+        assert!(decode_mark_value(&Any::BigInt(5)).is_err()); // wrong kind
+    }
+
+    #[test]
+    fn char_offsets_convert_to_utf16_across_astral_pairs() {
+        // Two astral characters, deliberately: yrs snaps an index that lands mid
+        // surrogate pair to the nearest boundary and silently corrects the off-by-one,
+        // so a single-astral case cannot tell a correct conversion from a broken one.
+        let s = "a🐱b🐱c"; // chars 0..5, UTF-16 units 0..7
+        assert_eq!(u16_offset(s, 0), 0);
+        assert_eq!(u16_offset(s, 1), 1); // after 'a'
+        assert_eq!(u16_offset(s, 2), 3); // after the first 🐱 (2 units)
+        assert_eq!(u16_offset(s, 3), 4); // after 'b'
+        assert_eq!(u16_offset(s, 4), 6); // after the second 🐱
+        assert_eq!(u16_offset(s, 5), 7); // end
+        // Past the end clamps rather than running off (remove_range would panic).
+        assert_eq!(u16_offset(s, 99), 7);
+        assert_eq!(u16_span(s, 1, 4), (1, 5)); // "🐱b🐱" is 5 UTF-16 units
     }
 }

--- a/crates/rinch-editor-collab/src/remote.rs
+++ b/crates/rinch-editor-collab/src/remote.rs
@@ -1,172 +1,31 @@
 //! Remote → model: turn a converged CRDT change back into editor steps.
 //!
-//! When a peer's change arrives, Automerge merges it (convergence is *its* job). This
-//! module closes the loop back to the model two ways:
+//! When a peer's change arrives, yrs merges it (convergence is *its* job). This module
+//! closes the loop back to the model: [`build_remote_transaction`] rebuilds the model
+//! from the converged CRDT ([`CollabDoc::to_doc`](crate::CollabDoc::to_doc)) and emits a
+//! minimal **block-level** `ReplaceStep` (common-prefix/suffix on blocks, so untouched
+//! blocks keep their identity). Because the model is rebuilt from the *same* CRDT both
+//! peers converge to, `model ≡ project(model)` is restored exactly — no position-math
+//! risk.
 //!
-//! * [`CollabDoc::patches_to_remote_ops`] translates the Automerge `diff` patches into
-//!   the salvaged high-level op shape (`InsertText`/`DeleteRange`/`SetBlockType`/
-//!   `AddMark`/`RemoveMark` — design §8, salvaging `patches_to_ce_ops`), expressed in
-//!   the model's char-based position space. This is the surgical, cursor-preserving
-//!   translation and is unit-tested directly.
-//! * [`build_remote_transaction`] is the **convergence-critical** path the session uses:
-//!   it rebuilds the model from the converged CRDT ([`CollabDoc::to_doc`]) and emits a
-//!   minimal **block-level** `ReplaceStep` (common-prefix/suffix on blocks, so untouched
-//!   blocks keep their identity). Because the model is rebuilt from the *same* CRDT both
-//!   peers converge to, `model ≡ project(model)` is restored exactly — no position-math
-//!   risk. The op translator above is the documented refinement toward full surgery.
+//! There is deliberately no engine type in this file. The convergence-critical path only
+//! ever needs "give me the converged document as a `Node`", which is why swapping the
+//! CRDT engine (#190) left it untouched.
+//!
+//! A surgical, cursor-preserving translation (a remote change described as
+//! insert/delete/mark ops, so a caret could be re-anchored instead of re-derived) used
+//! to sit alongside this and was **dropped with automerge**: it consumed
+//! `automerge::Patch`, was documented as not convergence-critical, and never fed the
+//! session. It can be rebuilt on yrs observer deltas (`TextRef::observe` → `TextEvent`)
+//! if a future refinement wants it.
 
 use rinch_editor_core::{EditorState, Fragment, Node, Selection, Slice, Transaction};
 
 use crate::error::Result;
-use crate::projection::CollabDoc;
-use crate::sync::ChangeHash;
-use automerge::{Patch, PatchAction, ReadDoc, ScalarValue, Value};
 
 /// Transaction meta key marking a transaction as a remote (collab) application, so the
 /// history plugin and any origin-sensitive logic can tell it apart from local typing.
 pub const ORIGIN_REMOTE: &str = "collabOriginRemote";
-
-/// A high-level description of one remote change, in the model's char position space.
-/// (Salvaged shape of the old `CeRemoteOp`, rebound onto depth-aware positions.)
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum RemoteOp {
-    /// Insert `text` at a model position.
-    InsertText { pos: usize, text: String },
-    /// Delete a model range.
-    DeleteRange { start: usize, end: usize },
-    /// A block's type changed (block index + new type name).
-    SetBlockType { block: usize, type_name: String },
-    /// Add a mark over a model range.
-    AddMark {
-        start: usize,
-        end: usize,
-        mark: String,
-    },
-    /// Remove a mark over a model range.
-    RemoveMark {
-        start: usize,
-        end: usize,
-        mark: String,
-    },
-}
-
-impl CollabDoc {
-    /// The model position just inside the start of block `index` (after its open token).
-    /// Fails loud if any preceding block is missing its map or text object, rather than
-    /// treating it as length 0 — a silent under-count would misalign every later patch
-    /// position and break convergence.
-    fn block_content_start(&self, index: usize) -> Result<usize> {
-        let mut pos = 0usize;
-        for j in 0..index {
-            let b = self
-                .block_obj(j)
-                .ok_or_else(|| crate::CollabError::schema(format!("block {j} is missing")))?;
-            let len = self
-                .block_text_obj(&b)
-                .map(|t| self.doc.length(&t))
-                .ok_or_else(|| crate::CollabError::schema(format!("block {j} has no text")))?;
-            pos += 2 + len; // open + content + close
-        }
-        Ok(pos + 1) // step inside the block's open token
-    }
-
-    /// Find the block index whose `text` object is `obj`.
-    fn block_of_text(&self, obj: &automerge::ObjId) -> Option<usize> {
-        for j in 0..self.block_count() {
-            if let Some(b) = self.block_obj(j)
-                && self.block_text_obj(&b).as_ref() == Some(obj)
-            {
-                return Some(j);
-            }
-        }
-        None
-    }
-
-    /// Translate Automerge diff patches into model-space [`RemoteOp`]s. Positions are
-    /// computed against the *current* (post-merge) CRDT structure.
-    ///
-    /// **Scope:** this covers in-block changes — text insert/delete, marks, and a
-    /// block's `type` — only. **Structural** patches (a block *inserted into* or
-    /// *deleted from* the content list — i.e. a split, join, or paste) are deliberately
-    /// not represented, because [`RemoteOp`] has no block-structure variant; they are
-    /// silently skipped here. The session's convergence-critical path
-    /// ([`CollabSession::integrate_incremental`](crate::CollabSession::integrate_incremental))
-    /// does **not** use this translator — it rebuilds from the converged CRDT
-    /// ([`CollabDoc::to_doc`]), which handles every change including structural ones.
-    /// Use this only for a surgical, text/mark-level view of a change.
-    pub fn patches_to_remote_ops(&self, patches: &[Patch]) -> Result<Vec<RemoteOp>> {
-        let mut ops = Vec::new();
-        for patch in patches {
-            match &patch.action {
-                PatchAction::SpliceText { index, value, .. } => {
-                    if let Some(block) = self.block_of_text(&patch.obj) {
-                        let text = value.make_string();
-                        if !text.is_empty() {
-                            ops.push(RemoteOp::InsertText {
-                                pos: self.block_content_start(block)? + index,
-                                text,
-                            });
-                        }
-                    }
-                }
-                PatchAction::DeleteSeq { index, length } => {
-                    if let Some(block) = self.block_of_text(&patch.obj) {
-                        let start = self.block_content_start(block)? + index;
-                        ops.push(RemoteOp::DeleteRange {
-                            start,
-                            end: start + length,
-                        });
-                    }
-                }
-                PatchAction::Mark { marks } => {
-                    if let Some(block) = self.block_of_text(&patch.obj) {
-                        let base = self.block_content_start(block)?;
-                        for m in marks {
-                            let (start, end) = (base + m.start, base + m.end);
-                            let mark = m.name().to_string();
-                            if m.value() == &ScalarValue::Null {
-                                ops.push(RemoteOp::RemoveMark { start, end, mark });
-                            } else {
-                                ops.push(RemoteOp::AddMark { start, end, mark });
-                            }
-                        }
-                    }
-                }
-                PatchAction::PutMap { key, value, .. } => {
-                    if key == "type"
-                        && let Some(block) = self.block_of_content_map(&patch.obj)
-                        && let Value::Scalar(s) = &value.0
-                        && let ScalarValue::Str(smol) = s.as_ref()
-                    {
-                        ops.push(RemoteOp::SetBlockType {
-                            block,
-                            type_name: smol.to_string(),
-                        });
-                    }
-                }
-                // Structural content-list patches (block insert/delete) and other
-                // actions are intentionally not represented — see the doc comment.
-                _ => {}
-            }
-        }
-        Ok(ops)
-    }
-
-    /// Find the block index whose map object is `obj` (for block-type patches).
-    fn block_of_content_map(&self, obj: &automerge::ObjId) -> Option<usize> {
-        (0..self.block_count()).find(|&j| self.block_obj(j).as_ref() == Some(obj))
-    }
-
-    /// The high-level remote ops describing how the CRDT changed since `before` heads.
-    /// The surgical, cursor-preserving view of a remote change (the documented
-    /// refinement of the session's converged-rebuild path). Text/mark/block-type
-    /// changes only — see [`CollabDoc::patches_to_remote_ops`] for the scope bound.
-    pub fn remote_ops_since(&mut self, before: &[ChangeHash]) -> Result<Vec<RemoteOp>> {
-        let after = self.get_heads();
-        let patches = self.diff(before, &after);
-        self.patches_to_remote_ops(&patches)
-    }
-}
 
 /// Build the transaction that brings `state`'s model up to the converged CRDT
 /// document `target`, as a minimal block-level replace. Returns `None` if nothing

--- a/crates/rinch-editor-collab/src/session.rs
+++ b/crates/rinch-editor-collab/src/session.rs
@@ -81,6 +81,14 @@ impl CollabSession {
     /// empty once anything has been deleted. A transaction's own update is constant-size
     /// and genuinely empty when there was no transaction.
     ///
+    /// The **first** delta of a session started with [`Self::new`] also carries the
+    /// initial projection of the document, by design: the outbox is armed before that
+    /// projection is written, so no content can ever escape the broadcast stream. A peer
+    /// that joined from [`Self::snapshot`] already has it and applies that part as a
+    /// no-op, since updates are idempotent. Draining the outbox in `snapshot` instead
+    /// would trade this one redundant delta for the risk of an *earlier* joiner missing a
+    /// real one.
+    ///
     /// Fails only if a parked update cannot be re-decoded to be merged with its
     /// neighbours, which would mean this replica produced a malformed update; the parked
     /// updates are left in place, so the error is not a silent loss.

--- a/crates/rinch-editor-collab/src/session.rs
+++ b/crates/rinch-editor-collab/src/session.rs
@@ -88,7 +88,7 @@ impl CollabSession {
     /// The next broadcast delta: everything produced since the previous call. Empty when
     /// there is genuinely nothing to send, so a caller can skip the transmission.
     ///
-    /// "Nothing to send" is decided from the *encoded delta* ([`EMPTY_UPDATE`]), never
+    /// "Nothing to send" is decided from the *encoded delta* (`EMPTY_UPDATE`), never
     /// from a state-vector comparison — a local deletion or mark removal does not move
     /// the state vector, and skipping on that basis would drop the change permanently.
     pub fn save_incremental(&mut self) -> Vec<u8> {

--- a/crates/rinch-editor-collab/src/session.rs
+++ b/crates/rinch-editor-collab/src/session.rs
@@ -9,8 +9,9 @@
 //!   `model ≡ project(model)` invariant and means there is never an unconfirmed backlog
 //!   to rebase).
 //! * **`save_incremental` / `state_vector` / `sync_diff`** — produce something to send:
-//!   the next broadcast delta, this replica's state vector, or the diff a peer at a
-//!   given state vector is missing.
+//!   the next broadcast delta (the updates of the local transactions since the last
+//!   call), this replica's state vector, or the diff a peer at a given state vector is
+//!   missing.
 //! * **`integrate_incremental`** — apply a peer's bytes, whatever transport produced
 //!   them: merge into the CRDT, rebuild the model from the *converged* CRDT, and return
 //!   the next [`EditorState`] (the change applied as a remote, non-undoable transaction).
@@ -29,14 +30,9 @@ use crate::projection::CollabDoc;
 use crate::remote::build_remote_transaction;
 
 /// An update that carries nothing, in the lib0 v1 encoding: zero blocks followed by a
-/// zero-length delete set.
-///
-/// Worth naming, because it is the **only** sound "nothing happened" test on this
-/// wire. A state vector counts the *inserts* a replica has seen and says nothing about
-/// deletions, so two docs can differ by an arbitrary number of deletes (and, since yrs
-/// implements un-formatting by deleting format markers, by arbitrary *mark removals*)
-/// while their state vectors are identical. Comparing state vectors to decide whether
-/// anything changed silently drops exactly those changes.
+/// zero-length delete set. A peer can legitimately send one (a reconciliation diff for a
+/// peer that is already up to date), so the inbound path recognises it instead of
+/// decoding it into a no-op transaction.
 const EMPTY_UPDATE: &[u8] = &[0, 0];
 
 /// One editor's collaboration session: its CRDT projection plus the lifecycle to drive
@@ -44,34 +40,22 @@ const EMPTY_UPDATE: &[u8] = &[0, 0];
 #[derive(Debug)]
 pub struct CollabSession {
     cdoc: CollabDoc,
-    /// The state vector as of the last [`Self::save_incremental`] — the watermark that
-    /// bounds how far back a broadcast delta has to reach for *inserts*. Deletions ride
-    /// along regardless: yrs writes the whole delete set into every diff, so a deletion
-    /// this watermark cannot represent still reaches every peer (and keeps reaching
-    /// them, which is why a missed delete self-heals).
-    ///
-    /// Deliberately *not* advanced by [`Self::snapshot`] or
-    /// [`Self::integrate_incremental`]: a snapshot handed to a late joiner must not
-    /// make the existing peers miss the next delta, and re-broadcasting a change that
-    /// arrived from a peer is harmless (updates are idempotent) where dropping one is
-    /// not.
-    last_saved: StateVector,
 }
 
 impl CollabSession {
     /// Start a session from a fresh editor state, projecting its document onto a new
     /// CRDT. Fails loud on content outside the staged scope (design A22).
     pub fn new(state: &EditorState) -> Result<CollabSession> {
-        let cdoc = CollabDoc::from_doc(&state.doc)?;
-        let last_saved = cdoc.state_vector();
-        Ok(CollabSession { cdoc, last_saved })
+        Ok(CollabSession {
+            cdoc: CollabDoc::from_doc(&state.doc)?,
+        })
     }
 
     /// Join an existing collaboration from a peer's saved CRDT bytes.
     pub fn from_bytes(bytes: &[u8]) -> Result<CollabSession> {
-        let cdoc = CollabDoc::load(bytes)?;
-        let last_saved = cdoc.state_vector();
-        Ok(CollabSession { cdoc, last_saved })
+        Ok(CollabSession {
+            cdoc: CollabDoc::load(bytes)?,
+        })
     }
 
     /// Save the whole CRDT (hand to a peer so they can `from_bytes` and join).
@@ -85,23 +69,27 @@ impl CollabSession {
         self.cdoc.project_change(before, after)
     }
 
-    /// The next broadcast delta: everything produced since the previous call. Empty when
-    /// there is genuinely nothing to send, so a caller can skip the transmission.
+    /// The next broadcast delta: the updates of every locally-projected transaction since
+    /// the previous call, as one update. **Empty** when nothing has been projected since,
+    /// so a caller can skip the transmission.
     ///
-    /// "Nothing to send" is decided from the *encoded delta* (`EMPTY_UPDATE`), never
-    /// from a state-vector comparison — a local deletion or mark removal does not move
-    /// the state vector, and skipping on that basis would drop the change permanently.
-    pub fn save_incremental(&mut self) -> Vec<u8> {
-        let delta = self.cdoc.diff_since(&self.last_saved);
-        self.last_saved = self.cdoc.state_vector();
-        if delta == EMPTY_UPDATE {
-            return Vec::new();
-        }
-        delta
+    /// This drains an outbox fed by an update observer rather than diffing against the
+    /// state vector of the last broadcast. The difference is not cosmetic:
+    /// `encode_diff_v1` writes the *complete* delete set whatever state vector it is
+    /// given, so a diff-based delta re-carries the document's entire deletion history on
+    /// every keystroke — growing without bound — and a "nothing new" diff never becomes
+    /// empty once anything has been deleted. A transaction's own update is constant-size
+    /// and genuinely empty when there was no transaction.
+    ///
+    /// Fails only if a parked update cannot be re-decoded to be merged with its
+    /// neighbours, which would mean this replica produced a malformed update; the parked
+    /// updates are left in place, so the error is not a silent loss.
+    pub fn save_incremental(&mut self) -> Result<Vec<u8>> {
+        self.cdoc.take_outbox()
     }
 
-    /// This replica's state vector, encoded for the wire — the inserts it has seen. Send
-    /// it to a peer, which answers with [`Self::sync_diff`].
+    /// This replica's state vector, encoded for the wire — the insertions it has seen.
+    /// Send it to a peer, which answers with [`Self::sync_diff`].
     ///
     /// **Not a convergence test.** Equal state vectors mean two replicas have seen the
     /// same insertions, not that they hold the same document: deletions (and mark
@@ -133,12 +121,18 @@ impl CollabSession {
     /// document, so a state-vector guard here would apply the change to the CRDT and
     /// then never tell the model about it, breaking `model ≡ project(model)` in a way
     /// that only shows up rounds later as divergence.
+    ///
+    /// Both spellings of "nothing arrived" are a no-op: the two-byte empty update, which is what a
+    /// reconciliation diff for an up-to-date peer encodes as, and an empty slice, which is
+    /// what [`Self::save_incremental`] returns when it has nothing to send. Neither is
+    /// decodable as an update, so recognising them here is what keeps a caller that
+    /// forwards its own empty delta from parking a spurious decode error.
     pub fn integrate_incremental(
         &mut self,
         state: &EditorState,
         changes: &[u8],
     ) -> Result<Option<EditorState>> {
-        if changes == EMPTY_UPDATE {
+        if changes.is_empty() || changes == EMPTY_UPDATE {
             return Ok(None);
         }
         self.cdoc.apply_update(changes)?;

--- a/crates/rinch-editor-collab/src/session.rs
+++ b/crates/rinch-editor-collab/src/session.rs
@@ -8,113 +8,146 @@
 //!   project the `before → after` change onto the CRDT (immediate projection keeps the
 //!   `model ≡ project(model)` invariant and means there is never an unconfirmed backlog
 //!   to rebase).
-//! * **`save_incremental` / `generate_sync_message`** — produce something to send.
-//! * **`integrate_incremental` / `integrate_sync_message`** — apply a peer's change:
-//!   merge it into the CRDT, rebuild the model from the *converged* CRDT, and return the
-//!   next [`EditorState`] (the change applied as a remote, non-undoable transaction).
+//! * **`save_incremental` / `state_vector` / `sync_diff`** — produce something to send:
+//!   the next broadcast delta, this replica's state vector, or the diff a peer at a
+//!   given state vector is missing.
+//! * **`integrate_incremental`** — apply a peer's bytes, whatever transport produced
+//!   them: merge into the CRDT, rebuild the model from the *converged* CRDT, and return
+//!   the next [`EditorState`] (the change applied as a remote, non-undoable transaction).
 //!
 //! Because both peers rebuild from the same converged CRDT, their models converge. The
 //! session never consults the host DOM — it is pure model ↔ CRDT.
+
+use yrs::StateVector;
+use yrs::updates::decoder::Decode;
+use yrs::updates::encoder::Encode;
 
 use rinch_editor_core::{EditorState, Node, Schema};
 
 use crate::error::Result;
 use crate::projection::CollabDoc;
 use crate::remote::build_remote_transaction;
-use crate::sync::{ChangeHash, SyncMessage, SyncState};
+
+/// An update that carries nothing, in the lib0 v1 encoding: zero blocks followed by a
+/// zero-length delete set.
+///
+/// Worth naming, because it is the **only** sound "nothing happened" test on this
+/// wire. A state vector counts the *inserts* a replica has seen and says nothing about
+/// deletions, so two docs can differ by an arbitrary number of deletes (and, since yrs
+/// implements un-formatting by deleting format markers, by arbitrary *mark removals*)
+/// while their state vectors are identical. Comparing state vectors to decide whether
+/// anything changed silently drops exactly those changes.
+const EMPTY_UPDATE: &[u8] = &[0, 0];
 
 /// One editor's collaboration session: its CRDT projection plus the lifecycle to drive
 /// it.
 #[derive(Debug)]
 pub struct CollabSession {
     cdoc: CollabDoc,
+    /// The state vector as of the last [`Self::save_incremental`] — the watermark that
+    /// bounds how far back a broadcast delta has to reach for *inserts*. Deletions ride
+    /// along regardless: yrs writes the whole delete set into every diff, so a deletion
+    /// this watermark cannot represent still reaches every peer (and keeps reaching
+    /// them, which is why a missed delete self-heals).
+    ///
+    /// Deliberately *not* advanced by [`Self::snapshot`] or
+    /// [`Self::integrate_incremental`]: a snapshot handed to a late joiner must not
+    /// make the existing peers miss the next delta, and re-broadcasting a change that
+    /// arrived from a peer is harmless (updates are idempotent) where dropping one is
+    /// not.
+    last_saved: StateVector,
 }
 
 impl CollabSession {
     /// Start a session from a fresh editor state, projecting its document onto a new
-    /// CRDT. Fails loud on any non-flat content (design A22).
+    /// CRDT. Fails loud on content outside the staged scope (design A22).
     pub fn new(state: &EditorState) -> Result<CollabSession> {
-        Ok(CollabSession {
-            cdoc: CollabDoc::from_doc(&state.doc)?,
-        })
+        let cdoc = CollabDoc::from_doc(&state.doc)?;
+        let last_saved = cdoc.state_vector();
+        Ok(CollabSession { cdoc, last_saved })
     }
 
     /// Join an existing collaboration from a peer's saved CRDT bytes.
     pub fn from_bytes(bytes: &[u8]) -> Result<CollabSession> {
-        Ok(CollabSession {
-            cdoc: CollabDoc::load(bytes)?,
-        })
+        let cdoc = CollabDoc::load(bytes)?;
+        let last_saved = cdoc.state_vector();
+        Ok(CollabSession { cdoc, last_saved })
     }
 
     /// Save the whole CRDT (hand to a peer so they can `from_bytes` and join).
-    pub fn snapshot(&mut self) -> Vec<u8> {
+    pub fn snapshot(&self) -> Vec<u8> {
         self.cdoc.save()
     }
 
     /// Project a just-applied local change (`before` = old `state.doc`, `after` = new
-    /// `state.doc`) onto the CRDT. Fails loud on non-flat content.
+    /// `state.doc`) onto the CRDT. Fails loud on out-of-scope content.
     pub fn record_local(&mut self, before: &Node, after: &Node) -> Result<()> {
         self.cdoc.project_change(before, after)
     }
 
-    /// The CRDT's current head frontier.
-    pub fn heads(&mut self) -> Vec<ChangeHash> {
-        self.cdoc.get_heads()
-    }
-
-    /// Save only the changes since the last save (broadcast delta).
+    /// The next broadcast delta: everything produced since the previous call. Empty when
+    /// there is genuinely nothing to send, so a caller can skip the transmission.
+    ///
+    /// "Nothing to send" is decided from the *encoded delta* ([`EMPTY_UPDATE`]), never
+    /// from a state-vector comparison — a local deletion or mark removal does not move
+    /// the state vector, and skipping on that basis would drop the change permanently.
     pub fn save_incremental(&mut self) -> Vec<u8> {
-        self.cdoc.save_incremental()
+        let delta = self.cdoc.diff_since(&self.last_saved);
+        self.last_saved = self.cdoc.state_vector();
+        if delta == EMPTY_UPDATE {
+            return Vec::new();
+        }
+        delta
     }
 
-    /// Generate a sync message for a peer (full sync protocol).
-    pub fn generate_sync_message(&mut self, sync_state: &mut SyncState) -> Option<SyncMessage> {
-        self.cdoc.generate_sync_message(sync_state)
+    /// This replica's state vector, encoded for the wire — the inserts it has seen. Send
+    /// it to a peer, which answers with [`Self::sync_diff`].
+    ///
+    /// **Not a convergence test.** Equal state vectors mean two replicas have seen the
+    /// same insertions, not that they hold the same document: deletions (and mark
+    /// removals, which yrs implements by deleting format markers) are absent from a
+    /// state vector. That is exactly why the reply to it — a diff — always carries the
+    /// complete delete set, and why reconciliation must apply that reply rather than
+    /// short-circuit on state-vector equality.
+    pub fn state_vector(&self) -> Vec<u8> {
+        self.cdoc.state_vector().encode_v1()
     }
 
-    /// Integrate a peer's broadcast delta: merge into the CRDT, rebuild the model from
-    /// the converged CRDT, and return the next state (or `None` if nothing changed).
+    /// The update a peer whose state vector is `remote_state_vector` is missing. Feed
+    /// the result to that peer's [`Self::integrate_incremental`]; one exchange in each
+    /// direction reconciles two replicas that have drifted apart.
+    pub fn sync_diff(&self, remote_state_vector: &[u8]) -> Result<Vec<u8>> {
+        let sv = StateVector::decode_v1(remote_state_vector)?;
+        Ok(self.cdoc.diff_since(&sv))
+    }
+
+    /// Integrate a peer's update bytes (a broadcast delta or a reconciliation diff —
+    /// same encoding, same path): merge into the CRDT, rebuild the model from the
+    /// converged CRDT, and return the next state (or `None` if the document did not
+    /// change).
+    ///
+    /// Whether anything changed is decided by rebuilding and *comparing documents*
+    /// ([`build_remote_transaction`] returns `None` for an identical rebuild), not by
+    /// comparing state vectors before and after: a delta that only deletes content — or
+    /// only removes a mark — leaves the state vector untouched while changing the
+    /// document, so a state-vector guard here would apply the change to the CRDT and
+    /// then never tell the model about it, breaking `model ≡ project(model)` in a way
+    /// that only shows up rounds later as divergence.
     pub fn integrate_incremental(
         &mut self,
         state: &EditorState,
         changes: &[u8],
     ) -> Result<Option<EditorState>> {
-        let before = self.cdoc.get_heads();
-        self.cdoc.load_incremental(changes)?;
-        let after = self.cdoc.get_heads();
-        if before == after {
+        if changes == EMPTY_UPDATE {
             return Ok(None);
         }
-        self.apply_converged(state)
-    }
-
-    /// Integrate a peer's sync message (full sync protocol).
-    pub fn integrate_sync_message(
-        &mut self,
-        state: &EditorState,
-        sync_state: &mut SyncState,
-        message: SyncMessage,
-    ) -> Result<Option<EditorState>> {
-        let before = self.cdoc.get_heads();
-        self.cdoc.receive_sync_message(sync_state, message)?;
-        let after = self.cdoc.get_heads();
-        if before == after {
-            return Ok(None);
-        }
+        self.cdoc.apply_update(changes)?;
         self.apply_converged(state)
     }
 
     /// Merge another peer's CRDT wholesale into this one (test/utility convenience).
-    pub fn merge(&mut self, other: &mut CollabSession) -> Result<()> {
-        self.cdoc.merge(&mut other.cdoc)
-    }
-
-    /// The high-level [`RemoteOp`](crate::RemoteOp)s describing how the CRDT changed
-    /// since the `before` heads (the surgical, cursor-preserving view of a remote
-    /// change). The session itself integrates via converged rebuild; this exposes the
-    /// op translation for callers that want to drive a finer-grained update.
-    pub fn remote_ops_since(&mut self, before: &[ChangeHash]) -> Result<Vec<crate::RemoteOp>> {
-        self.cdoc.remote_ops_since(before)
+    pub fn merge(&mut self, other: &CollabSession) -> Result<()> {
+        self.cdoc.merge_from(&other.cdoc)
     }
 
     /// The model document the CRDT currently projects to — the canonical converged

--- a/crates/rinch-editor-collab/src/sync.rs
+++ b/crates/rinch-editor-collab/src/sync.rs
@@ -5,48 +5,80 @@
 //! That is what collapses automerge's two separate transports (an incremental
 //! broadcast and a stateful sync protocol) into a single path:
 //!
-//! * **Broadcast** — [`CollabSession::save_incremental`](crate::CollabSession::save_incremental)
-//!   encodes everything produced since the last broadcast
-//!   ([`CollabDoc::diff_since`]) and every peer applies it.
+//! * **Broadcast** — a locally-projected transaction's own update is parked in the
+//!   outbox by the observer set up in [`CollabDoc`], and
+//!   [`CollabSession::save_incremental`](crate::CollabSession::save_incremental) drains
+//!   it. Constant-size per edit, and empty when there is nothing to send.
 //! * **Reconciliation** (a reconnect, an HTTP poll, a peer that was offline) — a peer
 //!   sends its [`state vector`](CollabDoc::state_vector), the other side answers with
-//!   `diff_since` that vector, and it is applied through the *same* entry point. No
-//!   per-peer protocol state is kept: the state vector is recomputed from the document,
-//!   which is exactly what a stateless server wants.
+//!   [`diff_since`](CollabDoc::diff_since) that vector, and the answer is applied through
+//!   the *same* entry point. No per-peer protocol state is kept: the state vector is
+//!   recomputed from the document, which is exactly what a stateless server wants.
+//!
+//! A state vector summarises *insertions* only, so it can say what a peer is missing but
+//! never that two peers agree — deletions are invisible to it. That asymmetry is safe
+//! because the *reply* to a state vector carries the whole delete set, so requesting a
+//! diff and applying it converges regardless; short-circuiting on state-vector equality
+//! does not.
 //!
 //! Updates are **idempotent** and order-insensitive, so re-sending an overlapping range
-//! is harmless — losing one is not, which is why reconciliation compares state vectors
-//! rather than trusting delivery.
+//! is harmless — losing one is not.
 //!
 //! Both leave the [`CollabDoc`] converged; turning the converged CRDT back into model
 //! [`Step`](rinch_editor_core::Step)s is [`crate::remote`]'s job.
 
 use yrs::updates::decoder::Decode;
-use yrs::{ReadTxn, StateVector, Transact, Update};
+use yrs::{Origin, ReadTxn, StateVector, Transact, Update, merge_updates_v1};
 
 use crate::error::Result;
-use crate::projection::CollabDoc;
+use crate::projection::{CollabDoc, REMOTE_ORIGIN};
 
 impl CollabDoc {
-    /// The CRDT's current state vector — "everything this replica has seen". Comparing
-    /// two of these is the convergence check (automerge's head frontier).
+    /// The CRDT's current state vector — the insertions this replica has seen. What to
+    /// send a peer so it can answer with [`Self::diff_since`]; **not** a convergence test
+    /// (see the module docs).
     pub fn state_vector(&self) -> StateVector {
         self.doc.transact().state_vector()
     }
 
-    /// Everything this replica has that a peer at `sv` does not — the delta to send,
-    /// whether that is a live broadcast or an offline reconciliation.
+    /// Everything this replica has that a peer at `sv` does not — the reconciliation
+    /// answer. Carries the complete delete set, so it repairs a missed deletion even
+    /// though `sv` could not describe one.
     pub fn diff_since(&self, sv: &StateVector) -> Vec<u8> {
         self.doc.transact().encode_diff_v1(sv)
     }
 
-    /// Apply a peer's update bytes, merging them into this CRDT. The single inbound
-    /// entry point: a broadcast delta, a reconciliation diff and a whole-document
-    /// snapshot are all the same encoding.
+    /// Apply a peer's update bytes, merging them into this CRDT. The single inbound entry
+    /// point: a broadcast delta, a reconciliation diff and a whole-document snapshot are
+    /// all the same encoding.
+    ///
+    /// The transaction is tagged `REMOTE_ORIGIN` so the update observer leaves it out of
+    /// the broadcast outbox — these bytes are already shared, and re-broadcasting them
+    /// would echo. Forwarding them to *other* peers is the transport's job.
     pub fn apply_update(&mut self, bytes: &[u8]) -> Result<()> {
         let update = Update::decode_v1(bytes)?;
-        self.doc.transact_mut().apply_update(update)?;
+        let mut txn = self.doc.transact_mut_with(Origin::from(REMOTE_ORIGIN));
+        txn.apply_update(update)?;
         Ok(())
+    }
+
+    /// Take everything the outbox has collected since the last drain, as one update.
+    ///
+    /// Empty when no locally-projected transaction has run since — unlike a
+    /// state-vector diff, which stays non-empty forever once anything has been deleted.
+    /// Several parked updates are combined with [`merge_updates_v1`] rather than
+    /// concatenated: concatenated updates are not a valid single update.
+    pub(crate) fn take_outbox(&mut self) -> Result<Vec<u8>> {
+        let mut parked = self.outbox.borrow_mut();
+        match parked.len() {
+            0 => Ok(Vec::new()),
+            1 => Ok(parked.drain(..).next().unwrap_or_default()),
+            _ => {
+                let merged = merge_updates_v1(parked.iter())?;
+                parked.clear();
+                Ok(merged)
+            }
+        }
     }
 
     /// Merge another peer's whole document into this one.

--- a/crates/rinch-editor-collab/src/sync.rs
+++ b/crates/rinch-editor-collab/src/sync.rs
@@ -1,70 +1,57 @@
-//! The Automerge sync transport, re-homed onto [`CollabDoc`].
+//! The yrs bytes transport, re-homed onto [`CollabDoc`].
 //!
-//! Salvaged from the old `rinch-editor` `sync.rs` (design §8: "the Automerge transport
-//! is salvaged"). Two transports are exposed:
+//! Everything a peer exchanges is one opaque `Vec<u8>` in the lib0 v1 encoding, and
+//! there is only **one** way to apply an inbound blob — [`CollabDoc::apply_update`].
+//! That is what collapses automerge's two separate transports (an incremental
+//! broadcast and a stateful sync protocol) into a single path:
 //!
-//! * **Full sync protocol** — [`generate_sync_message`](CollabDoc::generate_sync_message)
-//!   / [`receive_sync_message`](CollabDoc::receive_sync_message), with per-peer
-//!   [`SyncState`]. Deduplicating, state-negotiating; the right default for a live link.
-//! * **Incremental broadcast** — [`save_incremental`](CollabDoc::save_incremental) /
-//!   [`load_incremental`](CollabDoc::load_incremental). Simpler fan-out: save the delta
-//!   after a local edit, send to all peers, each applies it. No per-peer state.
+//! * **Broadcast** — [`CollabSession::save_incremental`](crate::CollabSession::save_incremental)
+//!   encodes everything produced since the last broadcast
+//!   ([`CollabDoc::diff_since`]) and every peer applies it.
+//! * **Reconciliation** (a reconnect, an HTTP poll, a peer that was offline) — a peer
+//!   sends its [`state vector`](CollabDoc::state_vector), the other side answers with
+//!   `diff_since` that vector, and it is applied through the *same* entry point. No
+//!   per-peer protocol state is kept: the state vector is recomputed from the document,
+//!   which is exactly what a stateless server wants.
+//!
+//! Updates are **idempotent** and order-insensitive, so re-sending an overlapping range
+//! is harmless — losing one is not, which is why reconciliation compares state vectors
+//! rather than trusting delivery.
 //!
 //! Both leave the [`CollabDoc`] converged; turning the converged CRDT back into model
 //! [`Step`](rinch_editor_core::Step)s is [`crate::remote`]'s job.
 
-pub use automerge::ChangeHash;
-pub use automerge::sync::Message as SyncMessage;
-pub use automerge::sync::State as SyncState;
-
-use automerge::Patch;
+use yrs::updates::decoder::Decode;
+use yrs::{ReadTxn, StateVector, Transact, Update};
 
 use crate::error::Result;
 use crate::projection::CollabDoc;
 
 impl CollabDoc {
-    /// Generate a sync message for a peer, or `None` if nothing new is pending.
-    pub fn generate_sync_message(&mut self, sync_state: &mut SyncState) -> Option<SyncMessage> {
-        use automerge::sync::SyncDoc;
-        self.doc.sync().generate_sync_message(sync_state)
+    /// The CRDT's current state vector — "everything this replica has seen". Comparing
+    /// two of these is the convergence check (automerge's head frontier).
+    pub fn state_vector(&self) -> StateVector {
+        self.doc.transact().state_vector()
     }
 
-    /// Receive a peer's sync message, merging its changes into this CRDT.
-    pub fn receive_sync_message(
-        &mut self,
-        sync_state: &mut SyncState,
-        message: SyncMessage,
-    ) -> Result<()> {
-        use automerge::sync::SyncDoc;
-        self.doc.sync().receive_sync_message(sync_state, message)?;
-        Ok(())
+    /// Everything this replica has that a peer at `sv` does not — the delta to send,
+    /// whether that is a live broadcast or an offline reconciliation.
+    pub fn diff_since(&self, sv: &StateVector) -> Vec<u8> {
+        self.doc.transact().encode_diff_v1(sv)
     }
 
-    /// The current heads (change frontier) of the CRDT.
-    pub fn get_heads(&mut self) -> Vec<ChangeHash> {
-        self.doc.get_heads()
-    }
-
-    /// Save only the changes since the last save (the broadcast primitive).
-    pub fn save_incremental(&mut self) -> Vec<u8> {
-        self.doc.save_incremental()
-    }
-
-    /// Apply a peer's broadcast delta, merging it into this CRDT.
-    pub fn load_incremental(&mut self, changes: &[u8]) -> Result<()> {
-        self.doc.load_incremental(changes)?;
+    /// Apply a peer's update bytes, merging them into this CRDT. The single inbound
+    /// entry point: a broadcast delta, a reconciliation diff and a whole-document
+    /// snapshot are all the same encoding.
+    pub fn apply_update(&mut self, bytes: &[u8]) -> Result<()> {
+        let update = Update::decode_v1(bytes)?;
+        self.doc.transact_mut().apply_update(update)?;
         Ok(())
     }
 
     /// Merge another peer's whole document into this one.
-    pub fn merge(&mut self, other: &mut CollabDoc) -> Result<()> {
-        self.doc.merge(&mut other.doc)?;
-        Ok(())
-    }
-
-    /// The diff (Automerge patches) between two head frontiers — the basis for
-    /// translating a remote change back into model steps ([`crate::remote`]).
-    pub(crate) fn diff(&mut self, before: &[ChangeHash], after: &[ChangeHash]) -> Vec<Patch> {
-        self.doc.diff(before, after)
+    pub fn merge_from(&mut self, other: &CollabDoc) -> Result<()> {
+        let missing = other.diff_since(&self.state_vector());
+        self.apply_update(&missing)
     }
 }

--- a/crates/rinch-editor-collab/src/sync.rs
+++ b/crates/rinch-editor-collab/src/sync.rs
@@ -31,7 +31,7 @@ use yrs::updates::decoder::Decode;
 use yrs::{Origin, ReadTxn, StateVector, Transact, Update, merge_updates_v1};
 
 use crate::error::Result;
-use crate::projection::{CollabDoc, REMOTE_ORIGIN};
+use crate::projection::{CollabDoc, ENGINE_APPLY_ORIGIN, lock_outbox};
 
 impl CollabDoc {
     /// The CRDT's current state vector — the insertions this replica has seen. What to
@@ -52,12 +52,14 @@ impl CollabDoc {
     /// point: a broadcast delta, a reconciliation diff and a whole-document snapshot are
     /// all the same encoding.
     ///
-    /// The transaction is tagged `REMOTE_ORIGIN` so the update observer leaves it out of
+    /// The transaction is tagged `ENGINE_APPLY_ORIGIN` so the update observer leaves it out of
     /// the broadcast outbox — these bytes are already shared, and re-broadcasting them
     /// would echo. Forwarding them to *other* peers is the transport's job.
     pub fn apply_update(&mut self, bytes: &[u8]) -> Result<()> {
         let update = Update::decode_v1(bytes)?;
-        let mut txn = self.doc.transact_mut_with(Origin::from(REMOTE_ORIGIN));
+        let mut txn = self
+            .doc
+            .transact_mut_with(Origin::from(ENGINE_APPLY_ORIGIN));
         txn.apply_update(update)?;
         Ok(())
     }
@@ -69,7 +71,7 @@ impl CollabDoc {
     /// Several parked updates are combined with [`merge_updates_v1`] rather than
     /// concatenated: concatenated updates are not a valid single update.
     pub(crate) fn take_outbox(&mut self) -> Result<Vec<u8>> {
-        let mut parked = self.outbox.borrow_mut();
+        let mut parked = lock_outbox(&self.outbox);
         match parked.len() {
             0 => Ok(Vec::new()),
             1 => Ok(parked.drain(..).next().unwrap_or_default()),

--- a/crates/rinch-editor-collab/tests/collab.rs
+++ b/crates/rinch-editor-collab/tests/collab.rs
@@ -338,7 +338,7 @@ fn incremental_broadcast_converges() {
     };
     a.type_at(6, " more");
     // broadcast delta from A to B
-    let delta = a.session.save_incremental();
+    let delta = a.session.save_incremental().expect("delta encodes");
     if let Some(ns) = b.session.integrate_incremental(&b.state, &delta).unwrap() {
         b.state = ns;
     }
@@ -709,6 +709,87 @@ fn unsupported_block_inside_a_list_item_fails_loud() {
     assert!(
         matches!(err, rinch_editor_collab::CollabError::Unsupported(_)),
         "an unsupported block nested in a list item must fail loud, got {err:?}"
+    );
+}
+
+#[test]
+fn a_delete_only_broadcast_delta_reaches_the_peer() {
+    // The session-layer twin of the handle-level deletion test. A state vector counts
+    // insertions, so a peer that only *deleted* leaves it unchanged — and yrs implements
+    // un-formatting by deleting format markers, so a mark removal is delete-only too.
+    // Any state-vector short-circuit in `save_incremental` or `integrate_incremental`
+    // drops these changes; this pins the broadcast path, where the sibling test pins the
+    // handle wiring and the fuzz suites pin it statistically.
+    let schema = Rc::new(Schema::starter_kit());
+    let (schema, mut a, mut b) = {
+        let _ = &schema;
+        two_peers(vec![para(&schema, "abcdef")])
+    };
+    // Drop whatever the initial projection queued; both peers already share it.
+    let _ = a.session.save_incremental().expect("drain");
+
+    let sv_before = a.session.state_vector();
+    a.local(|tr| {
+        tr.delete(3, 5).unwrap(); // remove "cd"
+    });
+    assert_eq!(
+        a.session.state_vector(),
+        sv_before,
+        "precondition: a delete-only edit leaves the state vector untouched"
+    );
+
+    let delta = a.session.save_incremental().expect("delta encodes");
+    assert!(
+        !delta.is_empty(),
+        "a delete-only edit must still produce something to broadcast"
+    );
+    if let Some(ns) = b
+        .session
+        .integrate_incremental(&b.state, &delta)
+        .expect("b integrates")
+    {
+        b.state = ns;
+    }
+    assert_converged(&a, &b, &schema);
+    assert!(
+        norm(&b.state.doc).contains("abef"),
+        "the deletion reached the peer: {}",
+        norm(&b.state.doc)
+    );
+}
+
+#[test]
+fn integrating_nothing_is_a_no_op_not_an_error() {
+    // `save_incremental` returns an empty Vec when there is nothing to send, and a
+    // reconciliation diff for an up-to-date peer encodes as the two-byte empty update.
+    // Neither decodes as an update, so both must be recognised rather than surfaced as a
+    // spurious decode error — a caller that forwards its own empty delta is not wrong.
+    let schema = Rc::new(Schema::starter_kit());
+    let (_schema, mut a, mut b) = {
+        let _ = &schema;
+        two_peers(vec![para(&schema, "steady")])
+    };
+    let before = norm(&b.state.doc);
+    for nothing in [Vec::new(), vec![0u8, 0u8]] {
+        assert!(
+            b.session
+                .integrate_incremental(&b.state, &nothing)
+                .expect("an empty update is a no-op, not an error")
+                .is_none(),
+            "nothing arrived, so nothing changed"
+        );
+    }
+    assert_eq!(norm(&b.state.doc), before, "the document is untouched");
+    // And an up-to-date peer's own reconciliation answer is exactly that empty update.
+    let self_diff = a
+        .session
+        .sync_diff(&a.session.state_vector())
+        .expect("self diff");
+    assert!(
+        a.session
+            .integrate_incremental(&a.state, &self_diff)
+            .expect("self diff integrates")
+            .is_none()
     );
 }
 

--- a/crates/rinch-editor-collab/tests/collab.rs
+++ b/crates/rinch-editor-collab/tests/collab.rs
@@ -8,7 +8,7 @@
 
 use std::rc::Rc;
 
-use rinch_editor_collab::{CollabPlugin, CollabSession, RemoteOp, rebase_steps};
+use rinch_editor_collab::{CollabPlugin, CollabSession, rebase_steps};
 use rinch_editor_core::{
     AttrValue, Attrs, EditorState, Fragment, Mark, Node, Plugin, Pos, Schema, Selection, Slice,
     Step, Transaction, default_plugins,
@@ -115,7 +115,7 @@ fn two_peers(blocks: Vec<Node>) -> (Rc<Schema>, Peer, Peer) {
     let schema = Rc::new(Schema::starter_kit());
     let a_state = EditorState::create(schema.clone(), doc_of(&schema, blocks), plugins());
     let session_a = CollabSession::new(&a_state).expect("session A");
-    let mut a = Peer {
+    let a = Peer {
         state: a_state,
         session: session_a,
     };
@@ -131,35 +131,51 @@ fn two_peers(blocks: Vec<Node>) -> (Rc<Schema>, Peer, Peer) {
     (schema, a, b)
 }
 
-/// Run the full Automerge sync protocol between two peers until convergence.
+/// Reconcile two peers by exchanging **state vectors** and the diffs they imply.
+///
+/// This replaces automerge's stateful sync-message ping-pong: each side says what it has
+/// (`state_vector`), the other answers with exactly what is missing (`sync_diff`), and
+/// that answer is applied through the ordinary `integrate_incremental` entry point —
+/// there is no per-peer protocol state to keep.
+///
+/// The exchange is unconditional: equal state vectors do **not** mean "already
+/// converged", because a state vector records insertions only and the peers may still
+/// differ by a deletion or a mark removal. Settling is therefore detected the honest way
+/// — both sides integrating without a document change — and failure to settle panics
+/// rather than quietly leaving the peers apart.
 fn sync(a: &mut Peer, b: &mut Peer) {
-    use rinch_editor_collab::SyncState;
-    let mut sa = SyncState::new();
-    let mut sb = SyncState::new();
-    for _ in 0..100 {
-        let ma = a.session.generate_sync_message(&mut sa);
-        let mb = b.session.generate_sync_message(&mut sb);
-        let done = ma.is_none() && mb.is_none();
-        if let Some(m) = ma
-            && let Some(ns) = b
-                .session
-                .integrate_sync_message(&b.state, &mut sb, m)
-                .expect("b integrate")
+    for _ in 0..8 {
+        let a_sv = a.session.state_vector();
+        let b_sv = b.session.state_vector();
+        let to_b = a.session.sync_diff(&b_sv).expect("diff for b");
+        let to_a = b.session.sync_diff(&a_sv).expect("diff for a");
+        let b_changed = match b
+            .session
+            .integrate_incremental(&b.state, &to_b)
+            .expect("b integrate")
         {
-            b.state = ns;
-        }
-        if let Some(m) = mb
-            && let Some(ns) = a
-                .session
-                .integrate_sync_message(&a.state, &mut sa, m)
-                .expect("a integrate")
+            Some(ns) => {
+                b.state = ns;
+                true
+            }
+            None => false,
+        };
+        let a_changed = match a
+            .session
+            .integrate_incremental(&a.state, &to_a)
+            .expect("a integrate")
         {
-            a.state = ns;
-        }
-        if done {
-            break;
+            Some(ns) => {
+                a.state = ns;
+                true
+            }
+            None => false,
+        };
+        if !a_changed && !b_changed {
+            return;
         }
     }
+    panic!("the state-vector exchange did not settle");
 }
 
 /// A canonical, mark-order-independent, run-coalesced string form of a flat doc, so
@@ -328,26 +344,6 @@ fn incremental_broadcast_converges() {
     }
     assert_converged(&a, &b, &schema);
     assert!(norm(&b.state.doc).contains("start more"));
-}
-
-#[test]
-fn remote_ops_translation_describes_a_remote_insert() {
-    // patches → RemoteOp translation (design: remote patches translated to steps).
-    let schema = Rc::new(Schema::starter_kit());
-    let (_schema, mut a, mut b) = {
-        let s = &schema;
-        two_peers(vec![para(s, "Hello")])
-    };
-    let before = b.session.heads();
-    a.type_at(6, " world"); // " world" at end
-    let delta = a.session.save_incremental();
-    b.session.integrate_incremental(&b.state, &delta).unwrap();
-    let ops = b.session.remote_ops_since(&before).unwrap();
-    assert!(
-        ops.iter()
-            .any(|o| matches!(o, RemoteOp::InsertText { text, .. } if text == " world")),
-        "expected an InsertText op for the remote insert, got {ops:?}"
-    );
 }
 
 #[test]
@@ -714,6 +710,114 @@ fn unsupported_block_inside_a_list_item_fails_loud() {
         matches!(err, rinch_editor_collab::CollabError::Unsupported(_)),
         "an unsupported block nested in a list item must fail loud, got {err:?}"
     );
+}
+
+// --- astral (non-BMP) offsets --------------------------------------------------
+//
+// The model indexes **chars** (Unicode scalars); yrs indexes **UTF-16 code units**. Every
+// index crossing into a block's text is converted, and getting it wrong is *silent*: yrs
+// snaps an index landing mid surrogate pair to the nearest boundary instead of erroring.
+// So each test below uses **two** astral characters — with only one, a conversion that
+// simply passes the char offset through still lands on a legal boundary and the test
+// would pass while the arithmetic was wrong.
+
+#[test]
+fn projection_round_trips_marks_across_astral_pairs() {
+    let schema = Rc::new(Schema::starter_kit());
+    let bold = Mark::simple(schema.mark_type("bold").unwrap().clone());
+
+    // chars 0:'a' 1:'🐱' 2:'b' 3:'🐶' 4:'c' — UTF-16 units 0..7, so a mark over chars
+    // 1..4 is UTF-16 1..6.
+    let spanning = schema
+        .create_node(
+            "paragraph",
+            Default::default(),
+            Fragment::from_children(vec![
+                schema.text("a").unwrap(),
+                schema
+                    .text_with_marks("🐱b🐶", vec![bold.clone()])
+                    .unwrap(),
+                schema.text("c").unwrap(),
+            ]),
+        )
+        .unwrap();
+
+    // The sharper case: mark ONLY the second astral char (chars 1..2 of "🐱🐶", i.e.
+    // UTF-16 2..4). Passing the char offsets straight through would ask for UTF-16 1..2,
+    // land inside the first surrogate pair, and get snapped onto the *first* cat — the
+    // round-trip would then come back with the wrong character marked.
+    let second_only = schema
+        .create_node(
+            "paragraph",
+            Default::default(),
+            Fragment::from_children(vec![
+                schema.text("🐱").unwrap(),
+                schema.text_with_marks("🐶", vec![bold]).unwrap(),
+            ]),
+        )
+        .unwrap();
+
+    let doc = doc_of(&schema, vec![spanning, second_only]);
+    let cdoc = rinch_editor_collab::CollabDoc::from_doc(&doc).unwrap();
+    let back = cdoc.to_doc(&schema).unwrap();
+    assert_eq!(norm(&doc), norm(&back));
+    assert_eq!(doc, back, "astral marks must round-trip byte-for-byte");
+}
+
+#[test]
+fn astral_inserts_and_deletes_keep_model_and_projection_in_step() {
+    let schema = Rc::new(Schema::starter_kit());
+    let (schema, mut a, _b) = {
+        let _ = &schema;
+        two_peers(vec![para(&schema, "🐱🐶")])
+    };
+    // Char positions: 1 = before 🐱, 2 = between the two, 3 = after 🐶.
+    let check = |a: &Peer, want: &str| {
+        let projected = a.session.projected_doc(&schema).unwrap();
+        assert_eq!(
+            norm(&a.state.doc),
+            norm(&projected),
+            "model ≡ project(model) across astral text"
+        );
+        assert!(
+            norm(&projected).contains(want),
+            "expected {want:?} in {}",
+            norm(&projected)
+        );
+    };
+
+    a.type_at(2, "X"); // insert *between* two surrogate pairs
+    check(&a, "🐱X🐶");
+    a.type_at(4, "🐭"); // insert an astral char after 🐶
+    check(&a, "🐱X🐶🐭");
+    a.local(|tr| {
+        tr.delete(1, 2).unwrap();
+    }); // delete the leading astral char
+    check(&a, "X🐶🐭");
+    a.bold(2, 4); // mark the two remaining astral chars
+    check(&a, "🐶🐭");
+    assert!(
+        norm(&a.state.doc).contains("bold["),
+        "the astral mark landed: {}",
+        norm(&a.state.doc)
+    );
+}
+
+#[test]
+fn concurrent_edits_around_astral_pairs_converge() {
+    let schema = Rc::new(Schema::starter_kit());
+    let (schema, mut a, mut b) = {
+        let _ = &schema;
+        two_peers(vec![para(&schema, "🐱🐶")])
+    };
+    a.type_at(2, "A"); // A types between the two surrogate pairs
+    b.bold(1, 3); // B marks both astral chars
+    sync(&mut a, &mut b);
+    assert_converged(&a, &b, &schema);
+    let t = norm(&a.session.projected_doc(&schema).unwrap());
+    assert!(t.contains('A'), "insert survived: {t}");
+    assert!(t.contains("bold["), "astral mark survived: {t}");
+    assert!(t.contains('🐱') && t.contains('🐶'), "text intact: {t}");
 }
 
 fn all_text(node: &Node) -> String {

--- a/crates/rinch-editor-collab/tests/collab.rs
+++ b/crates/rinch-editor-collab/tests/collab.rs
@@ -734,9 +734,7 @@ fn projection_round_trips_marks_across_astral_pairs() {
             Default::default(),
             Fragment::from_children(vec![
                 schema.text("a").unwrap(),
-                schema
-                    .text_with_marks("🐱b🐶", vec![bold.clone()])
-                    .unwrap(),
+                schema.text_with_marks("🐱b🐶", vec![bold.clone()]).unwrap(),
                 schema.text("c").unwrap(),
             ]),
         )

--- a/crates/rinch-editor-collab/tests/fuzz.rs
+++ b/crates/rinch-editor-collab/tests/fuzz.rs
@@ -234,7 +234,7 @@ fn fuzz_trial(seed: u64, peers: usize, rounds: usize) {
                 );
             }
             states[p] = next;
-            let delta = sessions[p].save_incremental();
+            let delta = sessions[p].save_incremental().expect("delta encodes");
             if !delta.is_empty() {
                 queue.push(delta);
             }

--- a/crates/rinch-editor-collab/tests/fuzz.rs
+++ b/crates/rinch-editor-collab/tests/fuzz.rs
@@ -191,7 +191,7 @@ fn fuzz_trial(seed: u64, peers: usize, rounds: usize) {
 
     // All peers start from peer 0's snapshot, so they share one CRDT lineage.
     let init = initial_state(&schema);
-    let mut host = CollabSession::new(&init).unwrap();
+    let host = CollabSession::new(&init).unwrap();
     let snapshot = host.snapshot();
 
     let mut states: Vec<EditorState> = Vec::with_capacity(peers);

--- a/crates/rinch-editor-core/Cargo.toml
+++ b/crates/rinch-editor-core/Cargo.toml
@@ -3,14 +3,14 @@ name = "rinch-editor-core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "Pure, renderer-agnostic core of the Rinch rich-text editor: document model, transforms (steps), schema, state, commands, history. No rinch-dom, winit, web_sys, parley, or automerge — wasm-clean."
+description = "Pure, renderer-agnostic core of the Rinch rich-text editor: document model, transforms (steps), schema, state, commands, history. No rinch-dom, winit, web_sys, parley, or CRDT engine — wasm-clean."
 
 [dependencies]
 thiserror.workspace = true
 # Input rules (M4): markdown-shortcut pattern matching. Pure Rust, wasm-clean.
 regex = "1"
 # Total, attr-aware serialization (M3). Both optional and wasm-clean.
-# NO automerge / rinch-dom / winit ever.
+# NO CRDT engine / rinch-dom / winit ever.
 serde = { version = "1", optional = true, features = ["derive"] }
 pulldown-cmark = { version = "0.12", optional = true, default-features = false }
 # Accessibility tree types (M7b). `accesskit` core is pure (only depends on uuid),

--- a/crates/rinch-editor-core/src/lib.rs
+++ b/crates/rinch-editor-core/src/lib.rs
@@ -5,7 +5,7 @@
 //! This crate is the single authoritative home of the editor's *document model*,
 //! *transform/step engine*, *schema*, *state*, *commands*, and *history*. It has
 //! **zero** dependency on `rinch-dom`, `winit`, `web_sys`, `parley`, `taffy`,
-//! `vello`, or `automerge`, and compiles cleanly to `wasm32`. Rendering and input
+//! `vello`, or a CRDT engine, and compiles cleanly to `wasm32`. Rendering and input
 //! live behind a `View` seam implemented by platform crates (desktop: `rinch`;
 //! web: `rinch-web`); collaboration is an optional, feature-gated adapter in
 //! `rinch-editor-collab`.

--- a/crates/rinch-editor-view/Cargo.toml
+++ b/crates/rinch-editor-view/Cargo.toml
@@ -8,8 +8,8 @@ description = "Renderer-agnostic rich-text editor view for Rinch: projects the p
 [dependencies]
 rinch-core = { workspace = true }
 rinch-editor-core = { workspace = true }
-# The Step↔Automerge collaboration adapter — opt-in, so default (desktop AND web)
-# builds link zero automerge. Enabled by the desktop `rinch`/`rinch-web` facades
+# The Step↔CRDT collaboration adapter (yrs) — opt-in, so default (desktop AND web)
+# builds link zero CRDT code. Enabled by the desktop `rinch`/`rinch-web` facades
 # only when their own `collaboration` feature is on.
 rinch-editor-collab = { workspace = true, optional = true }
 

--- a/crates/rinch-editor-view/src/handle.rs
+++ b/crates/rinch-editor-view/src/handle.rs
@@ -99,12 +99,13 @@ impl EditorCore {
             return;
         }
         match bridge.session.record_local(&prev.doc, &next.doc) {
-            Ok(()) => {
-                let delta = bridge.session.save_incremental();
-                if !delta.is_empty() {
-                    (bridge.outbound)(delta);
-                }
-            }
+            // An empty delta means the projection produced no CRDT change at all, so
+            // there is nothing for peers to apply.
+            Ok(()) => match bridge.session.save_incremental() {
+                Ok(delta) if !delta.is_empty() => (bridge.outbound)(delta),
+                Ok(_) => {}
+                Err(e) => bridge.last_error = Some(e),
+            },
             // Design A22 fail-loud: an edit outside the staged flat-text scope
             // (a table, a nested block) cannot be projected. Surface it rather than
             // silently diverging; apps should keep such edits out of a collab

--- a/crates/rinch-editor-view/src/handle.rs
+++ b/crates/rinch-editor-view/src/handle.rs
@@ -887,7 +887,7 @@ impl EditorHandle {
         outbound: impl Fn(Vec<u8>) + 'static,
     ) -> Result<Vec<u8>, CollabError> {
         let mut core = self.inner.borrow_mut();
-        let mut session = CollabSession::new(&core.state)?;
+        let session = CollabSession::new(&core.state)?;
         let snapshot = session.snapshot();
         core.collab = Some(CollabBridge::new(session, Box::new(outbound)));
         Ok(snapshot)
@@ -973,97 +973,60 @@ impl EditorHandle {
     /// peer: hand it to a new guest's [`Self::start_collaboration_guest`] so they
     /// adopt the current content (not just the host's original document). `None`
     /// when this editor isn't collaborating. Assumes a reliable, ordered delta
-    /// transport between existing peers; for lossy / out-of-order reconciliation use
-    /// the sync protocol ([`Self::collab_generate_sync_message`] /
-    /// [`Self::collab_receive_sync_message`]) instead.
+    /// transport between existing peers; for lossy / out-of-order reconciliation
+    /// exchange state vectors instead ([`Self::collab_state_vector`] /
+    /// [`Self::collab_sync_diff`]).
     pub fn collab_snapshot(&self) -> Option<Vec<u8>> {
         self.inner
-            .borrow_mut()
+            .borrow()
             .collab
-            .as_mut()
+            .as_ref()
             .map(|b| b.session.snapshot())
     }
 
-    /// Generate the next Automerge **sync-protocol** message for the peer tracked by
-    /// `sync_state`, or `None` when that peer is up to date (or this editor isn't
-    /// collaborating).
+    /// This editor's CRDT **state vector**: the opaque summary of what it has seen, to
+    /// hand a peer so the peer can answer with [`Self::collab_sync_diff`]. `None` when
+    /// this editor isn't collaborating.
     ///
-    /// This is the state-negotiating alternative to the incremental-delta broadcast
-    /// (`outbound` + [`Self::collab_receive`]). Prefer it when the transport is not a
-    /// reliable ordered stream — an HTTP poll, a reconnecting socket, a peer that was
-    /// offline — because it reconciles from each side's actual heads instead of
-    /// assuming every delta arrived exactly once.
+    /// Together with `collab_sync_diff` this is the reconciliation path, for transports
+    /// where the delta broadcast (`outbound` + [`Self::collab_receive`]) cannot be
+    /// trusted to deliver every message exactly once: an HTTP poll, a reconnecting
+    /// socket, a peer that was offline. A client sends its state vector, the server
+    /// replies with the diff plus its own state vector, the client applies that and
+    /// answers with the diff the server is missing — one round trip per direction, with
+    /// no per-peer protocol state to keep on either side.
     ///
-    /// The caller owns the [`SyncState`], one per peer. Generating a message mutates
-    /// protocol bookkeeping only; the document is untouched, so nothing needs saving
-    /// as a result of this call.
+    /// **Not a convergence test.** A state vector summarises *insertions*; deletions
+    /// (and mark removals, which the engine implements by deleting format markers) do
+    /// not appear in it, so two editors can hold different documents behind equal state
+    /// vectors. Its job is to *request* a diff — and the diff it gets back always
+    /// carries the deletions in full.
     ///
-    /// Uses `try_borrow_mut` and yields `None` if the handle is already borrowed, for
-    /// the same reason [`Self::collab_receive`] does.
-    pub fn collab_generate_sync_message(
-        &self,
-        sync_state: &mut rinch_editor_collab::SyncState,
-    ) -> Option<rinch_editor_collab::SyncMessage> {
+    /// Uses `try_borrow` and yields `None` if the handle is already borrowed, for the
+    /// same reason [`Self::collab_receive`] does.
+    pub fn collab_state_vector(&self) -> Option<Vec<u8>> {
+        let core = self.inner.try_borrow().ok()?;
+        core.collab.as_ref().map(|b| b.session.state_vector())
+    }
+
+    /// The update a peer whose state vector is `remote_state_vector` is missing — feed
+    /// it to that peer's [`Self::collab_receive`]. `None` when this editor isn't
+    /// collaborating, or when the bytes are not a decodable state vector (the error is
+    /// recorded and readable via [`Self::collab_take_error`]).
+    ///
+    /// This is a pure read of the CRDT: it broadcasts nothing and leaves both the
+    /// document and the broadcast watermark untouched, so a caller may answer any number
+    /// of peers without disturbing the live delta stream.
+    pub fn collab_sync_diff(&self, remote_state_vector: &[u8]) -> Option<Vec<u8>> {
         let mut core = self.inner.try_borrow_mut().ok()?;
-        core.collab
-            .as_mut()?
-            .session
-            .generate_sync_message(sync_state)
-    }
-
-    /// Integrate a peer's Automerge **sync-protocol** message: merge it into the CRDT,
-    /// rebuild the model from the *converged* CRDT, and re-project the view. Like
-    /// [`Self::collab_receive`], the change lands as a non-undoable, remote-origin
-    /// transaction and is **not** re-broadcast. Returns whether the document changed
-    /// (a message that only advances protocol state returns `false`).
-    ///
-    /// Must run on the main thread. A projection failure is recorded and readable via
-    /// [`Self::collab_take_error`].
-    pub fn collab_receive_sync_message(
-        &self,
-        sync_state: &mut rinch_editor_collab::SyncState,
-        message: rinch_editor_collab::SyncMessage,
-    ) -> bool {
-        let Ok(mut core) = self.inner.try_borrow_mut() else {
-            return false;
-        };
-        if core.collab.is_none() {
-            return false;
-        }
-        let prev = core.state.clone();
-        let result = core
-            .collab
-            .as_mut()
-            .unwrap()
-            .session
-            .integrate_sync_message(&prev, sync_state, message);
-        match result {
-            Ok(Some(next)) => {
-                core.state = next.clone();
-                if let Some(view) = core.view.as_mut() {
-                    view.update_dom(&prev, &next);
-                }
-                true
-            }
-            Ok(None) => false,
+        let bridge = core.collab.as_mut()?;
+        match bridge.session.sync_diff(remote_state_vector) {
+            Ok(diff) => Some(diff),
             Err(e) => {
-                if let Some(bridge) = core.collab.as_mut() {
-                    bridge.last_error = Some(e);
-                }
-                false
+                bridge.last_error = Some(e);
+                None
             }
         }
-    }
-
-    /// The CRDT's current heads (its change frontier), or `None` when this editor
-    /// isn't collaborating. Useful for persisting "what this peer had" alongside a
-    /// snapshot, and for diffing against a later frontier.
-    pub fn collab_heads(&self) -> Option<Vec<rinch_editor_collab::ChangeHash>> {
-        self.inner
-            .borrow_mut()
-            .collab
-            .as_mut()
-            .map(|b| b.session.heads())
     }
 
     /// Detach the collaboration session (stop projecting and broadcasting). The
@@ -2008,7 +1971,7 @@ mod tests {
                 host.collab_receive(&d);
             }
 
-            // Automerge convergence: identical documents on both peers.
+            // CRDT convergence: identical documents on both peers.
             let h = doc_text(&host);
             let g = doc_text(&guest);
             assert_eq!(h, g, "concurrent edits converge to one document");
@@ -2018,26 +1981,25 @@ mod tests {
             );
         }
 
-        /// Run the Automerge sync protocol between two handles until both go quiet,
-        /// each side keeping its own [`SyncState`] — the shape a networked caller uses.
+        /// Reconcile two handles by exchanging state vectors and the diffs they imply —
+        /// the shape a networked caller uses when it cannot trust delta delivery.
+        ///
+        /// The exchange is unconditional in both directions: equal state vectors would
+        /// not prove convergence (they summarise insertions only), so settling is
+        /// detected by both sides integrating without a document change.
         fn sync_until_quiet(a: &EditorHandle, b: &EditorHandle) {
-            use rinch_editor_collab::SyncState;
-            let mut a_state = SyncState::new();
-            let mut b_state = SyncState::new();
             for _ in 0..20 {
-                let a_to_b = a.collab_generate_sync_message(&mut a_state);
-                if let Some(m) = a_to_b.clone() {
-                    b.collab_receive_sync_message(&mut b_state, m);
-                }
-                let b_to_a = b.collab_generate_sync_message(&mut b_state);
-                if let Some(m) = b_to_a.clone() {
-                    a.collab_receive_sync_message(&mut a_state, m);
-                }
-                if a_to_b.is_none() && b_to_a.is_none() {
+                let a_sv = a.collab_state_vector().expect("a is collaborating");
+                let b_sv = b.collab_state_vector().expect("b is collaborating");
+                let to_b = a.collab_sync_diff(&b_sv).expect("diff for b");
+                let to_a = b.collab_sync_diff(&a_sv).expect("diff for a");
+                let b_changed = b.collab_receive(&to_b);
+                let a_changed = a.collab_receive(&to_a);
+                if !a_changed && !b_changed {
                     return;
                 }
             }
-            panic!("sync protocol did not settle");
+            panic!("the state-vector exchange did not settle");
         }
 
         #[test]
@@ -2046,9 +2008,9 @@ mod tests {
             let host = mount(doc_node(&s, vec![para(&s, "hello")])).handle;
             let guest = mount(doc_node(&s, vec![para(&s, "")])).handle;
 
-            // Deltas go nowhere: this models the transport the sync protocol exists
-            // for — an HTTP poll, a dropped socket, a peer that was offline. The
-            // broadcast path alone would leave these two permanently diverged.
+            // Deltas go nowhere: this models the transport reconciliation exists for —
+            // an HTTP poll, a dropped socket, a peer that was offline. The broadcast
+            // path alone would leave these two permanently diverged.
             let snapshot = host.start_collaboration_host(|_d| {}).unwrap();
             guest.start_collaboration_guest(&snapshot, |_d| {}).unwrap();
 
@@ -2065,38 +2027,36 @@ mod tests {
             sync_until_quiet(&host, &guest);
 
             let h = doc_text(&host);
-            assert_eq!(h, doc_text(&guest), "the sync protocol converged the peers");
+            assert_eq!(h, doc_text(&guest), "reconciliation converged the peers");
             assert!(
                 h.contains("world") && h.contains('G'),
                 "both offline edits survived: {h}"
             );
             assert_eq!(
-                host.collab_heads(),
-                guest.collab_heads(),
-                "converged peers share one change frontier"
+                host.collab_state_vector(),
+                guest.collab_state_vector(),
+                "converged peers have seen the same changes"
             );
         }
 
         #[test]
         fn sync_methods_are_inert_without_a_session() {
-            use rinch_editor_collab::SyncState;
             let s = schema();
             let solo = mount(doc_node(&s, vec![para(&s, "local only")])).handle;
-            let mut state = SyncState::new();
-            assert!(solo.collab_generate_sync_message(&mut state).is_none());
-            assert!(solo.collab_heads().is_none());
+            assert!(solo.collab_state_vector().is_none());
+            assert!(solo.collab_sync_diff(&[0]).is_none());
             assert_eq!(doc_text(&solo), "local only", "the document is untouched");
         }
 
         #[test]
-        fn integrating_a_sync_message_does_not_echo() {
+        fn integrating_a_reconciliation_diff_does_not_echo() {
             let s = schema();
             let host = mount(doc_node(&s, vec![para(&s, "ab")])).handle;
             let guest = mount(doc_node(&s, vec![para(&s, "")])).handle;
 
             let snapshot = host.start_collaboration_host(|_d| {}).unwrap();
-            // A sync-integrated change must not fire the broadcast sink either — a
-            // caller running both transports would otherwise loop.
+            // A change that arrives by reconciliation must not fire the broadcast sink
+            // either — a caller running both paths would otherwise loop.
             let guest_emits = Rc::new(Cell::new(0usize));
             let ge = guest_emits.clone();
             guest
@@ -2111,8 +2071,40 @@ mod tests {
             assert_eq!(
                 guest_emits.get(),
                 0,
-                "integrating a sync message must not broadcast a delta back"
+                "integrating a reconciliation diff must not broadcast a delta back"
             );
+        }
+
+        #[test]
+        fn reconciliation_carries_a_deletion_that_the_state_vector_cannot_express() {
+            // A state vector counts insertions, so a peer that only *deleted* leaves it
+            // unchanged. If any part of the path short-circuits on state-vector equality
+            // the deletion is silently lost — which is exactly the class of bug the fuzz
+            // suites caught during the engine swap, so it is pinned here at the handle
+            // level too.
+            let s = schema();
+            let host = mount(doc_node(&s, vec![para(&s, "abcdef")])).handle;
+            let guest = mount(doc_node(&s, vec![para(&s, "")])).handle;
+
+            let snapshot = host.start_collaboration_host(|_d| {}).unwrap();
+            guest.start_collaboration_guest(&snapshot, |_d| {}).unwrap();
+            assert_eq!(doc_text(&guest), "abcdef", "guest joined on the host's doc");
+
+            let sv_before = host.collab_state_vector().unwrap();
+            host.update(|st| {
+                let mut tr = st.tr();
+                tr.delete(3, 5).ok()?; // drop "cd"
+                Some(tr)
+            });
+            assert_eq!(doc_text(&host), "abef", "the host really deleted");
+            assert_eq!(
+                host.collab_state_vector().unwrap(),
+                sv_before,
+                "precondition: a delete-only change leaves the state vector untouched"
+            );
+
+            sync_until_quiet(&host, &guest);
+            assert_eq!(doc_text(&guest), "abef", "the deletion reached the guest");
         }
 
         #[test]

--- a/crates/rinch-editor-view/src/handle.rs
+++ b/crates/rinch-editor-view/src/handle.rs
@@ -883,6 +883,23 @@ impl EditorHandle {
     /// re-enter the *same* handle — forward the bytes to a transport/channel or to a
     /// *peer* handle ([`Self::collab_receive`] is borrow-soft, but the mutation
     /// methods are not).
+    ///
+    /// # The transport owns relaying
+    ///
+    /// `outbound` fires for this editor's **own** edits only. A delta that arrives through
+    /// [`Self::collab_receive`] is deliberately *not* re-broadcast — it is already in the
+    /// shared CRDT, and echoing it would loop between peers. So the adapter never relays
+    /// transitively, and the transport must be one of:
+    ///
+    /// * a **full mesh**, where every peer's `outbound` reaches every other peer; or
+    /// * a **hub**, where the server fans each received delta out to the other peers
+    ///   itself, forwarding the raw bytes (they need no re-encoding).
+    ///
+    /// A chain — A wired to B, B wired to C, with nothing joining A and C — silently
+    /// partitions: C never sees A's edits. It will not error; the two ends simply drift.
+    /// If a peer may fall behind for any reason, the repair is the reconciliation pair
+    /// ([`Self::collab_state_vector`] / [`Self::collab_sync_diff`]), which catches a peer
+    /// up from whatever it is missing.
     pub fn start_collaboration_host(
         &self,
         outbound: impl Fn(Vec<u8>) + 'static,
@@ -900,6 +917,11 @@ impl EditorHandle {
     /// same content. `outbound` carries this guest's local deltas back to peers.
     /// Returns a [`CollabError`] if the snapshot is unreadable or its content is
     /// outside the staged scope.
+    ///
+    /// As on the host, `outbound` fires for this editor's own edits only — an integrated
+    /// remote delta is never re-broadcast, so the transport must mesh the peers or fan out
+    /// received deltas itself. See "The transport owns relaying" on
+    /// [`Self::start_collaboration_host`].
     pub fn start_collaboration_guest(
         &self,
         snapshot: &[u8],

--- a/crates/rinch-editor-view/src/lib.rs
+++ b/crates/rinch-editor-view/src/lib.rs
@@ -34,11 +34,10 @@ pub use registry::{
 /// the [`EditorHandle`] collaboration methods.
 #[cfg(feature = "collaboration")]
 pub use rinch_editor_collab::CollabError;
-/// Automerge sync-protocol types (re-exported from `rinch-editor-collab`), so a caller
-/// driving [`EditorHandle::collab_generate_sync_message`] /
-/// [`EditorHandle::collab_receive_sync_message`] needs no direct `automerge` dependency.
-#[cfg(feature = "collaboration")]
-pub use rinch_editor_collab::{ChangeHash, SyncMessage, SyncState};
+// Reconciliation ([`EditorHandle::collab_state_vector`] /
+// [`EditorHandle::collab_sync_diff`]) needs no re-exported engine types: a state vector
+// and a diff are both opaque `Vec<u8>`, and a diff is applied through the same
+// [`EditorHandle::collab_receive`] as a broadcast delta.
 pub use view::RinchDomEditorView;
 
 use std::rc::Rc;

--- a/crates/rinch-storage/Cargo.toml
+++ b/crates/rinch-storage/Cargo.toml
@@ -28,7 +28,7 @@ web-sys = { version = "0.3", features = [
 
 # Native-only test deps. Deliberately just `tempfile`: a key/blob store persists
 # opaque bytes, so its tests must not depend on any particular consumer's payload
-# format. (`rinch-editor-collab` is the workspace's only automerge link.)
+# format. (`rinch-editor-collab` is the workspace's only CRDT-engine link.)
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tempfile = "3"
 

--- a/crates/rinch-web/Cargo.toml
+++ b/crates/rinch-web/Cargo.toml
@@ -24,7 +24,7 @@ rinch-editor-core = { workspace = true }
 # The renderer-agnostic rich-text editor (RinchDomEditorView/EditorHandle/Editor),
 # shared with the desktop editor. It projects onto WebDocument's DomDocument impl, so
 # the browser editor is the *same* model-first view — no contentEditable. Default
-# features only (collaboration is opt-in and links automerge; off here).
+# features only (collaboration is opt-in and links a CRDT engine; off here).
 rinch-editor-view = { workspace = true }
 
 # WASM bindings
@@ -58,8 +58,8 @@ wasm-bindgen-test = "0.3"
 
 [features]
 # Collaborative editing (M9): forwards to the editor view's collab adapter, which
-# is the only thing that links Automerge. Off by default, so a default web build
-# links zero automerge. A wasm app enabling this must also supply a randomness
-# source for the transitive automerge → uuid → getrandom (the getrandom 0.3
-# `wasm_js` backend) — see `examples/collab-editor-web`.
+# is the only thing that links a CRDT engine (yrs). Off by default, so a default web
+# build links zero CRDT code. Nothing else is required of a wasm app enabling it: yrs
+# carries `fastrand/js` itself and builds for wasm32 with no feature shims — see
+# `examples/collab-editor-web`.
 collaboration = ["rinch-editor-view/collaboration"]

--- a/crates/rinch-web/src/lib.rs
+++ b/crates/rinch-web/src/lib.rs
@@ -66,11 +66,9 @@ pub use rinch_editor_view::{Editor, EditorHandle, create_editor};
 // (that is the desktop runtime's off-thread marshaller).
 #[cfg(feature = "collaboration")]
 pub use rinch_editor_view::{CollabError, collab_receive_for};
-// The Automerge sync-protocol types, for a caller driving
-// `EditorHandle::collab_generate_sync_message` / `collab_receive_sync_message` (the
-// reconciling alternative to delta broadcast, for poll/reconnect transports).
-#[cfg(feature = "collaboration")]
-pub use rinch_editor_view::{ChangeHash, SyncMessage, SyncState};
+// Reconciliation for poll/reconnect transports (`EditorHandle::collab_state_vector` /
+// `collab_sync_diff`) needs no extra imports: state vectors and diffs are opaque
+// `Vec<u8>`, and a diff is applied through the same `collab_receive` as a delta.
 
 // ============================================================================
 // Mounted-root registry + per-page guards

--- a/crates/rinch/Cargo.toml
+++ b/crates/rinch/Cargo.toml
@@ -59,8 +59,8 @@ rinch-editor-core = { workspace = true, optional = true }
 # component, the registry, the caret-blink clock) — shared with the web editor
 # (rinch-web). This crate's `editor` module re-exports it and adds the desktop-only
 # pieces (Parley block virtualization, AccessKit a11y, the winit caret-blink driver).
-# `collaboration` forwards to this crate, which holds the only first-party automerge
-# link — so default builds (desktop AND web) link zero automerge.
+# `collaboration` forwards to this crate, which holds the only first-party CRDT link
+# — so default builds (desktop AND web) link zero CRDT code.
 rinch-editor-view = { workspace = true, optional = true }
 rinch-video = { workspace = true, optional = true }
 # HTTP client for the network image loader (image-network). Standalone, opt-in:
@@ -178,12 +178,11 @@ image-network = ["dep:rinch-http"]
 a11y = ["desktop", "rinch-editor-core/a11y", "dep:accesskit", "dep:accesskit_unix"]
 # Derive serde on the editor's durable wire shape (DocNode / BlockData).
 serde = ["rinch-editor-core/serde"]
-# Collaborative editing (M9): the Step↔Automerge adapter, wired into `EditorHandle`
-# inside rinch-editor-view. The ONLY thing in the workspace that links automerge —
+# Collaborative editing (M9): the Step↔CRDT adapter (yrs), wired into `EditorHandle`
+# inside rinch-editor-view. The ONLY thing in the workspace that links a CRDT engine —
 # opt-in, so it stays out of every default build (desktop AND web). Implies `desktop`
 # (the editor wiring is a desktop feature); forwards to the shared view crate, which is
-# wasm-compatible, so the web view reuses the SAME adapter (the web app supplies a wasm
-# randomness source for automerge→uuid).
+# wasm-compatible with no shims, so the web view reuses the SAME adapter.
 collaboration = ["desktop", "rinch-editor-view/collaboration"]
 
 # Probe app for the ignored e2e test tests/debug_event_latency.rs (issue #153).

--- a/crates/rinch/src/lib.rs
+++ b/crates/rinch/src/lib.rs
@@ -180,10 +180,9 @@ pub mod prelude {
     #[cfg(feature = "collaboration")]
     pub use crate::editor::{CollabError, collab_receive_for, post_remote_delta};
 
-    // The Automerge sync-protocol types, for a caller driving
-    // `EditorHandle::collab_generate_sync_message` / `collab_receive_sync_message`.
-    #[cfg(feature = "collaboration")]
-    pub use crate::editor::{ChangeHash, SyncMessage, SyncState};
+    // Reconciliation for poll/reconnect transports (`EditorHandle::collab_state_vector`
+    // / `collab_sync_diff`) needs no extra imports: state vectors and diffs are opaque
+    // `Vec<u8>`, and a diff is applied through the same `collab_receive` as a delta.
 
     // Desktop-only GPU types for render surfaces
     #[cfg(feature = "gpu")]

--- a/examples/collab-editor-demo/src/main.rs
+++ b/examples/collab-editor-demo/src/main.rs
@@ -1,5 +1,5 @@
 //! Live collaborative editing demo (M9). Two **independent** `EditorHandle`s share
-//! one document through the `rinch-editor-collab` Step↔Automerge adapter.
+//! one document through the `rinch-editor-collab` Step↔CRDT (yrs) adapter.
 //!
 //! There is no network here — the two editors are wired into a synchronous,
 //! in-process **loopback**: each side's outbound delta is delivered straight to the
@@ -35,7 +35,7 @@ fn app() -> NodeHandle {
                 h2 { style: "margin: 0 0 4px; color: #1f2328;", "Collaborative editing" }
                 p {
                     style: "margin: 0; color: #57606a; font-size: 14px;",
-                    "Two independent editors sharing one Automerge CRDT. Click into either pane and type — the edit converges in the other."
+                    "Two independent editors sharing one yrs CRDT. Click into either pane and type — the edit converges in the other."
                 }
             }
             div {

--- a/examples/collab-editor-web/Cargo.lock
+++ b/examples/collab-editor-web/Cargo.lock
@@ -18,26 +18,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "automerge"
-version = "0.5.12"
+name = "arc-swap"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0dae93622d3c6850d196503480004576249e0e391bddb3f54600974d92a790"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
- "cfg-if",
- "flate2",
- "fxhash",
- "hex",
- "im",
- "itertools",
- "leb128",
- "serde",
- "sha2",
- "smol_str",
- "thiserror",
- "tinyvec",
- "tracing",
- "unicode-segmentation",
- "uuid",
+ "rustversion",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -47,34 +55,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bitmaps"
-version = "2.1.0"
+name = "bitflags"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -109,7 +99,6 @@ dependencies = [
  "rinch-core",
  "rinch-editor-core",
  "rinch-web",
- "uuid",
  "wasm-bindgen",
 ]
 
@@ -134,15 +123,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,30 +132,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-common"
-version = "0.1.7"
+name = "crossbeam-utils"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
- "generic-array",
- "typenum",
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.7"
+name = "event-listener"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
-name = "either"
-version = "1.16.0"
+name = "event-listener-strategy"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+dependencies = [
+ "getrandom 0.4.3",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -218,25 +221,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,21 +238,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
+ "wasm-bindgen",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -285,29 +271,6 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "im"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
-dependencies = [
- "bitmaps",
- "rand_core",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itoa"
@@ -327,16 +290,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -365,6 +331,25 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -403,18 +388,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "rand_core"
-version = "0.6.4"
+name = "redox_syscall"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "rand_core",
+ "bitflags",
 ]
 
 [[package]]
@@ -476,18 +455,18 @@ dependencies = [
 name = "rinch-core"
 version = "0.1.0"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "rinch-editor-collab"
 version = "0.1.0"
 dependencies = [
- "automerge",
  "rinch-editor-core",
- "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
+ "yrs",
 ]
 
 [[package]]
@@ -495,7 +474,7 @@ name = "rinch-editor-core"
 version = "0.1.0"
 dependencies = [
  "regex",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -513,7 +492,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -607,6 +586,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,7 +618,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -650,17 +635,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,29 +647,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "smol_str"
-version = "0.2.2"
+name = "smallstr"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+checksum = "862077b1e764f04c251fe82a2ef562fd78d7cadaeb072ca7c2bcaf7217b1ff3b"
 dependencies = [
- "serde",
+ "smallvec",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "subtle"
@@ -715,12 +685,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -731,23 +721,19 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.11.0"
+name = "thiserror-impl"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
- "tinyvec_macros",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tracing"
@@ -768,7 +754,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -781,22 +767,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "untrusted"
@@ -840,24 +814,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
-name = "uuid"
-version = "1.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
-dependencies = [
- "getrandom 0.4.3",
- "js-sys",
- "serde_core",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,7 +851,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -936,6 +892,12 @@ checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -1018,6 +980,24 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "yrs"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d3a728b1abffeca5b9e5319c5b81e04b73790cbdc1e342da8d91b440b3026cb"
+dependencies = [
+ "arc-swap",
+ "async-lock",
+ "async-trait",
+ "dashmap",
+ "fastrand",
+ "serde",
+ "serde_json",
+ "smallstr",
+ "smallvec",
+ "thiserror 2.0.20",
+]
 
 [[package]]
 name = "zeroize"

--- a/examples/collab-editor-web/Cargo.toml
+++ b/examples/collab-editor-web/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 publish = false
-description = "Web collaborative rich-text editor demo: two editors sharing one Automerge CRDT in the browser (the same M9 adapter as desktop), in-process loopback, no contenteditable"
+description = "Web collaborative rich-text editor demo: two editors sharing one yrs CRDT in the browser (the same M9 adapter as desktop), in-process loopback, no contenteditable"
 
 [dependencies]
 # Rinch without desktop + the browser-native DOM backend with collaboration on (which
-# pulls in the rinch-editor-collab Automerge adapter — the same one desktop uses).
+# pulls in the rinch-editor-collab yrs adapter — the same one desktop uses).
 rinch = { path = "../../crates/rinch", default-features = false, features = ["components", "theme"] }
 rinch-core = { path = "../../crates/rinch-core", features = ["theme"] }
 rinch-web = { path = "../../crates/rinch-web", features = ["collaboration"] }
@@ -21,10 +21,9 @@ console_error_panic_hook = "0.1"
 console_log = "0.2"
 log = "0.4"
 
-# Browser randomness for the transitive automerge → uuid. `uuid`'s `js` feature wires
-# its wasm randomness to the Web Crypto API so Automerge can mint actor ids; without a
-# randomness feature `uuid` refuses to compile on wasm32-unknown-unknown.
-uuid = { version = "1", features = ["js"] }
+# No randomness shim: yrs carries `fastrand/js` itself and builds for
+# wasm32-unknown-unknown with no features, so nothing here has to wire up Web Crypto.
+# (Under automerge this app needed `uuid = { features = ["js"] }` to compile at all.)
 
 [profile.dev]
 opt-level = 1

--- a/examples/collab-editor-web/src/main.rs
+++ b/examples/collab-editor-web/src/main.rs
@@ -1,9 +1,9 @@
 //! Web collaborative rich-text editor demo for `rinch-web`.
 //!
 //! Two independent [`EditorHandle`]s share one document through the **same**
-//! `rinch-editor-collab` Step↔Automerge adapter the desktop uses — now running in the
-//! browser (Automerge compiled to wasm; randomness via the Web Crypto API, wired in
-//! `Cargo.toml` + `.cargo/config.toml`). The default web build links zero automerge;
+//! `rinch-editor-collab` Step↔CRDT adapter the desktop uses — now running in the
+//! browser (yrs compiled to wasm, with no randomness shim to wire up: it carries
+//! `fastrand/js` itself). The default web build links zero CRDT code;
 //! it is pulled in only by `rinch-web`'s `collaboration` feature.
 //!
 //! There is no network here — the two editors are wired into a synchronous, in-process
@@ -44,7 +44,7 @@ fn app() -> NodeHandle {
                 p {
                     id: "subtitle",
                     style: "margin: 0; color: #57606a; font-size: 14px;",
-                    "Two editors sharing one Automerge CRDT in the browser — the same adapter desktop uses. Click into either pane and type; the edit converges in the other."
+                    "Two editors sharing one yrs CRDT in the browser — the same adapter desktop uses. Click into either pane and type; the edit converges in the other."
                 }
             }
             div {

--- a/examples/events-web/Cargo.lock
+++ b/examples/events-web/Cargo.lock
@@ -18,197 +18,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-activity"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
-dependencies = [
- "android-properties",
- "bitflags 2.13.0",
- "cc",
- "jni 0.22.4",
- "libc",
- "log",
- "ndk",
- "ndk-context",
- "ndk-sys",
- "num_enum",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "android-properties"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "arboard"
-version = "3.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
-dependencies = [
- "clipboard-win",
- "image",
- "log",
- "objc2",
- "objc2-app-kit",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-foundation",
- "parking_lot",
- "percent-encoding",
- "windows-sys 0.60.2",
- "x11rb",
-]
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "ash"
-version = "0.38.0+1.3.281"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
-dependencies = [
- "libloading",
-]
-
-[[package]]
-name = "autocfg"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
-name = "automerge"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0dae93622d3c6850d196503480004576249e0e391bddb3f54600974d92a790"
-dependencies = [
- "cfg-if",
- "flate2",
- "fxhash",
- "hex",
- "im",
- "itertools",
- "leb128",
- "serde",
- "sha2",
- "smol_str",
- "thiserror 1.0.69",
- "tinyvec",
- "tracing",
- "unicode-segmentation",
- "uuid",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
-
-[[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
-
-[[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "byteorder-lite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -223,64 +42,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "clipboard-win"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
-dependencies = [
- "error-code",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
-dependencies = [
- "serde",
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
-name = "color"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ec7c5eb7a16992b1904d76c517d170ab353b0e0b3d5a0c81a8a0cd1037893cf"
-
-[[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
 
 [[package]]
 name = "console_error_panic_hook"
@@ -303,130 +72,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core-graphics-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
-dependencies = [
- "bitflags 2.13.0",
- "core-foundation",
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
-
-[[package]]
-name = "dispatch2"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
-dependencies = [
- "bitflags 2.13.0",
- "objc2",
-]
-
-[[package]]
-name = "document-features"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
-]
-
-[[package]]
-name = "either"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
-
-[[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "error-code"
-version = "3.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
-
-[[package]]
-name = "euclid"
-version = "0.22.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -440,21 +91,6 @@ dependencies = [
  "rinch-core",
  "rinch-web",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "fax"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
-
-[[package]]
-name = "fdeflate"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
-dependencies = [
- "simd-adler32",
 ]
 
 [[package]]
@@ -474,69 +110,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "font-types"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
-
-[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-intrusive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
-dependencies = [
- "futures-core",
- "lock_api",
- "parking_lot",
-]
 
 [[package]]
 name = "futures-task"
@@ -557,225 +134,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
-name = "gethostname"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
-dependencies = [
- "rustix",
- "windows-link",
-]
-
-[[package]]
-name = "getopts"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
-
-[[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
-]
-
-[[package]]
-name = "gl_generator"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
-dependencies = [
- "khronos_api",
- "log",
- "xml-rs",
-]
-
-[[package]]
-name = "glow"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
-dependencies = [
- "js-sys",
- "slotmap",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "glutin_wgl_sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
-dependencies = [
- "gl_generator",
-]
-
-[[package]]
-name = "gpu-alloc"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
-dependencies = [
- "bitflags 2.13.0",
- "gpu-alloc-types",
-]
-
-[[package]]
-name = "gpu-alloc-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
-dependencies = [
- "bitflags 2.13.0",
-]
-
-[[package]]
-name = "gpu-allocator"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
-dependencies = [
- "log",
- "presser",
- "thiserror 1.0.69",
- "windows",
-]
-
-[[package]]
-name = "gpu-descriptor"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
-dependencies = [
- "bitflags 2.13.0",
- "gpu-descriptor-types",
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "gpu-descriptor-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
-dependencies = [
- "bitflags 2.13.0",
-]
-
-[[package]]
-name = "guillotiere"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62d5865c036cb1393e23c50693df631d3f5d7bcca4c04fe4cc0fd592e74a782"
-dependencies = [
- "euclid",
- "svg_fmt",
-]
-
-[[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "num-traits",
- "zerocopy",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "foldhash 0.2.0",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hexf-parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "http"
@@ -794,141 +167,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "im"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
-dependencies = [
- "bitmaps",
- "rand_core",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
-]
-
-[[package]]
-name = "image"
-version = "0.25.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
-dependencies = [
- "bytemuck",
- "byteorder-lite",
- "moxcms",
- "num-traits",
- "png 0.18.1",
- "tiff",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
-dependencies = [
- "equivalent",
- "hashbrown 0.17.1",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys 0.3.1",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
-dependencies = [
- "cfg-if",
- "combine",
- "jni-macros",
- "jni-sys 0.4.1",
- "log",
- "simd_cesu8",
- "thiserror 2.0.18",
- "walkdir",
- "windows-link",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
-dependencies = [
- "jni-sys 0.4.1",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -942,88 +184,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "khronos-egl"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
-dependencies = [
- "libc",
- "libloading",
- "pkg-config",
-]
-
-[[package]]
-name = "khronos_api"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
-
-[[package]]
-name = "kurbo"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
-dependencies = [
- "arrayvec",
- "euclid",
- "polycool",
- "smallvec",
-]
-
-[[package]]
-name = "leb128"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "linebender_resource_handle"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -1032,34 +196,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
-
-[[package]]
-name = "metal"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
-dependencies = [
- "bitflags 2.13.0",
- "block",
- "core-graphics-types",
- "foreign-types",
- "log",
- "objc",
- "paste",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -1072,239 +212,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "moxcms"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
-dependencies = [
- "num-traits",
- "pxfm",
-]
-
-[[package]]
-name = "naga"
-version = "27.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
-dependencies = [
- "arrayvec",
- "bit-set",
- "bitflags 2.13.0",
- "cfg-if",
- "cfg_aliases",
- "codespan-reporting",
- "half",
- "hashbrown 0.16.1",
- "hexf-parse",
- "indexmap",
- "libm",
- "log",
- "num-traits",
- "once_cell",
- "rustc-hash",
- "spirv",
- "thiserror 2.0.18",
- "unicode-ident",
-]
-
-[[package]]
-name = "ndk"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
-dependencies = [
- "bitflags 2.13.0",
- "jni-sys 0.3.1",
- "log",
- "ndk-sys",
- "num_enum",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
-name = "ndk-sys"
-version = "0.6.0+11769913"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
-dependencies = [
- "jni-sys 0.3.1",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
- "libm",
-]
-
-[[package]]
-name = "num_enum"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
-dependencies = [
- "num_enum_derive",
- "rustversion",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
-]
-
-[[package]]
-name = "objc2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
-dependencies = [
- "objc2-encode",
-]
-
-[[package]]
-name = "objc2-app-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
-dependencies = [
- "bitflags 2.13.0",
- "objc2",
- "objc2-core-graphics",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags 2.13.0",
- "dispatch2",
- "objc2",
-]
-
-[[package]]
-name = "objc2-core-graphics"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
-dependencies = [
- "bitflags 2.13.0",
- "dispatch2",
- "objc2",
- "objc2-core-foundation",
- "objc2-io-surface",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
-name = "objc2-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
-dependencies = [
- "bitflags 2.13.0",
- "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-io-surface"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
-dependencies = [
- "bitflags 2.13.0",
- "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "ordered-float"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "peniko"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c8299360d2e998bdb106dc0a6cd71dcc5f4df51df1b620361bf50e283cca6"
-dependencies = [
- "color",
- "kurbo",
- "linebender_resource_handle",
- "smallvec",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -1319,77 +230,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "png"
-version = "0.17.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
-
-[[package]]
-name = "png"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
-dependencies = [
- "bitflags 2.13.0",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
-
-[[package]]
-name = "polycool"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
-name = "presser"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1399,107 +239,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "profiling"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
-dependencies = [
- "bitflags 2.13.0",
- "getopts",
- "memchr",
- "pulldown-cmark-escape",
- "unicase",
-]
-
-[[package]]
-name = "pulldown-cmark-escape"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
-
-[[package]]
-name = "pxfm"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "range-alloc"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
-
-[[package]]
-name = "raw-window-handle"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
-
-[[package]]
-name = "read-fonts"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
-dependencies = [
- "bytemuck",
- "font-types",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1532,19 +277,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
-name = "renderdoc-sys"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
-
-[[package]]
 name = "rinch"
 version = "0.1.0"
 dependencies = [
  "js-sys",
  "rinch-components",
  "rinch-core",
- "rinch-editor",
  "rinch-macros",
  "rinch-platform",
  "rinch-theme",
@@ -1552,28 +290,6 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rinch-android"
-version = "0.1.0"
-dependencies = [
- "android-activity",
- "jni 0.21.1",
- "log",
- "ndk-context",
-]
-
-[[package]]
-name = "rinch-clipboard"
-version = "0.1.0"
-dependencies = [
- "arboard",
- "js-sys",
- "rinch-android",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -1590,38 +306,25 @@ dependencies = [
 name = "rinch-core"
 version = "0.1.0"
 dependencies = [
- "thiserror 1.0.69",
+ "thiserror",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
-name = "rinch-editable"
-version = "0.1.0"
-
-[[package]]
-name = "rinch-editor"
+name = "rinch-editor-core"
 version = "0.1.0"
 dependencies = [
- "automerge",
- "getrandom 0.2.17",
- "pulldown-cmark",
  "regex",
- "rinch-clipboard",
- "rinch-core",
- "rinch-editable",
- "rinch-editor-macros",
- "thiserror 1.0.69",
- "tracing",
- "uuid",
+ "thiserror",
 ]
 
 [[package]]
-name = "rinch-editor-macros"
+name = "rinch-editor-view"
 version = "0.1.0"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "rinch-core",
+ "rinch-editor-core",
 ]
 
 [[package]]
@@ -1637,8 +340,6 @@ dependencies = [
 name = "rinch-platform"
 version = "0.1.0"
 dependencies = [
- "peniko",
- "vello",
  "web-time",
 ]
 
@@ -1664,6 +365,8 @@ dependencies = [
  "js-sys",
  "rinch",
  "rinch-core",
+ "rinch-editor-core",
+ "rinch-editor-view",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -1676,38 +379,10 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.17",
+ "getrandom",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags 2.13.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1752,34 +427,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
- "serde_derive",
 ]
 
 [[package]]
@@ -1816,17 +469,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1839,97 +481,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "simd_cesu8"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
-
-[[package]]
-name = "skrifa"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
-dependencies = [
- "bytemuck",
- "read-fonts",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "slotmap"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
-dependencies = [
- "version_check",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
-
-[[package]]
-name = "smol_str"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "spirv"
-version = "0.3.0+sdk-1.3.268.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
-dependencies = [
- "bitflags 2.13.0",
-]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "svg_fmt"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
 
 [[package]]
 name = "syn"
@@ -1943,30 +504,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1978,76 +521,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tiff"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
-dependencies = [
- "fax",
- "flate2",
- "half",
- "quick-error",
- "weezl",
- "zune-jpeg",
-]
-
-[[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "toml_parser",
- "winnow",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
-dependencies = [
- "winnow",
 ]
 
 [[package]]
@@ -2082,34 +555,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
-name = "unicase"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "untrusted"
@@ -2153,92 +602,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
-name = "uuid"
-version = "1.23.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
-dependencies = [
- "getrandom 0.4.3",
- "js-sys",
- "serde_core",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "vello"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72fef40773530322d5c2ffe3c1107e9874bd8239ac137d1c2b6c1edad695146e"
-dependencies = [
- "bytemuck",
- "futures-intrusive",
- "log",
- "peniko",
- "png 0.17.16",
- "skrifa",
- "static_assertions",
- "thiserror 2.0.18",
- "vello_encoding",
- "vello_shaders",
- "wgpu",
-]
-
-[[package]]
-name = "vello_encoding"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c91203ec4b483440614a9a5c7c2d991932af72c5349659a63ec49476f0b79c"
-dependencies = [
- "bytemuck",
- "guillotiere",
- "peniko",
- "skrifa",
- "smallvec",
-]
-
-[[package]]
-name = "vello_shaders"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a765d44d4bd354146e44f9a860f4e92effd91a97302549be9e47f0a18d8128c"
-dependencies = [
- "bytemuck",
- "log",
- "naga",
- "thiserror 2.0.18",
- "vello_encoding",
-]
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2251,16 +618,6 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2325,257 +682,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "weezl"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
-
-[[package]]
-name = "wgpu"
-version = "27.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
-dependencies = [
- "arrayvec",
- "bitflags 2.13.0",
- "cfg-if",
- "cfg_aliases",
- "document-features",
- "hashbrown 0.16.1",
- "js-sys",
- "log",
- "naga",
- "parking_lot",
- "portable-atomic",
- "profiling",
- "raw-window-handle",
- "smallvec",
- "static_assertions",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "wgpu-core",
- "wgpu-hal",
- "wgpu-types",
-]
-
-[[package]]
-name = "wgpu-core"
-version = "27.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
-dependencies = [
- "arrayvec",
- "bit-set",
- "bit-vec",
- "bitflags 2.13.0",
- "bytemuck",
- "cfg_aliases",
- "document-features",
- "hashbrown 0.16.1",
- "indexmap",
- "log",
- "naga",
- "once_cell",
- "parking_lot",
- "portable-atomic",
- "profiling",
- "raw-window-handle",
- "rustc-hash",
- "smallvec",
- "thiserror 2.0.18",
- "wgpu-core-deps-apple",
- "wgpu-core-deps-emscripten",
- "wgpu-core-deps-windows-linux-android",
- "wgpu-hal",
- "wgpu-types",
-]
-
-[[package]]
-name = "wgpu-core-deps-apple"
-version = "27.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0772ae958e9be0c729561d5e3fd9a19679bcdfb945b8b1a1969d9bfe8056d233"
-dependencies = [
- "wgpu-hal",
-]
-
-[[package]]
-name = "wgpu-core-deps-emscripten"
-version = "27.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06ac3444a95b0813ecfd81ddb2774b66220b264b3e2031152a4a29fda4da6b5"
-dependencies = [
- "wgpu-hal",
-]
-
-[[package]]
-name = "wgpu-core-deps-windows-linux-android"
-version = "27.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71197027d61a71748e4120f05a9242b2ad142e3c01f8c1b47707945a879a03c3"
-dependencies = [
- "wgpu-hal",
-]
-
-[[package]]
-name = "wgpu-hal"
-version = "27.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b21cb61c57ee198bc4aff71aeadff4cbb80b927beb912506af9c780d64313ce"
-dependencies = [
- "android_system_properties",
- "arrayvec",
- "ash",
- "bit-set",
- "bitflags 2.13.0",
- "block",
- "bytemuck",
- "cfg-if",
- "cfg_aliases",
- "core-graphics-types",
- "glow",
- "glutin_wgl_sys",
- "gpu-alloc",
- "gpu-allocator",
- "gpu-descriptor",
- "hashbrown 0.16.1",
- "js-sys",
- "khronos-egl",
- "libc",
- "libloading",
- "log",
- "metal",
- "naga",
- "ndk-sys",
- "objc",
- "once_cell",
- "ordered-float",
- "parking_lot",
- "portable-atomic",
- "portable-atomic-util",
- "profiling",
- "range-alloc",
- "raw-window-handle",
- "renderdoc-sys",
- "smallvec",
- "thiserror 2.0.18",
- "wasm-bindgen",
- "web-sys",
- "wgpu-types",
- "windows",
- "windows-core",
-]
-
-[[package]]
-name = "wgpu-types"
-version = "27.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
-dependencies = [
- "bitflags 2.13.0",
- "bytemuck",
- "js-sys",
- "log",
- "thiserror 2.0.18",
- "web-sys",
-]
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-strings",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2584,40 +696,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2626,38 +705,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2666,34 +722,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2702,28 +734,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2732,34 +746,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2768,86 +758,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "x11rb"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
-dependencies = [
- "gethostname",
- "rustix",
- "x11rb-protocol",
-]
-
-[[package]]
-name = "x11rb-protocol"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
-
-[[package]]
-name = "xml-rs"
-version = "0.8.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
-
-[[package]]
-name = "zerocopy"
-version = "0.8.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zeroize"
@@ -2860,18 +774,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zune-core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
-
-[[package]]
-name = "zune-jpeg"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
-dependencies = [
- "zune-core",
-]

--- a/examples/islands-web/Cargo.lock
+++ b/examples/islands-web/Cargo.lock
@@ -18,197 +18,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-activity"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
-dependencies = [
- "android-properties",
- "bitflags 2.13.0",
- "cc",
- "jni 0.22.4",
- "libc",
- "log",
- "ndk",
- "ndk-context",
- "ndk-sys",
- "num_enum",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "android-properties"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "arboard"
-version = "3.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
-dependencies = [
- "clipboard-win",
- "image",
- "log",
- "objc2",
- "objc2-app-kit",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-foundation",
- "parking_lot",
- "percent-encoding",
- "windows-sys 0.60.2",
- "x11rb",
-]
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "ash"
-version = "0.38.0+1.3.281"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
-dependencies = [
- "libloading",
-]
-
-[[package]]
-name = "autocfg"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
-name = "automerge"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0dae93622d3c6850d196503480004576249e0e391bddb3f54600974d92a790"
-dependencies = [
- "cfg-if",
- "flate2",
- "fxhash",
- "hex",
- "im",
- "itertools",
- "leb128",
- "serde",
- "sha2",
- "smol_str",
- "thiserror 1.0.69",
- "tinyvec",
- "tracing",
- "unicode-segmentation",
- "uuid",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
-
-[[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
-
-[[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "byteorder-lite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -223,64 +42,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "clipboard-win"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
-dependencies = [
- "error-code",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
-dependencies = [
- "serde",
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
-name = "color"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ec7c5eb7a16992b1904d76c517d170ab353b0e0b3d5a0c81a8a0cd1037893cf"
-
-[[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
 
 [[package]]
 name = "console_error_panic_hook"
@@ -293,145 +62,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core-graphics-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
-dependencies = [
- "bitflags 2.13.0",
- "core-foundation",
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
-
-[[package]]
-name = "dispatch2"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
-dependencies = [
- "bitflags 2.13.0",
- "objc2",
-]
-
-[[package]]
-name = "document-features"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
-]
-
-[[package]]
-name = "either"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
-
-[[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "error-code"
-version = "3.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
-
-[[package]]
-name = "euclid"
-version = "0.22.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "fax"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
-
-[[package]]
-name = "fdeflate"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
-dependencies = [
- "simd-adler32",
 ]
 
 [[package]]
@@ -451,69 +87,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "font-types"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
-
-[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-intrusive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
-dependencies = [
- "futures-core",
- "lock_api",
- "parking_lot",
-]
 
 [[package]]
 name = "futures-task"
@@ -534,225 +111,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
-name = "gethostname"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
-dependencies = [
- "rustix",
- "windows-link",
-]
-
-[[package]]
-name = "getopts"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
-
-[[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
-]
-
-[[package]]
-name = "gl_generator"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
-dependencies = [
- "khronos_api",
- "log",
- "xml-rs",
-]
-
-[[package]]
-name = "glow"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
-dependencies = [
- "js-sys",
- "slotmap",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "glutin_wgl_sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
-dependencies = [
- "gl_generator",
-]
-
-[[package]]
-name = "gpu-alloc"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
-dependencies = [
- "bitflags 2.13.0",
- "gpu-alloc-types",
-]
-
-[[package]]
-name = "gpu-alloc-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
-dependencies = [
- "bitflags 2.13.0",
-]
-
-[[package]]
-name = "gpu-allocator"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
-dependencies = [
- "log",
- "presser",
- "thiserror 1.0.69",
- "windows",
-]
-
-[[package]]
-name = "gpu-descriptor"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
-dependencies = [
- "bitflags 2.13.0",
- "gpu-descriptor-types",
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "gpu-descriptor-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
-dependencies = [
- "bitflags 2.13.0",
-]
-
-[[package]]
-name = "guillotiere"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62d5865c036cb1393e23c50693df631d3f5d7bcca4c04fe4cc0fd592e74a782"
-dependencies = [
- "euclid",
- "svg_fmt",
-]
-
-[[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "num-traits",
- "zerocopy",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "foldhash 0.2.0",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hexf-parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "http"
@@ -771,44 +144,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "im"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
-dependencies = [
- "bitmaps",
- "rand_core",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
-]
-
-[[package]]
-name = "image"
-version = "0.25.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
-dependencies = [
- "bytemuck",
- "byteorder-lite",
- "moxcms",
- "num-traits",
- "png 0.18.1",
- "tiff",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
-dependencies = [
- "equivalent",
- "hashbrown 0.17.1",
-]
-
-[[package]]
 name = "islands-web"
 version = "0.1.0"
 dependencies = [
@@ -820,103 +155,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys 0.3.1",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
-dependencies = [
- "cfg-if",
- "combine",
- "jni-macros",
- "jni-sys 0.4.1",
- "log",
- "simd_cesu8",
- "thiserror 2.0.18",
- "walkdir",
- "windows-link",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
-dependencies = [
- "jni-sys 0.4.1",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -930,88 +172,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "khronos-egl"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
-dependencies = [
- "libc",
- "libloading",
- "pkg-config",
-]
-
-[[package]]
-name = "khronos_api"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
-
-[[package]]
-name = "kurbo"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
-dependencies = [
- "arrayvec",
- "euclid",
- "polycool",
- "smallvec",
-]
-
-[[package]]
-name = "leb128"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "linebender_resource_handle"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -1020,34 +184,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
-
-[[package]]
-name = "metal"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
-dependencies = [
- "bitflags 2.13.0",
- "block",
- "core-graphics-types",
- "foreign-types",
- "log",
- "objc",
- "paste",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -1060,239 +200,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "moxcms"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
-dependencies = [
- "num-traits",
- "pxfm",
-]
-
-[[package]]
-name = "naga"
-version = "27.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
-dependencies = [
- "arrayvec",
- "bit-set",
- "bitflags 2.13.0",
- "cfg-if",
- "cfg_aliases",
- "codespan-reporting",
- "half",
- "hashbrown 0.16.1",
- "hexf-parse",
- "indexmap",
- "libm",
- "log",
- "num-traits",
- "once_cell",
- "rustc-hash",
- "spirv",
- "thiserror 2.0.18",
- "unicode-ident",
-]
-
-[[package]]
-name = "ndk"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
-dependencies = [
- "bitflags 2.13.0",
- "jni-sys 0.3.1",
- "log",
- "ndk-sys",
- "num_enum",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
-name = "ndk-sys"
-version = "0.6.0+11769913"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
-dependencies = [
- "jni-sys 0.3.1",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
- "libm",
-]
-
-[[package]]
-name = "num_enum"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
-dependencies = [
- "num_enum_derive",
- "rustversion",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
-]
-
-[[package]]
-name = "objc2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
-dependencies = [
- "objc2-encode",
-]
-
-[[package]]
-name = "objc2-app-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
-dependencies = [
- "bitflags 2.13.0",
- "objc2",
- "objc2-core-graphics",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags 2.13.0",
- "dispatch2",
- "objc2",
-]
-
-[[package]]
-name = "objc2-core-graphics"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
-dependencies = [
- "bitflags 2.13.0",
- "dispatch2",
- "objc2",
- "objc2-core-foundation",
- "objc2-io-surface",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
-name = "objc2-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
-dependencies = [
- "bitflags 2.13.0",
- "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-io-surface"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
-dependencies = [
- "bitflags 2.13.0",
- "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "ordered-float"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "peniko"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c8299360d2e998bdb106dc0a6cd71dcc5f4df51df1b620361bf50e283cca6"
-dependencies = [
- "color",
- "kurbo",
- "linebender_resource_handle",
- "smallvec",
-]
 
 [[package]]
 name = "percent-encoding"
@@ -1307,77 +218,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "png"
-version = "0.17.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
-
-[[package]]
-name = "png"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
-dependencies = [
- "bitflags 2.13.0",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
-
-[[package]]
-name = "polycool"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
-dependencies = [
- "arrayvec",
-]
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
-name = "presser"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,107 +227,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "profiling"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
-dependencies = [
- "bitflags 2.13.0",
- "getopts",
- "memchr",
- "pulldown-cmark-escape",
- "unicase",
-]
-
-[[package]]
-name = "pulldown-cmark-escape"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
-
-[[package]]
-name = "pxfm"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "range-alloc"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
-
-[[package]]
-name = "raw-window-handle"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
-
-[[package]]
-name = "read-fonts"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
-dependencies = [
- "bytemuck",
- "font-types",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1520,19 +265,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
-name = "renderdoc-sys"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
-
-[[package]]
 name = "rinch"
 version = "0.1.0"
 dependencies = [
  "js-sys",
  "rinch-components",
  "rinch-core",
- "rinch-editor",
  "rinch-macros",
  "rinch-platform",
  "rinch-theme",
@@ -1540,28 +278,6 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rinch-android"
-version = "0.1.0"
-dependencies = [
- "android-activity",
- "jni 0.21.1",
- "log",
- "ndk-context",
-]
-
-[[package]]
-name = "rinch-clipboard"
-version = "0.1.0"
-dependencies = [
- "arboard",
- "js-sys",
- "rinch-android",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -1578,38 +294,25 @@ dependencies = [
 name = "rinch-core"
 version = "0.1.0"
 dependencies = [
- "thiserror 1.0.69",
+ "thiserror",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
-name = "rinch-editable"
-version = "0.1.0"
-
-[[package]]
-name = "rinch-editor"
+name = "rinch-editor-core"
 version = "0.1.0"
 dependencies = [
- "automerge",
- "getrandom 0.2.17",
- "pulldown-cmark",
  "regex",
- "rinch-clipboard",
- "rinch-core",
- "rinch-editable",
- "rinch-editor-macros",
- "thiserror 1.0.69",
- "tracing",
- "uuid",
+ "thiserror",
 ]
 
 [[package]]
-name = "rinch-editor-macros"
+name = "rinch-editor-view"
 version = "0.1.0"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "rinch-core",
+ "rinch-editor-core",
 ]
 
 [[package]]
@@ -1625,8 +328,6 @@ dependencies = [
 name = "rinch-platform"
 version = "0.1.0"
 dependencies = [
- "peniko",
- "vello",
  "web-time",
 ]
 
@@ -1652,6 +353,8 @@ dependencies = [
  "js-sys",
  "rinch",
  "rinch-core",
+ "rinch-editor-core",
+ "rinch-editor-view",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -1664,38 +367,10 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.17",
+ "getrandom",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags 2.13.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1740,34 +415,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
- "serde_derive",
 ]
 
 [[package]]
@@ -1804,17 +457,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1827,97 +469,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "simd_cesu8"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
-
-[[package]]
-name = "skrifa"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
-dependencies = [
- "bytemuck",
- "read-fonts",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "slotmap"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
-dependencies = [
- "version_check",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
-
-[[package]]
-name = "smol_str"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "spirv"
-version = "0.3.0+sdk-1.3.268.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
-dependencies = [
- "bitflags 2.13.0",
-]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "svg_fmt"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
 
 [[package]]
 name = "syn"
@@ -1931,30 +492,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1966,76 +509,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tiff"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
-dependencies = [
- "fax",
- "flate2",
- "half",
- "quick-error",
- "weezl",
- "zune-jpeg",
-]
-
-[[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "toml_parser",
- "winnow",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
-dependencies = [
- "winnow",
 ]
 
 [[package]]
@@ -2070,34 +543,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
-name = "unicase"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "untrusted"
@@ -2141,92 +590,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
-name = "uuid"
-version = "1.23.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
-dependencies = [
- "getrandom 0.4.3",
- "js-sys",
- "serde_core",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "vello"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72fef40773530322d5c2ffe3c1107e9874bd8239ac137d1c2b6c1edad695146e"
-dependencies = [
- "bytemuck",
- "futures-intrusive",
- "log",
- "peniko",
- "png 0.17.16",
- "skrifa",
- "static_assertions",
- "thiserror 2.0.18",
- "vello_encoding",
- "vello_shaders",
- "wgpu",
-]
-
-[[package]]
-name = "vello_encoding"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c91203ec4b483440614a9a5c7c2d991932af72c5349659a63ec49476f0b79c"
-dependencies = [
- "bytemuck",
- "guillotiere",
- "peniko",
- "skrifa",
- "smallvec",
-]
-
-[[package]]
-name = "vello_shaders"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a765d44d4bd354146e44f9a860f4e92effd91a97302549be9e47f0a18d8128c"
-dependencies = [
- "bytemuck",
- "log",
- "naga",
- "thiserror 2.0.18",
- "vello_encoding",
-]
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2239,16 +606,6 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2313,257 +670,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "weezl"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
-
-[[package]]
-name = "wgpu"
-version = "27.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
-dependencies = [
- "arrayvec",
- "bitflags 2.13.0",
- "cfg-if",
- "cfg_aliases",
- "document-features",
- "hashbrown 0.16.1",
- "js-sys",
- "log",
- "naga",
- "parking_lot",
- "portable-atomic",
- "profiling",
- "raw-window-handle",
- "smallvec",
- "static_assertions",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "wgpu-core",
- "wgpu-hal",
- "wgpu-types",
-]
-
-[[package]]
-name = "wgpu-core"
-version = "27.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
-dependencies = [
- "arrayvec",
- "bit-set",
- "bit-vec",
- "bitflags 2.13.0",
- "bytemuck",
- "cfg_aliases",
- "document-features",
- "hashbrown 0.16.1",
- "indexmap",
- "log",
- "naga",
- "once_cell",
- "parking_lot",
- "portable-atomic",
- "profiling",
- "raw-window-handle",
- "rustc-hash",
- "smallvec",
- "thiserror 2.0.18",
- "wgpu-core-deps-apple",
- "wgpu-core-deps-emscripten",
- "wgpu-core-deps-windows-linux-android",
- "wgpu-hal",
- "wgpu-types",
-]
-
-[[package]]
-name = "wgpu-core-deps-apple"
-version = "27.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0772ae958e9be0c729561d5e3fd9a19679bcdfb945b8b1a1969d9bfe8056d233"
-dependencies = [
- "wgpu-hal",
-]
-
-[[package]]
-name = "wgpu-core-deps-emscripten"
-version = "27.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06ac3444a95b0813ecfd81ddb2774b66220b264b3e2031152a4a29fda4da6b5"
-dependencies = [
- "wgpu-hal",
-]
-
-[[package]]
-name = "wgpu-core-deps-windows-linux-android"
-version = "27.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71197027d61a71748e4120f05a9242b2ad142e3c01f8c1b47707945a879a03c3"
-dependencies = [
- "wgpu-hal",
-]
-
-[[package]]
-name = "wgpu-hal"
-version = "27.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b21cb61c57ee198bc4aff71aeadff4cbb80b927beb912506af9c780d64313ce"
-dependencies = [
- "android_system_properties",
- "arrayvec",
- "ash",
- "bit-set",
- "bitflags 2.13.0",
- "block",
- "bytemuck",
- "cfg-if",
- "cfg_aliases",
- "core-graphics-types",
- "glow",
- "glutin_wgl_sys",
- "gpu-alloc",
- "gpu-allocator",
- "gpu-descriptor",
- "hashbrown 0.16.1",
- "js-sys",
- "khronos-egl",
- "libc",
- "libloading",
- "log",
- "metal",
- "naga",
- "ndk-sys",
- "objc",
- "once_cell",
- "ordered-float",
- "parking_lot",
- "portable-atomic",
- "portable-atomic-util",
- "profiling",
- "range-alloc",
- "raw-window-handle",
- "renderdoc-sys",
- "smallvec",
- "thiserror 2.0.18",
- "wasm-bindgen",
- "web-sys",
- "wgpu-types",
- "windows",
- "windows-core",
-]
-
-[[package]]
-name = "wgpu-types"
-version = "27.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
-dependencies = [
- "bitflags 2.13.0",
- "bytemuck",
- "js-sys",
- "log",
- "thiserror 2.0.18",
- "web-sys",
-]
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-strings",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2572,40 +684,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2614,38 +693,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2654,34 +710,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2690,28 +722,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2720,34 +734,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2756,86 +746,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "x11rb"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
-dependencies = [
- "gethostname",
- "rustix",
- "x11rb-protocol",
-]
-
-[[package]]
-name = "x11rb-protocol"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
-
-[[package]]
-name = "xml-rs"
-version = "0.8.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
-
-[[package]]
-name = "zerocopy"
-version = "0.8.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zeroize"
@@ -2848,18 +762,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zune-core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
-
-[[package]]
-name = "zune-jpeg"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
-dependencies = [
- "zune-core",
-]

--- a/examples/paint-web/Cargo.lock
+++ b/examples/paint-web/Cargo.lock
@@ -18,197 +18,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-activity"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
-dependencies = [
- "android-properties",
- "bitflags 2.11.0",
- "cc",
- "jni 0.22.4",
- "libc",
- "log",
- "ndk",
- "ndk-context",
- "ndk-sys",
- "num_enum",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "android-properties"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "arboard"
-version = "3.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
-dependencies = [
- "clipboard-win",
- "image",
- "log",
- "objc2",
- "objc2-app-kit",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-foundation",
- "parking_lot",
- "percent-encoding",
- "windows-sys 0.59.0",
- "x11rb",
-]
-
-[[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
-name = "ash"
-version = "0.38.0+1.3.281"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
-dependencies = [
- "libloading",
-]
-
-[[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "automerge"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0dae93622d3c6850d196503480004576249e0e391bddb3f54600974d92a790"
-dependencies = [
- "cfg-if",
- "flate2",
- "fxhash",
- "hex",
- "im",
- "itertools",
- "leb128",
- "serde",
- "sha2",
- "smol_str",
- "thiserror 1.0.69",
- "tinyvec",
- "tracing",
- "unicode-segmentation",
- "uuid",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
-
-[[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
-
-[[package]]
-name = "bytemuck"
-version = "1.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "byteorder-lite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -223,64 +42,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "clipboard-win"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
-dependencies = [
- "error-code",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
-dependencies = [
- "serde",
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
-name = "color"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18ef4657441fb193b65f34dc39b3781f0dfec23d3bd94d0eeb4e88cde421edb"
-
-[[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
 
 [[package]]
 name = "console_error_panic_hook"
@@ -303,42 +72,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core-graphics-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation",
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,107 +81,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
-
-[[package]]
-name = "dispatch2"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
-]
-
-[[package]]
-name = "document-features"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
-]
-
-[[package]]
-name = "either"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
-
-[[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "error-code"
-version = "3.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
-
-[[package]]
-name = "euclid"
-version = "0.22.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fax"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
-
-[[package]]
-name = "fdeflate"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
-dependencies = [
- "simd-adler32",
-]
 
 [[package]]
 name = "find-msvc-tools"
@@ -467,283 +103,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "font-types"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4d2d0cf79d38430cc9dc9aadec84774bff2e1ba30ae2bf6c16cfce9385a23"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
-
-[[package]]
-name = "futures-core"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-intrusive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
-dependencies = [
- "futures-core",
- "lock_api",
- "parking_lot",
-]
-
-[[package]]
-name = "futures-task"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
-dependencies = [
- "futures-core",
- "futures-task",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
-name = "gethostname"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
-dependencies = [
- "rustix",
- "windows-link",
-]
-
-[[package]]
-name = "getopts"
-version = "0.2.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
-]
-
-[[package]]
-name = "gl_generator"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
-dependencies = [
- "khronos_api",
- "log",
- "xml-rs",
-]
-
-[[package]]
-name = "glow"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
-dependencies = [
- "js-sys",
- "slotmap",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "glutin_wgl_sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
-dependencies = [
- "gl_generator",
-]
-
-[[package]]
-name = "gpu-alloc"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
-dependencies = [
- "bitflags 2.11.0",
- "gpu-alloc-types",
-]
-
-[[package]]
-name = "gpu-alloc-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
-name = "gpu-allocator"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
-dependencies = [
- "log",
- "presser",
- "thiserror 1.0.69",
- "windows",
-]
-
-[[package]]
-name = "gpu-descriptor"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
-dependencies = [
- "bitflags 2.11.0",
- "gpu-descriptor-types",
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "gpu-descriptor-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
-name = "guillotiere"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62d5865c036cb1393e23c50693df631d3f5d7bcca4c04fe4cc0fd592e74a782"
-dependencies = [
- "euclid",
- "svg_fmt",
-]
-
-[[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "num-traits",
- "zerocopy",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -751,18 +118,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hexf-parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "http"
@@ -781,138 +136,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "im"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0acd33ff0285af998aaf9b57342af478078f53492322fafc47450e09397e0e9"
-dependencies = [
- "bitmaps",
- "rand_core",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
-]
-
-[[package]]
-name = "image"
-version = "0.25.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
-dependencies = [
- "bytemuck",
- "byteorder-lite",
- "moxcms",
- "num-traits",
- "png 0.18.1",
- "tiff",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
-dependencies = [
- "equivalent",
- "hashbrown 0.16.1",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
-
-[[package]]
-name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys 0.3.0",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
-dependencies = [
- "cfg-if",
- "combine",
- "jni-macros",
- "jni-sys 0.4.1",
- "log",
- "simd_cesu8",
- "thiserror 2.0.18",
- "walkdir",
- "windows-link",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
-
-[[package]]
-name = "jni-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -925,87 +152,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "khronos-egl"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
-dependencies = [
- "libc",
- "libloading",
- "pkg-config",
-]
-
-[[package]]
-name = "khronos_api"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
-
-[[package]]
-name = "kurbo"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7564e90fe3c0d5771e1f0bc95322b21baaeaa0d9213fa6a0b61c99f8b17b3bfb"
-dependencies = [
- "arrayvec",
- "euclid",
- "smallvec",
-]
-
-[[package]]
-name = "leb128"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
-
-[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
-
-[[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "linebender_resource_handle"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -1014,34 +164,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "metal"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
-dependencies = [
- "bitflags 2.11.0",
- "block",
- "core-graphics-types",
- "foreign-types",
- "log",
- "objc",
- "paste",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -1054,198 +180,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "moxcms"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
-dependencies = [
- "num-traits",
- "pxfm",
-]
-
-[[package]]
-name = "naga"
-version = "27.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
-dependencies = [
- "arrayvec",
- "bit-set",
- "bitflags 2.11.0",
- "cfg-if",
- "cfg_aliases",
- "codespan-reporting",
- "half",
- "hashbrown 0.16.1",
- "hexf-parse",
- "indexmap",
- "libm",
- "log",
- "num-traits",
- "once_cell",
- "rustc-hash",
- "spirv",
- "thiserror 2.0.18",
- "unicode-ident",
-]
-
-[[package]]
-name = "ndk"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
-dependencies = [
- "bitflags 2.11.0",
- "jni-sys 0.3.0",
- "log",
- "ndk-sys",
- "num_enum",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
-name = "ndk-sys"
-version = "0.6.0+11769913"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
-dependencies = [
- "jni-sys 0.3.0",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
- "libm",
-]
-
-[[package]]
-name = "num_enum"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
-dependencies = [
- "num_enum_derive",
- "rustversion",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
-]
-
-[[package]]
-name = "objc2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
-dependencies = [
- "objc2-encode",
-]
-
-[[package]]
-name = "objc2-app-kit"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
- "objc2-core-graphics",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-core-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
-dependencies = [
- "bitflags 2.11.0",
- "dispatch2",
- "objc2",
-]
-
-[[package]]
-name = "objc2-core-graphics"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
-dependencies = [
- "bitflags 2.11.0",
- "dispatch2",
- "objc2",
- "objc2-core-foundation",
- "objc2-io-surface",
-]
-
-[[package]]
-name = "objc2-encode"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
-
-[[package]]
-name = "objc2-foundation"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
-name = "objc2-io-surface"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
-dependencies = [
- "bitflags 2.11.0",
- "objc2",
- "objc2-core-foundation",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "ordered-float"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "paint"
@@ -1271,47 +209,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "peniko"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2b6aadb221872732e87d465213e9be5af2849b0e8cc5300a8ba98fffa2e00a"
-dependencies = [
- "color",
- "kurbo",
- "linebender_resource_handle",
- "smallvec",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,68 +221,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "png"
-version = "0.17.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
-
-[[package]]
-name = "png"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
-dependencies = [
- "bitflags 2.11.0",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
-name = "presser"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-dependencies = [
- "toml_edit",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,107 +230,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "profiling"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
-dependencies = [
- "bitflags 2.11.0",
- "getopts",
- "memchr",
- "pulldown-cmark-escape",
- "unicase",
-]
-
-[[package]]
-name = "pulldown-cmark-escape"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
-
-[[package]]
-name = "pxfm"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
-
-[[package]]
-name = "quick-error"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "range-alloc"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
-
-[[package]]
-name = "raw-window-handle"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
-
-[[package]]
-name = "read-fonts"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b634fabf032fab15307ffd272149b622260f55974d9fad689292a5d33df02e5"
-dependencies = [
- "bytemuck",
- "font-types",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1528,19 +268,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
-name = "renderdoc-sys"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
-
-[[package]]
 name = "rinch"
 version = "0.1.0"
 dependencies = [
  "js-sys",
  "rinch-components",
  "rinch-core",
- "rinch-editor",
  "rinch-macros",
  "rinch-platform",
  "rinch-theme",
@@ -1548,28 +281,6 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rinch-android"
-version = "0.1.0"
-dependencies = [
- "android-activity",
- "jni 0.21.1",
- "log",
- "ndk-context",
-]
-
-[[package]]
-name = "rinch-clipboard"
-version = "0.1.0"
-dependencies = [
- "arboard",
- "js-sys",
- "rinch-android",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -1586,38 +297,25 @@ dependencies = [
 name = "rinch-core"
 version = "0.1.0"
 dependencies = [
- "thiserror 1.0.69",
+ "thiserror",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
-name = "rinch-editable"
-version = "0.1.0"
-
-[[package]]
-name = "rinch-editor"
+name = "rinch-editor-core"
 version = "0.1.0"
 dependencies = [
- "automerge",
- "getrandom 0.2.17",
- "pulldown-cmark",
  "regex",
- "rinch-clipboard",
- "rinch-core",
- "rinch-editable",
- "rinch-editor-macros",
- "thiserror 1.0.69",
- "tracing",
- "uuid",
+ "thiserror",
 ]
 
 [[package]]
-name = "rinch-editor-macros"
+name = "rinch-editor-view"
 version = "0.1.0"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "rinch-core",
+ "rinch-editor-core",
 ]
 
 [[package]]
@@ -1633,8 +331,6 @@ dependencies = [
 name = "rinch-platform"
 version = "0.1.0"
 dependencies = [
- "peniko",
- "vello",
  "web-time",
 ]
 
@@ -1660,6 +356,8 @@ dependencies = [
  "js-sys",
  "rinch",
  "rinch-core",
+ "rinch-editor-core",
+ "rinch-editor-view",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -1672,38 +370,10 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.17",
+ "getrandom",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags 2.11.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1748,34 +418,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
- "serde_derive",
 ]
 
 [[package]]
@@ -1812,17 +460,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1835,97 +472,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
-name = "simd_cesu8"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
-dependencies = [
- "rustc_version",
- "simdutf8",
-]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
-
-[[package]]
-name = "skrifa"
-version = "0.40.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdfe3d2475fbd7ddd1f3e5cf8288a30eb3e5f95832829570cd88115a7434ac"
-dependencies = [
- "bytemuck",
- "read-fonts",
-]
-
-[[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "slotmap"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
-dependencies = [
- "version_check",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "smol_str"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "spirv"
-version = "0.3.0+sdk-1.3.268.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "svg_fmt"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
 
 [[package]]
 name = "syn"
@@ -1939,30 +489,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1974,76 +506,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tiff"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
-dependencies = [
- "fax",
- "flate2",
- "half",
- "quick-error",
- "weezl",
- "zune-jpeg",
-]
-
-[[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
-dependencies = [
- "indexmap",
- "toml_datetime",
- "toml_parser",
- "winnow",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
-dependencies = [
- "winnow",
 ]
 
 [[package]]
@@ -2078,34 +540,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
-name = "unicase"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "untrusted"
@@ -2149,92 +587,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
-name = "uuid"
-version = "1.23.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
-dependencies = [
- "getrandom 0.4.3",
- "js-sys",
- "serde_core",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "vello"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72fef40773530322d5c2ffe3c1107e9874bd8239ac137d1c2b6c1edad695146e"
-dependencies = [
- "bytemuck",
- "futures-intrusive",
- "log",
- "peniko",
- "png 0.17.16",
- "skrifa",
- "static_assertions",
- "thiserror 2.0.18",
- "vello_encoding",
- "vello_shaders",
- "wgpu",
-]
-
-[[package]]
-name = "vello_encoding"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c91203ec4b483440614a9a5c7c2d991932af72c5349659a63ec49476f0b79c"
-dependencies = [
- "bytemuck",
- "guillotiere",
- "peniko",
- "skrifa",
- "smallvec",
-]
-
-[[package]]
-name = "vello_shaders"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a765d44d4bd354146e44f9a860f4e92effd91a97302549be9e47f0a18d8128c"
-dependencies = [
- "bytemuck",
- "log",
- "naga",
- "thiserror 2.0.18",
- "vello_encoding",
-]
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2247,20 +603,6 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
-dependencies = [
- "cfg-if",
- "futures-util",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -2325,257 +667,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "weezl"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
-
-[[package]]
-name = "wgpu"
-version = "27.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
-dependencies = [
- "arrayvec",
- "bitflags 2.11.0",
- "cfg-if",
- "cfg_aliases",
- "document-features",
- "hashbrown 0.16.1",
- "js-sys",
- "log",
- "naga",
- "parking_lot",
- "portable-atomic",
- "profiling",
- "raw-window-handle",
- "smallvec",
- "static_assertions",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "wgpu-core",
- "wgpu-hal",
- "wgpu-types",
-]
-
-[[package]]
-name = "wgpu-core"
-version = "27.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
-dependencies = [
- "arrayvec",
- "bit-set",
- "bit-vec",
- "bitflags 2.11.0",
- "bytemuck",
- "cfg_aliases",
- "document-features",
- "hashbrown 0.16.1",
- "indexmap",
- "log",
- "naga",
- "once_cell",
- "parking_lot",
- "portable-atomic",
- "profiling",
- "raw-window-handle",
- "rustc-hash",
- "smallvec",
- "thiserror 2.0.18",
- "wgpu-core-deps-apple",
- "wgpu-core-deps-emscripten",
- "wgpu-core-deps-windows-linux-android",
- "wgpu-hal",
- "wgpu-types",
-]
-
-[[package]]
-name = "wgpu-core-deps-apple"
-version = "27.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0772ae958e9be0c729561d5e3fd9a19679bcdfb945b8b1a1969d9bfe8056d233"
-dependencies = [
- "wgpu-hal",
-]
-
-[[package]]
-name = "wgpu-core-deps-emscripten"
-version = "27.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06ac3444a95b0813ecfd81ddb2774b66220b264b3e2031152a4a29fda4da6b5"
-dependencies = [
- "wgpu-hal",
-]
-
-[[package]]
-name = "wgpu-core-deps-windows-linux-android"
-version = "27.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71197027d61a71748e4120f05a9242b2ad142e3c01f8c1b47707945a879a03c3"
-dependencies = [
- "wgpu-hal",
-]
-
-[[package]]
-name = "wgpu-hal"
-version = "27.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b21cb61c57ee198bc4aff71aeadff4cbb80b927beb912506af9c780d64313ce"
-dependencies = [
- "android_system_properties",
- "arrayvec",
- "ash",
- "bit-set",
- "bitflags 2.11.0",
- "block",
- "bytemuck",
- "cfg-if",
- "cfg_aliases",
- "core-graphics-types",
- "glow",
- "glutin_wgl_sys",
- "gpu-alloc",
- "gpu-allocator",
- "gpu-descriptor",
- "hashbrown 0.16.1",
- "js-sys",
- "khronos-egl",
- "libc",
- "libloading",
- "log",
- "metal",
- "naga",
- "ndk-sys",
- "objc",
- "once_cell",
- "ordered-float",
- "parking_lot",
- "portable-atomic",
- "portable-atomic-util",
- "profiling",
- "range-alloc",
- "raw-window-handle",
- "renderdoc-sys",
- "smallvec",
- "thiserror 2.0.18",
- "wasm-bindgen",
- "web-sys",
- "wgpu-types",
- "windows",
- "windows-core",
-]
-
-[[package]]
-name = "wgpu-types"
-version = "27.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
-dependencies = [
- "bitflags 2.11.0",
- "bytemuck",
- "js-sys",
- "log",
- "thiserror 2.0.18",
- "web-sys",
-]
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
- "windows-strings",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2584,31 +681,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2617,21 +690,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2641,21 +708,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2671,21 +726,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2695,85 +738,15 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winnow"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "x11rb"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
-dependencies = [
- "gethostname",
- "rustix",
- "x11rb-protocol",
-]
-
-[[package]]
-name = "x11rb-protocol"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
-
-[[package]]
-name = "xml-rs"
-version = "0.8.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
-
-[[package]]
-name = "zerocopy"
-version = "0.8.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zeroize"
@@ -2786,18 +759,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zune-core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
-
-[[package]]
-name = "zune-jpeg"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
-dependencies = [
- "zune-core",
-]


### PR DESCRIPTION
Implements the engine half of #190: `rinch-editor-collab` drops Automerge for **yrs 0.27**, and the `EditorHandle` sync surface becomes opaque bytes. Closes #169 (the automerge-0.10 regression concern is moot — automerge is gone from every lockfile in the repo).

## What changed

- **Same seam, new engine.** The M9 architecture, the `model ≡ project(model)` invariant, the A22 fail-loud staged scope, `build_remote_transaction`, `CollabPlugin`, and `rebase_steps` are unchanged. The wire shape mirrors the old one (root `content` array → block maps → text with native formatting attributes); the JSON-string mark-value indirection is gone — yrs format attributes carry structured values.
- **Sync surface is now engine-opaque.** `SyncState`/`SyncMessage`/`ChangeHash` (from #182, which never shipped to a consumer — PlotWeb's pin predates it) are replaced by `collab_state_vector()` + `collab_sync_diff(sv)`; `collab_receive` is unchanged and serves both broadcast deltas and reconciliation diffs, since in yrs they are the same update format. No per-peer protocol state anywhere.
- **Broadcast is an `observe_update_v1` outbox** (the rinch-ce precedent), not `encode_diff_v1`-vs-watermark: yrs's diff encoding structurally re-sends the entire historical delete set (measured 46→292 bytes/keystroke over 200 edits), so the diff approach regresses wire size forever after the first deletion. With the outbox, a nothing-new `save_incremental()` is literally empty. Foreign applies are origin-tagged and never re-broadcast — **the transport owns relaying** (documented on `start_collaboration_host`): full mesh, or a hub that fans received deltas out. The reconciliation pair repairs any peer that fell behind.
- **`Send` is preserved and now pinned.** The outbox is `Arc<Mutex<_>>` and yrs's `sync` feature (a bare marker — it only makes `Subscription` `Send`) keeps `CollabSession`/`CollabDoc` `Send` as they were on main; a `const` assertion in `lib.rs` makes any future regression a compile error. Matters because plotweb-crdt holds sessions across `.await`s.
- **`load()` validates content, not type.** yrs roots carry no wire type tag (a foreign root arrives as `Undefined` and typed accessors reinterpret rather than check), so the guard applies the update first, then requires a non-empty `content` array whose every entry reads back as a projected node — strictly stronger than the automerge guard. Probed against a 13-shape foreign-bytes matrix: every shape fails loud, none panic.
- **Offsets:** the doc is `OffsetKind::Utf16` (never `Doc::new()`, which defaults to byte offsets); char↔UTF-16 conversion happens at the projection boundary, with astral-pair tests (two astral chars, because yrs silently snaps mid-surrogate indexes).
- **wasm:** `rinch-editor-collab` now builds for wasm32 with zero shims; the `uuid/js` shim is deleted from `collab-editor-web`, and the crate joins CI's `clippy-wasm` list. Three stale example lockfiles regenerated — no lockfile in the repo mentions automerge.

## The trap this PR documents

A yrs **state vector counts insertions only** — delete-only updates and mark *removals* (yrs un-formats by deleting format markers) leave it unchanged. Nothing in this crate uses SV equality as a change or convergence test: integration decides by rebuild-and-compare, sends decide by outbox contents, and regression tests at both the session and handle layer pin the trap (they assert the SV is unchanged as a *precondition*, then that the deletion still propagates).

## Review

Implemented and then adversarially reviewed in three rounds (probes and counterfactuals, not just reading): the review killed an SV-equality short-circuit the fuzz suites caught, the delete-set wire regression, a type-blind load guard, an empty-delta error, the `!Send` regression, and a silent-corruption path in update merging (naive concatenation decodes *fine* and yields a wrong document — `merge_updates_v1` is load-bearing and now pinned by test). Pre-existing bugs found along the way are filed, not folded in: #192 (concurrent-deletion wedge, + late-joiner symptom), #193 (mark/attr clear-and-reapply clobber), #194 (A22 write-phase partial commit), #196 (mid-session foreign-bytes one-way partition).

## Tests

- rinch-editor-collab: 10 unit / 22 integration / 4 fuzz suites (2-, 3-, 4-, N-peer convergence with `model ≡ project(model)` asserted every round) / 1 doctest — all green
- rinch-editor-view `--features collaboration`: 72 green (every #182 sync-protocol test ported with assertions intact)
- `cargo clippy --workspace --all-targets -- -D warnings` clean; wasm clippy for the crate clean; fmt clean; full pre-commit hook passed
- `cargo tree -p rinch --features collaboration`: yrs v0.27.3, zero automerge

Docs (CLAUDE.md M9 section, guide, README, design addendum) follow in PR2 per #190.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
