### PR TITLE
fix(rinch,rinch-dom): #207 — a GameViewport hole is hittable by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1371,7 +1371,7 @@ Your game owns the window and wgpu device. Rinch runs headless — you feed it e
 | `RinchContext` | Main handle — `new()`, `update()`, `scene()`. Multiple contexts can coexist on one thread (#134): each holds its own `subscribe_signal_change` guard, and bounds signals / editor registrations / focus requests are scoped per document via `DomDocument::doc_key()`. Stores/contexts are namespaced per context with a thread-global fallback (#136): `create_store` inside a context lands in that context's namespace (cleared on drop), its effects/handlers resolve it first, and lookups fall back to stores created outside any context. |
 | `RinchContextConfig` | Width, height, scale factor, optional theme |
 | `RinchOverlayRenderer` | Convenience Vello-to-texture renderer |
-| `GameViewport` | Component marking a transparent hole for game rendering |
+| `GameViewport` | Component marking a transparent hole for game rendering. **Hittable by default** (#207): `wants_mouse` routes input by hit-testing the hole and walking up to `data-viewport`, so an unhittable hole makes the UI claim the mouse *everywhere*. `pointer-events: auto; background: transparent;` come from the UA stylesheet rule for `[data-viewport]` — not an inline style — so restyling the hole can't strip them, and a HUD root's inherited `pointer-events: none` can't reach it. Your own HUD controls under such a root still need `pointer-events: auto`. |
 | `LayoutRect` | `{x, y, width, height}` in logical pixels |
 
 **Typical game loop:**

--- a/crates/rinch-dom/src/dom_impl/mod.rs
+++ b/crates/rinch-dom/src/dom_impl/mod.rs
@@ -221,6 +221,20 @@ impl RinchDocument {
                 margin: 0;
                 overflow-y: auto;
             }
+
+            /* A `data-viewport` node is a compositing hole: the game/video frame
+               shows through it (find_viewport_rects punches the background) and a
+               pointer landing on it belongs to whatever renders into it, not to
+               the rinch UI. That routing is decided by hit-testing the hole, so
+               the hole must be HITTABLE — `pointer-events: none` on it makes the
+               UI claim the mouse everywhere instead (issue #207). Declaring it
+               here also beats a `pointer-events: none` inherited from a HUD root
+               (issue #195) while still losing to any author declaration on the
+               hole itself, so an app can still opt out. */
+            [data-viewport] {
+                pointer-events: auto;
+                background: transparent;
+            }
         "#;
 
         let url_data = UrlExtraData::from(url::Url::parse("about:ua-stylesheet").unwrap());

--- a/crates/rinch/src/embed.rs
+++ b/crates/rinch/src/embed.rs
@@ -629,8 +629,16 @@ impl RinchOverlayRenderer {
 /// scene to show through. Use [`RinchContext::viewport_rect`] to query
 /// the computed layout rect and render your game into that region.
 ///
-/// The component renders as a transparent `div` with `pointer-events: none`
-/// so mouse events pass through to the game.
+/// The component renders as a transparent, **hittable** `div`. Hittability is
+/// what routes input: [`RinchContext::wants_mouse`] hit-tests the DOM and walks
+/// up from the hit node looking for `data-viewport`, so a pointer that lands on
+/// the hole answers "the game owns this" (issue #207). The transparent
+/// background and `pointer-events: auto` come from the UA stylesheet rule for
+/// `[data-viewport]`, not from an inline style, so passing `style:` (which
+/// *replaces* the style attribute) can neither restore nor break them.
+///
+/// To hand a region back to the UI, declare `pointer-events: none` on the
+/// viewport yourself — an author declaration still wins over the UA default.
 ///
 /// # Example
 ///
@@ -656,7 +664,6 @@ pub fn game_viewport(__scope: &mut RenderScope, name: &str) -> NodeHandle {
     let div = __scope.create_element("div");
     div.set_attribute("class", "rinch-game-viewport");
     div.set_attribute("data-viewport", name);
-    div.set_attribute("style", "pointer-events: none; background: transparent;");
     div
 }
 

--- a/crates/rinch/tests/game_viewport_input.rs
+++ b/crates/rinch/tests/game_viewport_input.rs
@@ -1,0 +1,217 @@
+//! Empirical pinning tests for issue #207: a `GameViewport` hole must be
+//! hittable, because hittability is what routes the mouse.
+//!
+//! `RinchContext::wants_mouse` hit-tests the DOM and walks up from the hit node
+//! looking for `data-viewport`. A hole with `pointer-events: none` is skipped by
+//! `hit_test`, the hit falls through to `body`, no `data-viewport` ancestor is
+//! found, and `wants_mouse` answers `true` **everywhere** — the UI silently
+//! claims the mouse over the whole window and the game gets nothing.
+//!
+//! Every test therefore asserts a *pair*: a point inside the hole is game
+//! territory, and a point on the surrounding chrome is UI territory. The pair
+//! matters because `wants_mouse` also returns `false` when nothing is hit at
+//! all, so "false inside the hole" alone would be satisfiable by an empty
+//! document.
+//!
+//! Requires the `embed` (or `gpu`) feature:
+//!     cargo test -p rinch --features embed --test game_viewport_input
+
+#![cfg(any(feature = "gpu", feature = "embed"))]
+
+use std::sync::mpsc;
+use std::sync::{Mutex, OnceLock};
+
+use rinch::embed::{GameViewport, RinchContext, RinchContextConfig};
+use rinch::prelude::*;
+
+// ── harness ──────────────────────────────────────────────────────────────────
+
+type Job = Box<dyn FnOnce() + Send>;
+
+/// Run `f` on the single shared "UI" worker thread and propagate its panic (if
+/// any) back to the calling test thread.
+///
+/// `RinchContext::new` calls `rinch_core::register_main_thread()`, a
+/// process-wide `OnceLock`: the first test thread to create a context becomes
+/// "the main thread" forever. libtest gives each `#[test]` its own thread, so
+/// all bodies are marshalled onto one long-lived worker (which also serializes
+/// them). Same reasoning — and same helper — as `tests/multi_context.rs`.
+fn on_ui_thread<T: Send + 'static>(f: impl FnOnce() -> T + Send + 'static) -> T {
+    static SENDER: OnceLock<Mutex<mpsc::Sender<Job>>> = OnceLock::new();
+    let sender = SENDER.get_or_init(|| {
+        let (tx, rx) = mpsc::channel::<Job>();
+        std::thread::Builder::new()
+            .name("rinch-test-ui".into())
+            .spawn(move || {
+                for job in rx {
+                    job();
+                }
+            })
+            .expect("spawn ui worker");
+        Mutex::new(tx)
+    });
+
+    let (result_tx, result_rx) = mpsc::channel();
+    let job: Job = Box::new(move || {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+        let _ = result_tx.send(result);
+    });
+    sender
+        .lock()
+        .expect("ui sender lock")
+        .send(job)
+        .expect("ui worker alive");
+    match result_rx.recv().expect("ui worker responded") {
+        Ok(v) => v,
+        Err(panic) => std::panic::resume_unwind(panic),
+    }
+}
+
+const WIDTH: u32 = 800;
+const HEIGHT: u32 = 600;
+/// Height of the chrome strip above the viewport in every layout below.
+const TOOLBAR_H: f32 = 40.0;
+
+fn cfg() -> RinchContextConfig {
+    RinchContextConfig {
+        width: WIDTH,
+        height: HEIGHT,
+        scale_factor: 1.0,
+        theme: None,
+        fonts: Vec::new(),
+    }
+}
+
+/// Centre of the named viewport's rect, after asserting the rect is a real
+/// region (a zero-area hole would make the routing assertions vacuous).
+fn viewport_center(ctx: &RinchContext, name: &str) -> (f32, f32) {
+    let rect = ctx
+        .viewport_rect(name)
+        .unwrap_or_else(|| panic!("no viewport named {name:?} in the document"));
+    assert!(
+        rect.width > 1.0 && rect.height > 1.0,
+        "viewport {name:?} must have a real area to route pointers into, got {rect:?}"
+    );
+    (rect.x + rect.width / 2.0, rect.y + rect.height / 2.0)
+}
+
+// ── 1. the bare form ─────────────────────────────────────────────────────────
+
+/// `GameViewport { name: "main" }` with **no** props but the name — the form
+/// that #207 reported as silently starving the game of mouse input. The grid
+/// wrapper stretches the hole without putting a `style:` on it, so nothing here
+/// can accidentally clobber the component's own defaults.
+#[test]
+fn bare_game_viewport_gives_the_mouse_to_the_game() {
+    on_ui_thread(|| {
+        let mut ctx = RinchContext::new(cfg(), |__scope: &mut RenderScope| {
+            rsx! {
+                div { style: "display: flex; flex-direction: column; width: 800px; height: 600px;",
+                    div { style: "height: 40px;", "toolbar" }
+                    div { style: "display: grid; flex: 1;",
+                        GameViewport { name: "main" }
+                    }
+                }
+            }
+        });
+        ctx.update(&[]);
+
+        let (cx, cy) = viewport_center(&ctx, "main");
+        assert!(
+            !ctx.wants_mouse(cx, cy),
+            "a pointer inside the bare viewport hole belongs to the game, but the UI \
+             claimed it — the hole is not hittable (#207)"
+        );
+        assert!(
+            ctx.wants_mouse(400.0, TOOLBAR_H / 2.0),
+            "a pointer on the toolbar above the hole belongs to the UI"
+        );
+    });
+}
+
+// ── 2. the documented styled form ────────────────────────────────────────────
+
+/// The `style: "flex: 1;"` form from the guide. A component's universal
+/// `style:` prop *replaces* the style attribute, so this form must route
+/// identically to the bare one — before #207 it worked only because that
+/// replacement happened to wipe the baked-in `pointer-events: none`.
+#[test]
+fn styled_game_viewport_gives_the_mouse_to_the_game() {
+    on_ui_thread(|| {
+        let mut ctx = RinchContext::new(cfg(), |__scope: &mut RenderScope| {
+            rsx! {
+                div { style: "display: flex; flex-direction: column; width: 800px; height: 600px;",
+                    div { style: "height: 40px;", "toolbar" }
+                    GameViewport { name: "main", style: "flex: 1;" }
+                }
+            }
+        });
+        ctx.update(&[]);
+
+        let (cx, cy) = viewport_center(&ctx, "main");
+        assert!(
+            !ctx.wants_mouse(cx, cy),
+            "a pointer inside a `style:`-sized viewport hole belongs to the game"
+        );
+        assert!(
+            ctx.wants_mouse(400.0, TOOLBAR_H / 2.0),
+            "a pointer on the toolbar above the hole belongs to the UI"
+        );
+    });
+}
+
+// ── 3. the author override still wins ────────────────────────────────────────
+
+/// #207 changed the *default*, not the mechanism: the hole's hittability is a
+/// UA-stylesheet declaration, so an app that really wants the UI to claim a
+/// region can still say so on the viewport itself.
+#[test]
+fn author_pointer_events_none_hands_the_hole_back_to_the_ui() {
+    on_ui_thread(|| {
+        let mut ctx = RinchContext::new(cfg(), |__scope: &mut RenderScope| {
+            rsx! {
+                div { style: "display: flex; flex-direction: column; width: 800px; height: 600px;",
+                    div { style: "height: 40px;", "toolbar" }
+                    GameViewport { name: "main", style: "flex: 1; pointer-events: none;" }
+                }
+            }
+        });
+        ctx.update(&[]);
+
+        let (cx, cy) = viewport_center(&ctx, "main");
+        assert!(
+            ctx.wants_mouse(cx, cy),
+            "an author `pointer-events: none` on the viewport must still beat the UA \
+             default and hand the region back to the UI"
+        );
+    });
+}
+
+// ── 4. the inherited-`none` HUD root (#195) ──────────────────────────────────
+
+/// The sibling trap from #195: a click-through HUD root sets
+/// `pointer-events: none` and every descendant inherits it. A UA declaration on
+/// `[data-viewport]` beats inheritance, so the hole stays hittable and the game
+/// keeps its input even under such a root.
+#[test]
+fn hole_survives_pointer_events_none_inherited_from_a_hud_root() {
+    on_ui_thread(|| {
+        let mut ctx = RinchContext::new(cfg(), |__scope: &mut RenderScope| {
+            rsx! {
+                div { style: "display: flex; flex-direction: column; width: 800px; \
+                              height: 600px; pointer-events: none;",
+                    div { style: "height: 40px;", "click-through chrome" }
+                    GameViewport { name: "main", style: "flex: 1;" }
+                }
+            }
+        });
+        ctx.update(&[]);
+
+        let (cx, cy) = viewport_center(&ctx, "main");
+        assert!(
+            !ctx.wants_mouse(cx, cy),
+            "the viewport hole must not inherit `pointer-events: none` from a \
+             click-through HUD root (#195)"
+        );
+    });
+}

--- a/docs/src/guide/game-engine.md
+++ b/docs/src/guide/game-engine.md
@@ -334,42 +334,42 @@ if ctx.wants_keyboard() {
 }
 ```
 
-> **Always give the viewport hole `pointer-events: auto`.** `wants_mouse` only
-> reports "the game wants this" when the hit-tested node has a `data-viewport`
-> ancestor. A hole that is not hittable therefore inverts the routing: the hit
-> falls through to `body` behind it, the walk up from `body` finds no
+> **A viewport hole must stay hittable — that is what routes the mouse.**
+> `wants_mouse` only reports "the game wants this" when the hit-tested node has a
+> `data-viewport` ancestor. A hole that is *not* hittable inverts the routing: the
+> hit falls through to `body` behind it, the walk up from `body` finds no
 > `data-viewport`, and `wants_mouse` answers `true` — **everywhere**. The game
 > silently receives no mouse input at all, with nothing in the layout or the
 > render looking wrong.
 >
-> Two separate things can make the hole unhittable, and you generally want to
-> defend against both at once:
+> Since #207 `GameViewport` needs no defending: every `data-viewport` node gets
+> `pointer-events: auto; background: transparent;` from the UA stylesheet, so both
+> `GameViewport { name: "main" }` and `GameViewport { name: "main", style: "flex: 1;" }`
+> route correctly. Because those defaults are a UA rule rather than an inline
+> style, restyling the hole cannot strip them — worth knowing, since a component's
+> universal `style:` prop **replaces** the component's inline style rather than
+> merging with it. Being a UA declaration, it also survives `pointer-events: none`
+> inherited from a HUD root, and still loses to any `pointer-events` you declare on
+> the viewport yourself (which is how you deliberately hand a region back to the
+> UI).
 >
-> 1. **`GameViewport` ships with `pointer-events: none` on the hole div**, so the
->    bare `GameViewport { name: "main" }` form is not hittable as-is. Passing a
->    `style:` prop happens to cure it, because a component's universal `style:`
->    **replaces** the component's own inline style rather than merging with it —
->    which also drops the built-in `background: transparent`, so restate that too
->    if you relied on it.
-> 2. **`pointer-events` is inherited.** Putting `pointer-events: none` on a HUD
->    root — the natural way to let clicks fall through to the game — pushes it
->    back down onto the hole even if the hole's own `style:` omitted it.
->
-> Being explicit covers both:
+> **The inheritance trap is still real for everything you build yourself.**
+> `pointer-events` is inherited, so `pointer-events: none` on a HUD root — the
+> natural way to let clicks fall through to the game — reaches every descendant.
+> Your own HUD controls, and any hand-rolled hole that isn't a `data-viewport`
+> node, need an explicit opt-in:
 >
 > ```rust
 > div { style: "pointer-events: none;",          // HUD root: clicks fall through
->     GameViewport { name: "main", style: "flex: 1; pointer-events: auto; background: transparent;" }
+>     GameViewport { name: "main", style: "flex: 1;" }   // hittable by default
 >     div { style: "pointer-events: auto;", /* real HUD controls */ }
 > }
 > ```
 >
-> The inheritance half is spec-correct, not a bug — but the overlay idiom that
-> triggers it is the obvious one to reach for, so it is worth designing around up
-> front. The same `pointer-events: auto` opt-in applies to any HUD control you
-> want clickable inside a `pointer-events: none` root. (`visibility: hidden` is
-> stronger still: it makes an entire subtree unhittable and *cannot* be re-enabled
-> on a descendant.)
+> That inheritance is spec-correct, not a bug — but the overlay idiom that triggers
+> it is the obvious one to reach for, so it is worth designing around up front.
+> (`visibility: hidden` is stronger still: it makes an entire subtree unhittable
+> and *cannot* be re-enabled on a descendant.)
 
 ### Split Layout (Viewport Hole)
 
@@ -387,7 +387,7 @@ fn editor_ui() -> NodeHandle {
             }
             div { style: "display: flex; flex: 1;",
                 div { style: "width: 200px;", /* side panel */ }
-                GameViewport { name: "main", style: "flex: 1; pointer-events: auto; background: transparent;" }
+                GameViewport { name: "main", style: "flex: 1;" }
             }
         }
     }


### PR DESCRIPTION
Fixes #207. The viewport hole div hard-coded `pointer-events: none`, which inverted embed input routing: hittability *is* the routing (`wants_mouse` walks up from the hit node looking for `data-viewport`), so the bare `GameViewport { name }` form made the UI claim the mouse everywhere and the game silently received nothing — while the documented `style: \"flex: 1;\"` form worked only because the universal `style:` prop replaces the attribute and accidentally clobbered the `none`.

## Fix

The inline style is deleted and the defaults move to a UA-stylesheet rule in rinch-dom (`[data-viewport] { pointer-events: auto; background: transparent; }`) — rinch-dom already special-cases `data-viewport` in paint (the hole punch), so this is not a new concept for it. UA origin is the correct cascade slot: it beats inheritance (which also defuses #195's inherited-`none` trap for viewport holes specifically) and loses to any author declaration, so opting a region back to the UI still works — including `rinch-video`'s viewport, whose inline `pointer-events: none` is author-origin and deliberately unchanged. With no inline style left, a user's `style:` replacement can no longer strip hittability or the transparent background.

## Verification

Four tests driving the real `viewport_rect` + `wants_mouse` on a mounted context, each asserting the inside/outside pair (so a total-miss can't pass vacuously): bare form, styled form, author override, and inherited-`none` immunity. Mutation-attributed: full revert fails the bare + inherited tests with the exact #207 symptom while the styled form still passes (the "works by accident" half reproduced); removing only the UA rule fails exactly the inherited test.

Docs: game-engine.md's Input Routing rewritten (default is hittable; the cascade trap remains documented for hand-rolled overlay roots); `game_viewport()`'s previously-inverted doc comment corrected; CLAUDE.md's GameViewport row gains the hittability contract.

Gates: `cargo test -p rinch --features embed,theme,clipboard` all green (incl. the 4 new + multi_context 10), default-features green, workspace clippy `-D warnings` clean, `--no-default-features --features embed` check clean (warning set byte-identical to main), `cargo test -p rinch-dom` 283 green, full pre-commit gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)