### PR TITLE
fix(rinch-editor-collab): #192 — a zero-block CRDT is legitimate and self-healing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -780,7 +780,7 @@ Free functions `collab_receive_for(container_id, &delta)` (main thread) and `pos
 
 | File | Purpose |
 |------|---------|
-| `crates/rinch-editor-collab/src/projection.rs` | `CollabDoc` — the yrs wire shape (`content: Array<Map{type,attrs,text:Text}>`, marks as native yrs `Text` formatting attributes), `from_doc`/`to_doc`/`load`, the `observe_update_v1` broadcast outbox, fail-loud validation |
+| `crates/rinch-editor-collab/src/projection.rs` | `CollabDoc` — the yrs wire shape (`content: Array<Map{type,attrs,text:Text}>`, marks as native yrs `Text` formatting attributes, plus a `meta` root map carrying `format = "rinch-editor-collab/yrs-1"` — the marker `load` requires to tell our bytes from a foreign CRDT), `from_doc`/`to_doc`/`load`, the `observe_update_v1` broadcast outbox, fail-loud validation |
 | `crates/rinch-editor-collab/src/project.rs` | Local: `project_change` — block-list diff (Rc-identity prefix/suffix, minimal text splice) |
 | `crates/rinch-editor-collab/src/remote.rs` | Remote: `build_remote_transaction` — converged rebuild into a minimal block-level `ReplaceStep`; no engine type appears in this file |
 | `crates/rinch-editor-collab/src/session.rs` | `CollabSession` — the imperative model↔CRDT lifecycle (`new`/`from_bytes`, `record_local`, `save_incremental`/`state_vector`/`sync_diff`, `integrate_incremental`) |

--- a/crates/rinch-editor-collab/src/lib.rs
+++ b/crates/rinch-editor-collab/src/lib.rs
@@ -18,6 +18,15 @@
 //! > ([`CollabSession::integrate_incremental`]). Convergence then follows from yrs's own
 //! > convergence.
 //!
+//! **The one exception**, scoped exactly: a CRDT holding **zero** content blocks
+//! projects to the *starter-paragraph* model, because the editor schema admits no empty
+//! document. The two documents are still equal — [`CollabDoc::to_doc`] supplies that
+//! paragraph — but it is not backed by CRDT content, so it is the one block
+//! [`CollabDoc::project_change`] must insert rather than reconcile. Zero blocks is a
+//! reachable converged state (two peers concurrently deleting different blocks, issue
+//! #192), and it is self-healing: the next local edit projects the model wholesale and a
+//! fully-backed equality is restored.
+//!
 //! ## Staged scope (design A22)
 //!
 //! The first milestone covers **flat text-blocks + marks** (`paragraph`/`heading`/

--- a/crates/rinch-editor-collab/src/project.rs
+++ b/crates/rinch-editor-collab/src/project.rs
@@ -18,6 +18,11 @@
 //! keystroke inside one list item re-splices only that item's text object. Any node
 //! outside the supported scope (a non-list nested block, an inline atom) anywhere in
 //! `before` or `after` fails loud ([`CollabError::Unsupported`], design A22).
+//!
+//! The diff trusts `before` to describe what the CRDT holds — which is the invariant —
+//! with **one** exception it must handle itself: a CRDT holding zero blocks (issue #192)
+//! has no model that mirrors it, so `before` carries a starter paragraph the CRDT does
+//! not. That case skips the diff entirely and inserts the whole of `after`.
 
 use yrs::{Array, Transact};
 
