### PR TITLE
docs: #190 PR3 — rewrite the stale editor docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,78 +1,168 @@
 # AGENTS.md
 
-Guidance for AI agents working on the rinch codebase. See also `CLAUDE.md` for detailed API usage and examples.
+Guidance for AI agents working on the rinch codebase. `CLAUDE.md` is the detailed API
+and usage reference — read it for *how to write rinch code*. This file is about
+*working on rinch itself*: where things live, which invariants you must not break, and
+how to verify a change.
 
 ## Project Overview
 
-Rinch is a Rust-native GUI framework that uses HTML/CSS for layout with GPU rendering. The core design is **fine-grained reactivity** (SolidJS-style) — components run once, closures become Effects that surgically update individual DOM nodes. No virtual DOM, no diffing.
+Rinch is a Rust-native GUI framework that uses HTML/CSS for layout. The core design is
+**fine-grained reactivity** (SolidJS-style): components run **once**, closures become
+Effects that surgically update individual DOM nodes. No virtual DOM, no diffing, no
+re-renders.
 
-**Rendering pipeline:** Component → RenderScope/NodeHandle → RinchDocument (Stylo CSS + Taffy layout + Parley text) → Vello scene → wgpu
+**Desktop pipeline:** component → `RenderScope`/`NodeHandle` → `RinchDocument`
+(Stylo CSS + Taffy layout + Parley text) → `Painter` → window.
+The `Painter` is **tiny-skia + softbuffer by default**; the `gpu` feature swaps in
+Vello + wgpu.
+
+**Web pipeline:** the same component code → `WebDocument` (`rinch-web`) → real browser
+DOM. No Taffy/Parley/Vello — the browser lays out, shapes and paints.
+
+Both are the *same* `DomDocument` trait from `rinch-core`. That trait is the seam that
+makes the reactive layer renderer-agnostic; keep it that way.
 
 ## Workspace Structure
 
-```
-crates/
-├── rinch-core/          # Reactive primitives, DOM abstraction, hooks (7.6K lines)
-├── rinch-macros/        # rsx! macro, #[component] attribute (2.5K lines)
-├── rinch-dom/           # CSS + layout + paint engine (18.4K lines) — heaviest crate
-├── rinch-platform/      # Platform abstraction traits (500 lines)
-├── rinch/               # Desktop runtime, facade crate (15.8K lines)
-├── rinch-components/    # 56 Mantine-inspired components (17.8K lines, 113 files)
-├── rinch-theme/         # Theme system, CSS variables (1.5K lines)
-├── rinch-editor/        # ProseMirror-style rich-text editor (11.4K lines)
-├── rinch-editable/      # Text editing primitives (1.5K lines)
-├── rinch-editor-components/# Editor toolbar and controls (1.5K lines)
-├── rinch-editor-macros/ # Editor proc macros (231 lines)
-├── rinch-clipboard/     # Clipboard via arboard (373 lines)
-├── rinch-tabler-icons/  # 5000+ icons, fetched at build time (721 lines)
-├── rinch-debug/         # TCP IPC server for inspection (424 lines)
-├── rinch-mcp-server/    # MCP server for Claude integration (862 lines)
-├── rinch-visual-test/   # Visual regression test framework (2.1K lines)
-├── rinch-renderer/      # PLACEHOLDER — 9 lines, unused
-└── rinch-web/           # Browser-native DOM backend (WebDocument, event delegation, mount)
+`members = ["crates/*", "examples/*"]`, so **every** directory under `crates/` is a
+member unless listed in the root `exclude` (currently `crates/rinch-visual-test` plus
+the `*-web` examples). Verify against the root `Cargo.toml` rather than trusting this
+list if something looks off.
 
-examples/
-├── ui-zoo/              # Shared component showcase (primary dev target)
-├── ui-zoo-desktop/      # Desktop entry point
-├── ui-zoo-web/          # WASM entry (excluded from workspace; built on rinch-web)
-├── hello_rinch_dom/     # Minimal hello world
-├── fine_grained_window/ # Fine-grained rendering demo
-└── todo-app/
-```
+**Framework core**
+
+| Crate | Role |
+|---|---|
+| `rinch` | Facade + desktop runtime. `app/` (platform-agnostic app logic), `shell/` (winit + renderer), `menu/`, `editor/` (desktop editor wiring), `embed.rs`, `render_surface.rs`. |
+| `rinch-core` | The reactive kernel and the DOM abstraction. `reactive/` (Signal, Effect, Memo, Scope), `dom/` (NodeHandle, RenderScope, `DomDocument`), `events/`, control flow (`show.rs`, `for_loop.rs`, `match_dom.rs`), `context.rs`, `timer.rs`. Almost no external deps. |
+| `rinch-macros` | `rsx!` and `#[component]`. |
+| `rinch-platform` | Platform abstraction traits: `PlatformWindow`, `PlatformRenderer`, `PlatformEventLoop`, `PlatformMenu`, plus `PlatformEvent` / `AppAction`. |
+| `rinch-dom` | CSS + layout + paint engine (Stylo, Taffy, Parley, Vello/tiny-skia). The heaviest crate. |
+| `stylo-taffy` | Vendored Stylo↔Taffy interop. Pins Taffy alongside `rinch-dom`. |
+| `rinch-renderer` | Near-empty stub (two empty modules). Optional dep of `rinch` under `gpu`; nothing meaningful lives here yet. |
+
+**UI**
+
+| Crate | Role |
+|---|---|
+| `rinch-components` | The Mantine-inspired component library. |
+| `rinch-theme` | Theme system, colour palettes, CSS variable generation. |
+| `rinch-tabler-icons` | Tabler Icons; `build.rs` downloads them and generates `TablerIcon` / `TablerIconStyle` / `render_tabler_icon`. |
+
+**Rich-text editor** (see `docs/src/architecture/editor.md` for the full picture)
+
+| Crate | Role |
+|---|---|
+| `rinch-editor-core` | The pure model: document tree, `Pos`, schema/`ContentMatch`, `Step`s, `EditorState`/`Transaction`, commands, plugins, serialization. **wasm-clean; no renderer, no CRDT.** |
+| `rinch-editor-view` | Renderer-agnostic view: `RinchDomEditorView`, `EditorHandle`, the `Editor {}` component, the mounted-editor registry. Shared by desktop and web. |
+| `rinch-editor-collab` | Optional (`collaboration` feature) CRDT adapter over **yrs**. The only crate in the workspace that links a CRDT engine. |
+| `rinch-editable` | **Unrelated** engine for single-line `<input>`/`<textarea>`. Shares no code or types with the rich editor despite overlapping names (`Selection`, `Position`). |
+
+**Web**
+
+| Crate | Role |
+|---|---|
+| `rinch-web` | Browser-native backend: `WebDocument` over `web_sys`, document-level event delegation, `mount`, the browser editor glue. Depends on `rinch` with `default-features = false`, so it links no desktop stack. |
+
+**Platform services**
+
+`rinch-clipboard` (arboard / web-sys) · `rinch-storage` (filesystem / IndexedDB) ·
+`rinch-http` (ureq / fetch) · `rinch-ws` (tungstenite / WebSocket) · `rinch-android`
+(the JNI bridge to Android platform services: clipboard, IME, camera, permissions, …).
+
+**Media**
+
+`rinch-video` · `rinch-av` · `rinch-webrtc` (str0m / web_sys) · `rinch-signaling` ·
+`rinch-signaling-server` · `rinch-screen-capture`.
+
+**Tooling**
+
+| Crate | Role |
+|---|---|
+| `rinch-debug` | TCP IPC server embedded in an app (`debug` feature); writes `~/.rinch/debug/{pid}.json`. |
+| `rinch-mcp-server` | Standalone MCP server Claude talks to; discovers and drives running apps. |
+| `rinch-test` / `rinch-test-cli` | MCP-based test harness ("Playwright for rinch") and its CLI (binary name `rinch-test`). |
+| `rinch-visual-test` | Visual regression testing. **Excluded from the workspace.** |
+
+**Examples.** `ui-zoo-desktop` (+ the shared `ui-zoo` library) is the primary
+development target. The `*-web` examples (`ui-zoo-web`, `paint-web`, `editor-web`,
+`collab-editor-web`, `events-web`, `islands-web`, `webgpu-surface-web`) are **excluded
+from the workspace** — build them with `--target wasm32-unknown-unknown` or from their
+own directory. Others of note: `markdown-editor`, `collab-editor-demo`, `game-embed`,
+`gpu-device-config`, `todo-app`, `hello-android`.
 
 ## Crate Dependency Graph
 
 ```
 rinch (facade)
-  ├── rinch-core (always)
-  ├── rinch-macros (always)
-  ├── rinch-platform (always)
-  ├── rinch-dom (desktop feature)
-  ├── rinch-theme (theme feature)
-  ├── rinch-components (components feature → pulls theme)
-  ├── rinch-debug (debug feature)
-  └── winit, wgpu, vello, muda (desktop feature)
+  ├── rinch-core, rinch-macros, rinch-platform   (always)
+  ├── rinch-dom, rinch-editable, rinch-editor-core, rinch-editor-view,
+  │   winit, muda, parley, softbuffer            (desktop feature)
+  ├── vello, wgpu, rinch-renderer                (gpu feature → implies desktop)
+  ├── rinch-theme                                (theme feature)
+  ├── rinch-components                           (components feature → implies theme)
+  ├── rinch-clipboard / rfd / tray-icon / rinch-debug / rinch-video / rinch-http
+  │                                              (clipboard / file-dialogs /
+  │                                               system-tray / debug / video /
+  │                                               image-network)
+  └── rinch-editor-view/collaboration            (collaboration → implies desktop)
 
-rinch-dom
-  ├── rinch-core
-  └── stylo, stylo_taffy, taffy, parley, vello, cssparser
-
-rinch-components → rinch-core, rinch-theme, rinch-macros
-rinch-editor → rinch-core, rinch-editable, rinch-clipboard, automerge
+rinch-dom            → rinch-core + stylo, stylo_taffy, taffy, parley, vello,
+                       tiny-skia (software-renderer), cssparser
+rinch-components     → rinch-core, rinch-theme, rinch-macros, rinch-tabler-icons
+rinch-web            → rinch-core, rinch (no default features), rinch-editor-core,
+                       rinch-editor-view, wasm-bindgen/js-sys/web-sys
+rinch-editor-core    → thiserror, regex (+ optional serde, pulldown-cmark, accesskit)
+rinch-editor-view    → rinch-core, rinch-editor-core (+ optional rinch-editor-collab)
+rinch-editor-collab  → rinch-editor-core, yrs
 ```
+
+**Every heavy dependency in `rinch` is optional**, including `rinch-dom`, `parley` and
+`vello`. A build with `default-features = false` links none of them — which is exactly
+how `rinch-web` consumes the facade. Don't make a dep non-optional without checking the
+wasm build.
 
 ## Key Conventions
 
-### Reactivity Model
+### Reactivity model
 
-- `Signal<T>` and `Memo<T>` are `Copy` — no `.clone()` needed before closures
-- `{|| expr}` in rsx! creates an Effect for surgical DOM updates
-- `{expr}` without closure captures the value once at render time and never updates
-- Components run **once** to build the DOM. All reactive updates go through Effects.
+- `Signal<T>` and `Memo<T>` are `Copy` — never `.clone()` one before a closure.
+- `{|| expr}` in `rsx!` creates an Effect for surgical DOM updates. `{expr}` without
+  the closure captures once and **never** updates. This is the #1 source of "the UI
+  doesn't update" bugs.
+- Components run **once**. Never write code that rebuilds a DOM subtree to "refresh"
+  it — that is a re-render, and it is always the wrong fix.
 
