### PR TITLE
docs: #190 PR2 — yrs migration docs sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -709,15 +709,17 @@ The editor ships its own default light/dark stylesheet (`editor/styles.rs`, inje
 
 ### Collaboration (optional, opt-in — M9)
 
-Real-time collaborative editing is a feature-gated adapter, **not** part of the model. The pure `rinch-editor-core` model stays renderer- and CRDT-agnostic; `rinch-editor-collab` projects it onto an **Automerge** CRDT so concurrent edits converge, then translates remote CRDT changes back into editor `Step`s. This crate is the **only** thing in the workspace that links `automerge`.
+Real-time collaborative editing is a feature-gated adapter, **not** part of the model. The pure `rinch-editor-core` model stays renderer- and CRDT-agnostic; `rinch-editor-collab` projects it onto a **yrs 0.27** (Yjs) CRDT so concurrent edits converge, then translates remote CRDT changes back into editor `Step`s. This crate is the **only** thing in the workspace that links a CRDT engine (yrs replaced Automerge in issue #190).
 
-It is gated behind the optional `collaboration` feature (which implies `desktop`, since the editor wiring lives there), so **default builds — desktop AND web — link zero automerge**. The adapter itself is pure model↔CRDT logic with no platform deps and is **wasm-compatible** (a wasm app supplies a randomness source for the transitive `automerge → uuid`, e.g. `uuid`/`getrandom` `js` feature), so a future Rust web editor view can reuse this *same* adapter rather than bridging to a separate JS CRDT.
+It is gated behind the optional `collaboration` feature (which implies `desktop`, since the editor wiring lives there), so **default builds — desktop AND web — link zero CRDT code**. The adapter itself is pure model↔CRDT logic with no platform deps and is **wasm-compatible with no shims** — yrs carries its own `fastrand/js` randomness source and builds for `wasm32-unknown-unknown` with no extra features — so a future Rust web editor view can reuse this *same* adapter rather than bridging to a separate JS CRDT.
 
 Enable with `features = ["collaboration"]` on the `rinch` facade (or depend on `rinch-editor-collab` directly).
 
-The design rests on one invariant — **`model ≡ project(model)`**: every local step is projected onto the CRDT, every remote CRDT change is rebuilt into the model. Convergence then follows from Automerge's own convergence.
+The design rests on one invariant — **`model ≡ project(model)`**: every local step is projected onto the CRDT, every remote CRDT change is rebuilt into the model. Convergence then follows from yrs's own convergence.
 
-**Staged scope (design A22):** the first milestone covers **flat text-blocks + marks** (`paragraph`/`heading`/`code_block` with text + bold/italic/link/… marks). Anything outside that scope — a nested block (blockquote, list, table), an inline atom (`image`, `hard_break`) — is `CollabError::Unsupported`: the adapter **fails loud** rather than silently dropping a change (a silent drop would reintroduce the exact divergence class the editor rewrite killed).
+**Staged scope (design A22):** the first milestone covers **flat text-blocks + marks** (`paragraph`/`heading`/`code_block` with text + bold/italic/link/… marks) plus the **list containers** `bullet_list`/`ordered_list`/`list_item`, nested into each other and around text-blocks to any depth. Anything else — `blockquote`, tables, `task_list`/`task_item`, or an inline atom (`image`, `hard_break`, `horizontal_rule`) — is `CollabError::Unsupported`: the adapter **fails loud** rather than silently dropping a change (a silent drop would reintroduce the exact divergence class the editor rewrite killed).
+
+**Collab bytes are opaque.** A snapshot, a broadcast delta, a state vector, and a sync diff are all just `Vec<u8>` in yrs's lib0 v1 encoding — callers move them between calls without decoding them.
 
 ```rust
 use rinch_editor_collab::CollabSession;
@@ -729,10 +731,14 @@ let mut b = CollabSession::from_bytes(&a.snapshot())?;
 // After the editor applies a local transaction, project before→after onto the CRDT:
 a.record_local(&old_state.doc, &new_state.doc)?;
 
-// Broadcast a delta (or use the full sync protocol: generate/integrate_sync_message):
-let delta = a.save_incremental();
+// Broadcast a delta:
+let delta = a.save_incremental()?;
 if let Some(next) = b.integrate_incremental(&b_state, &delta)? { b_state = next; }
 // `next` applies the remote change as a non-undoable `origin=remote` transaction.
+
+// Reconciliation for a peer that fell behind (offline, a dropped delta):
+let to_b = a.sync_diff(&b.state_vector())?;   // "what does b not have yet"
+if let Some(next) = b.integrate_incremental(&b_state, &to_b)? { b_state = next; }
 ```
 
 **The desktop editor wires this in for you** (M9) — you do not drive `CollabSession` directly. Every local edit through an `EditorHandle` projects + broadcasts automatically; a peer's delta integrates + re-projects through `collab_receive`. One peer **hosts** (owns the starting document), the others **join** from its snapshot. The transport is the app's concern — `outbound` carries bytes out, `post_remote_delta` carries them back in from any thread:
@@ -750,24 +756,34 @@ post_remote_delta(container_id, delta_bytes);
 |---|---|
 | `start_collaboration_host(outbound) -> Result<Vec<u8>, CollabError>` | Host a fresh session; returns the join snapshot |
 | `start_collaboration_guest(&snapshot, outbound) -> Result<(), CollabError>` | Join from a host snapshot (adopts its document) |
-| `collab_receive(&delta) -> bool` | Integrate a peer's delta (main thread, `try_borrow_mut`-soft); re-projects, does **not** re-broadcast |
+| `collab_receive(&delta) -> bool` | Integrate a peer's delta or reconciliation diff (main thread, `try_borrow_mut`-soft); re-projects, does **not** re-broadcast |
+| `collab_state_vector() -> Option<Vec<u8>>` | This editor's state vector, to hand a peer for `collab_sync_diff` |
+| `collab_sync_diff(remote_state_vector) -> Option<Vec<u8>>` | The update a peer at `remote_state_vector` is missing; feed the result to that peer's `collab_receive` |
 | `is_collaborating()` / `stop_collaboration()` | Query / detach the session |
 | `collab_snapshot() -> Option<Vec<u8>>` | Current shared-doc snapshot for a *late*-joining guest |
 | `collab_take_error() -> Option<CollabError>` | Take a fail-loud A22 projection error (the CRDT is left untouched — projection is all-or-nothing) |
 
 Free functions `collab_receive_for(container_id, &delta)` (main thread) and `post_remote_delta(container_id, delta)` (any thread) route an inbound delta to a registered editor. Runnable two-pane in-process loopback: `examples/collab-editor-demo`.
 
-`CollabPlugin` (key `"collab"`) folds collab bookkeeping (version + unconfirmed local steps) into `EditorState`; `rebase_steps(steps, &mapping)` is the ProseMirror rebase primitive (`Step::map`); `CollabDoc::patches_to_remote_ops` / `remote_ops_since` expose the surgical patch→`RemoteOp` translation. The session itself integrates via converged rebuild (`to_doc`), which is provably convergent.
+**The transport owns relaying.** `outbound` fires only for an editor's own local edits — a delta integrated via `collab_receive` is never re-broadcast (it's already in the shared CRDT; echoing it back would loop). So the transport must be a **full mesh** (every peer's `outbound` reaches every other peer) or a **hub** that fans each delta it receives out to the others, forwarding the raw bytes unchanged. A chain — A wired to B, B wired to C, nothing joining A and C — silently partitions: C never sees A's edits, and nothing errors. The repair for a peer that fell behind is the reconciliation pair above (`collab_state_vector` → `collab_sync_diff` → `collab_receive`).
+
+**Never use state-vector equality as a convergence test.** A yrs state vector counts *insertions* only — a deletion, or a mark *removal* (yrs un-formats a mark by deleting its format marker), leaves it unchanged, so two replicas can hold different documents behind equal state vectors. That's why `integrate_incremental`/`collab_receive` decide "did anything change" by rebuilding and comparing documents, never by comparing state vectors before/after — and why reconciliation always requests-and-applies a diff (whose reply carries the full delete set) rather than short-circuiting when two state vectors look equal.
+
+`CollabPlugin` (key `"collab"`) folds collab bookkeeping (version + unconfirmed local steps) into `EditorState`; `rebase_steps(steps, &mapping)` is the ProseMirror rebase primitive (`Step::map`). The session integrates by converged rebuild (`CollabDoc::to_doc` → `build_remote_transaction`), which is provably convergent — there's no separate patch→op translation layer. One used to exist (`CollabDoc::patches_to_remote_ops`/`remote_ops_since`, consuming `automerge::Patch`) but it was **deleted**, not ported, with the yrs migration: it was documented as non-convergence-critical and had no session consumer. `remote.rs`'s module doc notes it could be rebuilt on yrs observer deltas (`TextRef::observe` → `TextEvent`) if a future cursor-preserving refinement ever wants it.
 
 | File | Purpose |
 |------|---------|
-| `crates/rinch-editor-collab/src/projection.rs` | `CollabDoc` — the Automerge wire shape (`content: List<Block{type,attrs,text:Text}>`, marks over the Text), `from_doc`/`to_doc`, fail-loud validation |
+| `crates/rinch-editor-collab/src/projection.rs` | `CollabDoc` — the yrs wire shape (`content: Array<Map{type,attrs,text:Text}>`, marks as native yrs `Text` formatting attributes), `from_doc`/`to_doc`/`load`, the `observe_update_v1` broadcast outbox, fail-loud validation |
 | `crates/rinch-editor-collab/src/project.rs` | Local: `project_change` — block-list diff (Rc-identity prefix/suffix, minimal text splice) |
-| `crates/rinch-editor-collab/src/remote.rs` | Remote: `patches_to_remote_ops` (salvaged shape) + `build_remote_transaction` (converged rebuild) |
-| `crates/rinch-editor-collab/src/session.rs` | `CollabSession` — the imperative model↔CRDT lifecycle |
-| `crates/rinch-editor-collab/src/sync.rs` | Salvaged Automerge sync transport (sync protocol + incremental broadcast) |
+| `crates/rinch-editor-collab/src/remote.rs` | Remote: `build_remote_transaction` — converged rebuild into a minimal block-level `ReplaceStep`; no engine type appears in this file |
+| `crates/rinch-editor-collab/src/session.rs` | `CollabSession` — the imperative model↔CRDT lifecycle (`new`/`from_bytes`, `record_local`, `save_incremental`/`state_vector`/`sync_diff`, `integrate_incremental`) |
+| `crates/rinch-editor-collab/src/sync.rs` | The yrs bytes transport on `CollabDoc` (`state_vector`, `diff_since`, `apply_update`, the outbox drain) |
 | `crates/rinch-editor-collab/src/plugin.rs` | `CollabPlugin` + `CollabState` |
 | `crates/rinch-editor-collab/src/rebase.rs` | `rebase_steps` — local steps rebased over a remote mapping |
+| `crates/rinch-editor-collab/src/error.rs` | `CollabError` — the crate's one error type (`Engine`/`Unsupported`/`Schema`) |
+| `crates/rinch-editor-view/src/handle.rs` | `EditorHandle`'s collab methods (`start_collaboration_host/guest`, `collab_receive`, `collab_state_vector`, `collab_sync_diff`, `collab_snapshot`, `collab_take_error`, `stop_collaboration`, `is_collaborating`) — **not** in `rinch-editor-collab` |
+| `crates/rinch-editor-view/src/collab.rs` | `CollabBridge` — the seam driving `CollabSession` from an `EditorHandle` (outbound sink + last error) |
+| `crates/rinch-editor-view/src/registry.rs` | `collab_receive_for(container_id, &delta)` — routes an inbound delta to a registered editor |
 
 ## Drag and Drop
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ rsx! {
 
 **Platform Integration.** Native menus via muda. File dialogs. Clipboard. System tray with minimize-to-tray. Transparent borderless windows with custom chrome. Keyboard shortcuts.
 
-**Rich Text Editing.** CRDT-backed editor (Automerge), 22 formatting extensions, markdown input rules, syntax highlighting, find & replace. Not a toy.
+**Rich Text Editing.** CRDT-backed editor (yrs), 22 formatting extensions, markdown input rules, syntax highlighting, find & replace. Not a toy.
 
 **Game Engine Embedding.** Two modes: `RenderSurface` (Rinch owns the window, your renderer submits frames) or `RinchContext` (your engine owns the window, Rinch produces a Vello scene you composite). Either way, Rinch handles the UI and gets out of your way.
 
@@ -410,7 +410,7 @@ The full layout is in `CLAUDE.md` if you want the gory details.
 
 ## Standing On Shoulders
 
-[Stylo](https://github.com/nickel-org/stylo) (CSS resolution) · [Taffy](https://github.com/DioxusLabs/taffy) (flexbox) · [Parley](https://github.com/linebender/parley) (text) · [Vello](https://github.com/linebender/vello) (GPU rendering) · [tiny-skia](https://github.com/nickel-org/tiny-skia) (software rendering) · [winit](https://github.com/rust-windowing/winit) (windowing) · [muda](https://github.com/tauri-apps/muda) (menus) · [Automerge](https://automerge.org/) (CRDT)
+[Stylo](https://github.com/nickel-org/stylo) (CSS resolution) · [Taffy](https://github.com/DioxusLabs/taffy) (flexbox) · [Parley](https://github.com/linebender/parley) (text) · [Vello](https://github.com/linebender/vello) (GPU rendering) · [tiny-skia](https://github.com/nickel-org/tiny-skia) (software rendering) · [winit](https://github.com/rust-windowing/winit) (windowing) · [muda](https://github.com/tauri-apps/muda) (menus) · [yrs](https://github.com/y-crdt/y-crdt) (CRDT)
 
 ## License
 

--- a/docs/design/yrs-migration.md
+++ b/docs/design/yrs-migration.md
@@ -1,0 +1,208 @@
+# Collab Engine Migration — Automerge → yrs
+
+**Status:** Implemented (issue #190, PR1 = `d963ac4`).
+**Scope:** `rinch-editor-collab`'s CRDT engine only. The M9 collaboration
+architecture — the crate boundary, the `EditorHandle` seam, the model↔CRDT
+invariant — is unchanged and stays documented in
+[`editor-rearchitecture.md`](./editor-rearchitecture.md); this is an addendum
+recording *why* the engine swapped and what a future reader needs to know that
+isn't visible from the code alone.
+
+## Decision
+
+`rinch-editor-collab` dropped Automerge for **yrs 0.27**, as a rip-and-replace
+(not a parallel adapter) — the whole crate now speaks one CRDT engine, same as
+before. Decided by Joe, 2026-08-10.
+
+**Evidence (issue #169):** Automerge 0.5.12 performed fine at the time (~660µs to
+apply a remote change to a 90KB document), but Automerge 0.10 was a ~22× regression
+on the same benchmark — so staying on Automerge meant either eating that regression
+on upgrade or freezing on an old version indefinitely. Neither is viable long-term.
+yrs 0.27 does the same remote-apply work in ~0.9µs, and — the more important number —
+that cost is **flat at every document size** (O(update), not O(document)), because
+yrs garbage-collects tombstoned content instead of accumulating it forever the way
+Automerge's document-wide history does. yrs also builds for `wasm32-unknown-unknown`
+with zero feature shims, where Automerge's transitive `uuid` dependency needed the
+app to wire up a `getrandom`/`uuid` `js` feature just to compile.
+
+**Precedent:** two sibling projects had already made this exact swap and their
+lessons are folded into this migration: rinch-ce (commit `503fa78`) and Playweft
+(commit `2b5973f`, plus the "wipe don't convert" persistence lesson in `a734e11`).
+
+## What stayed: the seam
+
+M9 already concentrated the CRDT behind a seam, and the point of that seam was
+exactly this — the engine should be swappable without touching the model or the
+editor. It held. Unchanged by this migration:
+
+- The invariant **`model ≡ project(model)`**: every local step is projected onto
+  the CRDT, every remote CRDT change is rebuilt into the model, and convergence
+  follows from the CRDT's own convergence rather than from any hand-written merge
+  logic.
+- The **A22 fail-loud staged scope**: the adapter supports flat text-blocks + marks
+  and the list containers (`bullet_list`/`ordered_list`/`list_item`, nested to any
+  depth); everything else is `CollabError::Unsupported`, never a silent drop. The
+  all-or-nothing validation pre-pass — validate every touched node before the first
+  CRDT write — is unchanged in intent (see the load-bearing gotcha below).
+- **`build_remote_transaction`** (`remote.rs`) — the convergence-critical path that
+  turns a rebuilt `Node` into a minimal block-level `ReplaceStep`. It contains no
+  engine type at all; it only ever needed "give me the converged document as a
+  `Node`", which is why the engine swap left it untouched.
+- `CollabSession`'s lifecycle shape, `CollabPlugin` (pure ProseMirror-style
+  version/unconfirmed-steps bookkeeping), `rebase_steps`, `ORIGIN_REMOTE`, the
+  `NodeData`/`BlockData`/`SpanMark` intermediate representation, and the block-list
+  diff in `project_change`.
+- The **opaque `Vec<u8>` byte surfaces** — `snapshot()`, a broadcast delta, an
+  incremental update. Callers already treated these as blobs; only the encoding
+  inside them changed.
+- **The tests are the contract.** Every existing assertion carried over: the
+  integration suite, the seeded N-peer fuzz suites (re-checking
+  `model ≡ project(model)` every round), the projection unit guards, the plugin
+  tests, and the handle-level collaboration tests in `rinch-editor-view` — including
+  the three sync-protocol tests from #182 (see the engine mapping table below).
+
+## Engine mapping
+
+| Automerge (before) | yrs (after) |
+|---|---|
+| `AutoCommit` + `ObjId` object graph | `Doc::with_options(Options { offset_kind: OffsetKind::Utf16, .. })` |
+| `content: List<Block{type, attrs, text: Text}>` + marks over `Text` | `content: Array<Map{type, attrs, text: Text}>`; marks are the `Text`'s own native formatting attributes |
+| JSON-string-encoded mark values (`encode_attrs`/`decode_mark_value`) | **Deleted.** yrs format attributes carry structured `Any` values natively — the JSON indirection existed only because Automerge marks carried a scalar |
+| `get_heads()` / `ChangeHash` compare | `state_vector()` bytes — but see "never a convergence test" below; the comparison semantics are not equivalent |
+| `save_incremental()` broadcast delta | an `observe_update_v1` outbox drained by `CollabSession::save_incremental` (see below — this is *not* a straight rename) |
+| `sync.rs` re-exporting `ChangeHash`/`SyncMessage`/`SyncState` | **Deleted.** Replaced by `state_vector()` + `encode_diff_v1(&peer_sv)` (`CollabDoc::diff_since`) + `apply_update` |
+| `EditorHandle::collab_generate_sync_message`/`collab_receive_sync_message`/`collab_heads` (#182) | **Deleted**, replaced by `collab_state_vector()` + `collab_sync_diff(remote_sv)`; `collab_receive` is unchanged and now serves both broadcast and reconciliation, since in yrs they're the same wire format |
+| `CollabDoc::patches_to_remote_ops` / `remote_ops_since` (consuming `automerge::Patch`) | **Deleted, not ported.** Was already documented as non-convergence-critical with zero session consumers; can be rebuilt on yrs observer deltas (`TextRef::observe` → `TextEvent`) if a future cursor-preserving refinement wants it |
+| `CollabError::Automerge(String)` | `CollabError::Engine(String)`, with `From` impls for yrs's decode/update error types |
+| `uuid`/`getrandom` `js` shims (Automerge's transitive actor-id dependency) | **Deleted.** yrs carries `fastrand/js` itself; `collab-editor-web`'s shim is gone and the crate joined CI's `clippy-wasm` job |
+
+## Two hard-won design points
+
+**Broadcast is an `observe_update_v1` outbox, not a diff against the last-sent state
+vector.** The obvious design — remember the state vector you last broadcast from,
+and diff against it each time — does not work with yrs: `encode_diff_v1` writes the
+*complete* delete set regardless of the state vector it's given. Once a document has
+seen any deletion, every subsequent "diff since last broadcast" re-carries the
+document's entire deletion history, growing without bound (measured 46→292
+bytes/keystroke over 200 edits during review). The adapter instead subscribes to
+`observe_update_v1` on the yrs document and parks each committed transaction's own
+update in an outbox (`Arc<Mutex<Vec<Vec<u8>>>>`) for `save_incremental` to drain.
+That update is constant-size per edit and genuinely empty when nothing happened.
+Updates applied from a peer are tagged with an origin the observer checks for and
+skips — otherwise a re-broadcast would echo a change straight back to whoever sent
+it.
+
+**State vectors are never used as a change or convergence test — anywhere in this
+crate.** A yrs state vector summarizes *insertions* only: a delete-only change, and a
+mark *removal* (yrs implements un-formatting by deleting the format marker), leave
+the state vector completely unchanged. Two replicas can hold different documents
+behind equal state vectors. This shows up in two places that both had to get it
+right independently:
+- `CollabSession::integrate_incremental` decides "did the document change" by
+  rebuilding from the converged CRDT and comparing the resulting `Node`s
+  (`build_remote_transaction` returns `None` for an identical rebuild) — never by
+  comparing state vectors before and after the merge.
+- The reconciliation protocol (`state_vector()` / `sync_diff(remote_sv)`) always
+  requests-and-applies a diff rather than short-circuiting when two state vectors
+  compare equal; the diff reply carries the full delete set regardless, which is
+  what actually repairs a peer that missed a deletion.
+
+The review process caught an SV-equality short-circuit that had crept into an early
+draft of the reconciliation path; the regression tests at both the session and
+handle layer now pin the trap directly — they assert the state vector is unchanged
+as a *precondition*, then assert the deletion still propagates.
+
+## `load()` validates content, not a type tag
+
+Joining from a peer's snapshot (`CollabDoc::load`) has to reject bytes that aren't
+actually a rinch projection — otherwise a version mismatch or a stray CRDT document
+would silently "join" an empty collaboration with no shared content. Automerge could
+check this by object type. yrs cannot: a root type carries **no wire type tag** — a
+foreign root arrives as `Out::UndefinedRef`, and asking for it as a typed ref (e.g.
+`get_or_insert_array`) *reinterprets* whatever is actually there rather than failing
+(a foreign `Map` root named `content` reads back as a zero-length array; a `Text`
+root reads back as an array of single characters). So the guard applies the update
+first, then requires the `content` array to be non-empty and every one of its
+entries to read back as a valid projected node — strictly stronger than the type
+check it replaced, since a `content` array full of type-tag-passing junk would have
+sailed through the old check. This was probed against a 13-shape foreign-bytes
+matrix during review; every shape fails loud, none panic.
+
+## The `Send` contract, pinned
+
+`CollabSession`/`CollabDoc` must stay `Send` — a server holds a session across an
+`.await` (plotweb-crdt does this), so losing the bound breaks a downstream consumer
+at their next dependency bump, which is the worst place to find out. It was lost
+once already during this migration: moving the broadcast delta to an
+observer-fed outbox introduced both a shared queue and yrs's `Subscription` type,
+and `Subscription` is only `Send` with yrs's `sync` feature enabled. The fix is the
+`sync` feature (a bare marker — it adds no dependencies, so it cannot affect the
+wasm build) plus making the outbox an `Arc<Mutex<_>>` rather than the more natural
+single-threaded `Rc<RefCell<_>>`. A `const` assertion in `lib.rs` (`assert_send::<CollabDoc>()`,
+`assert_send::<CollabSession>()`) turns any future regression into a compile error
+instead of a downstream surprise.
+
+## Offsets
+
+The projection is built with `OffsetKind::Utf16` — **never `Doc::new()`**, whose
+default is `OffsetKind::Bytes`. `rinch-editor-core` positions are Unicode scalars
+(chars); yrs offers only byte or UTF-16 offsets, so every index crossing a `Text`
+boundary is converted at the projection boundary. Getting this wrong is silent: yrs
+snaps an index that lands mid-surrogate-pair to the nearest boundary instead of
+erroring, which is why the offset tests specifically use **two** astral characters —
+a single astral character (or none) cannot distinguish a correct conversion from a
+silently-snapped one. This is Playweft's lesson, carried over rather than
+rediscovered the hard way.
+
+## Undo: yrs `UndoManager` was deliberately rejected
+
+The editor's undo history stays exactly what it already was — the model-layer Step
+history — rather than adopting yrs's own `UndoManager`. Both prior-art projects
+(rinch-ce, Playweft) independently rejected it for the same two reasons: its default
+clock is compiled out on `wasm32` (no `Instant`), and origin-scoped undo has the
+wrong semantics under concurrent editing (undoing "my last change" when a peer's
+edit landed in between does not mean what a user expects). Remote transactions stay
+`ORIGIN_REMOTE` and non-undoable, exactly as before the migration.
+
+## Follow-up issues filed during review
+
+Adversarial review of the PR1 branch found four **pre-existing** bugs — verified
+code-identical on `main` before this migration, not introduced by it, and
+deliberately not folded into PR1's scope:
+
+- **#192** — concurrent deletion of two different blocks by two peers converges to
+  an empty content list and permanently wedges the session.
+- **#193** — the mark/attr resync clears and re-applies *every* mark (or replaces
+  the whole attrs map) on a changed block instead of diffing per mark/key, silently
+  discarding a peer's concurrent unrelated mark or attr edit on the same block.
+- **#194** — the A22 "all-or-nothing" guarantee only covers the validation pre-pass;
+  an error partway through the write phase itself can commit a partial change and
+  still broadcast it. PR1 narrowed an overclaiming comment describing this guarantee
+  to match what it actually covers, without fixing the underlying gap.
+- **#196** — mid-session (not join-time) foreign bytes whose `content` root was
+  created as a `Text` type elsewhere leave the session in a one-way partition:
+  inbound integration fails forever, but local edits keep committing and
+  broadcasting into the void.
+
+## Downstream: PlotWeb
+
+PlotWeb pins rinch by git revision and upgrades deliberately, so nothing breaks
+silently — but the exposure is real: `plotweb-crdt` consumes
+`rinch-editor-collab`'s projection directly, and `plotweb-web` builds with
+`collaboration` on both wasm and desktop. Two migration paths, depending on what
+PlotWeb's persisted CRDT blobs turn out to be:
+
+- If PlotWeb's durable truth is git-committed `DocNode`s (`plotweb-git`) and the CRDT
+  is only ever a live projection of that, migration is re-projection from
+  `DocNode` — construct a fresh session from the model, discard the old CRDT bytes
+  entirely. Playweft's "wipe, not convert" precedent (`a734e11`) applies: tag every
+  persisted blob with its engine, and refuse to load an untagged or wrongly-tagged
+  one rather than guessing.
+- If any stored CRDT blob is itself authoritative (no `DocNode` to re-derive from),
+  the lossless path is: old-crate `CollabDoc::to_doc()` → `Node` → new-crate
+  `CollabDoc::from_doc()`. This round-trips through the model rather than trying to
+  transcode Automerge bytes into yrs bytes directly (the two engines share no wire
+  format).
+
+PlotWeb's own separate `automerge = "0.5"` usage (its structure docs, `local_book.rs`)
+is unaffected by this migration and is PlotWeb's own call to make.

--- a/docs/src/guide/contenteditable.md
+++ b/docs/src/guide/contenteditable.md
@@ -316,6 +316,15 @@ guest.start_collaboration_guest(&snapshot, move |delta| transport.send(delta))?;
 guest.collab_receive(&delta_bytes);
 ```
 
+On desktop, network callbacks usually arrive on a background socket/data-channel
+thread — use the `Send`-safe entry point, which marshals the delta onto the main
+thread for you:
+
+```rust
+use rinch::prelude::*;
+post_remote_delta(editor_container_id, delta_bytes); // any thread → main
+```
+
 **The transport owns relaying.** `outbound` fires only for an editor's own local
 edits — a delta that arrives through `collab_receive` is never re-broadcast (it's
 already in the shared CRDT; echoing it back would loop). So the transport must be a

--- a/docs/src/guide/contenteditable.md
+++ b/docs/src/guide/contenteditable.md
@@ -270,7 +270,7 @@ pub fn start() {
 ```
 
 A runnable demo is `examples/editor-web` (built with `trunk serve`). The browser
-build links **no** `rinch-dom`/Parley/automerge — the browser handles layout, text,
+build links **no** `rinch-dom`/Parley/CRDT engine — the browser handles layout, text,
 and painting.
 
 **Supported today:** typing, the full command/toolbar surface, keyboard shortcuts,
@@ -291,11 +291,11 @@ through it. This mirrors the CodeMirror / ProseMirror hidden-input technique.
 ## Collaboration (optional, `collaboration` feature)
 
 Two editors can share one live document. Enable the `collaboration` feature and the
-editor projects every local edit onto an [Automerge](https://automerge.org) CRDT,
-broadcasts the resulting delta, and rebuilds the model from a peer's delta when one
-arrives — so concurrent edits converge. The CRDT adapter
+editor projects every local edit onto a [yrs](https://github.com/y-crdt/y-crdt) (Yjs)
+CRDT, broadcasts the resulting delta, and rebuilds the model from a peer's delta when
+one arrives — so concurrent edits converge. The CRDT adapter
 ([`rinch-editor-collab`](https://docs.rs/rinch-editor-collab)) is the only thing in a
-rinch app that links automerge; default builds link none of it.
+rinch app that links a CRDT engine; default builds link none of it.
 
 ```toml
 rinch = { workspace = true, features = ["desktop", "collaboration"] }
@@ -316,29 +316,58 @@ guest.start_collaboration_guest(&snapshot, move |delta| transport.send(delta))?;
 guest.collab_receive(&delta_bytes);
 ```
 
-The transport is yours to pick — the seam is just bytes in and bytes out — and it
-should deliver deltas **reliably and in order** (the seam carries incremental
-Automerge changes; the full sync protocol for lossy/out-of-order resync is not yet
-exposed through the handle). From a background socket/data-channel thread, use the
-`Send`-safe entry point, which marshals the delta onto the main thread for you:
+**The transport owns relaying.** `outbound` fires only for an editor's own local
+edits — a delta that arrives through `collab_receive` is never re-broadcast (it's
+already in the shared CRDT; echoing it back would loop). So the transport must be a
+**full mesh** (every peer's `outbound` reaches every other peer directly) or a **hub**
+that fans each delta it receives out to the other peers, forwarding the raw bytes
+unchanged. A chain — A wired to B, B wired to C, with nothing joining A and C —
+silently partitions: C never sees A's edits, and nothing errors.
+
+If a peer might have missed deltas — offline, reconnecting, or polling over HTTP with
+no persistent connection at all — reconcile with a **state vector + diff** exchange
+instead of relying on delta delivery being perfect:
 
 ```rust
-use rinch::prelude::*;
-post_remote_delta(editor_container_id, delta_bytes); // any thread → main
+// The peer that might be behind sends its state vector...
+let my_sv = editor.collab_state_vector().unwrap();
+transport.send(my_sv);
+
+// ...the other side answers with what it's missing, plus its own state vector...
+let diff = peer.collab_sync_diff(&my_sv).unwrap();
+let peer_sv = peer.collab_state_vector().unwrap();
+transport.send((diff, peer_sv));
+
+// ...and the first peer applies it (and can answer the second peer's state vector
+// the same way, to reconcile in the other direction too):
+editor.collab_receive(&diff);
 ```
+
+`collab_receive` is the same entry point for a broadcast delta and a reconciliation
+diff — they're the same wire format, so there's no separate sync protocol and no
+per-peer state to keep on either side; a stateless server can answer each state
+vector it's handed with nothing held between requests.
+
+**Never use state-vector equality as a convergence check.** A state vector counts
+*insertions* only, so a deletion — or a mark *removal* (yrs un-formats a mark by
+deleting its format marker) — leaves it unchanged, and two editors can hold different
+documents behind equal state vectors. Always request and apply a diff instead; the
+diff reply always carries the full delete set, which is what actually converges the
+peer.
 
 `is_collaborating()`, `stop_collaboration()`, `collab_snapshot()` (a fresh snapshot
 for a *late*-joining peer to `start_collaboration_guest` from), and
 `collab_take_error()` round out the API. The first milestone covers **flat
-text-blocks + marks** (paragraphs, headings, code blocks, bold/italic/link/…); an
-edit outside that scope fails loud rather than silently diverging —
+text-blocks + marks** (paragraphs, headings, code blocks, bold/italic/link/…) plus
+list containers (bullet/ordered lists and list items, nested to any depth); an edit
+outside that scope fails loud rather than silently diverging —
 `collab_take_error()` surfaces it, and the CRDT is left untouched (the local edit is
 not projected). A runnable two-pane loopback (both editors in one window, no network)
 lives at `examples/collab-editor-demo/src/main.rs`.
 
 ### On the web
 
-The **same** adapter runs in the browser — Automerge compiled to wasm. Enable the
+The **same** adapter runs in the browser — yrs compiled to wasm. Enable the
 `collaboration` feature on `rinch-web`:
 
 ```toml
@@ -352,10 +381,11 @@ The `EditorHandle` collab API is identical to desktop, with two web specifics:
   `handle.collab_receive(&bytes)` (or `collab_receive_for(container_id, &bytes)`)
   directly. There is no `post_remote_delta` on web (that is the desktop runtime's
   off-thread marshaller).
-- **Randomness.** Automerge mints actor ids via `uuid`, which needs a randomness
-  source on `wasm32-unknown-unknown`. Add `uuid = { version = "1", features = ["js"] }`
-  to your app (it routes to the Web Crypto API); without it the wasm build won't
-  compile. `rinch-web` deliberately does not pin this — it is the app's choice.
+- **No randomness shim needed.** yrs carries its own `fastrand/js` source and builds
+  for `wasm32-unknown-unknown` with no extra features — unlike Automerge, which
+  needed the app to add `uuid = { version = "1", features = ["js"] }` just to make the
+  wasm build compile. `rinch-web`'s `collaboration` feature now needs nothing else
+  configured by the app.
 
 A runnable two-pane web loopback is `examples/collab-editor-web` (built with
 `trunk serve`), the browser counterpart of `collab-editor-demo`.


### PR DESCRIPTION
PR2 of #190, following the merged engine swap (#197).

- **CLAUDE.md** — the M9 collaboration section now describes the yrs adapter: opaque-bytes surfaces, the `collab_state_vector`/`collab_sync_diff` reconciliation pair, the two behavioral contracts (the transport owns relaying; never use state-vector equality as a convergence test), the corrected staged scope (lists were already supported but undocumented), and a corrected file/purpose table (the handle/bridge/registry live in `rinch-editor-view`, and the deleted `patches_to_remote_ops` surgical path is described as deleted, not renamed).
- **docs/src/guide/contenteditable.md** — collaboration section rewritten for the state-vector/diff reconciliation model with a poll-flow example, the relay contract, the SV-convergence warning, and the web section updated (no uuid shim needed anymore). The desktop `post_remote_delta` example is retained.
- **README.md** — the two Automerge mentions now point at yrs.
- **docs/design/yrs-migration.md** (new) — the design addendum: decision + #169 evidence, what the seam preserved, the engine mapping table, the two hard-won design points (outbox-vs-diff, the state-vector trap), the `load()` content-validation rationale, the pinned `Send` contract, offsets/astral lessons, the rejected `UndoManager`, follow-ups #192/#193/#194/#196, and the PlotWeb migration paths. `editor-rearchitecture.md` stays untouched as the historical M9 record.

Not in scope (PR3, pending Joe's call per #190): `docs/src/architecture/{editor,overview}.md`, `AGENTS.md`, and the stale general editor file table above the collab section in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)