### PR TITLE
fix(rinch-dom): #202 — scale CSS translate into physical px in compose_node_transform

### DIFF
--- a/crates/rinch-dom/src/paint/mod.rs
+++ b/crates/rinch-dom/src/paint/mod.rs
@@ -223,6 +223,10 @@ pub fn compute_absolute_position(tree: &NodeTree, node_id: RawNodeId, scale: f64
 /// single source of truth for transform composition — the paint arms, the
 /// dirty-region cull test, dirty-region tracking, and hit testing must all
 /// agree on it (#142, #143, #199).
+///
+/// The result is covariant in `scale`: composing at `(s·x, s·y, s)` equals
+/// `S · compose(x, y, 1) · S⁻¹` for `S = scale(s)`, which is what lets hit
+/// testing pass `scale = 1.0` and work in layout pixels (#202).
 pub fn compose_node_transform(
     node: &Node,
     x: f64,
@@ -240,6 +244,14 @@ pub fn compose_node_transform(
         m[4] += tf.translate_x_pct * node.layout.width as f64;
         m[5] += tf.translate_y_pct * node.layout.height as f64;
     }
+    // The translate components are *lengths*: `m[4]`/`m[5]` come from the
+    // stylesheet in CSS px and the percentage part resolves against the CSS-px
+    // layout box, so both need converting to the physical-pixel space this
+    // function composes in (its `x`/`y` inputs and the origin below already
+    // are). The linear part (a, b, c, d) is a pure ratio — unit-invariant —
+    // and must NOT be scaled (#202).
+    m[4] *= scale;
+    m[5] *= scale;
     let cs = &node.computed_style;
     let ox = cs.transform_origin_x.resolve(node.layout.width);
     let oy = cs.transform_origin_y.resolve(node.layout.height);

--- a/crates/rinch-dom/tests/paint_tests.rs
+++ b/crates/rinch-dom/tests/paint_tests.rs
@@ -566,12 +566,18 @@ mod transform_paint {
     /// Paint the document with the tiny-skia software painter for pixel
     /// assertions.
     fn paint_skia(doc: &mut RinchDocument, painter: &mut TinySkiaPainter) {
+        paint_skia_at(doc, painter, 1.0);
+    }
+
+    /// Same, at an explicit DPI scale (layout stays in CSS px — the paint
+    /// pipeline is what scales, exactly as the embed/Android runtimes drive it).
+    fn paint_skia_at(doc: &mut RinchDocument, painter: &mut TinySkiaPainter, scale: f64) {
         let mut paint_layout_cx: parley::LayoutContext<Brush> = parley::LayoutContext::new();
         rinch_dom::paint::paint_document(
             &doc.tree,
             painter,
-            1.0,
-            (800.0, 600.0),
+            scale,
+            (800.0 * scale as f32, 600.0 * scale as f32),
             &mut doc.font_cx,
             &mut paint_layout_cx,
         );
@@ -784,6 +790,171 @@ mod transform_paint {
         assert!(
             region.y0 > 100.0,
             "region should not start at the untransformed layout rect, got {region:?}"
+        );
+    }
+
+    /// Bounding box of the opaque-red pixels as `(x0, y0, x1, y1)`, inclusive.
+    fn red_bbox(painter: &TinySkiaPainter) -> Option<(u32, u32, u32, u32)> {
+        let (mut x0, mut y0, mut x1, mut y1) = (u32::MAX, u32::MAX, 0_u32, 0_u32);
+        let mut found = false;
+        for y in 0..painter.height() {
+            for x in 0..painter.width() {
+                if is_opaque_red(pixel_at(painter, x, y)) {
+                    found = true;
+                    x0 = x0.min(x);
+                    y0 = y0.min(y);
+                    x1 = x1.max(x);
+                    y1 = y1.max(y);
+                }
+            }
+        }
+        found.then_some((x0, y0, x1, y1))
+    }
+
+    /// #202 (pixel level): a translated element must paint at
+    /// `scale · (layout + translate)`, not `scale · layout + translate`. The
+    /// painted box at scale 2 must therefore land at exactly twice the
+    /// coordinates it occupies at scale 1 — the covariance oracle, observed
+    /// through the software rasterizer.
+    #[test]
+    fn test_translate_scales_with_dpi() {
+        fn paint_at(scale: f64) -> (u32, u32, u32, u32) {
+            let mut doc = RinchDocument::new();
+            let body = doc.body();
+            let div = doc.create_element("div");
+            doc.set_attribute(
+                div,
+                "style",
+                "width: 20px; height: 20px; background-color: red; \
+                 transform: translate(40px, 30px)",
+            );
+            doc.append_child(body, div);
+            doc.resolve_layout(800.0, 600.0);
+
+            let mut painter = TinySkiaPainter::new(400, 400);
+            paint_skia_at(&mut doc, &mut painter, scale);
+            red_bbox(&painter).expect("translated red box should paint somewhere")
+        }
+
+        let at1 = paint_at(1.0);
+        let at2 = paint_at(2.0);
+
+        for (label, one, two) in [
+            ("x0", at1.0, at2.0),
+            ("y0", at1.1, at2.1),
+            ("x1", at1.2, at2.2),
+            ("y1", at1.3, at2.3),
+        ] {
+            let expected = 2 * one as i64;
+            assert!(
+                (two as i64 - expected).abs() <= 2,
+                "{label} at scale 2 should be ~2x its scale-1 value \
+                 (expected ~{expected}, got {two}); scale-1 bbox {at1:?}, \
+                 scale-2 bbox {at2:?} — an under-translated box means the CSS \
+                 translate was not multiplied by the DPI scale (#202)"
+            );
+        }
+    }
+}
+
+// ── #202: DPI-scale covariance of transform composition ──────────────────────
+
+/// The mechanical correctness criterion for `compose_node_transform`: it must be
+/// *covariant* under the physical/layout change of units. Composing at
+/// `(s·x, s·y, s)` has to equal `S · compose(x, y, 1.0) · S⁻¹` for `S = scale(s)`
+/// — i.e. "compose in physical px" and "compose in layout px, then convert" are
+/// the same map. That identity is exactly what lets hit testing (`local_point`
+/// in `crates/rinch/src/app/hit_testing.rs`) compose at `scale = 1.0` in layout
+/// space and still mirror paint at any DPI.
+///
+/// The linear part (rotate/scale/skew) is unit-invariant, so it satisfies this
+/// for free; the *translate* part is a length and only satisfies it when scaled
+/// (#202).
+mod transform_dpi_covariance {
+    use super::*;
+    use peniko::kurbo::Affine;
+
+    /// One `<div>` carrying `style`, laid out, plus its node id.
+    fn styled_div(style: &str) -> (RinchDocument, usize) {
+        let mut doc = RinchDocument::new();
+        let body = doc.body();
+        let div = doc.create_element("div");
+        doc.set_attribute(div, "style", style);
+        doc.append_child(body, div);
+        doc.resolve_layout(800.0, 600.0);
+        (doc, div.0)
+    }
+
+    fn affine_mismatch(actual: Affine, expected: Affine) -> Option<String> {
+        let (a, e) = (actual.as_coeffs(), expected.as_coeffs());
+        let bad = (0..6).find(|&i| (a[i] - e[i]).abs() >= 1e-6)?;
+        Some(format!(
+            "coefficient {bad} differs — got {a:?}, expected {e:?}"
+        ))
+    }
+
+    #[test]
+    fn compose_node_transform_is_covariant_in_scale() {
+        // (name, transform declaration)
+        let transforms: [(&str, &str); 6] = [
+            ("translate(px)", "transform: translate(30px, 15px)"),
+            ("translate(%)", "transform: translate(50%, -25%)"),
+            ("rotate", "transform: rotate(30deg)"),
+            ("scale", "transform: scale(1.5, 0.5)"),
+            (
+                "rotate+scale+translate",
+                "transform: rotate(20deg) scale(1.3) translate(12px, 7px)",
+            ),
+            (
+                "matrix() with m4/m5",
+                "transform: matrix(1.2, 0.3, -0.4, 0.9, 25, -18)",
+            ),
+        ];
+        let origins: [(&str, &str); 2] = [
+            ("default origin", ""),
+            ("non-default origin", "transform-origin: 10px 70%;"),
+        ];
+
+        // An arbitrary non-zero layout-space position for the node's box.
+        let (x, y) = (37.0_f64, 23.0_f64);
+        // Every case is checked before failing, so a regression report names
+        // *all* the transform kinds that broke, not just the first.
+        let mut failures: Vec<String> = Vec::new();
+
+        for (tf_name, tf) in transforms {
+            for (origin_name, origin) in origins {
+                let style = format!("width: 80px; height: 40px; {origin} {tf}");
+                let (doc, id) = styled_div(&style);
+                let node = doc.tree.get(id).expect("div should be in the tree");
+                assert!(
+                    !node.computed_style.transform.is_identity,
+                    "{tf_name} / {origin_name}: transform did not parse"
+                );
+
+                let base =
+                    rinch_dom::paint::compose_node_transform(node, x, y, 1.0, Affine::IDENTITY);
+
+                for s in [1.0_f64, 1.5, 2.0] {
+                    let scaled = rinch_dom::paint::compose_node_transform(
+                        node,
+                        s * x,
+                        s * y,
+                        s,
+                        Affine::IDENTITY,
+                    );
+                    let conjugated = Affine::scale(s) * base * Affine::scale(1.0 / s);
+                    if let Some(why) = affine_mismatch(scaled, conjugated) {
+                        failures.push(format!("{tf_name} / {origin_name} at scale {s}: {why}"));
+                    }
+                }
+            }
+        }
+
+        assert!(
+            failures.is_empty(),
+            "compose_node_transform is not covariant in scale for {} case(s) (#202):\n{}",
+            failures.len(),
+            failures.join("\n")
         );
     }
 }

--- a/crates/rinch/src/app/hit_testing.rs
+++ b/crates/rinch/src/app/hit_testing.rs
@@ -20,9 +20,10 @@ pub(crate) fn hit_test(tree: &rinch_dom::NodeTree, x: f32, y: f32) -> Option<usi
 /// inverse of paint's accumulated transform.
 ///
 /// `scale = 1.0` because hit testing works in layout pixels while paint works in
-/// physical pixels; the linear part (scale/rotate/skew) is invariant under that
-/// change of units, and `compose_node_transform` applies CSS-px translate
-/// components unscaled, so the two spaces agree exactly at DPI scale 1.
+/// physical pixels. `compose_node_transform` is covariant in that argument — it
+/// multiplies the CSS-px translate components by `scale`, and the linear part
+/// (scale/rotate/skew) is unit-invariant — so composing at `scale = 1.0` yields
+/// exactly paint's transform expressed in layout pixels, at any DPI (#202).
 ///
 /// Returns `None` when the transform is not invertible (`scale(0)`, a degenerate
 /// matrix): such a subtree paints to zero area, so nothing in it can be hit.


### PR DESCRIPTION
Fixes #202. `compose_node_transform` composes in physical-pixel space but applied CSS translate components (absolute px and percentage-resolved) unscaled, so translated elements painted under-translated by the DPI factor at scale ≠ 1. Two lines: `m[4] *= scale; m[5] *= scale;` — the linear part is a unit-invariant ratio and is untouched.

**Who this affects:** the embed path (the reporter's case) and **Android, always** (every real device density is 2.0–3.5 — the bug was live there, not just embed). Desktop has a separate pre-existing DPI incoherence (layout at physical px + paint at scale_factor + buffer at size×scale) filed separately — it makes desktop-at-HiDPI a meaningless baseline for judging this fix; embed and Android are the baselines. There is no zoom-via-paint-scale path (CLAUDE.md's documented Ctrl± zoom shortcut has no implementation — also filed).

**Reconvergence:** the #199 hit-testing fix deliberately implemented CSS-correct translation; with this fix, `compose_node_transform` is covariant in `scale` (composing at `(s·x, s·y, s)` ≡ `S·compose(x,y,1)·S⁻¹`), so hit testing's `scale = 1.0` layout-space math now mirrors paint exactly at any DPI. Hit-test docs updated; no hit-test code changed; all 11 #199 tests pass untouched.

**Tests:** a covariance-oracle test (6 transform kinds × 2 origins × 3 scales, driven through real CSS so the Stylo→TransformValue path is exercised) and a pixel-level tiny-skia test (translated red div at scale 2 lands at 2× its scale-1 bbox). Mutation check: reverting the fix fails exactly the 16 translate-bearing oracle cases (linear coefficients identical in got/expected — only translation diverges) and the pixel test, with everything at s=1.0 passing. No existing test encoded the old expectation; all 4 helper call sites verified free of compensating logic.

Gates: rinch-dom 285 green (paint 34, transition 24), rinch 25 green (all hit-testing), embed check clean, clippy `-D warnings` clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)