-### RSX Macro Auto-Wrapping
+### Reactive resource ownership (#141)
 
-The `rsx!` macro auto-wraps component prop values. **Never** manually wrap in `Some(...)`, `Rc::new(...)`, or `Callback::new(...)`:
+A scope **owns** every `Signal`/`Memo`/`Effect`/event handler created while it was the
+ambient owner, and disposing the scope **frees** them: reads of a freed handle panic,
+writes are warn-once no-ops. Check with `is_alive()`. No ambient owner (`main()`, a
+timer callback, a detached thread) means app lifetime.
+
+Opt out inside a render with `unowned(|| …)` or `.leak()`. A process-lifetime registry
+that holds scope-owned state **must** call `rinch_core::reactive::on_cleanup` to let go.
+
+### Effect execution order is a contract (#154)
+
+Effects observing the same signal run in **registration order**, and the pending queue
+drains FIFO. This is enforced by `BTreeSet<ObserverId>` subscriber sets (ids are
+monotonic and never reused, so ascending id *is* registration order) plus `pop_front`
+in the flush. **Do not** swap either for a `HashSet` or a LIFO stack — an effect
+registered after an `rsx!` tree relies on seeing the post-patch DOM in the same flush.
+
+### Threading
+
+Rinch owns the main thread and all UI state is `!Send` (thread-local reactive system).
+`Signal::set()` / `update()` **panic** off the main thread; use `send()` /
+`update_send()`, which marshal onto the main thread. The runtime installs the
+dispatcher at startup via `register_main_thread()` + `set_cross_thread_dispatcher()`.
+
+### RSX macro auto-wrapping
+
+The `rsx!` macro auto-wraps component prop values. **Never** manually wrap in
+`Some(...)`, `Rc::new(...)`, or `Callback::new(...)`:
 
 ```rust
 // CORRECT — macro wraps for you
@@ -82,9 +172,15 @@ Button { variant: "filled", onclick: move || do_thing() }
 Button { variant: Some(String::from("filled")), onclick: Some(Callback::new(|| do_thing())) }
 ```
 
-### Native Control Flow in RSX
+The fallback codegen is `.into()`, so a bare `T` auto-wraps into an `Option<T>` field.
+The one exception: `Option<Rc<dyn Fn(...)>>` props still need `Some(Rc::new(...))`,
+because `.into()` cannot trigger Rust's unsizing coercion.
 
-The `rsx!` macro supports native Rust `if`/`for`/`match`. All control flow is **always reactive** — conditions and iterators are auto-wrapped in closures and tracked by Effects.
+### Native control flow in RSX
+
+`rsx!` supports native Rust `if`/`for`/`match`, and all of it is **always reactive** —
+conditions, iterators and scrutinees are auto-wrapped in closures and tracked by
+Effects.
 
 ```rust
 rsx! {
@@ -92,7 +188,7 @@ rsx! {
         // if/else — desugars to show_dom()
         if visible.get() { p { "Shown" } } else { p { "Hidden" } }
 
-        // for — desugars to for_each_dom_typed(), uses keyed reconciliation
+        // for — desugars to for_each_dom_typed(), keyed reconciliation (LIS)
         for todo in todos.get() {
             div { key: todo.id, {todo.name.clone()} }
         }
@@ -107,15 +203,16 @@ rsx! {
 }
 ```
 
-`if let`, `else if` chains, match guards, and pattern bindings are all supported. The `Show` and `For` components remain available but native syntax is preferred for new code.
+`if let`, `else if` chains, match guards and pattern bindings are all supported. For
+loop items need `Clone + PartialEq + 'static`, and a `key:` prop for stable identity.
 
-### Component Pattern
+### Component pattern
 
 ```rust
 #[component]
 fn my_component(title: &str) -> NodeHandle {
     // __scope is auto-injected by the macro
-    let count = use_signal(|| 0);
+    let count = Signal::new(0);
     rsx! {
         div {
             h1 { {title} }
@@ -126,161 +223,178 @@ fn my_component(title: &str) -> NodeHandle {
 }
 ```
 
-### Hooks Rules
+A **PascalCase** `#[component]` name generates a struct + `Component` impl instead;
+its params become public owned fields, and `children: &[NodeHandle]` is special-cased
+to the trait's `render`.
 
-Hooks must be called in the same order every render — no conditional hooks, no hooks inside event handlers or loops. Always call at the top of the component.
+There are **no hooks**. `use_signal`/`use_effect`/`use_memo`/`HookRegistry` were
+removed — call `Signal::new()` / `Effect::new()` / `Memo::new()` directly. There is no
+"hook ordering" rule to obey, and no `Show`/`For` components (only the runtime
+functions `show_dom()` / `for_each_dom_typed()` / `match_dom()`).
 
 ## Per-Crate Agent Guidance
 
-### rinch-core (reactive kernel)
+### rinch-core (reactive kernel) — highest risk
 
-**Key files:**
-- `reactive.rs` (1,384 lines) — Signal, Effect, Memo, reactive graph. **Highest risk** — bugs here break everything.
-- `dom.rs` (1,534 lines) — NodeHandle, RenderScope, DomDocument trait. This is the contract between the reactive layer and rendering.
-- `hooks.rs` (1,342 lines) — use_signal, use_effect, use_memo, use_derived, use_context, etc.
-- `for_loop.rs` — Keyed list reconciliation (LIS algorithm), `for_each_dom()` and `for_each_dom_typed()`
-- `show.rs` — Conditional rendering (`show_dom()`)
-- `match_dom.rs` — Multi-branch conditional rendering (`match_dom()`)
-- `element.rs` (593 lines) — Component trait, Element enum, callback types
-- `events.rs` (940 lines) — Event types, event handler registration
+`reactive/scope.rs` (ownership, disposal, the dispose fixpoint) and `reactive/mod.rs`
+(the runtime, subscriber sets, flush) are the most dangerous files in the workspace: a
+bug there breaks every app. `reactive/signal.rs`, `effect.rs`, `memo.rs` sit on top.
+`dom/traits.rs` (`DomDocument`), `dom/mod.rs` (`NodeHandle`) and `dom/render_scope.rs`
+(`RenderScope`) are the contract between the reactive layer and every renderer, so a
+signature change there ripples into `rinch-dom`, `rinch-web`, `rinch-editor-view` and
+`rinch` at once.
 
-**When working here:**
-- Changes to `DomDocument` trait signatures ripple through rinch-dom and rinch
-- Changes to `Signal`/`Effect`/`Memo` affect the entire framework
-- 65 tests cover reactivity, hooks, and reconciliation
+`dom/mock.rs` (`MockDomDocument`, behind the `test-util` feature) is how downstream
+crates test against the seam without a renderer. Prefer it over reaching for
+`rinch-dom` in a test.
 
 ### rinch-dom (CSS + layout + paint)
 
-**Key files:**
-- `computed_style.rs` (3,066 lines) — CSS computed style extraction from Stylo
-- `paint.rs` (2,353 lines) — Vello scene construction (backgrounds, borders, text, shadows, transforms)
-- `stylesheet.rs` (1,567 lines) — CSS parsing and stylesheet management
-- `style_resolution.rs` (1,040 lines) — Stylo style resolution bridge
-- `transition.rs` (1,003 lines) — CSS transitions engine
-- `dom_impl.rs` (972 lines) — `RinchDocument` implementing `DomDocument`
-- `layout.rs` (879 lines) — Taffy layout integration
-- `ifc.rs` (859 lines) — Inline formatting context (text layout)
-- `node.rs` (636 lines) — DOM node types, dirty flags, layout results
+`ifc.rs` (inline formatting / Parley), `paint/` (the `Painter` trait plus the Vello and
+tiny-skia backends), `layout_engine.rs` + `layout.rs` (Taffy), `computed_style/` (Stylo
+→ computed values), `style_resolution/`, `stylesheet/`, `dom_impl/` (`RinchDocument`),
+`stylo_impl.rs` (the Stylo DOM trait impls).
 
-**When working here:**
-- 207 tests across 7 dedicated test files in `tests/`
-- Stylo integration (`stylo_impl.rs`, `style_resolution.rs`) is complex — understand the Stylo DOM trait requirements
-- Paint order matters: backgrounds → borders → content → outlines → shadows
-- Layout uses Taffy for flexbox; inline text uses Parley for shaping
+- Stylo integration has many trait impls with subtle requirements — read before editing.
+- Paint order matters; layout measurement and paint must use the same font stack or
+  text clips.
+- Taffy is pinned at **0.12** in two places (`rinch-dom` and the vendored
+  `stylo-taffy`) which must move together.
 
 ### rinch-macros (proc macros)
 
