### PR TITLE
docs: stale-docs batch — icons, RenderSurface API, embed input traps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,8 @@ crates/
 ├── rinch-core/               # Core types
 │   ├── src/element.rs        # Element enum (Html, Fragment, Component only), prop types
 │   ├── src/context.rs        # Context API (create_context, use_context)
-│   ├── src/reactive.rs       # Signal, Effect, Memo primitives
-│   ├── src/dom.rs            # NodeHandle, RenderScope, DomDocument trait
-│   └── src/icon.rs           # Icon enum for type-safe icons
+│   ├── src/reactive/         # Signal, Effect, Memo primitives
+│   └── src/dom/              # NodeHandle, RenderScope, DomDocument trait
 ├── rinch-theme/              # Theme system (optional, enable with `theme` feature)
 │   └── src/
 │       ├── colors.rs         # Mantine color palettes (10 shades each)
@@ -61,11 +60,16 @@ crates/
 │       ├── stack.rs          # Vertical flex layout
 │       ├── group.rs          # Horizontal flex layout
 │       ├── badge.rs          # Status indicator
-│       ├── icons.rs          # SVG icon rendering (render_icon function)
+│       ├── icons.rs          # Hand-built chrome glyphs (chevron_up_dom, checkmark_dom, ...)
 │       └── styles.rs         # Component CSS generation
-├── rinch-tabler-icons/       # 5000+ Tabler Icons (build.rs fetches from tabler.io)
-│   ├── build.rs              # Downloads and generates icon data from Tabler
+├── rinch-tabler-icons/       # ~4,980 Tabler Icons (generated from vendored JSON)
+│   ├── build.rs              # Generates the TablerIcon enum from data/ (downloads only as fallback)
+│   ├── data/                 # Vendored Tabler JSON, committed — lets the crate build offline
 │   └── src/lib.rs            # TablerIcon enum, render_tabler_icon function
+├── rinch-editor-core/        # Pure editor model: steps, schema, state, commands, history (wasm-clean)
+├── rinch-editor-view/        # Editor view over any DomDocument: EditorHandle, Editor component
+├── rinch-editor-collab/      # Optional collab adapter: model <-> yrs (Yjs) CRDT; off by default
+├── rinch-editable/           # Single-line <input>/<textarea> engine (not the rich editor)
 ├── rinch-debug/              # Debug IPC server (optional, enable with `debug` feature)
 │   ├── src/lib.rs            # Public API: attach(), CommandSender, CommandReceiver
 │   ├── src/protocol.rs       # Wire protocol: length-prefixed JSON, handshake