@@ -43,6 +48,20 @@ impl CollabDoc {
     /// Project an arbitrary `before → after` document change (also the building block
     /// for loading content). Both must be within the projected scope.
     pub fn project_change(&mut self, before: &Node, after: &Node) -> Result<()> {
+        // A CRDT holding zero blocks is a legitimate converged state (issue #192: two
+        // peers deleting *different* blocks concurrently deletes every block), and the
+        // model cannot mirror it — the schema requires at least one block, so `to_doc`
+        // hands the editor a starter paragraph the CRDT does not contain. `before`
+        // therefore describes a block that is not there, and diffing against it would try
+        // to reconcile a node the CRDT lacks (`reconcile_node: missing node`, which used
+        // to wedge the session permanently: nothing projected, nothing broadcast, no
+        // recovery). With no blocks in the CRDT every block of `after` is an insert, and
+        // that restores `model ≡ project(model)` exactly.
+        let crdt_blocks = self.content.len(&self.doc.transact());
+        if crdt_blocks == 0 {
+            return self.project_whole_doc(after);
+        }
+
         let bn = before.child_count();
         let an = after.child_count();
 
@@ -114,6 +133,26 @@ impl CollabDoc {
         for idx in (prefix + common..prefix + pre_mid).rev() {
             check_index(&txn, &content, idx as u32, false)?;
             content.remove(&mut txn, idx as u32);
+        }
+        Ok(())
+    }
+
+    /// Insert every block of `doc` into a CRDT that holds **no** blocks — the recovery
+    /// path out of the zero-block state (see [`CollabDoc::project_change`]). There is
+    /// nothing to diff against, so this is an unconditional whole-document insert, which
+    /// leaves the CRDT projecting to exactly `doc`.
+    ///
+    /// The A22 pre-pass applies here too: validate every node before opening the write
+    /// transaction, so an out-of-scope document leaves the (empty) CRDT untouched.
+    fn project_whole_doc(&mut self, doc: &Node) -> Result<()> {
+        let mut nodes = Vec::with_capacity(doc.child_count());
+        for i in 0..doc.child_count() {
+            nodes.push(read_node(doc.child(i))?);
+        }
+        let content = self.content.clone();
+        let mut txn = self.doc.transact_mut();
+        for (i, nd) in nodes.iter().enumerate() {
+            insert_node(&mut txn, &content, i as u32, nd)?;
         }
         Ok(())
     }

--- a/crates/rinch-editor-collab/src/projection.rs
+++ b/crates/rinch-editor-collab/src/projection.rs
@@ -14,6 +14,9 @@
 //! *or* a container (carries a `content` array of child nodes):
 //!
 //! ```text
+//! root Map "meta"                 // the projection-format marker (see `load`)
+//!   "format" -> "rinch-editor-collab/yrs-1"
+//!
 //! root Array "content"            // a named root type, holding the top-level blocks
 //!   Node (Map):
 //!     "type"  -> string           // "paragraph" | "heading" | "bullet_list" | …
@@ -104,6 +107,20 @@ const CONTENT: &str = "content";
 const TYPE: &str = "type";
 const ATTRS: &str = "attrs";
 const TEXT: &str = "text";
+/// The root map holding the projection-format marker, and its one key.
+const META: &str = "meta";
+const FORMAT: &str = "format";
+
+/// The projection-format marker written into the `meta` root at creation and required
+/// by [`CollabDoc::load`]. It identifies bytes as *this* crate's projection at *this*
+/// wire version, which is what lets a legitimately empty document (zero content
+/// blocks — see [`CollabDoc::load`]) be told apart from a foreign CRDT that merely
+/// reinterprets as an empty `content` array.
+///
+/// Bump the trailing version when the wire shape changes incompatibly: an older peer
+/// then refuses the bytes loudly instead of half-understanding them. (Playweft's
+/// "wipe, don't convert" precedent — tag every blob, refuse an untagged one.)
+const FORMAT_TAG: &str = "rinch-editor-collab/yrs-1";
 
 /// Origin tag for a yrs transaction that applies bytes received from a peer, as opposed to
 /// one that projects a local edit. The update observer skips these: they are already
@@ -272,12 +289,19 @@ impl CollabDoc {
         }
 
         let (ydoc, outbox, updates) = CollabDoc::blank();
+        // Both roots are resolved before the write transaction opens: resolving one takes
+        // exclusive store access and panics if a transaction is already live.
         let content = ydoc.get_or_insert_array(CONTENT);
+        let meta = ydoc.get_or_insert_map(META);
         // A plain local transaction, so the initial projection lands in the outbox and is
         // broadcast like any other local change. A peer that joined from a snapshot
         // already has it and applies it as a no-op (updates are idempotent).
+        //
+        // The format marker rides in the **same** transaction as the content, so a
+        // fresh projection is still exactly one broadcast.
         {
             let mut txn = ydoc.transact_mut();
+            meta.insert(&mut txn, FORMAT, Any::String(FORMAT_TAG.into()));
             for (i, node) in nodes.iter().enumerate() {
                 insert_node(&mut txn, &content, i as u32, node)?;
             }
@@ -296,14 +320,27 @@ impl CollabDoc {
     /// projections, rather than silently adopting an empty document and collaborating on
     /// content no peer shares.
     ///
-    /// The guard validates **content, not the root's type**, because a root type carries
-    /// no type tag on the wire: a root arriving from a peer reads as `Out::UndefinedRef`
-    /// whatever it really is, and asking for it as an array *reinterprets* whatever is
-    /// there (a foreign `Map` root named `content` then reads as a zero-length array, a
-    /// `Text` root as an array of single characters). So the check is that the array is
-    /// non-empty and that every entry reads back as a projected node — which is strictly
-    /// stronger than the type check this replaced, since a `content` list full of junk
-    /// would have passed that.
+    /// Two gates, in this order:
+    ///
+    /// 1. **The format marker** ([`FORMAT_TAG`] under the `meta` root) must be present
+    ///    and exact. This is the discriminator for "are these our bytes at all", and it
+    ///    cannot be replaced by a check on the root's *type*, because a root type carries
+    ///    no type tag on the wire: a root arriving from a peer reads as
+    ///    `Out::UndefinedRef` whatever it really is, and asking for it as an array
+    ///    *reinterprets* whatever is there (a foreign `Map` root named `content` then
+    ///    reads as a zero-length array, a `Text` root as an array of single characters).
+    ///    A marker is an ordinary map entry, so it survives that hazard — it is *content*,
+    ///    and content is what the wire carries.
+    /// 2. **Every content entry** must read back as a projected node, so a `content`
+    ///    array full of junk is refused even if it somehow carried the marker.
+    ///
+    /// A **zero-block** document passes: that is a legitimate converged state (issue
+    /// #192 — two peers deleting different blocks concurrently leaves the content array
+    /// empty), and refusing it locked a late joiner out of such a session. Emptiness used
+    /// to stand in for gate 1; the marker replaces it, which is what makes admitting zero
+    /// blocks safe. [`CollabDoc::to_doc`] then hands the editor the starter paragraph its
+    /// schema requires, and the first local edit projects that paragraph into the CRDT
+    /// (see [`CollabDoc::project_change`]).
     pub fn load(bytes: &[u8]) -> Result<CollabDoc> {
         let update = Update::decode_v1(bytes)?;
         let (ydoc, outbox, updates) = CollabDoc::blank();
@@ -311,16 +348,22 @@ impl CollabDoc {
             let mut txn = ydoc.transact_mut_with(Origin::from(ENGINE_APPLY_ORIGIN));
             txn.apply_update(update)?;
         }
+        // Root handles first (each takes exclusive store access), then one read
+        // transaction for both gates.
         let content = ydoc.get_or_insert_array(CONTENT);
+        let meta = ydoc.get_or_insert_map(META);
         {
             let txn = ydoc.transact();
-            let n = content.len(&txn);
-            if n == 0 {
-                return Err(CollabError::schema(
-                    "these CRDT bytes carry no `content` blocks — not a rinch editor projection",
-                ));
+            match meta.get(&txn, FORMAT) {
+                Some(Out::Any(Any::String(tag))) if &*tag == FORMAT_TAG => {}
+                other => {
+                    return Err(CollabError::schema(format!(
+                        "these CRDT bytes are not a rinch editor projection: expected \
+                         `{META}.{FORMAT}` = `{FORMAT_TAG}`, found {other:?}"
+                    )));
+                }
             }
-            for i in 0..n {
+            for i in 0..content.len(&txn) {
                 read_node_data(&txn, &content, i)?;
             }
         }
@@ -342,6 +385,17 @@ impl CollabDoc {
 
     /// Rebuild the whole model document from the projection (the canonical, total
     /// read-back; both peers reconstruct identically, so equal CRDTs give equal docs).
+    ///
+    /// # The one exception to `model ≡ project(model)`
+    ///
+    /// A CRDT holding **zero** content blocks is a legitimate converged state (issue
+    /// #192), but the editor schema requires at least one block, so there is no model that
+    /// mirrors it. This returns the starter paragraph instead — an **unprojected** block:
+    /// the document equality still holds (both sides are `doc(paragraph())`), but that
+    /// paragraph has no CRDT content behind it. The exception is scoped to exactly that
+    /// state and is cured by the next local edit, which
+    /// [`CollabDoc::project_change`] projects wholesale rather than diffing against a
+    /// CRDT that does not hold it.
     pub fn to_doc(&self, schema: &Schema) -> Result<Node> {
         let mut blocks = {
             let txn = self.doc.transact();
@@ -354,7 +408,9 @@ impl CollabDoc {
             blocks
         };
         if blocks.is_empty() {
-            // An editor doc is never empty; mirror the starter empty paragraph.
+            // An editor doc is never empty; mirror the starter empty paragraph. See the
+            // exception documented on this method — this block is not in the CRDT, and
+            // `project_change` knows it.
             let para = schema
                 .branch("paragraph", Fragment::empty())
                 .map_err(CollabError::from)?;
@@ -1234,6 +1290,143 @@ mod tests {
         let cdoc = CollabDoc::from_doc(&doc).unwrap();
         let loaded = CollabDoc::load(&cdoc.save()).unwrap();
         assert_eq!(loaded.to_doc(&s).unwrap(), doc);
+    }
+
+    /// One projectable paragraph, for building foreign documents that *look* like a
+    /// projection.
+    fn plausible_block() -> NodeData {
+        NodeData::Block(BlockData {
+            type_name: "paragraph".into(),
+            attrs: Attrs::new(),
+            text: "hi".into(),
+            marks: vec![],
+        })
+    }
+
+    #[test]
+    fn load_requires_the_projection_format_marker() {
+        // The marker is the discriminator for "are these our bytes at all", which is what
+        // lets `load` admit a legitimately empty document (see the test below) without
+        // also admitting a foreign CRDT that merely reinterprets as an empty `content`
+        // array. Neither case below is caught by the content check: both carry a content
+        // array whose entries read back as perfectly valid projected nodes.
+
+        // A foreign document that would sail through a content-only guard: the right root
+        // name, holding a real projected block — but no format marker.
+        let markerless = foreign_update(|d| {
+            let a = d.get_or_insert_array(CONTENT);
+            let mut txn = d.transact_mut();
+            insert_node(&mut txn, &a, 0, &plausible_block()).unwrap();
+        });
+        let err = CollabDoc::load(&markerless).unwrap_err();
+        assert!(matches!(err, CollabError::Schema(_)), "got {err:?}");
+
+        // A *wrong* marker — e.g. a peer still speaking an older wire shape — must fail
+        // just as loudly as a missing one, rather than being half-understood.
+        let wrong_version = foreign_update(|d| {
+            let a = d.get_or_insert_array(CONTENT);
+            let m = d.get_or_insert_map(META);
+            let mut txn = d.transact_mut();
+            m.insert(
+                &mut txn,
+                FORMAT,
+                Any::String("rinch-editor-collab/yrs-0".into()),
+            );
+            insert_node(&mut txn, &a, 0, &plausible_block()).unwrap();
+        });
+        let err = CollabDoc::load(&wrong_version).unwrap_err();
+        assert!(matches!(err, CollabError::Schema(_)), "got {err:?}");
+
+        // A marker of the wrong *kind* (not a string) is not a marker either.
+        let wrong_kind = foreign_update(|d| {
+            let a = d.get_or_insert_array(CONTENT);
+            let m = d.get_or_insert_map(META);
+            let mut txn = d.transact_mut();
+            m.insert(&mut txn, FORMAT, Any::Bool(true));
+            insert_node(&mut txn, &a, 0, &plausible_block()).unwrap();
+        });
+        let err = CollabDoc::load(&wrong_kind).unwrap_err();
+        assert!(matches!(err, CollabError::Schema(_)), "got {err:?}");
+
+        // The `meta` root is subject to the same reinterpretation hazard as `content` — a
+        // foreign root of ANY type arrives untagged and is reinterpreted as the map we ask
+        // for. Reading a missing key out of a reinterpreted sequence must fail loud, not
+        // panic. Both sequence kinds, since they reinterpret differently.
+        for (label, build) in [
+            (
+                "text root named meta",
+                Box::new(|d: &Doc| {
+                    let t = d.get_or_insert_text(META);
+                    t.insert(&mut d.transact_mut(), 0, "format");
+                }) as Box<dyn FnOnce(&Doc)>,
+            ),
+            (
+                "array root named meta",
+                Box::new(|d: &Doc| {
+                    let a = d.get_or_insert_array(META);
+                    a.insert(&mut d.transact_mut(), 0, Any::String(FORMAT_TAG.into()));
+                }),
+            ),
+        ] {
+            let bytes = foreign_update(build);
+            let err = CollabDoc::load(&bytes).unwrap_err();
+            assert!(
+                matches!(err, CollabError::Schema(_)),
+                "{label}: got {err:?}"
+            );
+        }
+
+        // And the marker alone is not enough: the content entries are still validated.
+        let marked_junk = foreign_update(|d| {
+            let a = d.get_or_insert_array(CONTENT);
+            let m = d.get_or_insert_map(META);
+            let mut txn = d.transact_mut();
+            m.insert(&mut txn, FORMAT, Any::String(FORMAT_TAG.into()));
+            a.insert(&mut txn, 0, Any::String("junk".into()));
+        });
+        let err = CollabDoc::load(&marked_junk).unwrap_err();
+        assert!(matches!(err, CollabError::Schema(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn load_accepts_a_projection_that_has_no_blocks_left() {
+        // Zero blocks is a legitimate converged state (#192: two peers deleting different
+        // blocks concurrently), and refusing it locked a late joiner out of such a
+        // session. The marker — not emptiness — is what tells our bytes from a stranger's,
+        // so the empty document loads and projects to the starter paragraph the editor
+        // schema requires.
+        let s = schema();
+        let para = s
+            .branch("paragraph", Fragment::from_node(s.text("hi").unwrap()))
+            .unwrap();
+        let doc = s.branch("doc", Fragment::from_node(para)).unwrap();
+        let cdoc = CollabDoc::from_doc(&doc).unwrap();
+
+        // Empty the content array the way a converged double-delete does.
+        {
+            let mut txn = cdoc.doc.transact_mut();
+            cdoc.content.remove(&mut txn, 0);
+        }
+        assert_eq!(cdoc.content.len(&cdoc.doc.transact()), 0);
+
+        let starter = s
+            .branch(
+                "doc",
+                Fragment::from_node(s.branch("paragraph", Fragment::empty()).unwrap()),
+            )
+            .unwrap();
+        assert_eq!(
+            cdoc.to_doc(&s).unwrap(),
+            starter,
+            "an empty projection reads back as the starter paragraph"
+        );
+
+        let loaded = CollabDoc::load(&cdoc.save()).expect("a zero-block snapshot is joinable");
+        assert_eq!(
+            loaded.to_doc(&s).unwrap(),
+            starter,
+            "and a late joiner adopts that same starter paragraph"
+        );
     }
 
     #[test]

--- a/crates/rinch-editor-collab/src/projection.rs
+++ b/crates/rinch-editor-collab/src/projection.rs
@@ -1430,6 +1430,42 @@ mod tests {
     }
 
     #[test]
+    fn two_independently_created_projections_merge_and_keep_one_readable_marker() {
+        // Every other path creates the second peer by *joining* the first
+        // (`load`/`from_bytes`), so both share one lineage and one marker write. Two peers
+        // that each ran `from_doc` instead both wrote `meta.format` under their own client
+        // id, and merging them is a map-key conflict. yrs resolves it to one writer; both
+        // wrote the same value, so the marker must still read back — and the merged
+        // document must still be joinable from its own snapshot.
+        let s = schema();
+        let doc_of = |t: &str| {
+            let p = s
+                .branch("paragraph", Fragment::from_node(s.text(t).unwrap()))
+                .unwrap();
+            s.branch("doc", Fragment::from_node(p)).unwrap()
+        };
+        let mut a = CollabDoc::from_doc(&doc_of("alpha")).unwrap();
+        let b = CollabDoc::from_doc(&doc_of("beta")).unwrap();
+        a.merge_from(&b).unwrap();
+
+        let merged = a.to_doc(&s).unwrap();
+        assert_eq!(merged.child_count(), 2, "both peers' blocks survived");
+        let meta = a.doc.get_or_insert_map(META);
+        assert!(
+            matches!(
+                meta.get(&a.doc.transact(), FORMAT),
+                Some(Out::Any(Any::String(tag))) if &*tag == FORMAT_TAG
+            ),
+            "the marker survives the conflicting write"
+        );
+        assert_eq!(
+            CollabDoc::load(&a.save()).unwrap().to_doc(&s).unwrap(),
+            merged,
+            "and the merged document is joinable from its own snapshot"
+        );
+    }
+
+    #[test]
     fn the_outbox_collects_local_writes_and_skips_applied_bytes() {
         // The broadcast contract: a locally-projected transaction is a broadcast, an
         // applied peer update is not (re-broadcasting it would echo).

--- a/crates/rinch-editor-collab/tests/collab.rs
+++ b/crates/rinch-editor-collab/tests/collab.rs
@@ -120,15 +120,21 @@ fn two_peers(blocks: Vec<Node>) -> (Rc<Schema>, Peer, Peer) {
         session: session_a,
     };
 
-    let snap = a.session.snapshot();
-    let session_b = CollabSession::from_bytes(&snap).expect("session B");
-    let b_doc = session_b.projected_doc(&schema).expect("project B");
-    let b_state = EditorState::create(schema.clone(), b_doc, plugins());
-    let b = Peer {
-        state: b_state,
-        session: session_b,
-    };
+    let b = join(&schema, &a.session.snapshot());
     (schema, a, b)
+}
+
+/// Join an existing session from `snapshot`, adopting the document it projects — the
+/// session-level shape of `EditorHandle::start_collaboration_guest`.
+fn join(schema: &Rc<Schema>, snapshot: &[u8]) -> Peer {
+    let session = CollabSession::from_bytes(snapshot).expect("join from snapshot");
+    let doc = session
+        .projected_doc(schema)
+        .expect("project the joined document");
+    Peer {
+        state: EditorState::create(schema.clone(), doc, plugins()),
+        session,
+    }
 }
 
 /// Reconcile two peers by exchanging **state vectors** and the diffs they imply.
@@ -755,6 +761,114 @@ fn a_delete_only_broadcast_delta_reaches_the_peer() {
         norm(&b.state.doc).contains("abef"),
         "the deletion reached the peer: {}",
         norm(&b.state.doc)
+    );
+}
+
+// --- the zero-block state (issue #192) -----------------------------------------
+
+/// Delete block `index` outright (its open token through its close token).
+fn delete_block(peer: &mut Peer, index: usize) {
+    let doc = peer.state.doc.clone();
+    let start: usize = (0..index).map(|i| doc.child(i).node_size()).sum();
+    let end = start + doc.child(index).node_size();
+    peer.local(|tr| {
+        tr.delete(start, end).unwrap();
+    });
+}
+
+#[test]
+fn concurrent_deletion_of_different_blocks_empties_the_crdt_and_self_heals() {
+    // The #192 repro at the session layer. Two peers concurrently delete *different*
+    // blocks, so the union of the deletions is every block and the converged content
+    // array is empty — a state no model can mirror, since the schema requires a block.
+    // Before the fix the next local edit died with `Schema("reconcile_node: missing
+    // node")`, nothing was broadcast, and the session never recovered.
+    let schema = Rc::new(Schema::starter_kit());
+    let (schema, mut a, mut b) = {
+        let _ = &schema;
+        two_peers(vec![para(&schema, "one"), para(&schema, "two")])
+    };
+    delete_block(&mut a, 1); // A drops "two"
+    delete_block(&mut b, 0); // B drops "one"
+    assert_eq!(a.state.doc.child_count(), 1, "each peer deleted one block");
+    assert_eq!(b.state.doc.child_count(), 1);
+    sync(&mut a, &mut b);
+
+    // The invariant's one exception: with zero blocks in the CRDT the read-back is the
+    // starter paragraph — equal to each peer's model, but not backed by CRDT content.
+    let starter = norm(&doc_of(&schema, vec![para(&schema, "")]));
+    assert_eq!(
+        norm(&a.state.doc),
+        starter,
+        "A converged to the starter paragraph"
+    );
+    assert_eq!(
+        norm(&b.state.doc),
+        starter,
+        "B converged to the starter paragraph"
+    );
+    assert_converged(&a, &b, &schema);
+
+    // The next local edit on either peer must project, broadcast and converge.
+    a.type_at(1, "Z");
+    sync(&mut a, &mut b);
+    assert_converged(&a, &b, &schema);
+    assert!(
+        norm(&b.state.doc).contains('Z'),
+        "A's first edit after the empty state reached B: {}",
+        norm(&b.state.doc)
+    );
+
+    b.type_at(1, "Y");
+    sync(&mut a, &mut b);
+    assert_converged(&a, &b, &schema);
+    let t = norm(&a.state.doc);
+    assert!(
+        t.contains('Y') && t.contains('Z'),
+        "both post-recovery edits survived: {t}"
+    );
+}
+
+#[test]
+fn a_late_joiner_can_join_a_session_with_no_blocks_left() {
+    // The second symptom of #192: `load` used to reject a zero-block projection as "not a
+    // rinch editor projection", locking a late joiner out of a session that had reached
+    // that state. The format marker is the discriminator now, so the join succeeds and
+    // the joiner adopts the starter paragraph.
+    let schema = Rc::new(Schema::starter_kit());
+    let (schema, mut a, mut b) = {
+        let _ = &schema;
+        two_peers(vec![para(&schema, "one"), para(&schema, "two")])
+    };
+    delete_block(&mut a, 1);
+    delete_block(&mut b, 0);
+    sync(&mut a, &mut b);
+
+    let starter = norm(&doc_of(&schema, vec![para(&schema, "")]));
+    let mut c = join(&schema, &a.session.snapshot());
+    assert_eq!(
+        norm(&c.state.doc),
+        starter,
+        "the late joiner adopts the starter paragraph"
+    );
+
+    // And edits flow both ways between the joiner and an existing peer.
+    c.type_at(1, "L");
+    sync(&mut a, &mut c);
+    assert_converged(&a, &c, &schema);
+    assert!(
+        norm(&a.state.doc).contains('L'),
+        "the joiner's edit reached the existing peer: {}",
+        norm(&a.state.doc)
+    );
+
+    a.type_at(1, "H");
+    sync(&mut a, &mut c);
+    assert_converged(&a, &c, &schema);
+    let t = norm(&c.state.doc);
+    assert!(
+        t.contains('H') && t.contains('L'),
+        "both directions synced: {t}"
     );
 }
 

--- a/crates/rinch-editor-collab/tests/fuzz.rs
+++ b/crates/rinch-editor-collab/tests/fuzz.rs
@@ -52,15 +52,24 @@ fn schema() -> Rc<Schema> {
     Rc::new(Schema::starter_kit())
 }
 
+fn para(schema: &Schema, text: &str) -> Node {
+    let content = if text.is_empty() {
+        Fragment::empty()
+    } else {
+        Fragment::from_node(schema.text(text).unwrap())
+    };
+    schema.branch("paragraph", content).unwrap()
+}
+
+fn doc_of(schema: &Schema, blocks: Vec<Node>) -> Node {
+    schema
+        .branch("doc", Fragment::from_children(blocks))
+        .unwrap()
+}
+
 /// `doc(paragraph("start"))` — the shared initial document.
 fn initial_state(schema: &Rc<Schema>) -> EditorState {
-    let para = schema
-        .branch(
-            "paragraph",
-            Fragment::from_node(schema.text("start").unwrap()),
-        )
-        .unwrap();
-    let doc = schema.branch("doc", Fragment::from_node(para)).unwrap();
+    let doc = doc_of(schema, vec![para(schema, "start")]);
     EditorState::create(schema.clone(), doc, default_plugins())
 }
 
@@ -183,116 +192,246 @@ fn same(a: &Node, b: &Node) -> bool {
     a == b
 }
 
+/// N peers sharing one CRDT lineage, plus the global delta queue and each peer's
+/// delivery watermark. Both fuzz shapes below drive this one harness: the random-edit
+/// trials and the scripted deletion-to-empty scenario.
+struct Swarm {
+    schema: Rc<Schema>,
+    states: Vec<EditorState>,
+    sessions: Vec<CollabSession>,
+    /// Every delta produced, in production order — a topological order of the change
+    /// DAG, so FIFO delivery always satisfies dependencies.
+    queue: Vec<Vec<u8>>,
+    /// `seen[p]` = how many of `queue`'s deltas peer `p` has integrated.
+    seen: Vec<usize>,
+    /// Local edits projected so far (a trial that made none proves nothing).
+    edits: usize,
+}
+
+impl Swarm {
+    /// `peers` peers over `doc`, the others joining from peer 0's snapshot.
+    fn new(schema: Rc<Schema>, doc: Node, peers: usize) -> Swarm {
+        let init = EditorState::create(schema.clone(), doc, default_plugins());
+        let host = CollabSession::new(&init).unwrap();
+        let snapshot = host.snapshot();
+
+        let mut states: Vec<EditorState> = Vec::with_capacity(peers);
+        let mut sessions: Vec<CollabSession> = Vec::with_capacity(peers);
+        states.push(init.clone());
+        sessions.push(host);
+        for _ in 1..peers {
+            states.push(init.clone());
+            sessions.push(CollabSession::from_bytes(&snapshot).unwrap());
+        }
+        Swarm {
+            schema,
+            states,
+            sessions,
+            queue: Vec::new(),
+            seen: vec![0usize; peers],
+            edits: 0,
+        }
+    }
+
+    fn peers(&self) -> usize {
+        self.states.len()
+    }
+
+    /// Project peer `p`'s move to `next`, check the load-bearing invariant, and queue
+    /// whatever it broadcasts.
+    fn record_local(&mut self, seed: u64, p: usize, next: EditorState) {
+        self.sessions[p]
+            .record_local(&self.states[p].doc, &next.doc)
+            .expect("flat edit projects cleanly");
+        let projected = self.sessions[p].projected_doc(&self.schema).unwrap();
+        if !same(&projected, &next.doc) {
+            use rinch_editor_core::serialize::node_to_html;
+            panic!(
+                "model ≡ project(model) violated on a local edit \
+                 (seed={seed}, peer={p}, edit#{})\n\
+                 BEFORE: {}\n  MODEL: {}\nPROJECTED: {}",
+                self.edits,
+                node_to_html(&self.states[p].doc),
+                node_to_html(&next.doc),
+                node_to_html(&projected),
+            );
+        }
+        self.states[p] = next;
+        let delta = self.sessions[p].save_incremental().expect("delta encodes");
+        if !delta.is_empty() {
+            self.queue.push(delta);
+        }
+        self.edits += 1;
+    }
+
+    /// Deliver peer `q`'s next unseen delta (a no-op when it is already caught up).
+    fn deliver(&mut self, seed: u64, q: usize) {
+        if self.seen[q] >= self.queue.len() {
+            return;
+        }
+        let delta = self.queue[self.seen[q]].clone();
+        self.seen[q] += 1;
+        if let Some(next) = self.sessions[q]
+            .integrate_incremental(&self.states[q], &delta)
+            .expect("delta integrates")
+        {
+            // A remote integration also lands the model at project(CRDT).
+            assert!(
+                same(
+                    &self.sessions[q].projected_doc(&self.schema).unwrap(),
+                    &next.doc
+                ),
+                "model ≡ project(model) violated after integrate (seed={seed}, peer={q})"
+            );
+            self.states[q] = next;
+        }
+    }
+
+    /// Every peer integrates every remaining delta.
+    fn flush(&mut self, seed: u64) {
+        for q in 0..self.peers() {
+            while self.seen[q] < self.queue.len() {
+                self.deliver(seed, q);
+            }
+        }
+    }
+
+    /// `rounds` interleaved random edit/deliver steps.
+    fn run_rounds(&mut self, seed: u64, rounds: usize, rng: &mut Rng) {
+        for _ in 0..rounds {
+            // 60% make a local edit, 40% deliver a pending delta.
+            if rng.chance(60) {
+                let p = rng.below(self.peers());
+                let Some(next) = random_edit(rng, &self.states[p]) else {
+                    continue;
+                };
+                self.record_local(seed, p, next);
+            } else {
+                let q = rng.below(self.peers());
+                self.deliver(seed, q);
+            }
+        }
+    }
+
+    /// Convergence: every peer projects to the identical document, and that document is
+    /// what its own model holds (model ≡ project, post-flush).
+    fn assert_converged(&self, seed: u64) {
+        let reference = self.sessions[0].projected_doc(&self.schema).unwrap();
+        for q in 0..self.peers() {
+            let projected = self.sessions[q].projected_doc(&self.schema).unwrap();
+            assert!(
+                same(&projected, &reference),
+                "peers diverged after flush (seed={seed}, peer {q} vs peer 0)"
+            );
+            assert!(
+                same(&self.states[q].doc, &reference),
+                "peer {q}'s model disagrees with its CRDT after flush (seed={seed})"
+            );
+        }
+        assert!(
+            self.edits > 0,
+            "trial should have made at least one edit (seed={seed})"
+        );
+    }
+}
+
 /// Run one fuzz trial: `peers` peers, `rounds` interleaved edit/deliver steps, then a
 /// flush, asserting the two invariants throughout.
 fn fuzz_trial(seed: u64, peers: usize, rounds: usize) {
     let schema = schema();
     let mut rng = Rng::new(seed);
+    let mut swarm = Swarm::new(schema.clone(), initial_state(&schema).doc.clone(), peers);
+    swarm.run_rounds(seed, rounds, &mut rng);
+    swarm.flush(seed);
+    swarm.assert_converged(seed);
+}
 
-    // All peers start from peer 0's snapshot, so they share one CRDT lineage.
-    let init = initial_state(&schema);
-    let host = CollabSession::new(&init).unwrap();
-    let snapshot = host.snapshot();
+/// Delete block `index` of `state`'s document outright (its open token through its
+/// close token).
+fn delete_block(state: &EditorState, index: usize) -> Option<EditorState> {
+    let doc = &state.doc;
+    let start: usize = (0..index).map(|i| doc.child(i).node_size()).sum();
+    let end = start + doc.child(index).node_size();
+    let mut tr = state.tr();
+    tr.delete(start, end).ok()?;
+    Some(state.apply(tr))
+}
 
-    let mut states: Vec<EditorState> = Vec::with_capacity(peers);
-    let mut sessions: Vec<CollabSession> = Vec::with_capacity(peers);
-    states.push(init.clone());
-    sessions.push(host);
-    for _ in 1..peers {
-        states.push(init.clone());
-        sessions.push(CollabSession::from_bytes(&snapshot).unwrap());
+/// Type `text` at model position `pos`.
+fn insert_at(state: &EditorState, pos: usize, text: &str) -> Option<EditorState> {
+    let mut tr = state.tr();
+    tr.set_selection(Selection::cursor(Pos(pos)));
+    tr.insert_text(text).ok()?;
+    Some(state.apply(tr))
+}
+
+/// The #192 scenario, scripted so it is exercised **by construction** rather than left to
+/// chance: `peers` peers over a document of one paragraph per peer, each deleting a
+/// *different* block before seeing anyone else's delta. The union of those deletions is
+/// every block, so the converged content array is provably empty — the state that used to
+/// wedge the session forever. Random edits then run on top of the healed state, so the
+/// ordinary invariant checks cover everything downstream of the recovery.
+fn fuzz_deletion_to_empty_trial(seed: u64, peers: usize, rounds: usize) {
+    assert!(peers >= 2, "the scenario needs two blocks to delete apart");
+    let schema = schema();
+    let mut rng = Rng::new(seed);
+    let blocks: Vec<Node> = (0..peers)
+        .map(|i| para(&schema, &format!("block{i}")))
+        .collect();
+    let mut swarm = Swarm::new(schema.clone(), doc_of(&schema, blocks), peers);
+
+    // Concurrent: every peer deletes its own block, none having seen the others'.
+    for p in 0..peers {
+        let next = delete_block(&swarm.states[p], p).expect("a whole-block delete applies");
+        assert_eq!(
+            next.doc.child_count(),
+            peers - 1,
+            "peer {p} deleted exactly one block (seed={seed})"
+        );
+        swarm.record_local(seed, p, next);
     }
+    swarm.flush(seed);
 
-    // A global FIFO of every delta produced (production order is a topological order
-    // of the change DAG, so FIFO delivery always satisfies dependencies). `seen[p]`
-    // is how many of the queue's deltas peer `p` has integrated.
-    let mut queue: Vec<Vec<u8>> = Vec::new();
-    let mut seen = vec![0usize; peers];
-
-    let mut edits = 0usize;
-    for _ in 0..rounds {
-        // 60% make a local edit, 40% deliver a pending delta.
-        if rng.chance(60) {
-            let p = rng.below(peers);
-            let Some(next) = random_edit(&mut rng, &states[p]) else {
-                continue;
-            };
-            // Project the local change and check the load-bearing invariant.
-            sessions[p]
-                .record_local(&states[p].doc, &next.doc)
-                .expect("flat edit projects cleanly");
-            let projected = sessions[p].projected_doc(&schema).unwrap();
-            if !same(&projected, &next.doc) {
-                use rinch_editor_core::serialize::node_to_html;
-                panic!(
-                    "model ≡ project(model) violated on a local edit \
-                     (seed={seed}, peer={p}, edit#{edits})\n\
-                     BEFORE: {}\n  MODEL: {}\nPROJECTED: {}",
-                    node_to_html(&states[p].doc),
-                    node_to_html(&next.doc),
-                    node_to_html(&projected),
-                );
-            }
-            states[p] = next;
-            let delta = sessions[p].save_incremental().expect("delta encodes");
-            if !delta.is_empty() {
-                queue.push(delta);
-            }
-            edits += 1;
-        } else {
-            // Deliver the next unseen delta to a random peer (FIFO per peer).
-            let q = rng.below(peers);
-            if seen[q] < queue.len() {
-                let delta = queue[seen[q]].clone();
-                seen[q] += 1;
-                if let Some(next) = sessions[q]
-                    .integrate_incremental(&states[q], &delta)
-                    .expect("delta integrates")
-                {
-                    // A remote integration also lands the model at project(CRDT).
-                    assert!(
-                        same(&sessions[q].projected_doc(&schema).unwrap(), &next.doc),
-                        "model ≡ project(model) violated after integrate (seed={seed}, peer={q})"
-                    );
-                    states[q] = next;
-                }
-            }
-        }
-    }
-
-    // Flush: every peer integrates every remaining delta.
-    for q in 0..peers {
-        while seen[q] < queue.len() {
-            let delta = queue[seen[q]].clone();
-            seen[q] += 1;
-            if let Some(next) = sessions[q]
-                .integrate_incremental(&states[q], &delta)
-                .expect("delta integrates on flush")
-            {
-                states[q] = next;
-            }
-        }
-    }
-
-    // Convergence: every peer projects to the identical document, and that document
-    // is what its own model holds (model ≡ project, post-flush).
-    let reference = sessions[0].projected_doc(&schema).unwrap();
-    for q in 0..peers {
-        let projected = sessions[q].projected_doc(&schema).unwrap();
+    // The invariant's ONE exception, asserted precisely. With zero blocks in the CRDT
+    // there is no model that mirrors it — the schema requires at least one block — so the
+    // read-back is the starter paragraph: equal to what every peer's model holds, but NOT
+    // backed by CRDT content. Nothing else is weakened; the equality itself must still
+    // hold on both sides, on every peer.
+    let starter = doc_of(&schema, vec![para(&schema, "")]);
+    for p in 0..peers {
+        let projected = swarm.sessions[p].projected_doc(&schema).unwrap();
         assert!(
-            same(&projected, &reference),
-            "peers diverged after flush (seed={seed}, peer {q} vs peer 0)"
+            same(&projected, &starter),
+            "every block was deleted, so peer {p} must project the starter paragraph \
+             (seed={seed})"
         );
         assert!(
-            same(&states[q].doc, &reference),
-            "peer {q}'s model disagrees with its CRDT after flush (seed={seed})"
+            same(&swarm.states[p].doc, &starter),
+            "peer {p}'s model must equal that projection (seed={seed})"
         );
     }
 
-    assert!(
-        edits > 0,
-        "trial should have made at least one edit (seed={seed})"
-    );
+    // Every peer now types from the empty state, so every peer exercises the recovery
+    // path — and they do it concurrently, which converges to one block per peer by
+    // ordinary concurrent-insert semantics rather than corrupting anything.
+    for p in 0..peers {
+        let next = insert_at(&swarm.states[p], 1, "R").expect("typing into the starter block");
+        swarm.record_local(seed, p, next);
+    }
+    swarm.flush(seed);
+    for p in 0..peers {
+        assert_eq!(
+            swarm.states[p].doc.child_count(),
+            peers,
+            "each peer's concurrent first edit became its own block (seed={seed})"
+        );
+    }
+    swarm.assert_converged(seed);
+
+    // Then the ordinary random interleaving on top of the healed state.
+    swarm.run_rounds(seed, rounds, &mut rng);
+    swarm.flush(seed);
+    swarm.assert_converged(seed);
 }
 
 #[test]
@@ -321,5 +460,22 @@ fn fuzz_many_peers_converge() {
     // A few wider trials: more peers, longer runs, to shake out tail cases.
     for seed in 300..=305u64 {
         fuzz_trial(seed, 6, 500);
+    }
+}
+
+#[test]
+fn fuzz_deletion_to_empty_recovers_and_converges() {
+    // Issue #192: the random trials above never reach a zero-block CRDT — a single peer's
+    // model cannot get there (the schema forbids it), and only concurrent deletions of
+    // *different* blocks empty it on every peer at once, which random editing effectively
+    // never produces. So the emptying is scripted, and the random fuzz resumes afterwards.
+    for seed in 400..=407u64 {
+        fuzz_deletion_to_empty_trial(seed, 2, 220);
+    }
+    for seed in 500..=505u64 {
+        fuzz_deletion_to_empty_trial(seed, 3, 320);
+    }
+    for seed in 600..=603u64 {
+        fuzz_deletion_to_empty_trial(seed, 4, 400);
     }
 }

--- a/crates/rinch-editor-collab/tests/fuzz.rs
+++ b/crates/rinch-editor-collab/tests/fuzz.rs
@@ -12,8 +12,13 @@
 //!    Once every peer has seen every delta, all peers must project to the *identical*
 //!    document. This is the exact incremental-delta path pimble / `EditorHandle` use.
 //!
-//! Deterministic (a fixed-seed xorshift PRNG) so any failure reproduces from its
-//! `(seed, peers, rounds)` triple.
+//! The **edit script** is deterministic — a fixed-seed xorshift PRNG — so a
+//! `(seed, peers, rounds)` triple always produces the same sequence of edits and
+//! deliveries. A failing trial is **not** replayable bit-for-bit, though: yrs breaks
+//! concurrent-insert ties by client id, `CollabDoc::blank()` takes yrs's default random
+//! one, and the resulting document feeds back into later positions, so two runs of the
+//! same binary at the same seed can diverge in edit count. Reproducing a failure exactly
+//! needs the client ids pinned as well.
 
 use std::rc::Rc;
 

--- a/crates/rinch-editor-view/src/handle.rs
+++ b/crates/rinch-editor-view/src/handle.rs
@@ -2216,6 +2216,239 @@ mod tests {
             );
         }
 
+        // ── The zero-block state (issue #192) ────────────────────────────────
+        //
+        // Two peers deleting *different* blocks concurrently deletes every block, so
+        // the shared CRDT converges to an empty content list. No model can mirror that
+        // (the schema requires a block), so both peers show the starter paragraph while
+        // the CRDT holds nothing. That state used to wedge the session permanently: the
+        // next local edit tried to reconcile a block the CRDT did not have, failed with
+        // `Schema("reconcile_node: missing node")`, broadcast nothing, and never
+        // recovered.
+
+        /// Delete a whole block from `h` by its index, tokens included.
+        fn delete_block(h: &EditorHandle, index: usize) {
+            let doc = h.doc();
+            let start: usize = (0..index).map(|i| doc.child(i).node_size()).sum();
+            let end = start + doc.child(index).node_size();
+            h.update(|st| {
+                let mut tr = st.tr();
+                tr.delete(start, end).ok()?;
+                Some(tr)
+            });
+        }
+
+        /// Wire `host` and `guest` through a **buffered** loopback: deltas pile up
+        /// instead of being delivered, so edits made between exchanges are genuinely
+        /// concurrent. The returned closure drains both directions until quiet.
+        fn buffered_loopback(host: &EditorHandle, guest: &EditorHandle) -> impl Fn() {
+            let to_guest: Rc<RefCell<Vec<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
+            let to_host: Rc<RefCell<Vec<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
+            let tg = to_guest.clone();
+            let snapshot = host
+                .start_collaboration_host(move |d| tg.borrow_mut().push(d))
+                .expect("host projects its document");
+            let th = to_host.clone();
+            guest
+                .start_collaboration_guest(&snapshot, move |d| th.borrow_mut().push(d))
+                .expect("guest joins from the snapshot");
+            let h = host.clone();
+            let g = guest.clone();
+            move || {
+                // An integrated delta is never re-broadcast, so this settles in one
+                // pass; the loop keeps that from being an assumption.
+                for _ in 0..4 {
+                    let out_g: Vec<Vec<u8>> = to_guest.borrow_mut().drain(..).collect();
+                    let out_h: Vec<Vec<u8>> = to_host.borrow_mut().drain(..).collect();
+                    if out_g.is_empty() && out_h.is_empty() {
+                        return;
+                    }
+                    for d in out_g {
+                        g.collab_receive(&d);
+                    }
+                    for d in out_h {
+                        h.collab_receive(&d);
+                    }
+                }
+                panic!("the buffered loopback did not settle");
+            }
+        }
+
+        /// Drive two peers to the converged zero-block state: each deletes a different
+        /// block of a two-block document, then the deltas are exchanged.
+        fn empty_the_shared_document(
+            host: &EditorHandle,
+            guest: &EditorHandle,
+            exchange: &impl Fn(),
+        ) {
+            assert_eq!(doc_text(host), "one\ntwo");
+            assert_eq!(
+                doc_text(guest),
+                "one\ntwo",
+                "the guest joined on the host's doc"
+            );
+            delete_block(host, 1); // host drops "two"
+            delete_block(guest, 0); // guest drops "one"
+            assert_eq!(doc_text(host), "one");
+            assert_eq!(doc_text(guest), "two");
+            exchange();
+            assert_eq!(doc_text(host), "", "every block was deleted");
+            assert_eq!(doc_text(guest), "");
+            assert_eq!(
+                host.doc().child_count(),
+                1,
+                "the starter paragraph stands in"
+            );
+            assert_eq!(guest.doc().child_count(), 1);
+        }
+
+        #[test]
+        fn concurrent_block_deletions_do_not_wedge_the_session() {
+            let s = schema();
+            let host = mount(doc_node(&s, vec![para(&s, "one"), para(&s, "two")])).handle;
+            let guest = mount(doc_node(&s, vec![para(&s, "")])).handle;
+            let exchange = buffered_loopback(&host, &guest);
+            empty_the_shared_document(&host, &guest, &exchange);
+            assert!(
+                host.collab_take_error().is_none() && guest.collab_take_error().is_none(),
+                "converging to an empty document is not an error"
+            );
+
+            // The host types: the edit must project, broadcast, and reach the guest.
+            host.set_selection(Selection::cursor(Pos(1)));
+            assert!(host.insert_text("Z"));
+            assert_eq!(doc_text(&host), "Z");
+            assert!(
+                host.collab_take_error().is_none(),
+                "the first edit after the empty state must project cleanly"
+            );
+            exchange();
+            assert_eq!(
+                doc_text(&guest),
+                "Z",
+                "the recovered edit reached the guest"
+            );
+
+            // And so must the guest's, in the other direction.
+            guest.set_selection(Selection::cursor(Pos(1)));
+            assert!(guest.insert_text("Y"));
+            assert_eq!(doc_text(&guest), "YZ");
+            assert!(guest.collab_take_error().is_none());
+            exchange();
+            assert_eq!(doc_text(&host), "YZ", "the guest's edit reached the host");
+            assert!(
+                host.collab_take_error().is_none() && guest.collab_take_error().is_none(),
+                "no collaboration error surfaced anywhere in the recovery"
+            );
+        }
+
+        #[test]
+        fn concurrent_first_edits_after_the_empty_state_converge() {
+            // Both peers type before seeing the other, so both project their starter
+            // paragraph into the CRDT. Two concurrent inserts into an empty array is
+            // ordinary CRDT behaviour: two blocks, identical on both peers.
+            let s = schema();
+            let host = mount(doc_node(&s, vec![para(&s, "one"), para(&s, "two")])).handle;
+            let guest = mount(doc_node(&s, vec![para(&s, "")])).handle;
+            let exchange = buffered_loopback(&host, &guest);
+            empty_the_shared_document(&host, &guest, &exchange);
+
+            host.set_selection(Selection::cursor(Pos(1)));
+            assert!(host.insert_text("H"));
+            guest.set_selection(Selection::cursor(Pos(1)));
+            assert!(guest.insert_text("G"));
+            exchange();
+
+            use rinch_editor_core::serialize::node_to_html;
+            assert_eq!(
+                node_to_html(&host.doc()),
+                node_to_html(&guest.doc()),
+                "concurrent first edits out of the empty state converge"
+            );
+            assert_eq!(host.doc().child_count(), 2, "one block per peer");
+            let t = doc_text(&host);
+            assert!(
+                t.contains('H') && t.contains('G'),
+                "both edits survived: {t}"
+            );
+            assert!(host.collab_take_error().is_none() && guest.collab_take_error().is_none());
+        }
+
+        #[test]
+        fn a_late_joiner_can_join_a_session_with_no_blocks_left() {
+            // The second symptom of #192: `load` used to reject a zero-block projection
+            // as "not a rinch editor projection", locking a late joiner out of exactly
+            // the state above.
+            let s = schema();
+            let host = mount(doc_node(&s, vec![para(&s, "one"), para(&s, "two")])).handle;
+            let guest = mount(doc_node(&s, vec![para(&s, "")])).handle;
+
+            // Manual buffers rather than the helper: the host's deltas have to fan out to
+            // two peers once the late joiner arrives.
+            let to_peers: Rc<RefCell<Vec<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
+            let to_host: Rc<RefCell<Vec<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
+            let tp = to_peers.clone();
+            let snapshot = host
+                .start_collaboration_host(move |d| tp.borrow_mut().push(d))
+                .unwrap();
+            let th = to_host.clone();
+            guest
+                .start_collaboration_guest(&snapshot, move |d| th.borrow_mut().push(d))
+                .unwrap();
+
+            delete_block(&host, 1);
+            delete_block(&guest, 0);
+            for d in to_peers.borrow_mut().drain(..) {
+                guest.collab_receive(&d);
+            }
+            for d in to_host.borrow_mut().drain(..) {
+                host.collab_receive(&d);
+            }
+            assert_eq!(
+                doc_text(&host),
+                "",
+                "precondition: the CRDT holds no blocks"
+            );
+            assert_eq!(doc_text(&guest), "");
+
+            // A third peer joins from the host's CURRENT (zero-block) snapshot.
+            let late = mount(doc_node(&s, vec![para(&s, "stale")])).handle;
+            let late_out: Rc<RefCell<Vec<Vec<u8>>>> = Rc::new(RefCell::new(Vec::new()));
+            let lo = late_out.clone();
+            let snapshot = host.collab_snapshot().expect("host is collaborating");
+            late.start_collaboration_guest(&snapshot, move |d| lo.borrow_mut().push(d))
+                .expect("a zero-block snapshot is joinable");
+            assert_eq!(
+                doc_text(&late),
+                "",
+                "the late joiner adopts the starter paragraph"
+            );
+            assert_eq!(late.doc().child_count(), 1);
+
+            // The joiner types: the host converges.
+            late.set_selection(Selection::cursor(Pos(1)));
+            assert!(late.insert_text("L"));
+            for d in late_out.borrow_mut().drain(..) {
+                host.collab_receive(&d);
+                guest.collab_receive(&d);
+            }
+            assert_eq!(doc_text(&host), "L", "the joiner's edit reached the host");
+            assert!(late.collab_take_error().is_none());
+
+            // The host types: the joiner converges.
+            host.set_selection(Selection::cursor(Pos(2)));
+            assert!(host.insert_text("H"));
+            for d in to_peers.borrow_mut().drain(..) {
+                late.collab_receive(&d);
+                guest.collab_receive(&d);
+            }
+            assert_eq!(doc_text(&late), "LH", "the host's edit reached the joiner");
+            assert!(
+                host.collab_take_error().is_none() && late.collab_take_error().is_none(),
+                "no collaboration error surfaced in either direction"
+            );
+        }
+
         #[test]
         fn unsupported_local_edit_fails_loud_without_touching_the_peer() {
             let s = schema();

--- a/docs/design/yrs-migration.md
+++ b/docs/design/yrs-migration.md
@@ -132,7 +132,10 @@ like any other data. The per-entry content check still runs afterwards, so a `co
 array full of junk is refused even if it somehow carried the marker. This is Playweft's
 "wipe, don't convert" precedent (`a734e11`): tag every blob, refuse an untagged one
 rather than guessing. Bump the trailing version if the wire shape ever changes
-incompatibly.
+incompatibly. One consequence is inherent and intended: a snapshot produced between the
+engine swap and this change carries no `meta` root at all, so it is refused like any other
+untagged blob — re-project such a document from the model rather than trying to load it.
+Nothing downstream had shipped on yrs, so that costs nobody.
 
 The marker **replaced emptiness as the discriminator**, and that was the point of adding
 it (issue #192). The original guard rejected a zero-block `content` array as "not a rinch

--- a/docs/design/yrs-migration.md
+++ b/docs/design/yrs-migration.md
@@ -66,7 +66,7 @@ editor. It held. Unchanged by this migration:
 | Automerge (before) | yrs (after) |
 |---|---|
 | `AutoCommit` + `ObjId` object graph | `Doc::with_options(Options { offset_kind: OffsetKind::Utf16, .. })` |
-| `content: List<Block{type, attrs, text: Text}>` + marks over `Text` | `content: Array<Map{type, attrs, text: Text}>`; marks are the `Text`'s own native formatting attributes |
+| `content: List<Block{type, attrs, text: Text}>` + marks over `Text` | `content: Array<Map{type, attrs, text: Text}>`; marks are the `Text`'s own native formatting attributes; plus a `meta` root map carrying the projection-format marker (see `load()` below) |
 | JSON-string-encoded mark values (`encode_attrs`/`decode_mark_value`) | **Deleted.** yrs format attributes carry structured `Any` values natively — the JSON indirection existed only because Automerge marks carried a scalar |
 | `get_heads()` / `ChangeHash` compare | `state_vector()` bytes — but see "never a convergence test" below; the comparison semantics are not equivalent |
 | `save_incremental()` broadcast delta | an `observe_update_v1` outbox drained by `CollabSession::save_incremental` (see below — this is *not* a straight rename) |
@@ -112,7 +112,7 @@ draft of the reconciliation path; the regression tests at both the session and
 handle layer now pin the trap directly — they assert the state vector is unchanged
 as a *precondition*, then assert the deletion still propagates.
 
-## `load()` validates content, not a type tag
+## `load()` validates a format marker and the content, not a type tag
 
 Joining from a peer's snapshot (`CollabDoc::load`) has to reject bytes that aren't
 actually a rinch projection — otherwise a version mismatch or a stray CRDT document
@@ -121,12 +121,40 @@ check this by object type. yrs cannot: a root type carries **no wire type tag** 
 foreign root arrives as `Out::UndefinedRef`, and asking for it as a typed ref (e.g.
 `get_or_insert_array`) *reinterprets* whatever is actually there rather than failing
 (a foreign `Map` root named `content` reads back as a zero-length array; a `Text`
-root reads back as an array of single characters). So the guard applies the update
-first, then requires the `content` array to be non-empty and every one of its
-entries to read back as a valid projected node — strictly stronger than the type
-check it replaced, since a `content` array full of type-tag-passing junk would have
-sailed through the old check. This was probed against a 13-shape foreign-bytes
-matrix during review; every shape fails loud, none panic.
+root reads back as an array of single characters).
+
+So the projection tags itself. A `meta` root map carries
+`format = "rinch-editor-collab/yrs-1"`, written at creation in the same transaction as
+the initial content, and `load` requires it **first**: missing or mismatched is a loud
+`Schema` error. A marker is ordinary map *content*, which is exactly why it survives the
+hazard above — content is what the wire carries, and a non-empty root map is transmitted
+like any other data. The per-entry content check still runs afterwards, so a `content`
+array full of junk is refused even if it somehow carried the marker. This is Playweft's
+"wipe, don't convert" precedent (`a734e11`): tag every blob, refuse an untagged one
+rather than guessing. Bump the trailing version if the wire shape ever changes
+incompatibly.
+
+The marker **replaced emptiness as the discriminator**, and that was the point of adding
+it (issue #192). The original guard rejected a zero-block `content` array as "not a rinch
+projection" — a heuristic that happened to catch the foreign shapes above because they all
+reinterpret as empty. But zero blocks is also a *legitimate* converged state: two peers
+concurrently deleting different blocks deletes every block, so the emptiness heuristic
+locked a late joiner out of a real session. With the marker doing the discriminating,
+`load` accepts any block count including zero. `to_doc` then supplies the starter
+paragraph the editor schema requires, `project_change` knows that paragraph is not in the
+CRDT and inserts it on the next local edit, and the invariant reads:
+
+> `model ≡ project(model)`, **except** that a CRDT holding zero content blocks projects
+> to the starter-paragraph model — an equality of documents that is not backed by CRDT
+> content, scoped to that one state, and cured by the next local edit.
+
+Eleven foreign-bytes shapes are pinned by unit tests — the four original foreign roots,
+undecodable bytes, a missing marker on an otherwise-valid projection, a wrong marker
+version, a marker of the wrong value kind, a `Text` and an `Array` root named `meta` (the
+reinterpretation hazard aimed at the marker itself), and a correct marker over junk
+content. All fail loud; none panic. Note that without the marker the shapes that
+reinterpret as *empty* would now sail through, so the two halves of this design are
+load-bearing together — which the tests pin from both directions.
 
 ## The `Send` contract, pinned
 
@@ -171,7 +199,9 @@ code-identical on `main` before this migration, not introduced by it, and
 deliberately not folded into PR1's scope:
 
 - **#192** — concurrent deletion of two different blocks by two peers converges to
-  an empty content list and permanently wedges the session.
+  an empty content list and permanently wedges the session. **Fixed** since (in its own
+  change, not PR1): see the `load()` section above for the marker and the scoped
+  invariant exception.
 - **#193** — the mark/attr resync clears and re-applies *every* mark (or replaces
   the whole attrs map) on a changed block instead of diffing per mark/key, silently
   discarding a peer's concurrent unrelated mark or attr edit on the same block.


### PR DESCRIPTION
Fixes #192 (both symptoms: the permanent wedge and the late-joiner lockout).

## The bug
Two peers concurrently deleting different blocks converge the CRDT to an EMPTY content array; `to_doc` invents the starter paragraph (the schema forbids an empty document), so every model holds a block the CRDT lacks — and every subsequent local edit failed `Schema("reconcile_node: missing node")`, broadcast nothing, and diverged the peers permanently. The `load` guard also refused zero-block snapshots, locking late joiners out.

## The fix — two halves that must land together
1. **`project_change` reads the CRDT's own block count first**; zero → `project_whole_doc(after)` (A22 pre-pass intact, then insert everything). Count-based rather than flag-based: it asserts what the CRDT holds, not what the model should be, so after the heal `model ≡ project(model)` is restored *exactly* — including multi-block first edits, `load_doc`, and models that drifted via a rejected edit. The invariant gains one precisely-scoped exception: an empty CRDT projects to the starter-paragraph model (equal documents, unprojected block, cured by the next local edit). The document-equality fuzz checks needed **no** relaxation.
2. **The wire shape gains a `meta` root map with `format = \"rinch-editor-collab/yrs-1\"`**, written in the same transaction as the initial content (a fresh projection is still exactly one broadcast — pinned). `load` gates marker → per-entry content validation → any block count including zero. The marker replaces emptiness as the foreign-bytes discriminator — necessary, since admitting zero blocks without it would silently re-open the original foreign shapes (mutation-verified). **Breaking wire change**, taken deliberately now while zero deployed consumers exist (PlotWeb pins pre-yrs; pre-marker snapshots from the last day are refused — re-project from the model). Playweft precedent: tag every blob, refuse untagged.

## Verification
Triple mutation matrix (each half + the marker gate independently attributed); adversarial review with no blocking findings — the guard proven tight (relaxing `== 0` to `<= 1` breaks all five fuzz suites), 3-peer concurrent heals with re-delivered deltas converge, A22 on the recovery path leaves the empty CRDT untouched, transaction discipline verified, eleven+ adversarial marker shapes fail loud without panicking. New scripted fuzz suite empties the document by construction across 2/3/4 peers, heals concurrently, then runs hundreds of random rounds on top. The review also proved the fuzz-harness refactor byte-identical across all 64 pre-existing trials, and surfaced that fuzz trials aren't bit-replayable (yrs's random client id decides tie-breaks) — module doc corrected here, seam tracked as #214.

Tests: rinch-editor-collab 13/24/5/1 green; rinch-editor-view --features collaboration 75 green; wasm check clean; workspace clippy -D warnings clean; full pre-commit gate passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)