-**Key files:**
-- `dom_codegen/mod.rs` — RSX macro code generation (dispatches to submodules)
-- `dom_codegen/control_flow.rs` — Codegen for Show, For, and native `if`/`for`/`match`
-- `dom_codegen/html.rs` — HTML element codegen
-- `dom_codegen/component_codegen.rs` — Component codegen
-- `element.rs` — Element parsing
-- `node.rs` — Node parsing (includes `RsxIfBlock`, `RsxForLoop`, `RsxMatchBlock`)
-
-**When working here:**
-- Changes affect every component in the project
-- 79 tests cover RSX parsing and codegen
-- Be careful with the auto-wrapping logic for component props (Some, Rc, callbacks)
-- Native control flow (`if`/`for`/`match`) desugars to `show_dom()`/`for_each_dom_typed()`/`match_dom()`
+`dom_codegen/` (`control_flow.rs` is the biggest and trickiest), `node.rs`,
+`element.rs`, `prop.rs`. Changes here affect every component in the project, and prop
+auto-wrapping is the subtlest part — a wrong wrap surfaces as a confusing type error in
+user code, far from the macro. Codegen is mostly permissive rather than validating (a
+prop the macro doesn't recognise falls through to `.into()`), so a typo in `rsx!`
+usually shows up as a type error at the component's field, not as a macro diagnostic.
 
 ### rinch (desktop runtime / facade)
 
-**Key files:**
-- `app.rs` (7,211 lines) — **Monolith.** Entire application lifecycle, event processing, rendering loop. Highest-coupling file in the project.
-- `shell/window_manager.rs` (2,491 lines) — Multi-window management
-- `shell/fine_grained_runtime.rs` (779 lines) — Fine-grained rendering runtime
-- `shell/rinch_runtime.rs` (745 lines) — Event loop, window creation
-- `shell/devtools.rs` — DevTools panel (F12)
-- `shell/transparent_renderer.rs` — Transparent window rendering
-- `menu/mod.rs` — Native menu system via muda
+`app/event_dispatch.rs` and `app/mod.rs` are the highest-coupling files — event
+processing, hit testing, focus, the render loop. `shell/rinch_runtime.rs` owns the
+winit event loop and window creation. Also here: `shell/desktop.rs` (wgpu / GPU device
+injection), `shell/softbuffer_renderer.rs`, `shell/devtools_panel.rs`,
+`render_surface.rs`, `embed.rs`, `menu/`, `editor/`.
 
-**When working here:**
-- `app.rs` is the most dangerous file to modify — side effects are likely
-- The `prelude` module re-exports everything from sub-crates
-- Feature flags gate heavy dependencies (desktop, components, theme, debug, etc.)
+The `prelude` re-exports everything downstream users need; feature flags gate the heavy
+dependencies.
 
-### rinch-components (56 components)
+### rinch-components
 
-**Key files:**
-- `styles/` directory — CSS generation for each component
-- Individual component files (e.g., `button.rs`, `text_input.rs`, `modal.rs`, `tabs.rs`)
-- `icons.rs` (855 lines) — SVG icon rendering
-- `tree.rs` (703 lines) — Most complex component
+Each component is self-contained and low-risk to modify individually. They implement
+`Component::render(&self, scope, children) -> NodeHandle`. Follow existing patterns —
+`badge.rs` for something simple, `tabs.rs` or `tree.rs` for something complex. `_fn`
+suffix props (`value_fn`, `checked_fn`) exist for surgical updates without a full
+component re-render. There are no unit tests here; verify visually through ui-zoo.
 
-**When working here:**
-- Each component is self-contained — low risk to modify individually
-- Components implement `Component::render(&self, scope, children) -> NodeHandle`
-- Follow existing patterns: look at `badge.rs` (simple) or `tabs.rs` (complex) as templates
-- **No unit tests** on individual components currently — test via ui-zoo visually
-- `_fn` suffix props (e.g., `value_fn`, `checked_fn`) enable surgical DOM updates
+### The editor crates
 
-### rinch-editor (rich-text editor)
-
-**Key files:**
-- `document/model.rs` (1,697 lines) — Document tree model
-- `schema/mod.rs` (807 lines) — Document schema definition
-- `extensions/starter_kit.rs` (1,457 lines) — Default extension pack
-- `view/input_bridge.rs` (878 lines) — Input handling bridge
-- `view/render.rs` (685 lines) — Editor rendering
-- `extensions/table_model.rs` (667 lines) — Table support
-
-**When working here:**
-- 294 tests — best-covered crate in the workspace
-- Schema-based: understand the node/mark type system before making changes
-- Uses Automerge CRDT for collaboration support
-- Extensions are modular — safe to add/modify individually
+Read `docs/src/architecture/editor.md` before touching any of them. The invariant that
+matters: **the model is the only source of truth and the host tree is derived from it.**
+Never read the host for content, never add a second mutation path, and keep
+`rinch-editor-core` free of renderer and CRDT dependencies (its manifest states the ban
+list; CI lints it for `wasm32`).
 
 ## Build & Test
 
 ```bash
-cargo build                         # Build all crates
-cargo build -p ui-zoo-desktop       # Build the main example
-cargo run -p ui-zoo-desktop         # Run it
-cargo test --workspace              # Run all 700 tests
-cargo clippy --workspace            # Lint (CI uses -D warnings)
-cargo fmt --check                   # Format check
+cargo build                          # Build all workspace crates
+cargo build -p ui-zoo-desktop        # Build the primary example
+cargo run --release -p ui-zoo-desktop  # Run it — ALWAYS use --release, debug is too slow
+cargo test --workspace               # Tests
+cargo clippy --workspace --all-targets -- -D warnings   # Lint (matches CI)
+cargo fmt --all -- --check           # Format check
 ```
 
-**System deps (Linux):** GTK3, Pango, Cairo development libraries.
+WASM: `cargo check --target wasm32-unknown-unknown`, or
+`cd examples/ui-zoo-web && trunk serve --release`. Android:
+`./examples/hello-android/build-apk.sh`.
 
-**wgpu fork:** The workspace patches 5 wgpu crates from `joeleaver/wgpu-fork` (branch `rinch-patch`) for transparent window support. Downstream consumers must copy the `[patch.crates-io]` section.
+**The pre-commit hook is the correctness gate.** `./scripts/setup-hooks.sh` installs a
+hook that runs fmt → clippy (`-D warnings`) → the `ui-zoo-web` wasm check → the full
+workspace test suite. It mirrors CI, so a clean hook run means a clean CI run.
+
+**CI jobs** (`.github/workflows/ci.yml`): `test` (workspace tests **plus** an explicit
+feature-gated set), `clippy`, `clippy-wasm` (per-crate `wasm32` lint for
+`rinch-core`, `rinch-editor-core`, `rinch-editor-collab`, `rinch-editor-view`,
+`rinch-http`, `rinch-ws`, `rinch-web`), `test-wasm` (headless Chrome, for
+`rinch-storage` and `rinch-web`), and `fmt`.
+
+**Feature-gated tests are a trap.** A test file whose `cfg` is false compiles to an
+*empty* binary that still prints `Running tests/x.rs` — only the test **count** reveals
+it. And `cargo test --workspace` unifies features across members, so a gated test can
+be alive purely because some unrelated example turns its feature on. If you add a
+gated test, add its feature combination to the "Run feature-gated tests" step; don't
+assume the workspace run covers it. (`--all-features` is not an option — it pulls a
+transitive `ashpd` that fails to build.)
+
+**System deps (Linux):** GTK3, GLib, ATK, Cairo, Pango, gdk-pixbuf, libxdo, libmpv
+development packages.
+
+**wgpu fork:** the workspace patches wgpu crates from `joeleaver/wgpu-fork` (branch
+`rinch-patch`) for transparent-window support. Cargo patches are not transitive, so
+downstream consumers must copy the `[patch.crates-io]` section into their own
+workspace.
 
 ## Common Pitfalls
 
-1. **Double-wrapping props** — The rsx! macro auto-wraps. Writing `Some(...)` or `Callback::new(...)` in rsx! causes confusing type errors.
-2. **Non-reactive expressions** — `{count.get()}` captures once; `{|| count.get()}` creates an Effect that updates. This is the #1 source of "UI doesn't update" bugs.
-3. **Conditional hooks** — Hooks must be called unconditionally, in the same order. Use `if`/`else` or `Show` for conditional rendering instead.
-4. **Missing `desktop` feature** — The workspace default-features is false. Without `features = ["desktop"]`, `run()` and rendering APIs are unavailable.
-5. **app.rs coupling** — The 7K-line monolith means changes to event handling, rendering, or window management can have unexpected interactions.
-6. **Stylo complexity** — The Firefox CSS engine integration has many trait implementations with subtle requirements. Read existing code carefully before modifying.
+1. **Non-reactive expressions.** `{count.get()}` captures once; `{|| count.get()}`
+   creates an Effect. The most common bug by a wide margin.
+2. **Double-wrapping props.** The `rsx!` macro auto-wraps; `Some(...)` or
+   `Callback::new(...)` inside `rsx!` produces confusing type errors.
+3. **Missing `desktop` feature.** The workspace dependency sets
+   `default-features = false`, so `run()` and the rendering APIs are unavailable
+   without `features = ["desktop"]`.
+4. **Cross-thread signal writes.** `set()`/`update()` panic off the main thread; use
+   `send()`/`update_send()`.
+5. **Using a disposed reactive handle.** Since #141, a freed `Signal`/`Memo` panics on
+   read. If a resource can outlive its component (a timer, a global registry, a parked
+   callback), cancel it on unmount or explicitly `.leak()` it.
+6. **Thread-local registries keyed by bare node id.** Node ids are per-document slab
+   indices and collide across documents on one thread (two windows, two embedded
+   contexts). Always key by `DomDocument::doc_key()` too.
+7. **`app/event_dispatch.rs` coupling.** Event handling, hit testing, focus and
+   rendering interact; changes there have non-obvious reach.
+8. **Stylo complexity.** The Firefox CSS engine integration has many trait impls with
+   subtle requirements. Read existing code carefully first.
+9. **Concurrent cargo processes** block on the target-dir file lock. Kill stale ones;
+   don't run cargo in parallel across agents.
+10. **`cargo check` inside `examples/ui-zoo-web`** fails on fontconfig — Parley pulls
+    it in on native Linux only. Always pass `--target wasm32-unknown-unknown` there.
 
 ## Testing with MCP
 
-The project includes a dedicated MCP server (`rinch-mcp-server`) for AI-driven visual testing:
+The `rinch-mcp-server` binary lets an agent see and drive a running app — screenshots,
+live DOM with layout bounds and computed styles, and input injection. Use it to
+*verify* a visual change instead of guessing.
 
 ```
-launch_app(package: "ui-zoo-desktop")  # Build, launch, auto-connect
-screenshot()                           # Inline PNG — directly viewable
-dom_tree()                             # Full DOM with layout + computed styles
-click(x: 100, y: 200)                 # Simulate input
-close_app()                            # Clean shutdown
+launch_app(package: "ui-zoo-desktop")   # Build, launch, auto-connect
+screenshot()                            # Inline PNG — directly viewable
+dom_tree()                              # Full DOM with layout + computed styles
+query_selector(selector: ".my-class")   # Find nodes
+get_computed_styles(id: 42)             # Resolved CSS for a node
+click(x: 100, y: 200) / wait_frame()    # Simulate input, then re-screenshot
+close_app()                             # Clean shutdown
 ```
 
-Build the MCP server first: `cargo build -p rinch-mcp-server`
+The repo's `.mcp.json` invokes `rinch-mcp-server` **by name**, so it must be on `PATH`:
+install it with `cargo install --path crates/rinch-mcp-server`, and **re-install after
+changing its source** — a `cargo build` alone won't update the installed binary. (An
+alternative `.mcp.json` can point `command` at `target/debug/rinch-mcp-server` instead.)
 
-## Test Coverage Map
+Node geometry is reported twice: `layout` is **parent-relative**, `absolute` is
+on-screen — pass `absolute` coordinates to `click()`. Headless: run under Xvfb with
+`DISPLAY` set (`launch_app` forwards it).
 