@@ -111,19 +115,16 @@ fn my_component() -> NodeHandle {
 
 ## Icon System
 
-Rinch has two icon systems:
+There is **one** icon system: the **`TablerIcon` enum** in `rinch-tabler-icons`, which is also what every component's icon prop takes (`Option<TablerIcon>`). There is no `Icon` enum in the workspace — an older curated `rinch-core` `Icon` enum was removed, so treat any doc comment or snippet still showing `Icon::CheckCircle` as stale.
 
-1. **`Icon` enum** (rinch-core) - A curated set of ~40 common icons, used by components
-2. **`TablerIcon` enum** (rinch-tabler-icons) - 5000+ icons from [Tabler Icons](https://tabler.io/icons)
-
-### Tabler Icons (Recommended)
-
-The `rinch-tabler-icons` crate provides 5000+ free SVG icons from [Tabler Icons](https://tabler.io/icons). Icons are downloaded at build time from the Tabler CDN.
+`TablerIcon` is **not** in the `rinch` prelude — the facade doesn't depend on `rinch-tabler-icons`. Any crate that names an icon variant (including one just passing `icon:` to a component) must depend on it directly.
 
 **Add to Cargo.toml:**
 ```toml
 rinch-tabler-icons = { workspace = true }
 ```
+
+The crate generates the enum at build time from **vendored JSON committed under `crates/rinch-tabler-icons/data/`**, pinned to `@tabler/icons@3.36.1`, so it builds with no network. It only downloads from unpkg if a vendored file is missing or invalid.
 
 **Usage:**
 ```rust
@@ -143,12 +144,17 @@ fn my_component() -> NodeHandle {
 }
 ```
 
+The `tabler_icon!` macro is a shorter equivalent when the icon is a literal variant name: `tabler_icon!(__scope, Home)` (Outline is the default style) or `tabler_icon!(__scope, Home, Filled)`.
+
+For size, stroke width, or a CSS class, use `render_tabler_icon_with_options(__scope, icon, TablerIconOptions { style, class, size, stroke_width })` — all fields but `style` are `Option`, so `..Default::default()` covers the rest.
+
 **Features:**
-- **5000+ icons** in both Outline and Filled styles
+- **4,983 icons** (`ICON_COUNT`; iterate `ALL_ICONS`), every one available in Outline
+- **Filled is a subset** — about 1,000 icons have real filled artwork. Asking for `TablerIconStyle::Filled` on any other icon silently falls back to its outline paths, so a glyph that still looks like an outline is expected, not a bug
 - **Type-safe** - Use enum variants instead of strings
-- **Tree-shaking friendly** - Rust dead code elimination removes unused icons
-- **Consistent styling** - All icons render at 24x24 with `currentColor`
-- **Build-time download** - Icons fetched from Tabler CDN during `cargo build`
+- **Scales with font size** - Icons carry a `0 0 24 24` viewBox and are sized `1em` unless you pass an explicit `size`, so they track the parent's `font-size`
+- **Themeable** - Outline icons use `stroke: currentColor` (default `stroke-width: 2`), filled icons `fill: currentColor`
+- **Offline build** - Generated from the vendored JSON in `data/`; no network needed
 
 **Using with ActionIcon:**
 ```rust
@@ -168,32 +174,27 @@ ActionIcon {
 - Media: `Photo`, `Video`, `Music`, `Microphone`, `Camera`, `PlayerPlay`
 - Files: `File`, `Folder`, `Download`, `Upload`, `Copy`, `ClipboardCopy`
 
-### Built-in Icon Enum (Legacy)
-
-The `Icon` enum in rinch-core provides a smaller curated set of ~40 icons. These are used internally by components like `Alert`, `Notification`, etc.
-
-| Category | Icons |
-|----------|-------|
-| **Navigation** | `ChevronUp`, `ChevronDown`, `ChevronLeft`, `ChevronRight`, `ChevronsLeft`, `ChevronsRight`, `ArrowUp`, `ArrowDown`, `ArrowLeft`, `ArrowRight` |
-| **Actions** | `Close`, `Check`, `Plus`, `Minus`, `Search`, `Settings`, `Edit`, `Trash` |
-| **Status/Alerts** | `InfoCircle`, `CheckCircle`, `AlertCircle`, `AlertTriangle`, `XCircle` |
-| **Content** | `User`, `Mail`, `Phone`, `Calendar`, `Clock`, `File`, `Folder`, `Image`, `Link`, `ExternalLink` |
-| **UI** | `Eye`, `EyeOff`, `Menu`, `MoreHorizontal`, `MoreVertical`, `Loader`, `Quote` |
-
 ### Components with Icon Support
 
-| Component | Icon Props |
-|--------|-----------|
-| `Alert` | `icon: Option<Icon>` |
-| `Notification` | `icon: Option<Icon>` |
-| `AccordionControl` | `icon: Option<Icon>` |
-| `Blockquote` | `icon: Option<Icon>` |
-| `List`, `ListItem` | `icon: Option<Icon>` |
-| `Stepper` | `completed_icon`, `progress_icon: Option<Icon>` |
-| `StepperStep` | `icon`, `completed_icon`, `progress_icon: Option<Icon>` |
-| `NavLink` | `left_section`, `right_section: Option<Icon>` |
-| `DropdownMenuItem` | `left_section`, `right_section: Option<Icon>` |
-| `Tab` | `left_section`, `right_section: Option<Icon>` |
+Every one of these props is `Option<TablerIcon>`. The `rsx!` macro adds the `Some(...)` for you, so write `icon: TablerIcon::Check`, never `icon: Some(TablerIcon::Check)`.
+
+| Component | Icon props | Source |
+|--------|-----------|--------|
+| `ActionIcon` | `icon` | `action_icon.rs:122` |
+| `Alert` | `icon` | `alert.rs:161` |
+| `Notification` | `icon` | `notification.rs:112` |
+| `AccordionControl` | `icon` | `accordion.rs:242` |
+| `Blockquote` | `icon` | `blockquote.rs:25` |
+| `List`, `ListItem` | `icon` | `list.rs:102`, `list.rs:176` |
+| `Stepper` | `completed_icon`, `progress_icon` | `stepper.rs:104`, `:106` |
+| `StepperStep` | `icon`, `completed_icon`, `progress_icon` | `stepper.rs:185`, `:187`, `:189` |
+| `NavLink` | `left_section`, `right_section` | `navlink.rs:100`, `:102` |
+| `DropdownMenuItem` | `left_section`, `right_section` | `dropdown_menu.rs:472`, `:474` |
+| `Tab` | `left_section`, `right_section` | `tabs.rs:392`, `:394` |
+
+The `Tree` component takes its icons through data rather than a prop: `TreeNodeData::icon` (`tree.rs:56`), set with the `with_icon(TablerIcon)` builder.
+
+Paths are relative to `crates/rinch-components/src/`. `ActionIcon`'s `icon` prop is a convenience that renders the icon for you as Outline, sized from the component's own `size` prop. It is **mutually exclusive with children** — `loading` wins, then `icon`, and children render only if neither is set — so pass a rendered icon as a child (not via `icon:`) when you need a filled or custom-sized glyph.
 
 ## Dependencies and Imports
 
@@ -687,6 +688,9 @@ fn app() -> NodeHandle {
 | **Dispatch** | `command(name) -> bool`, `update(\|state\| -> Option<Transaction>)`, `insert_text(&str)`, `replace_selection_with_html/text(&str)`, `insert_image(src, alt)`, `toggle_link(href)` |
 | **Query (read state)** | `can_run(name)`, `is_mark_active(mark)`, `active_link_href() -> Option<String>`, `current_block_type()`, `in_node_type(type)`, `doc() -> Node`, `state()`, `selection()` |
 | **Content / selection** | `load_html(&str)`, `load_doc(Node)`, `set_selection(Selection)`, `selection_clipboard()`, `set_dark_mode(bool)` |
+| **Notification** | `on_change(impl Fn() + 'static)` — the autosave / dirty-marking hook |
+
+`on_change` fires only for **local, document-changing** edits: `update` (which typing, paste and IME commit all funnel through), `command`, and `insert_image`. It deliberately does **not** fire for selection-only changes, for `load_doc`/`load_html` (a programmatic load isn't a user edit — firing would make an autosave consumer immediately re-save what it just loaded), or for `collab_receive` (already in the shared CRDT). The callback runs with no internal borrow held, so it may re-enter the handle freely — e.g. call `doc()` to serialize for the save.
 
 Command names (dispatch by string): `toggleBold/Italic/Underline/Strike/Code/Highlight/Subscript/Superscript`, `setParagraph`, `setHeading1..6`, `setCodeBlock`, `setTextAlign{Left,Center,Right,Justify}`, `toggleBulletList`, `toggleOrderedList`, `toggleTaskList`, `wrapInBlockquote`, `sinkListItem`/`liftListItem` (indent/outdent), `insertHorizontalRule`, `insertHardBreak`, `insertTable`, `addRow{After,Before}`, `addColumn{After,Before}`, `deleteRow`/`deleteColumn`/`deleteTable`, `mergeCells`/`splitCell`, `removeLink`, `undo`/`redo`. (Adding a link needs an `href` arg, so it is **not** a string command — use `handle.toggle_link(href)`.)
 
@@ -1327,7 +1331,7 @@ std::thread::spawn(move || {
 
 // Or for GPU textures:
 let registrar = surface.gpu_registrar();
-registrar.set_texture_source(wgpu_view, w, h);
+registrar.set_texture_source(wgpu_texture, wgpu_view, w, h);
 registrar.notify_frame_ready();
 
 rsx! { RenderSurface { surface: Some(surface), style: "flex: 1;" } }
@@ -1611,7 +1615,7 @@ The `rsx!` macro **automatically wraps** component prop values. You must NOT man
 | `on*` (closure) | `onclick: move \|\| do_thing()` | `(Callback::new(move \|\| do_thing())).into()` |
 | `on*` (value) | `onclick: my_callback` | `(my_callback).into()` |
 | `*_fn` (reactive) | `value_fn: move \|\| text.get()` | `Some(Rc::new(move \|\| text.get()))` |
-| `icon`, `*_icon` | `icon: Icon::Check` | `Some(Icon::Check)` |
+| `icon`, `*_icon` | `icon: TablerIcon::Check` | `Some(TablerIcon::Check)` |
 | bool literal | `disabled: true` | `true` (no wrapping) |
 | int literal | `size: 42` | `Some(42)` |
 | float literal | `value: 30.0` | `Some(30.0)` |
@@ -1635,10 +1639,10 @@ Button { onclick: move || do_something() }
 // RIGHT - you can also forward an existing Callback directly
 Button { onclick: my_callback }
 
-// WRONG - double-wraps into Some(Some(Icon::Check))
-Alert { icon: Some(Icon::Check) }
+// WRONG - double-wraps into Some(Some(TablerIcon::Check))
+Alert { icon: Some(TablerIcon::Check) }
 // RIGHT - macro adds Some(...) for you
-Alert { icon: Icon::Check }
+Alert { icon: TablerIcon::Check }
 
 // WRONG - component expects String, not Option<String>
 Button { variant: Some(String::from("filled")) }
@@ -1772,7 +1776,7 @@ Make changes, rebuild, launch again. The full cycle:
 ### Common Issues
 
 - **Text wrapping/clipping**: Check that layout measurement and paint use the same font stack
-- **Elements stacking wrong**: Check `display` property — default is `flex row wrap`
+- **Elements stacking wrong**: Check the `display` property. `div` and other block elements default to `display: block` (per the UA stylesheet in `crates/rinch-dom/src/dom_impl/mod.rs`), so flex properties like `align-items` and `justify-content` do nothing until you set `display: flex` explicitly
 - **Text not updating**: Verify signal/effect wiring in the component
 - **No display (headless)**: Use Xvfb with `DISPLAY=:99` when running without a monitor
 - **MCP tools not available**: Ensure `rinch-mcp-server` is built (`cargo build -p rinch-mcp-server`) and `.mcp.json` points to the binary

--- a/docs/src/guide/component-props.md
+++ b/docs/src/guide/component-props.md
@@ -422,7 +422,7 @@ Text input with inline color preview and dropdown ColorPicker.
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `cite` | `Option<String>` | `None` | Citation source |
-| `icon` | `Option<Icon>` | `None` | |
+| `icon` | `Option<TablerIcon>` | `None` | |
 | `color` | `Option<String>` | `None` | |
 | `radius` | `Option<String>` | `None` | |
 
@@ -532,10 +532,10 @@ Custom Default: `ignore_case` defaults to `true`.
 | `size` | `Option<String>` | `None` | |
 | `spacing` | `Option<String>` | `None` | |
 | `center` | `bool` | `false` | Center items with icons |
-| `icon` | `Option<Icon>` | `None` | Default icon for all items |
+| `icon` | `Option<TablerIcon>` | `None` | Default icon for all items |
 | `with_padding` | `bool` | `false` | |
 
-**ListItem:** `icon: Option<Icon>` — per-item icon override.
+**ListItem:** `icon: Option<TablerIcon>` — per-item icon override.
 
 ---
 
@@ -550,7 +550,7 @@ Custom Default: `ignore_case` defaults to `true`.
 | `title` | `Option<String>` | `None` | |
 | `radius` | `Option<String>` | `None` | |
 | `with_close_button` | `bool` | `false` | |
-| `icon` | `Option<Icon>` | `None` | |
+| `icon` | `Option<TablerIcon>` | `None` | |
 | `onclose` | `Option<Callback>` | `None` | |
 
 ### Loader
@@ -667,7 +667,7 @@ Custom Default: `with_close_button` defaults to `true`.
 | `radius` | `Option<String>` | `None` | |
 | `with_close_button` | `bool` | **`true`** | |
 | `with_border` | `bool` | `false` | |
-| `icon` | `Option<Icon>` | `None` | |
+| `icon` | `Option<TablerIcon>` | `None` | |
 | `auto_close` | `u32` | `0` | Auto-close delay in ms (0 = disabled) |
 | `loading` | `bool` | `false` | |
 | `z_index` | `Option<i32>` | `None` | |
@@ -725,8 +725,8 @@ Custom Default: `close_on_click_outside` and `close_on_item_click` default to `t
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `left_section` | `Option<Icon>` | `None` | |
-| `right_section` | `Option<Icon>` | `None` | |
+| `left_section` | `Option<TablerIcon>` | `None` | |
+| `right_section` | `Option<TablerIcon>` | `None` | |
 | `color` | `Option<String>` | `None` | |
 | `disabled` | `bool` | `false` | |
 | `onclick` | `Option<Callback>` | `None` | |
@@ -785,8 +785,8 @@ Sub-components: **HoverCardTarget** (no props), **HoverCardDropdown** (no props)
 |------|------|---------|-------------|
 | `value` | `Option<String>` | `None` | Tab identifier |
 | `disabled` | `bool` | `false` | |
-| `left_section` | `Option<Icon>` | `None` | |
-| `right_section` | `Option<Icon>` | `None` | |
+| `left_section` | `Option<TablerIcon>` | `None` | |
+| `right_section` | `Option<TablerIcon>` | `None` | |
 | `onclick` | `Option<Callback>` | `None` | |
 
 **TabsPanel:** `value: Option<String>` — matches the Tab value.
@@ -805,7 +805,7 @@ Sub-components: **HoverCardTarget** (no props), **HoverCardDropdown** (no props)
 
 **AccordionItem:** `value: Option<String>`.
 
-**AccordionControl:** `disabled: bool`, `icon: Option<Icon>`, `onclick: Option<Callback>`.
+**AccordionControl:** `disabled: bool`, `icon: Option<TablerIcon>`, `onclick: Option<Callback>`.
 
 **AccordionPanel:** No props.
 
@@ -848,8 +848,8 @@ Custom Default: `total`, `value`, `siblings`, `boundaries` default to `1`; `with
 | `active_fn` | `Option<ReactiveBool>` | `None` | Reactive active binding (auto-wrapped) |
 | `variant` | `Option<String>` | `None` | "light", "filled", "subtle" |
 | `color` | `Option<String>` | `None` | |
-| `left_section` | `Option<Icon>` | `None` | |
-| `right_section` | `Option<Icon>` | `None` | |
+| `left_section` | `Option<TablerIcon>` | `None` | |
+| `right_section` | `Option<TablerIcon>` | `None` | |
 | `disabled` | `bool` | `false` | |
 | `children_offset` | `Option<String>` | `None` | Indentation for nested NavLinks |
 | `opened` | `bool` | `false` | Nested section expanded |
@@ -868,8 +868,8 @@ Custom Default: `total`, `value`, `siblings`, `boundaries` default to `1`; `with
 | `radius` | `Option<String>` | `None` | |
 | `icon_size` | `Option<String>` | `None` | |
 | `allow_next_steps_select` | `bool` | `false` | |
-| `completed_icon` | `Option<Icon>` | `None` | Default completed icon for all steps |
-| `progress_icon` | `Option<Icon>` | `None` | Default in-progress icon |
+| `completed_icon` | `Option<TablerIcon>` | `None` | Default completed icon for all steps |
+| `progress_icon` | `Option<TablerIcon>` | `None` | Default in-progress icon |
 
 **StepperStep:**
 
@@ -877,9 +877,9 @@ Custom Default: `total`, `value`, `siblings`, `boundaries` default to `1`; `with
 |------|------|---------|-------------|
 | `label` | `Option<String>` | `None` | |
 | `description` | `Option<String>` | `None` | |
-| `icon` | `Option<Icon>` | `None` | Default icon |
-| `completed_icon` | `Option<Icon>` | `None` | Per-step override |
-| `progress_icon` | `Option<Icon>` | `None` | Per-step override |
+| `icon` | `Option<TablerIcon>` | `None` | Default icon |
+| `completed_icon` | `Option<TablerIcon>` | `None` | Per-step override |
+| `progress_icon` | `Option<TablerIcon>` | `None` | Per-step override |
 | `allow_step_click` | `bool` | `false` | |
 | `allow_step_select` | `bool` | `false` | |
 | `loading` | `bool` | `false` | |
@@ -904,7 +904,7 @@ Custom Default: `level_offset` defaults to `Some("md")`, `expand_on_click` defau
 | `onexpand` | `Option<ValueCallback<String>>` | `None` | |
 | `oncollapse` | `Option<ValueCallback<String>>` | `None` | |
 
-**TreeNodeData:** `value: String`, `label: String`, `children: Vec<TreeNodeData>`, `disabled: bool`, `icon: Option<Icon>`, `payload: Option<Rc<dyn Any>>`.
+**TreeNodeData:** `value: String`, `label: String`, `children: Vec<TreeNodeData>`, `disabled: bool`, `icon: Option<TablerIcon>`, `payload: Option<Rc<dyn Any>>`.
 
 ---
 

--- a/docs/src/guide/components.md
+++ b/docs/src/guide/components.md
@@ -1016,30 +1016,38 @@ Other types (e.g., custom structs) fall back to `Default::default()`, so they mu
 
 ## Icon System
 
-Rinch provides a type-safe icon system with a curated library of SVG icons. Instead of passing arbitrary HTML strings, components accept `Icon` enum values for discoverability and consistency.
+Rinch provides a type-safe icon system built on [Tabler Icons](https://tabler.io/icons). Instead of passing arbitrary HTML strings, components accept `TablerIcon` enum values for discoverability and consistency.
+
+`TablerIcon` lives in the `rinch-tabler-icons` crate and is **not** re-exported through the `rinch` prelude, so add it alongside `rinch`:
+
+```toml
+rinch-tabler-icons = { workspace = true }
+```
+
+> Older snippets may show a curated `Icon` enum from `rinch-core`. That enum no longer exists — every icon prop takes `Option<TablerIcon>`. A few names were spelled differently: `Icon::CheckCircle` is now `TablerIcon::CircleCheck`, and `Icon::XCircle` is `TablerIcon::CircleX`.
 
 ### Basic Usage
 
 ```rust
 use rinch::prelude::*;
-use rinch::components::*;
+use rinch_tabler_icons::TablerIcon;
 
 #[component]
 fn app() -> NodeHandle {
     rsx! {
-        Alert { icon: Icon::InfoCircle, color: "blue", title: "Information",
+        Alert { icon: TablerIcon::InfoCircle, color: "blue", title: "Information",
             "This is an informational message."
         }
 
-        Alert { icon: Icon::CheckCircle, color: "green", title: "Success",
+        Alert { icon: TablerIcon::CircleCheck, color: "green", title: "Success",
             "Operation completed successfully."
         }
 
-        Alert { icon: Icon::AlertTriangle, color: "yellow", title: "Warning",
+        Alert { icon: TablerIcon::AlertTriangle, color: "yellow", title: "Warning",
             "Please review this carefully."
         }
 
-        Alert { icon: Icon::XCircle, color: "red", title: "Error",
+        Alert { icon: TablerIcon::CircleX, color: "red", title: "Error",
             "Something went wrong."
         }
     }
@@ -1048,29 +1056,44 @@ fn app() -> NodeHandle {
 
 ### Available Icons
 
+All 4,983 Tabler icons are available as enum variants — browse them at
+[tabler.io/icons](https://tabler.io/icons), or iterate `ALL_ICONS` (with
+`ICON_COUNT`) to build a picker. A sample of the common ones:
+
 | Category | Icons |
 |----------|-------|
-| **Navigation** | `ChevronUp`, `ChevronDown`, `ChevronLeft`, `ChevronRight`, `ChevronsLeft`, `ChevronsRight`, `ArrowUp`, `ArrowDown`, `ArrowLeft`, `ArrowRight` |
-| **Actions** | `Close`, `Check`, `Plus`, `Minus`, `Search`, `Settings`, `Edit`, `Trash` |
-| **Status/Alerts** | `InfoCircle`, `CheckCircle`, `AlertCircle`, `AlertTriangle`, `XCircle` |
-| **Content** | `User`, `Mail`, `Phone`, `Calendar`, `Clock`, `File`, `Folder`, `Image`, `Link`, `ExternalLink` |
-| **UI** | `Eye`, `EyeOff`, `Menu`, `MoreHorizontal`, `MoreVertical`, `Loader`, `Quote` |
+| **Navigation** | `Home`, `ChevronUp`, `ChevronDown`, `ArrowLeft`, `ArrowRight`, `Menu2` |
+| **Actions** | `Plus`, `Minus`, `X`, `Check`, `Search`, `Settings`, `Edit`, `Trash` |
+| **Status/Alerts** | `InfoCircle`, `CircleCheck`, `AlertCircle`, `AlertTriangle`, `CircleX` |
+| **Content** | `User`, `Mail`, `Phone`, `File`, `Folder`, `Photo`, `Copy` |
+| **UI** | `Bell`, `Message`, `Send`, `Share`, `Download`, `Upload` |
+
+Every icon has an Outline form; roughly a thousand also have real Filled
+artwork, and asking for `TablerIconStyle::Filled` on one that doesn't falls back
+to its outline paths. See [Icon System in CLAUDE.md](https://github.com/joeleaver/rinch/blob/main/CLAUDE.md#icon-system) for rendering icons standalone with `render_tabler_icon`.
 
 ### Components with Icon Support
 
+Every prop below is `Option<TablerIcon>`; `rsx!` supplies the `Some(...)`, so
+write `icon: TablerIcon::Check`, not `icon: Some(TablerIcon::Check)`.
+
 | Component | Icon Props |
 |--------|-----------|
-| `Alert` | `icon: Option<Icon>` |
-| `Notification` | `icon: Option<Icon>` |
-| `AccordionControl` | `icon: Option<Icon>` |
-| `Blockquote` | `icon: Option<Icon>` |
-| `List` | `icon: Option<Icon>` |
-| `ListItem` | `icon: Option<Icon>` |
-| `Stepper` | `completed_icon`, `progress_icon: Option<Icon>` |
-| `StepperStep` | `icon`, `completed_icon`, `progress_icon: Option<Icon>` |
-| `NavLink` | `left_section`, `right_section: Option<Icon>` |
-| `DropdownMenuItem` | `left_section`, `right_section: Option<Icon>` |
-| `Tab` | `left_section`, `right_section: Option<Icon>` |
+| `ActionIcon` | `icon` |
+| `Alert` | `icon` |
+| `Notification` | `icon` |
+| `AccordionControl` | `icon` |
+| `Blockquote` | `icon` |
+| `List` | `icon` |
+| `ListItem` | `icon` |
+| `Stepper` | `completed_icon`, `progress_icon` |
+| `StepperStep` | `icon`, `completed_icon`, `progress_icon` |
+| `NavLink` | `left_section`, `right_section` |
+| `DropdownMenuItem` | `left_section`, `right_section` |
+| `Tab` | `left_section`, `right_section` |
+
+`Tree` takes its icons through data instead: `TreeNodeData::icon`, set with the
+`with_icon(TablerIcon)` builder.
 
 ### Examples
 
@@ -1078,15 +1101,15 @@ fn app() -> NodeHandle {
 // NavLink with icons
 NavLink {
     label: "Dashboard",
-    left_section: Icon::Settings,
+    left_section: TablerIcon::Settings,
     active: true
 }
 
 // Tab with icon
 Tabs {
     TabsList {
-        Tab { value: "home", left_section: Icon::User, "Profile" }
-        Tab { value: "settings", left_section: Icon::Settings, "Settings" }
+        Tab { value: "home", left_section: TablerIcon::User, "Profile" }
+        Tab { value: "settings", left_section: TablerIcon::Settings, "Settings" }
     }
 }
 
@@ -1096,18 +1119,18 @@ DropdownMenu {
         Button { "Actions" }
     }
     DropdownMenuDropdown {
-        DropdownMenuItem { left_section: Icon::Edit, "Edit" }
-        DropdownMenuItem { left_section: Icon::Trash, color: "red", "Delete" }
+        DropdownMenuItem { left_section: TablerIcon::Edit, "Edit" }
+        DropdownMenuItem { left_section: TablerIcon::Trash, color: "red", "Delete" }
     }
 }
 
 // Blockquote with quote icon
-Blockquote { icon: Icon::Quote, cite: "— Unknown",
+Blockquote { icon: TablerIcon::Quote, cite: "— Unknown",
     "The best code is no code at all."
 }
 
 // Stepper with custom icons
-Stepper { active: 1, completed_icon: Icon::CheckCircle,
+Stepper { active: 1, completed_icon: TablerIcon::CircleCheck,
     StepperStep { label: "Account" }
     StepperStep { label: "Verify" }
     StepperStep { label: "Complete" }

--- a/docs/src/guide/game-engine.md
+++ b/docs/src/guide/game-engine.md
@@ -89,9 +89,11 @@ let queue = &gpu.queue;
 let texture = device.create_texture(&wgpu::TextureDescriptor { /* ... */ });
 // ... render into texture ...
 
-// Register the texture view for compositing
+// Register the texture for compositing — pass BOTH the texture and its view.
+// rinch needs the texture for the GPU→CPU readback path (inline-painted
+// RenderSurface) and the view for compositing it directly.
 let view = texture.create_view(&Default::default());
-registrar.set_texture_source(view, width, height);
+registrar.set_texture_source(texture, view, width, height);
 registrar.notify_frame_ready();
 ```
 
@@ -226,7 +228,7 @@ Notes:
 | `set_resize_callback(cb)` | `FnMut(w, h)` fired on backing-size change (physical px) — reconfigure a GPU surface |
 | `layout_size()` | Get current physical `(width, height)` (web: CSS px × devicePixelRatio) |
 | `canvas_element()` | **(web only)** the `<canvas>` after mount — create a WebGPU/WebGL context on it |
-| `set_texture_source(view, w, h)` | **(desktop, gpu)** Set GPU texture directly (main thread only) |
+| `set_texture_source(texture, view, w, h)` | **(desktop, gpu)** Set GPU texture directly (main thread only) |
 | `has_texture_source()` | Check if a GPU texture is registered |
 | `id()` | Surface ID |
 | `viewport_name()` | Internal viewport name |
@@ -332,6 +334,43 @@ if ctx.wants_keyboard() {
 }
 ```
 
+> **Always give the viewport hole `pointer-events: auto`.** `wants_mouse` only
+> reports "the game wants this" when the hit-tested node has a `data-viewport`
+> ancestor. A hole that is not hittable therefore inverts the routing: the hit
+> falls through to `body` behind it, the walk up from `body` finds no
+> `data-viewport`, and `wants_mouse` answers `true` — **everywhere**. The game
+> silently receives no mouse input at all, with nothing in the layout or the
+> render looking wrong.
+>
+> Two separate things can make the hole unhittable, and you generally want to
+> defend against both at once:
+>
+> 1. **`GameViewport` ships with `pointer-events: none` on the hole div**, so the
+>    bare `GameViewport { name: "main" }` form is not hittable as-is. Passing a
+>    `style:` prop happens to cure it, because a component's universal `style:`
+>    **replaces** the component's own inline style rather than merging with it —
+>    which also drops the built-in `background: transparent`, so restate that too
+>    if you relied on it.
+> 2. **`pointer-events` is inherited.** Putting `pointer-events: none` on a HUD
+>    root — the natural way to let clicks fall through to the game — pushes it
+>    back down onto the hole even if the hole's own `style:` omitted it.
+>
+> Being explicit covers both:
+>
+> ```rust
+> div { style: "pointer-events: none;",          // HUD root: clicks fall through
+>     GameViewport { name: "main", style: "flex: 1; pointer-events: auto; background: transparent;" }
+>     div { style: "pointer-events: auto;", /* real HUD controls */ }
+> }
+> ```
+>
+> The inheritance half is spec-correct, not a bug — but the overlay idiom that
+> triggers it is the obvious one to reach for, so it is worth designing around up
+> front. The same `pointer-events: auto` opt-in applies to any HUD control you
+> want clickable inside a `pointer-events: none` root. (`visibility: hidden` is
+> stronger still: it makes an entire subtree unhittable and *cannot* be re-enabled
+> on a descendant.)
+
 ### Split Layout (Viewport Hole)
 
 Use `GameViewport` to mark a transparent region where the game renders:
@@ -348,7 +387,7 @@ fn editor_ui() -> NodeHandle {
             }
             div { style: "display: flex; flex: 1;",
                 div { style: "width: 200px;", /* side panel */ }
-                GameViewport { name: "main", style: "flex: 1;" }
+                GameViewport { name: "main", style: "flex: 1; pointer-events: auto; background: transparent;" }
             }
         }
     }
@@ -363,6 +402,21 @@ if let Some(rect) = ctx.viewport_rect("main") {
 }
 ```
 
+> **Overlays need a parent with real height.** On the embed path layout runs
+> through Taffy, which treats an absolutely positioned child's **direct parent**
+> as its containing block — it does not walk up to the nearest *positioned*
+> ancestor the way browser CSS does ([#204]). So a `position: absolute; inset: 0`
+> overlay sizes against whatever element directly encloses it, and if that element
+> has **auto** height the overlay gets essentially no height. Nothing errors and
+> the styles are correct, so this reads as a broken overlay. Give the enclosing
+> element an explicit height (`height: 100%` on the chain up from the root, or a
+> flex parent that stretches it) rather than assuming the overlay will fill the
+> window. This is also a porting difference worth knowing: the same markup can
+> lay out differently under `rinch-web`, where the real browser applies the
+> nearest-positioned-ancestor rule.
+
+[#204]: https://github.com/joeleaver/rinch/issues/204
+
 ### Resize and Scale Factor
 
 ```rust
@@ -370,6 +424,20 @@ ctx.resize(new_width, new_height);
 overlay.resize(&device, new_width, new_height);
 ctx.set_scale_factor(window.scale_factor());
 ```
+
+Hit testing is transform-aware, so the usual `position: absolute; left: 50%;
+top: 50%; transform: translate(-50%, -50%)` centering idiom is fully clickable —
+a transformed subtree is hit where it is *painted*.
+
+> **Caveat at HiDPI on the embed path.** The embed path resolves layout at logical
+> size, so `set_scale_factor` genuinely matters here — and paint currently applies
+> a CSS `translate` without multiplying it by that scale ([#202]). At any scale
+> other than `1.0`, a **translated** element therefore paints slightly off from
+> where it hit-tests. Only `translate` is affected (`rotate`/`scale`/`skew` are
+> unit-invariant), and only on the embed path. Centering with flexbox instead of a
+> `translate` sidesteps it entirely until that fix lands.
+
+[#202]: https://github.com/joeleaver/rinch/issues/202
 
 ### Platform Events
 

--- a/docs/src/guide/rsx-syntax.md
+++ b/docs/src/guide/rsx-syntax.md
@@ -148,7 +148,7 @@ rsx! {
         "Click me"
     }
 
-    Alert { icon: Icon::InfoCircle, color: "blue", title: "Info",
+    Alert { icon: TablerIcon::InfoCircle, color: "blue", title: "Info",
         "This is an informational message."
     }
 }

--- a/docs/src/guide/writing-components.md
+++ b/docs/src/guide/writing-components.md
@@ -58,7 +58,7 @@ rsx! {
 |---|---|
 | `onclick: \|\| do_thing()` | `Callback::new(\|\| do_thing()).into()` |
 | `oninput: move \|v: String\| ...` | `InputCallback::new(move \|v\| ...).into()` |
-| `icon: Icon::Check` | `Some(Icon::Check)` |
+| `icon: TablerIcon::Check` | `Some(TablerIcon::Check)` |
 | `variant: "filled"` | `String::from("filled")` |
 | `disabled: true` | `true` (no wrapping) |
 | `size: 42` | `Some(42)` |


### PR DESCRIPTION
Batched docs corrections riding on #201/#191/#195/#199. Closes #191.

- **CLAUDE.md** — Icon System rewritten around `TablerIcon` as the one system (the `Icon` enum no longer exists; every icon-prop row re-verified against component sources, two missing entries added, the Filled-is-a-subset fallback and vendored-not-CDN build reality documented); architecture tree gains the four editor crates and loses `src/icon.rs`; `EditorHandle.on_change` row added; the false "default display is flex row wrap" line replaced (UA default for div is `block` — the likely cause of #199's align-items misreport).
- **docs/src/guide/game-engine.md** — the one real #191 mismatch fixed in both places (`set_texture_source(texture, view, width, height)` — the guide omitted the texture arg); #195's pointer-events cascade trap documented in Input Routing with the `pointer-events: auto` fix, and both `GameViewport` snippets made explicit about it; transform-centering note updated post-#205 with the #202 HiDPI-embed caveat.
- **Guide sweep** (components.md, component-props.md, rsx-syntax.md, writing-components.md) — the removed `Icon` enum was still documented as current in four user-facing pages with would-not-compile snippets; all rewritten with variant names verified against the generated enum (`CheckCircle`→`CircleCheck`, `XCircle`→`CircleX`).

Notable non-fix: #191's claim that `style:` on `RenderSurface` implies a missing struct field is wrong — `style:`/`class:` are universal component props applied to the rendered root; the snippet is valid and stays.

Two spin-offs filed separately: the `GameViewport` hard-coded `pointer-events: none` default (real input-routing bug), and component-props.md's systemic `Option<String>` typing.

mdbook build: zero warnings, identical to the main baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)