-| Crate | Tests | Notes |
-|-------|-------|-------|
-| rinch-editor | 294 | Best covered — model, schema, commands, history, tables |
-| rinch-dom | 207 | Computed styles, DOM ops, IFC, layout, paint, transitions |
-| rinch-macros | 79 | RSX parsing, codegen, native control flow |
-| rinch-core | 65 | Reactivity, hooks, reconciliation, show/for/match |
-| rinch-editor-components | 32 | Toolbar, controls |
-| rinch-visual-test | 22 | Capture, comparison, CSS export |
-| rinch-editable | 10 | Input, state |
-| rinch | 5 | HTML parser only |
-| rinch-components | 0 | No unit tests — tested visually via ui-zoo |
-| rinch-debug | 0 | No tests |
-| rinch-mcp-server | 0 | No tests |
+The app under test needs `features = ["debug"]`; the server auto-starts and can be
+disabled at runtime with `RINCH_DEBUG=0`.
+
+## Documentation Expectations
+
+User-facing changes must update the docs in the same change: the relevant page under
+`docs/src/guide/`, `docs/src/architecture/` for structural changes, doc comments on new
+public APIs, and `CLAUDE.md` when adding a reactive primitive, an element type, or an
+architectural boundary. Add new pages to `docs/src/SUMMARY.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -651,7 +651,7 @@ MenuItem::new("Reset Counter").on_click(move || count.set(0))
 
 ## Rich-Text Editor
 
-Rinch's rich-text editor is a ProseMirror-style, **model-first** editor. The document lives in `rinch-editor-core` (a pure, wasm-clean crate: `Node`/`Mark`/`Fragment`/`Slice`, one char-based `Pos` space, a real `ContentMatch` schema, invertible `Step`s, `Transaction`/`EditorState`, plugins/commands/keymap/input-rules, a single Step-based history). The desktop view (in `crates/rinch/src/editor/`) projects that model onto rinch-dom primitives and renders the caret/selection from `Selection` after layout. It is a **desktop feature** (folded into `desktop`); the web view is a follow-up. There is no `contenteditable` attribute engine anymore — mount the `Editor {}` component instead.
+Rinch's rich-text editor is a ProseMirror-style, **model-first** editor. The document lives in `rinch-editor-core` (a pure, wasm-clean crate: `Node`/`Mark`/`Fragment`/`Slice`, one char-based `Pos` space, a real `ContentMatch` schema, invertible `Step`s, `Transaction`/`EditorState`, plugins/commands/keymap/input-rules, a single Step-based history). The view lives in `rinch-editor-view` — **renderer-agnostic**: it projects that model onto any `rinch-core` `DomDocument` host and renders the caret/selection from `Selection` after layout, so desktop (rinch-dom) and web (`web_sys`) share one view. On desktop it arrives with the `desktop` feature and `crates/rinch/src/editor/` re-exports it; on web, `rinch-web` re-exports it. There is no `contenteditable` attribute engine anymore — mount the `Editor {}` component instead.
 
 **Mutation flows one way:** every edit is a `Transaction` applied by `EditorState::apply` → the view diffs old/new doc + decorations and patches the DOM. Commands read **state**, never the DOM.
 
@@ -692,19 +692,22 @@ Command names (dispatch by string): `toggleBold/Italic/Underline/Strike/Code/Hig
 
 **Markdown shortcuts (input rules).** As you type, the default `MarkdownInputRulesPlugin` rewrites markdown shortcuts (these run inside `EditorHandle::insert_text`, so every text-entry path gets them). Block shortcuts at the line start: `# `…`###### ` → headings, ` ``` ` → code block, `> ` → blockquote, `- `/`* `/`+ ` → bullet list, `1. ` → ordered list, `[ ] `/`[x] ` → task list. Inline mark shortcuts (fire on the closing delimiter): `**bold**`/`__bold__`, `*italic*`/`_italic_`, `~~strike~~`, `==highlight==`, `` `code` ``. The rule set lives in `rinch-editor-core/src/input_rules.rs` (`markdown_input_rules()`); add a `mark_input_rule`/`wrapping_input_rule` there to extend it. Task items render a checkbox from their `checked` attr via the default stylesheet (`[data-pm-type="task_item"]`); `Enter` makes a fresh unchecked item, `Enter` on an empty item exits the list.
 
-The editor ships its own default light/dark stylesheet (`editor/styles.rs`, injected once by the view); toggle dark mode with `handle.set_dark_mode(true)` (sets `data-pm-theme="dark"` on the container). Don't hand-roll editor CSS.
+The editor ships its own default light/dark stylesheet (`rinch-editor-view/src/styles.rs`, injected once by the view); toggle dark mode with `handle.set_dark_mode(true)` (sets `data-pm-theme="dark"` on the container). Don't hand-roll editor CSS.
 
 ### Key Source Files
 
 | File | Purpose |
 |------|---------|
-| `crates/rinch-editor-core/src/` | Pure model: `model/*`, `pos/*`, `schema/*`, `transform/*` (Steps), `state/*`, `commands/*`, `plugins/*`, `serialize/*`, `tables.rs`, `a11y.rs` |
-| `crates/rinch/src/editor/mod.rs` | `create_editor`, the registry, the two-phase caret/overlay passes |
-| `crates/rinch/src/editor/component.rs` | The `Editor {}` rsx component |
-| `crates/rinch/src/editor/handle.rs` | `EditorHandle` — the imperative app/component API |
-| `crates/rinch/src/editor/view.rs` | `RinchDomEditorView` (the `EditorView` impl: `ViewDesc` diff, caret/selection/decoration overlays) |
-| `crates/rinch/src/editor/styles.rs` | Default light/dark stylesheet |
-| `crates/rinch/src/editor/virtual_window.rs` | Block virtualization for large docs |
+| `crates/rinch-editor-core/src/` | Pure model: `model/*`, `pos/*`, `schema/*`, `transform/*` (Steps), `state/*`, `commands/*`, `plugins/*`, `serialize/*`, `tables.rs`, `a11y.rs`, and `view.rs` (the `EditorView` seam) |
+| `crates/rinch-editor-view/src/lib.rs` | `create_editor`, `mount_editor`, `caret_blink_tick` |
+| `crates/rinch-editor-view/src/handle.rs` | `EditorHandle` — the imperative app/component API |
+| `crates/rinch-editor-view/src/view.rs` | `RinchDomEditorView` (the `EditorView` impl: `ViewDesc` diff, caret/selection/decoration overlays) |
+| `crates/rinch-editor-view/src/component.rs` | The `Editor {}` rsx component |
+| `crates/rinch-editor-view/src/registry.rs` | The mounted-editor registry (keyed by `doc_key` + container id) and `update_all_carets`, the post-layout overlay pass |
+| `crates/rinch-editor-view/src/styles.rs` | Default light/dark stylesheet |
+| `crates/rinch/src/editor/` | **Desktop-only** wiring; re-exports all of `rinch-editor-view`. Block virtualization (`virtualization.rs` + `virtual_window.rs`), AccessKit (`a11y.rs`), and the `Send`-safe `post_remote_delta` |
+| `crates/rinch/src/app/event_dispatch.rs`, `app/focus.rs` | Desktop input glue: key/pointer/IME → `EditorHandle` calls, and the focus arbiter |
+| `crates/rinch-web/src/editor_input.rs` | The same glue for the browser (the web editor shares the view crate) |
 | `crates/rinch-editable/src/` | The separate single-line `<input>`/`<textarea>` engine (`EditCommand`, `InputHandler`) — unrelated to the rich editor |
 
 ### Collaboration (optional, opt-in — M9)

--- a/README.md
+++ b/README.md
@@ -401,7 +401,8 @@ rinch-dom          <- Stylo + Taffy + Parley. The "browser engine" bits.
 rinch-components   <- 60+ UI components
 rinch-theme        <- CSS variable generation, color palettes
 rinch-tabler-icons <- 5000+ icons, downloaded at build time
-rinch-editor       <- Rich text editor core
+rinch-editor-core  <- Rich text editor model (pure, renderer-agnostic)
+rinch-editor-view  <- Rich text editor view (shared by desktop and web)
 rinch-debug        <- TCP IPC server for tooling
 rinch-mcp-server   <- MCP server for Claude Code integration
 ```

--- a/docs/src/architecture/editor.md
+++ b/docs/src/architecture/editor.md
@@ -1,578 +1,276 @@
 # Rich-Text Editor Architecture
 
-The rinch-editor is a comprehensive rich-text editor built for the Rinch GUI framework with full collaborative editing support through Automerge CRDT.
+This page is the **structural** view of the editor: which crate owns what, how data
+flows between them, which invariants each boundary exists to protect, and why the
+boundaries are where they are.
 
-## Design Overview
+It deliberately does not duplicate the concepts or the API:
 
-The editor uses a **Hidden Textarea + Custom Virtual DOM** approach to balance:
-- Full IME and clipboard support
-- Native browser input handling (without being in a browser)
-- Surgical DOM updates (only changed nodes update)
-- Collaboration-friendly undo/redo
+- [Rich-Text Editor](../guide/editor.md) — the model, positions, schema, steps,
+  transactions, commands, history, plugins. Read that first if you want to
+  *understand* the editor.
+- [Rich-text editing](../guide/contenteditable.md) — `create_editor()`, the
+  `Editor {}` component, `EditorHandle`, the command catalogue.
+- `docs/design/editor-rearchitecture.md` (in the repo, not in this book) — the design
+  record: the milestone plan and the numbered decisions (§6, A3, A7, A22 …) that the
+  source comments cite.
 
-### Key Principle
+## Crate map
 
+Three editor crates plus two platform-wiring crates, split along one axis: **how much
+a crate is allowed to know about a renderer.**
+
+| Crate | Knows about | Role |
+|---|---|---|
+| `rinch-editor-core` | nothing | The pure model: document tree, positions, schema, steps, state, commands, plugins, serialization. Defines the `EditorView` seam. |
+| `rinch-editor-view` | `rinch-core`'s `DomDocument` trait | The projection: `RinchDomEditorView`, `EditorHandle`, the `Editor {}` component, the mounted-editor registry, the default stylesheet, the caret-blink clock. |
+| `rinch-editor-collab` | a CRDT engine (`yrs`) | Optional, off by default: projects the model onto a CRDT and rebuilds remote changes back into `Step`s. |
+| `rinch` | `rinch-dom`, winit, AT-SPI | Desktop wiring: input translation, the layout-coupled caret pass, block virtualization, accessibility, the cross-thread collab inbound. |
+| `rinch-web` | `web_sys` | Browser wiring: the same jobs against the real browser DOM. |
+
+`rinch-editor-core`'s manifest states the ban list as a contract — no `rinch-dom`,
+`winit`, `web_sys`, `parley`, `taffy`, `vello`, and no CRDT engine — and it compiles
+to `wasm32` unchanged. That is not tidiness for its own sake: it is what makes the
+model testable without a renderer, shareable between desktop and browser, and
+projectable onto a CRDT without either side learning about the other.
+
+```text
+┌──────────────────── rinch-editor-core (pure, wasm-clean) ─────────────────────┐
+│  model/  Node · Mark · Fragment · Slice     pos/       Pos · ResolvedPos      │
+│  schema/ NodeSpec · MarkSpec · ContentMatch transform/ Step · Mapping         │
+│  state/  EditorState · Transaction          commands/ plugins/ serialize/     │
+│  view.rs  trait EditorView   ◄── the only outward seam                       │
+└───────────────────────────────┬───────────────────────────────────────────────┘
+                                │ implements EditorView
+┌───────────────────────────────▼───────────────────────────────────────────────┐
+│  rinch-editor-view — RinchDomEditorView over ANY rinch-core DomDocument       │
+│  EditorHandle (owns state + view) · Editor {} component · registry · styles   │
+└──────┬───────────────────────────────┬────────────────────────────┬───────────┘
+       │ desktop host                  │ browser host               │ optional
+┌──────▼─────────────────────┐  ┌──────▼──────────────────┐  ┌──────▼───────────┐
+│ rinch — rinch-dom renderer │  │ rinch-web — web_sys DOM │  │ rinch-editor-    │
+│ input glue · caret pass    │  │ input glue · caret pass │  │ collab (yrs)     │
+│ a11y · block virtualization│  │                         │  │ `collaboration`  │
+└────────────────────────────┘  └─────────────────────────┘  └──────────────────┘
 ```
-Hidden Textarea → Key Events → Editor Commands → Document Model → Virtual DOM Render
-                  (Clipboard)      (Dispatch)      (Automerge)      (NodeHandle)
-```
 
-The document model (Automerge CRDT) is the **single source of truth**. All mutations go through commands, which update the document, which then updates the DOM via Effects.
+## The invariant everything else serves
 
-## Core Components
+**The model is the only source of truth, and the host tree is derived from it.**
 
-### Editor Instance
+`EditorState { doc, selection, stored_marks, plugin_state }` is a value.
+`state.apply(tr)` is pure and returns a *new* state. The host tree — rinch-dom nodes
+on desktop, real DOM elements in the browser — is a projection of that state and is
+**never read back for content**. There is no `contenteditable` attribute anywhere;
+the editor container is marked `data-pm-editor` precisely so nothing mistakes it for
+a browser-managed editing surface.
+
+Everything downstream is a consequence:
+
+- **One mutation path.** Every edit becomes a `Transaction` of invertible `Step`s,
+  applied by `EditorState::apply`, then projected. In `rinch-editor-view` that
+  funnel is literally one function, `EditorCore::commit`: store the new state,
+  call the view's phase-1 update, and (if collaborating) record the change onto the
+  CRDT. `EditorHandle::update` and `EditorHandle::command` are the only two entry
+  points that reach it, and typing, paste, IME commit and toolbar clicks all route
+  through one of those two.
+- **Commands read state, never the DOM.** Toolbar enablement (`can_run`), mark state
+  (`is_mark_active`), block type (`current_block_type`) are all state queries. A
+  command that consulted the host would be reading its own output.
+- **"The DOM and the model disagree" is structurally impossible** — the failure class
+  that motivated the rewrite. The previous architecture had several mutation paths
+  writing to different sources of truth (the host tree, an Automerge document, a
+  second cursor model) with no reconciliation between them; the design record's audit
+  names that as the root cause.
+
+## `rinch-editor-core` — the pure layer
+
+The guide covers what these are; the architectural points are *why each is a single
+thing rather than several*:
+
+- **One position space.** `Pos` is a single depth-aware integer space (one unit per
+  node boundary, one per Unicode scalar of text). Byte offsets exist only transiently
+  at platform seams — Parley layout, IME — and never in the model. A second position
+  representation would need a conversion at every boundary, and every conversion is a
+  place for the two to drift.
+- **The schema is enforced at the step boundary, not by convention.** Content
+  expressions compile to a `ContentMatch` NFA. Every replace reconstructs its parent
+  through one gate that checks the resulting child sequence against that parent's
+  content expression *and* each child's marks against the allowed set; a violation is a
+  `StepError`, the step is never accumulated into the transaction, and the edit is a
+  no-op. Invalid structure is therefore unrepresentable in a committed state, so no
+  downstream consumer — view, serializer, CRDT projection — needs a defensive path
+  for it.
+- **A deliberately minimal `Step` set.** `ReplaceStep`, `ReplaceAroundStep`,
+  `AddMarkStep`, `RemoveMarkStep`, `SetNodeAttrStep`, `SetDocAttrStep`. Steps are
+  invertible (undo), mappable (redo, decoration tracking, collaboration rebase) and
+  composable. Tables and collaboration add **no** new step kinds — that is the test
+  of whether the set is actually primitive.
+- **Persistent tree, so identity is cheap.** `Node` is `Rc`-shared and every edit
+  produces a new tree sharing unchanged subtrees. `Node::same_ref` (an `Rc::ptr_eq`)
+  therefore answers "did this subtree change?" in constant time — which is what makes
+  history cheap to keep and the view diff cheap to run.
+- **Nothing is special-cased.** The command catalogue + keymap
+  (`BaseCommandsPlugin`), the markdown input rules (`MarkdownInputRulesPlugin`) and
+  undo/redo (`HistoryPlugin`) are all plugins; `default_plugins()` just lists them.
+  History has no privileged hook in `apply` — it folds its state forward like any
+  other plugin. Features that cannot be added as plugins are a design smell, not an
+  excuse to reach into the core.
+
+## The view seam
+
+`rinch-editor-core::view` defines the whole outward contract in two methods:
 
 ```rust
-pub struct Editor {
-    pub doc: EditorDocument,           // Automerge CRDT document
-    pub schema: Schema,                // Validation rules
-    pub selection: SelectionState,     // Cursor/selection
-    pub history: History,              // Local undo/redo
-    pub commands: CommandDispatcher,   // Command execution
-    pub extensions: ExtensionRegistry, // Loaded plugins
-    pub input_rules: InputRuleSet,     // Auto-transforms
-    pub shortcuts: ShortcutRegistry,   // Keyboard bindings
-    pub events: EventDispatcher,       // Event routing
-    pub config: EditorConfig,          // Settings
+pub trait EditorView {
+    fn update_dom(&mut self, prev: &EditorState, next: &EditorState) -> Vec<ViewRequest>;
+    fn update_caret(&mut self, next: &EditorState) -> Vec<ViewRequest>;
 }
 ```
 
-### Document Model
-
-The `EditorDocument` wraps an Automerge document:
-
-```rust
-pub struct EditorDocument {
-    // Contains:
-    // - Block nodes (paragraph, heading, list, code_block, etc.)
-    // - Inline content (text, marks)
-    // - Mark data (bold, italic, link, etc.)
-    //
-    // Operations:
-    // - insert_text(pos, text)
-    // - delete_range(range)
-    // - add_mark(range, mark, attrs)
-    // - remove_mark(range, mark)
-    // - split_block(pos)
-}
-```
-
-**Key properties:**
-- **CRDT-backed**: Changes can be merged with remote edits
-- **Immutable snapshots**: Document state at any point can be accessed
-- **Collaborative**: Multiple users can edit simultaneously
-- **Local undo**: Operations track inverses for reversal
-
-### Schema System
-
-The schema defines valid document structure:
-
-```rust
-pub struct Schema {
-    pub nodes: HashMap<String, NodeSpec>,
-    pub marks: HashMap<String, MarkSpec>,
-    pub top_node: String,  // Usually "doc"
-}
-
-pub struct NodeSpec {
-    pub name: String,
-    pub content: Option<String>,      // "block+", "inline*", etc.
-    pub group: Option<String>,        // block, inline grouping
-    pub attrs: HashMap<String, AttrSpec>,
-    pub inline: bool,
-    pub atom: bool,                   // No content (leaf node)
-    pub isolating: bool,              // Boundary for operations
-    pub marks: MarkSet,               // Which marks allowed
-}
-
-pub struct MarkSpec {
-    pub name: String,
-    pub attrs: HashMap<String, AttrSpec>,
-    pub inclusive: bool,              // Extend to new typing
-    pub excludes: Option<String>,     // Conflicting marks
-}
-```
-
-### Extension System
-
-Extensions are plugins that contribute to the editor:
-
-```rust
-pub trait Extension: Debug {
-    fn name(&self) -> &str;
-    fn priority(&self) -> i32 { 100 }
-    fn nodes(&self) -> Vec<NodeSpec> { vec![] }
-    fn marks(&self) -> Vec<MarkSpec> { vec![] }
-    fn commands(&self) -> Vec<CommandRegistration> { vec![] }
-    fn keyboard_shortcuts(&self) -> Vec<(KeyboardShortcut, String)> { vec![] }
-    fn input_rules(&self) -> Vec<InputRule> { vec![] }
-    fn on_init(&self, editor: &mut Editor) -> Result<(), EditorError> { Ok(()) }
-}
-```
-
-**Extension lifecycle:**
-1. Extensions register nodes, marks, commands
-2. Schema is built from all extensions
-3. Shortcuts and input rules are collected
-4. Extensions are initialized in priority order
-5. Editor is ready for editing
-
-## Command System
-
-All mutations are commands dispatched through `CommandDispatcher`:
-
-```rust
-pub type Command = fn(&mut Editor) -> Result<(), EditorError>;
-
-pub struct CommandDispatcher {
-    commands: HashMap<String, Command>,
-}
-```
-
-### Command Categories
-
-**Text Commands:**
-- Direct text insertion/deletion
-- Operations on the text content level
-
-**Formatting Commands:**
-- Toggle marks (bold, italic, etc.)
-- Add/remove marks on ranges
-- Set mark attributes (e.g., link href)
-
-**Structure Commands:**
-- Change block type (paragraph to heading)
-- Wrap in container (create blockquote)
-- Lift out of container (remove list wrapper)
-- Split/join blocks
-
-### Command Execution Flow
-
-```
-User Input (keyboard/UI)
-    ↓
-Resolve to command name (shortcut or direct call)
-    ↓
-CommandDispatcher.execute(name)
-    ↓
-Call command function with &mut Editor
-    ↓
-Command updates EditorDocument
-    ↓
-Document mutations trigger Effects
-    ↓
-DOM nodes update (NodeHandle calls)
-```
-
-## Input System
-
-### Keyboard Shortcuts
-
-```rust
-pub struct KeyboardShortcut {
-    pub key: String,              // "Mod-B", "Ctrl+I", etc.
-    normalized: String,           // Normalized for matching
-    pub description: String,
-}
-
-pub struct ShortcutRegistry {
-    shortcuts: HashMap<String, String>,  // normalized → command name
-}
-```
-
-**Key parsing:**
-- Mod = Ctrl (Windows/Linux) or Cmd (Mac)
-- Separators: `-` or `+` (normalized to `+`)
-- Case-insensitive (normalized to lowercase)
-
-### Input Rules
-
-```rust
-pub struct InputRule {
-    pub pattern: Regex,
-    pub description: String,
-    pub handler: fn(&mut Editor, &Captures) -> Result<(), EditorError>,
-}
-
-pub struct InputRuleSet {
-    rules: Vec<InputRule>,
-}
-```
-
-**Examples:**
-- Pattern: `^# $` → Convert to Heading 1
-- Pattern: `**(.+)\*\*$` → Apply bold mark
-- Pattern: `^---$` → Insert horizontal rule
-
-Input rules run AFTER text insertion, checking if the last line matches a pattern. If matched, the handler modifies the document.
-
-## History and Undo/Redo
-
-The `History` system is designed for collaborative editing:
-
-```rust
-pub struct History {
-    pub undo_stack: Vec<UndoOperation>,
-    pub redo_stack: Vec<UndoOperation>,
-}
-
-pub struct UndoOperation {
-    pub changes: Vec<DocumentChange>,
-    pub inverse: Vec<DocumentChange>,  // Reverses these changes
-}
-```
-
-**Key design:**
-- Operations are atomic (multiple DOM changes = one undo step)
-- Inverses are automatically computed
-- Compatible with CRDT merging (local undo doesn't break collaboration)
-- Redo pushes undone operations back to undo stack
-
-## StarterKit: 22 Default Extensions
-
-The `StarterKit` bundles 22 extensions for full-featured editing:
-
-### Nodes (12)
-
-| Name | Group | Content | Purpose |
-|------|-------|---------|---------|
-| doc | - | block+ | Root node |
-| paragraph | block | inline* | Default text block |
-| text | inline | - | Inline text (atomic) |
-| heading | block | inline* | h1-h6 with level attr |
-| blockquote | block | block+ | Quote wrapper |
-| bullet_list | block | list_item+ | Unordered list |
-| ordered_list | block | list_item+ | Numbered list |
-| list_item | - | block+ | List entry |
-| code_block | block | text* | Pre-formatted code |
-| horizontal_rule | block | - | Visual divider (atomic) |
-| hard_break | inline | - | Line break (atomic) |
-| image | inline | - | Image embed (atomic) |
-
-### Marks (10)
-
-| Name | Shortcut | HTML | Attributes |
-|------|----------|------|------------|
-| bold | Mod-B | `<strong>` | - |
-| italic | Mod-I | `<em>` | - |
-| underline | Mod-U | `<u>` | - |
-| strike | Mod-Shift-X | `<s>` | - |
-| code | Mod-E | `<code>` | excludes: bold, italic, underline, strike |
-| link | - | `<a>` | href (required), title, target |
-| highlight | Mod-Shift-H | `<mark>` | color (optional) |
-| subscript | Mod-, | `<sub>` | excludes: superscript |
-| superscript | Mod-. | `<sup>` | excludes: subscript |
-| text_color | - | `<span>` | color (required) |
-
-## Table Extension
-
-The optional `TableExtension` adds table editing:
-
-```rust
-pub struct TableExtension;
-
-impl Extension for TableExtension {
-    fn nodes(&self) -> Vec<NodeSpec> {
-        vec![
-            NodeSpec::builder("table")      // block container
-                .content("table_row+")
-                .isolating(true)            // Operations don't cross boundary
-                .build(),
-            NodeSpec::builder("table_row")
-                .content("table_cell+")
-                .build(),
-            NodeSpec::builder("table_cell")
-                .content("block+")
-                .attr("colspan", AttrSpec::optional("1"))
-                .attr("rowspan", AttrSpec::optional("1"))
-                .build(),
-            NodeSpec::builder("table_header")
-                .content("block+")
-                .attr("colspan", AttrSpec::optional("1"))
-                .attr("rowspan", AttrSpec::optional("1"))
-                .build(),
-        ]
-    }
-}
-```
-
-**Commands (11 total):**
-- `insert_table` - Create 3x3 table
-- `delete_table` - Remove table
-- `add_row_before`, `add_row_after`, `delete_row`
-- `add_column_before`, `add_column_after`, `delete_column`
-- `merge_cells` - Combine selected cells
-- `split_cell` - Undo colspan/rowspan
-- `toggle_header_row` - Promote first row
-
-**Navigation:**
-- Tab = Next cell
-- Shift-Tab = Previous cell
-
-## Selection and Positions
-
-### Position
-
-```rust
-pub struct Position {
-    pub offset: usize,  // Byte offset in document
-}
-
-impl Position {
-    pub fn new(offset: usize) -> Self
-}
-```
-
-Positions are 0-indexed from document start.
-
-### Range
-
-```rust
-pub struct Range {
-    pub start: Position,
-    pub end: Position,
-}
-```
-
-### Selection
-
-```rust
-pub struct Selection {
-    pub anchor: Position,   // Selection start (fixed)
-    pub head: Position,     // Selection end (can move)
-}
-
-impl Selection {
-    pub fn cursor(pos: Position) -> Self      // anchor == head
-    pub fn range(start: Position, end: Position) -> Self
-    pub fn is_collapsed(&self) -> bool        // Is it just a cursor?
-}
-```
-
-**Key insight:** Even when selecting, both anchor and head point to positions in the document. Cursor operations check `is_collapsed()`.
-
-## Rendering Integration
-
-### Hidden Textarea Approach
-
-```html
-<!-- Editor container -->
-<div class="editor">
-    <!-- Hidden textarea for input -->
-    <textarea style="position: absolute; opacity: 0;"></textarea>
-
-    <!-- Rendered document (from NodeHandle API) -->
-    <div class="document">
-        <!-- Rendered nodes from editor.doc -->
-    </div>
-
-    <!-- Selection overlay -->
-    <div class="selection-overlay">
-        <!-- Cursor and selection highlights -->
-    </div>
-</div>
-```
-
-**Why hidden textarea?**
-- Captures all keyboard input (arrow keys, meta keys, etc.)
-- Full IME support (for CJK input)
-- Native clipboard events (Ctrl-C/V, Cmd-C/V)
-- Works without browser context
-
-### Document Rendering
-
-The editor must render its document to Rinch NodeHandles:
-
-```rust
-fn render_editor_doc(__scope: &mut RenderScope, editor: &Editor) -> NodeHandle {
-    let container = __scope.create_element("div");
-    container.set_attribute("class", "editor-doc");
-
-    // Render document nodes
-    for node in &editor.doc.nodes {
-        let rendered = render_node(__scope, node);
-        container.append_child(&rendered);
-    }
-
-    container
-}
-
-fn render_node(__scope: &mut RenderScope, node: &DocumentNode) -> NodeHandle {
-    match node.type_name.as_str() {
-        "paragraph" => {
-            let p = __scope.create_element("p");
-            for child in &node.children {
-                let rendered = render_node(__scope, child);
-                p.append_child(&rendered);
-            }
-            p
-        }
-        "text" => {
-            let text = __scope.create_text(&node.content);
-            text
-        }
-        // ... other node types
-        _ => __scope.create_text(""),
-    }
-}
-```
-
-### Marks Rendering
-
-Marks are applied after text nodes are created:
-
-```rust
-// For each mark span in the document:
-let span = __scope.create_element("strong");  // For bold
-for text in &mark.content {
-    span.append_child(&__scope.create_text(text));
-}
-```
-
-## Event Flow
-
-```
-Keyboard Event
-    ↓
-Hidden Textarea captures (e.g., "a" key)
-    ↓
-Check InputRules (does "a" complete a pattern?)
-    ↓
-Insert text in document
-    ↓
-Check shortcuts (is Mod-B pressed?)
-    ↓
-Execute command if matched
-    ↓
-EditorDocument updated
-    ↓
-Effects trigger DOM updates
-    ↓
-Render marks and styles
-```
-
-## CRDT Collaboration
-
-The Automerge document enables offline editing and collaboration:
-
-```
-Local Editor          Remote Editor
-    │                      │
-    ├─ Edit locally ────→ Receive update
-    │                      ├─ Merge into document
-    ├─ Create change  ←─── Send change
-    │                      └─ Re-render
-    └─ Merge remote
-```
-
-Each change is recorded with metadata (actor, timestamp) allowing automatic merging without conflicts.
-
-## Error Handling
-
-```rust
-pub enum EditorError {
-    InvalidNodeType(String),
-    InvalidMarkType(String),
-    InvalidSelection,
-    DocumentError(String),
-    CommandNotFound(String),
-    // ...
-}
-```
-
-All document mutations return `Result<(), EditorError>`, allowing graceful error handling:
-
-```rust
-editor.doc.insert_text(pos, "hello")?;  // Propagate errors
-match editor.commands.execute("toggle_bold") {
-    Ok(()) => { /* success */ }
-    Err(e) => eprintln!("Command failed: {}", e),
-}
-```
-
-## Performance Characteristics
-
-### Time Complexity
-
-| Operation | Complexity | Notes |
-|-----------|-----------|-------|
-| Insert text | O(n) | n = document length |
-| Delete range | O(n) | Proportional to range size |
-| Toggle mark | O(n) | Scans range for existing marks |
-| Apply input rule | O(1) | Regex on last line only |
-| Command dispatch | O(log k) | k = number of commands |
-| Schema lookup | O(1) | HashMap |
-
-### Memory
-
-- Document size proportional to content
-- CRDT overhead: ~2x text size (metadata)
-- Undo stack: One entry per atomic operation
-- Selection state: Minimal (two positions)
-
-## Testing Utilities
-
-Rinch provides test helpers:
-
-```rust
-#[cfg(test)]
-fn test_example() {
-    let schema = Schema::starter_kit();
-    let config = EditorConfig::default();
-    let mut editor = Editor::new(schema, config).unwrap();
-
-    // Insert and verify
-    editor.doc.insert_text(Position::new(0), "hello").unwrap();
-    assert_eq!(editor.doc.length(), 5);
-
-    // Toggle formatting
-    editor.commands.execute("toggle_bold").unwrap();
-
-    // Check result
-    let marks = editor.doc.marks_at(Position::new(2));
-    assert!(marks.iter().any(|m| m.name == "bold"));
-}
-```
-
-## Extensibility Points
-
-### Custom Extensions
-
-Implement `Extension` to add:
-- New node types (with content rules)
-- New mark types (with attributes)
-- Commands (via `CommandRegistration`)
-- Shortcuts (via `KeyboardShortcut`)
-- Input rules (via `InputRule`)
-
-### Custom Schema
-
-Build your own schema without StarterKit:
-
-```rust
-let mut schema = Schema::new();
-schema.add_node(my_custom_node);
-schema.add_mark(my_custom_mark);
-```
-
-### Custom Commands
-
-Register commands directly:
-
-```rust
-editor.commands.register("my_command", |editor| {
-    // Command implementation
-    Ok(())
-})?;
-```
-
-### Custom Renderers
-
-Implement rendering for your document structure using Rinch's NodeHandle API (set_text, set_attribute, append_child, etc.).
-
-## Related Documentation
-
-- [User Guide: Rich-Text Editor](../guide/editor.md)
-- [RenderScope API](./render-scope.md)
-- [Fine-Grained Reactivity](./fine-grained.md)
+Three structural decisions live in that shape.
+
+**It is two phases because layout sits between them.** `update_dom` runs *before*
+layout and mutates the host. `update_caret` runs *after* layout, once the host has
+fresh geometry, and computes caret/selection rectangles and the IME candidate box.
+Caret geometry computed in the call that mutates the host would read stale layout —
+so the seam straddles the host's *mutate → layout → measure* pipeline rather than
+pretending it isn't there.
+
+**Requests cross back as data.** The view owns no window; only the runtime does. So
+"scroll the selection into view" is a returned `ViewRequest` the runtime fulfils, not
+a call the view makes.
+
+**Input translation is deliberately absent from the trait.** Turning a key, pointer
+or IME event into a command is irreducibly platform-specific — desktop reads Parley
+geometry to map a click to a `Pos`; the browser has its own event model — so each
+runtime owns that glue. The trait covers only the state→host direction, which is the
+part that *can* be shared.
+
+## `rinch-editor-view` — one projection, two hosts
+
+`RinchDomEditorView` implements `EditorView` against
+`rinch_core::dom::DomDocument`, the same trait the reactive layer uses. It holds
+only a `Weak` reference to the document and never names a concrete renderer — which
+is why the desktop (`rinch-dom`) and browser (`web_sys`) editors are the *same* view
+code, and why its own tests project onto a mock document with no renderer present at
+all.
+
+**The `ViewDesc` tree** mirrors the document: one descriptor per model node, holding
+its host node, its mark-wrapper chain, and its children. Diffing walks descriptors
+against the new document, with `Node::same_ref` as a fast skip — an unchanged subtree
+costs one pointer comparison. The diff is **positional, not keyed**: text edits are
+local, so position is a good proxy for identity, and a keyed/LIS pass would buy
+nothing until reorder churn matters. A node whose *kind* changed (tag or mark set)
+is rebuilt and swapped rather than patched in place, because a changed mark set
+alters the wrapper chain around it. The root's host element is created by the caller
+(the `Editor` component) and is never replaced — only its children reconcile.
+
+**Decorations diff independently of the document.** A transaction that changes only
+decorations — an IME preedit, a placeholder appearing — must still produce a visible
+update, so `update_dom` runs the document diff and a separate decoration sync. Folding
+them together would make preedit invisible whenever the document happened not to
+change.
+
+**`EditorHandle` owns both the state and its projection**, behind an `Rc<RefCell<…>>`
+so it is cheap to clone into toolbar closures and the runtime alike. It works
+*unmounted*: `create_editor()` builds a handle over a fresh document with no host at
+all, and `load_html` / `command` / `set_selection` operate on the owned state, which
+the view renders when the `Editor {}` component mounts it. This is what lets a handle
+be created in a component body and handed to buttons *and* to `Editor {}` in the same
+`rsx!` block.
+
+**The registry is keyed by `(doc_key, container_id)`, not by container id alone.**
+Container ids are per-document slab indices, so two documents on one thread — two
+desktop windows, or two embedded `RinchContext`s — collide at the same id (issue
+#134). Keyboard focus is *not* tracked here: the platform runtime is the single focus
+authority, and it resolves its focused container id to a handle through the registry.
+The `Editor` component registers on mount and unregisters via `scope.on_cleanup`, so
+a hidden tab's editor stops being driven while its handle (and state) may live on.
+
+## Platform wiring
+
+The wiring crates hold exactly what cannot cross the `DomDocument` seam.
+
+**Desktop (`crates/rinch/src/editor/`)** re-exports `rinch-editor-view` wholesale and
+adds three things that reach past the seam into the `rinch-dom` renderer or a native
+platform API:
+
+| Path | Why it can't be in the shared view |
+|---|---|
+| `virtualization.rs`, `virtual_window.rs` | Block virtualization gives off-screen blocks a fixed estimated height so Taffy skips their Parley measurement. It manipulates the concrete Taffy layout tree. |
+| `a11y.rs` | The accessibility *derivation* is portable (`rinch_editor_core::a11y` → an `accesskit::TreeUpdate`); only the adapter is not. Linux uses `accesskit_unix` over AT-SPI; other desktops get a no-op bridge. |
+| `post_remote_delta` | The `Send`-safe collaboration inbound: marshals a delta from a network thread onto the main thread, then integrates it and wakes the runtime. |
+
+Input translation and the caret pass live in the runtime proper:
+`app/event_dispatch.rs` turns platform key/pointer/IME events into `KeyBinding`s and
+handle calls, `app/focus.rs` holds the focus arbiter, and `shell/rinch_runtime.rs`
+drives the post-layout caret pass and the blink clock.
+
+**Browser (`crates/rinch-web/`)** does the same jobs against the browser DOM in
+`editor_input.rs`, and re-exports `Editor` / `EditorHandle` / `create_editor` so web
+app code is *identical* to desktop app code. `rinch-web` depends on
+`rinch-editor-view` unconditionally; on desktop the editor arrives with the `desktop`
+feature.
+
+## Serialization
+
+`rinch-editor-core::serialize` is the durability boundary, and its contract is
+**totality**: a node or mark either round-trips faithfully or the boundary returns an
+error. Nothing is dropped silently and nothing is rendered to a fallback tag.
+
+| Module | Shape | Notes |
+|---|---|---|
+| `doc_json` (feature `serde`) | `DocNode` | The durable save/load shape. `Node::to_doc()` ⇄ `Schema::node_from_doc()`. Unknown types and missing required attrs are hard errors. |
+| `html` | HTML string | Schema-driven tags (`node_dom_tag` / `mark_dom_tag`), whitelist parse. The *same* table the view uses to pick host tags and that `Editor { content: … }` / `load_html` parse with. |
+| `markdown` (feature `markdown`) | markdown | Via `pulldown-cmark`. |
+| `text` | plain text | The lossy `text/plain` clipboard fallback. |
+
+That the view and the serializers share one tag table is the point: copy-out,
+paste-in, and on-screen rendering cannot disagree about what a `heading` is.
+
+## Collaboration — an optional projection
+
+`rinch-editor-collab` projects the model onto a **yrs** (Yjs) CRDT and rebuilds
+remote CRDT changes back into `Step`s. Architecturally it is a *peer* of the view: a
+second projection of the same model, sitting behind the same one-way mutation path.
+The model does not know it exists.
+
+- **Off by default.** Gated behind the `collaboration` feature, so default builds —
+  desktop *and* web — link zero CRDT code. This is the only crate in the workspace
+  that links a CRDT engine.
+- **One invariant:** `model ≡ project(model)`. Every local step is projected onto the
+  CRDT; every remote change is rebuilt into the model. Convergence then follows from
+  the CRDT's own convergence rather than from hand-written merge logic.
+- **Fail loud, never silently drop.** Content outside the staged scope returns
+  `CollabError::Unsupported` and leaves the CRDT untouched — projection is
+  all-or-nothing. A silent drop would reintroduce exactly the divergence class the
+  rewrite eliminated.
+- **wasm-compatible with no shims**, so the desktop and browser editors share one
+  adapter instead of bridging to a separate JS CRDT.
+
+For the API, the staged scope, the transport contract and the engine-choice rationale
+see the Collaboration section of CLAUDE.md, the
+[Rich-text editing](../guide/contenteditable.md) guide, and
+`docs/design/yrs-migration.md`.
+
+## Not the rich-text editor: `rinch-editable`
+
+`rinch-editable` is a **separate, unrelated** engine for single-line `<input>` and
+`<textarea>` widgets: `StringDocument`, `EditCommand`, `EditableState`,
+`InputHandler`, and its own `Position`/`Selection`/`UndoStack` types. It shares no
+code and no types with `rinch-editor-core` — the identical names live in different
+crates. The quickest tell: `rinch-editable`'s `Selection` is a **struct** of two
+`Position`s, while `rinch-editor-core`'s is an **enum** of `Text`/`Node`/`Cell`.
+
+The split is intentional: a text field does not need a schema, steps, or a CRDT, and
+the rich editor should not carry a second document model for the sake of one.
+
+## Related
+
+- [Rich-Text Editor](../guide/editor.md) — the model and its concepts.
+- [Rich-text editing](../guide/contenteditable.md) — the component and command API.
+- [Architecture Overview](./overview.md) — where these crates sit in the whole system.
+- [RenderScope API](./render-scope.md) — the `DomDocument` / `NodeHandle` seam the
+  view projects onto.
+- [Fine-Grained Reactivity](./fine-grained.md) — how the surrounding UI updates.

--- a/docs/src/architecture/overview.md
+++ b/docs/src/architecture/overview.md
@@ -20,17 +20,19 @@ Signal.set()
 rinch/
 ├── crates/
 │   ├── rinch/              # Main application crate
-│   │   ├── src/app.rs      # Platform-agnostic RinchApp
+│   │   ├── src/app/        # Platform-agnostic RinchApp
 │   │   └── src/shell/      # Desktop backend (winit + wgpu)
 │   ├── rinch-core/         # Core types, reactive primitives, DOM abstractions
 │   ├── rinch-macros/       # rsx! proc macro
 │   ├── rinch-dom/          # HTML/CSS DOM (Taffy + Parley + Stylo + Vello)
 │   ├── rinch-platform/     # Platform abstraction traits
 │   ├── rinch-web/          # Browser-native DOM backend (WebDocument over web_sys)
-│   ├── rinch-editor/       # Rich-text editor (CRDT)
+│   ├── rinch-editor-core/  # Rich-text editor model (pure, renderer-agnostic)
+│   ├── rinch-editor-view/  # Rich-text editor view (desktop + web projection)
+│   ├── rinch-editor-collab/# Optional CRDT collaboration adapter (yrs)
 │   ├── rinch-theme/        # Theme system (CSS variables)
-│   ├── rinch-components/   # UI component library (~55 components)
-│   ├── rinch-editable/     # Text editing abstractions
+│   ├── rinch-components/   # UI component library
+│   ├── rinch-editable/     # Single-line <input>/<textarea> editing primitives
 │   ├── rinch-clipboard/    # Cross-platform clipboard
 │   ├── rinch-tabler-icons/ # 5000+ Tabler Icons
 │   ├── rinch-debug/        # Debug IPC server
@@ -39,6 +41,9 @@ rinch/
     ├── ui-zoo-desktop/     # Desktop component showcase + rich-text editor
     └── ui-zoo-web/         # Web (WASM) component showcase using browser-native DOM
 ```
+
+These are the principal crates; the workspace `Cargo.toml` has the full member list
+(networking, storage, media, testing and platform-specific crates are omitted here).
 
 ## Layer Diagram
 
@@ -49,9 +54,9 @@ rinch/
 ├──────────────────────────────────────────────────────────────┤
 │                         rinch                                 │
 │  ┌──────────────────────────────────────────────────┐        │
-│  │          RinchApp (app.rs)                        │        │
+│  │          RinchApp (app/)                          │        │
 │  │  Platform-agnostic application logic              │        │
-│  │  handle_event(PlatformEvent) -> Vec<AppAction>    │        │
+│  │  handle_event(PlatformEvent, …) -> Vec<AppAction> │        │
 │  └──────────────────────────────────────────────────┘        │
 │                          │                                    │
 │         ┌────────────────┼────────────────┐                  │
@@ -69,7 +74,7 @@ rinch/
 │  Signal, Effect, Memo, RenderScope, NodeHandle, DomDocument  │
 ├──────────────────────────────────────────────────────────────┤
 │  rinch-dom    │  rinch-theme  │  rinch-components            │
-│  (HTML/CSS)   │  (CSS vars)   │  (~55 components)            │
+│  (HTML/CSS)   │  (CSS vars)   │  (component library)         │
 ├──────────────────────────────────────────────────────────────┤
 │                    External Crates                            │
 │  Taffy (layout) │ Parley (text) │ Stylo (CSS) │ Vello/tiny-skia │
@@ -83,13 +88,18 @@ Rinch uses a platform abstraction pattern to support multiple backends (desktop,
 ```rust
 // Platform-agnostic application logic
 impl RinchApp {
-    fn handle_event(&mut self, event: PlatformEvent) -> Vec<AppAction> {
+    pub fn handle_event(
+        &mut self,
+        event: PlatformEvent,
+        window_size: (u32, u32),
+        scale_factor: f64,
+    ) -> Vec<AppAction> {
         match event {
             PlatformEvent::MouseDown { x, y, button } => {
                 // Handle click, update DOM
                 vec![AppAction::RequestRedraw]
             }
-            PlatformEvent::KeyPress { key, modifiers } => {
+            PlatformEvent::KeyDown { key, modifiers, .. } => {
                 // Handle keyboard input
                 vec![AppAction::RequestRedraw]
             }
@@ -119,12 +129,13 @@ This separation allows:
 
 The foundation layer containing:
 
-- **Reactive primitives** - `Signal<T>`, `Effect`, `Memo<T>` for state management
+- **Reactive primitives** - `Signal::new()`, `Effect::new()`, `Memo::new()`, plus
+  scopes/ownership and `create_context()` / `create_store()`
 - **DOM abstractions** - `RenderScope`, `NodeHandle`, `DomDocument` trait
-- **Reactive Primitives** - `Signal::new()`, `Effect::new()`, `Memo::new()`, `create_context()`
+- **Control flow** - `show_dom()`, `for_each_dom_typed()`, `match_dom()` (what rsx
+  `if`/`for`/`match` desugar to)
 - **Element types** - Minimal enum: `Html`, `Fragment`, `Component` only
-- **Event handling** - Input and click event dispatch
-- **Icon enum** - Curated set of ~40 common icons for components
+- **Event handling** - Input, click, keyboard and drag event dispatch
 
 ### rinch-macros
 
@@ -148,10 +159,12 @@ rsx! {
 
 The main crate that ties everything together:
 
-- **RinchApp** (`app.rs`) - Platform-agnostic application logic
+- **RinchApp** (`app/`) - Platform-agnostic application logic (event dispatch, hit
+  testing, focus arbitration, text selection)
 - **Desktop backend** (`shell/rinch_runtime.rs`) - Event loop, window creation, rendering
-- **Event loop** (`shell/rinch_runtime.rs`) - Desktop runtime: event loop, window creation, rendering
 - **Menu Manager** - Native menu support via muda
+- **Editor wiring** (`editor/`) - Desktop-only editor pieces: block virtualization,
+  AccessKit accessibility, the cross-thread collaboration inbound
 
 ### rinch-platform
 
@@ -172,12 +185,16 @@ HTML/CSS DOM implementation:
 
 ### rinch-web
 
-Browser-native DOM backend (the WASM target). Consumed by `examples/ui-zoo-web` and `examples/paint-web`:
+Browser-native DOM backend (the WASM target). Consumed by the `*-web` examples —
+`ui-zoo-web`, `paint-web`, `editor-web`, `collab-editor-web`, and others:
 
 - **WebDocument** - Implements `DomDocument` via `web_sys`, creating real browser DOM elements
 - **No Taffy/Parley/Vello** - The browser handles layout, text shaping, and painting natively
 - **Event delegation** - `setup_event_delegation` installs document-level listeners that dispatch via `data-rid` attributes (plus drag, render-surface routing, and `data-onsubmit`/`data-oninput`)
 - **`mount` helper** - One call wires the WebDocument, builds the component tree, installs event delegation, and injects theme CSS
+- **Rich-text editor** - Re-exports `Editor` / `EditorHandle` / `create_editor` from
+  `rinch-editor-view` and owns the browser input glue, so editor app code is identical
+  to desktop
 - **Smaller binary** - ~3.2MB WASM (vs 11MB+ with Vello rendering)
 
 ### rinch-theme
@@ -189,25 +206,36 @@ Theme system with CSS variables:
 - Dark mode support
 - CSS variable generation for components
 
-### rinch-editor
+### rinch-editor-core / rinch-editor-view / rinch-editor-collab
 
-Rich-text editor with collaborative editing support:
+The ProseMirror-style rich-text editor, split by how much each crate may know about a
+renderer:
 
-- **CRDT-backed document** - Automerge for offline editing and conflict resolution
-- **Schema system** - Define valid document structure with nodes and marks
-- **22 StarterKit extensions** - Complete editing experience out of the box
-- **Command system** - All mutations go through named commands
-- **Extension system** - Add custom nodes, marks, commands, shortcuts
-- **Keyboard shortcuts** - 16+ built-in shortcuts (Mod-B, Mod-I, etc.)
-- **Markdown input rules** - Auto-convert markdown patterns (# heading, **bold**, etc.)
-- **Table editing** - Full table support with merge/split/navigation
-- **Local undo/redo** - Compatible with collaborative editing
+- **rinch-editor-core** — the **model-first** source of truth, and pure: no rinch-dom,
+  winit, web_sys, parley, taffy, vello, or CRDT engine, and it compiles to `wasm32`.
+  It holds the immutable `Node`/`Mark`/`Fragment`/`Slice` document tree, one char-based
+  `Pos` space, a `ContentMatch` schema that is *enforced* at the step boundary,
+  invertible `Step`s, `EditorState`/`Transaction`, the command catalogue and keymap,
+  markdown input rules, Step-based undo/redo, and total schema-derived serialization
+  (`DocNode` JSON, HTML, markdown). It defines the `EditorView` seam and knows nothing
+  about any renderer.
+- **rinch-editor-view** — the projection: `RinchDomEditorView` renders an
+  `EditorState` onto *any* `DomDocument` host, so the desktop (rinch-dom) and browser
+  (`web_sys`) editors share one view. Also the `Editor {}` component, the imperative
+  `EditorHandle`, the mounted-editor registry and the default stylesheet.
+- **rinch-editor-collab** — optional, off by default: projects the model onto a **yrs**
+  (Yjs) CRDT for real-time collaboration and rebuilds remote changes back into `Step`s.
+  The only crate in the workspace that links a CRDT engine.
+
+**Mutation flows one way:** every edit is a `Transaction` applied by
+`EditorState::apply`, after which the view diffs the document and patches the host.
+The host tree is never read back for content, and commands query state, never the DOM.
 
 See [Editor Architecture](./editor.md) for technical details.
 
 ### rinch-components
 
-UI component library (~55 components):
+UI component library:
 
 - Input components: TextInput, Checkbox, Switch, Select, Slider
 - Display components: Button, Badge, Alert, Card, Notification
@@ -219,11 +247,15 @@ UI component library (~55 components):
 
 ### rinch-editable
 
-Text editing abstractions:
+Editing primitives for single-line `<input>` and `<textarea>` widgets — a **separate
+engine**, unrelated to the rich-text editor above (they share no code and no types,
+despite both having a `Selection`):
 
 - **EditableDocument** - Trait for text editing operations
+- **StringDocument** - Single-line text document
 - **EditCommand** - Enum of editing commands (insert, delete, etc.)
 - **EditableState** - Cursor position, selection state
+- **InputHandler** - Maps keyboard input to commands
 
 ### rinch-clipboard
 
@@ -348,7 +380,7 @@ This is much more efficient than regenerating HTML and replacing the entire docu
 | **winit** | Cross-platform windowing and input |
 | **muda** | Native menu support (macOS/Windows/Linux) |
 | **arboard** | Cross-platform clipboard access |
-| **Automerge** | CRDT for collaborative editing (rinch-editor) |
+| **yrs** | CRDT for collaborative editing (rinch-editor-collab, opt-in) |
 
 ## Design Principles
 

--- a/docs/src/guide/contenteditable.md
+++ b/docs/src/guide/contenteditable.md
@@ -8,11 +8,11 @@ You add it with the `Editor {}` component and drive it through an `EditorHandle`
 > model — the document tree, steps and transactions, the schema, commands, and the
 > view seam — see the [Rich-Text Editor](./editor.md) guide.
 
-> **Desktop today.** The editor view is a **desktop** feature (gated behind the
-> `desktop` cargo feature). The editor *core* is renderer-agnostic; a web view (over
-> the browser's native contentEditable) is a planned follow-up. There is no
-> `contenteditable` HTML attribute and no DOM-level editing API to wire up — the
-> `Editor` component is the whole surface.
+> **Desktop and web.** On desktop the editor arrives with the `desktop` cargo feature;
+> in the browser `rinch-web` re-exports it (see [On the web](#on-the-web-rinch-web)
+> below) — the app code is identical, because both share the renderer-agnostic view in
+> `rinch-editor-view`. There is no `contenteditable` HTML attribute and no DOM-level
+> editing API to wire up — the `Editor` component is the whole surface.
 
 ## Quick start
 

--- a/docs/src/guide/editor.md
+++ b/docs/src/guide/editor.md
@@ -1,10 +1,11 @@
 # Rich-Text Editor
 
 Rinch's rich-text editor is a **ProseMirror-faithful architecture in idiomatic
-Rust**: a pure, renderer-agnostic core (`rinch-editor-core`) plus a desktop view
-that projects it onto rinch-dom. This page is the conceptual guide to that core —
-the document model, schema, steps and transactions, state, commands, history, and
-the view seam.
+Rust**: a pure, renderer-agnostic core (`rinch-editor-core`) plus an equally
+renderer-agnostic view (`rinch-editor-view`) that projects it onto whichever host tree
+the platform provides — rinch-dom on desktop, the browser DOM on web. This page is the
+conceptual guide to that core — the document model, schema, steps and transactions,
+state, commands, history, and the view seam.
 
 > **Just adding an editor to a screen?** Start with the
 > [Rich-text editing](./contenteditable.md) guide — `create_editor()`, the
@@ -18,8 +19,8 @@ There is exactly one source of truth and exactly one way to change it:
    No DOM node is ever authoritative.
 2. **Every edit is a `Transaction` of invertible `Step`s**. `state.apply(tr)`
    returns a *new* `EditorState`; it is pure and side-effect-free.
-3. **The view is a pure function of state.** The desktop view diffs the old and new
-   document and patches the host tree; it renders the caret and selection from
+3. **The view is a pure function of state.** The view diffs the old and new document
+   and patches the host tree; it renders the caret and selection from
    `state.selection`. The host tree is never read back for content.
 4. **Input produces transactions, not DOM edits.** Keys, IME, paste, and pointer
    selection are translated into commands/transactions.
@@ -241,26 +242,30 @@ features compose without bloating the core.
 ## The view seam
 
 The core defines an `EditorView` trait and a small request/event vocabulary; it knows
-nothing about any renderer. The **desktop view lives in the `rinch` crate** — the
-only rinch-dom touchpoint — and a **web view (a follow-up) will live in `rinch-web`**,
-delegating to the browser's native contentEditable. Nothing else knows the renderer.
+nothing about any renderer. The view that implements it — `RinchDomEditorView` — lives
+in **`rinch-editor-view`** and is itself renderer-agnostic: it projects onto any
+`rinch-core` `DomDocument`, so the desktop (rinch-dom) and browser (`web_sys`) editors
+run the *same* view code. Only the thin input glue and the layout-coupled extras are
+per-platform (`rinch` on desktop, `rinch-web` in the browser).
 
-The desktop view, on each transaction:
+The view, on each transaction:
 
-1. **Diffs** `prev.doc` against `next.doc`. Because the model is persistent,
-   `Rc::ptr_eq` makes the diff cheap — unchanged subtrees are skipped entirely.
-2. **Patches** rinch-dom for the changed regions via the standard primitives
-   (`create_element` / `create_text` / `append_child` / `insert_before` / `remove` /
-   `set_text` / `set_attribute` / `set_style`), choosing tags from the schema-driven
-   serializer. **Leaf node-views** (image, horizontal rule, table cell) own their own
-   subtree; the diff stops at their boundary and delegates.
-3. **Renders the caret and selection from `state.selection`** (after layout),
-   converting the model's char `Pos` to a byte offset for Parley only at this render
-   edge.
+1. **Diffs** the new document against the descriptor tree it retained from the previous
+   one. Because the model is persistent, `Node::same_ref` (an `Rc::ptr_eq`) makes the
+   diff cheap — unchanged subtrees are skipped entirely. The diff is positional, and a
+   node whose tag or mark set changed is rebuilt rather than patched.
+2. **Patches** the host for the changed regions via the standard `DomDocument`
+   primitives (`create_element` / `create_text` / `append_child` / `insert_before` /
+   `remove` / `set_text` / `set_attribute` / `set_style`), choosing tags from the
+   schema-driven serializer. Decorations (placeholder, IME preedit) diff separately, so
+   a decoration-only transaction still produces a visible update.
+3. **Renders the caret and selection from `state.selection`** (after layout, in the
+   second phase), converting the model's char `Pos` to a byte offset for the platform's
+   text layout only at this render edge.
 
-The view also owns block virtualization (skipping layout for off-screen blocks while
-keeping their real height), IME positioning, and — under the opt-in `a11y` feature —
-deriving an accessibility tree from the state.
+Around that, the platform crates own block virtualization (skipping layout for
+off-screen blocks while keeping their real height), IME positioning, and — under the
+opt-in `a11y` feature — pushing an accessibility tree derived from the state.
 
 ## End-to-end edit flow
 
@@ -289,4 +294,5 @@ types are rejected on load, never silently dropped.
 - [Rich-text editing](./contenteditable.md) — the practical component + command API.
 - `examples/markdown-editor` and `examples/ui-zoo/src/sections/editor.rs` — working
   editors driving the command API.
-- [Editor Architecture](../architecture/editor.md) — deeper technical notes.
+- [Editor Architecture](../architecture/editor.md) — the crate boundaries, data flow,
+  and the invariants each boundary protects.


### PR DESCRIPTION
PR3 of #190, per Joe's decisions: rewrite (not delete) the architecture page, full refresh (not thin) of AGENTS.md.

- **docs/src/architecture/editor.md** — rewritten from scratch (578 → 276 lines). The old page described the deleted pre-rearchitecture design end to end (Automerge-as-model, Extension trait, hidden-textarea input — none of it survived even at the type level). The new page is the structural view: the crate map keyed on renderer-knowledge, the model-is-truth invariant and its consequences, the EditorView seam and why it's two-phase, the ViewDesc diff (positional, not keyed — and why), platform wiring, serialization totality, collab as a peer projection, and the rinch-editable boundary.
- **AGENTS.md** — fully regenerated from the current workspace (crate list derived from members minus excludes; per-crate roles from each manifest's own description). Hooks-era content deleted (no hook system, no Show/For components), dead file references replaced, volatile metrics dropped per drift-proofing, and the #141 ownership + #154 ordering contracts added as named invariants with verified file:line anchors.
- **docs/src/architecture/overview.md** — surgical fixes: the flagged Automerge/rinch-editor passages, plus seven more verified falsehoods found while in there (no `app.rs`, no `Icon` enum, `PlatformEvent::KeyPress` → `KeyDown`, duplicated bullets, rinch-editable conflation, stale example list, incomplete crate tree now labeled as principal-crates-only).
- **CLAUDE.md** — the general editor Key Source Files table now points at the real `rinch-editor-view` paths; the "web view is a follow-up" claim corrected (it shipped: `rinch-web/src/editor_input.rs`, `examples/editor-web`).
- **docs/src/guide/editor.md**, **docs/src/guide/contenteditable.md**, **README.md** — the same stale fact (view-crate extraction + web view shipping) fixed where it contradicted the new page, including guide/editor.md's claims of a `prev.doc` diff and a node-view mechanism that don't exist.

mdbook build: zero warnings before and after (baselined against main). The only remaining "Automerge" in docs/src is one deliberate historical sentence.

Follow-ups deliberately not folded in (same-class staleness, bigger surface): CLAUDE.md's Icon System section (no `Icon` enum exists anymore), its top-level architecture tree, the missing `on_change` row in the EditorHandle table, and `rinch-editor-core/src/view.rs` module docs (source file, out of scope for a docs PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)