### PR TITLE
fix(rinch-editor-collab): #193 — diff marks and attrs per key in resync instead of clear-and-reapply

### DIFF
--- a/crates/rinch-editor-collab/src/projection.rs
+++ b/crates/rinch-editor-collab/src/projection.rs
@@ -571,12 +571,14 @@ pub(crate) fn reconcile_node(
     if node_type(txn, &node).as_deref() != Some(target.type_name()) {
         node.insert(txn, TYPE, Any::String(target.type_name().into()));
     }
-    // attrs — only rebuild when they changed. Replacing the attrs object on every
-    // keystroke would churn the CRDT and clobber a concurrent remote attr edit on
-    // the same node.
-    if node_attrs(txn, &node) != *target.attrs() {
-        let attrs_obj = node.insert(txn, ATTRS, MapPrelim::default());
-        write_attrs(txn, &attrs_obj, target.attrs());
+    // attrs — diff per key when they changed. Replacing the whole attrs object would
+    // clobber a concurrent remote edit to a *different* key of the same node (issue
+    // #193): yrs merges map conflicts per key, but only within one map object — a
+    // freshly-installed object is a conflict on the node's `attrs` entry itself, one
+    // object wins wholesale, and the other peer's key is silently gone.
+    let current_attrs = node_attrs(txn, &node);
+    if current_attrs != *target.attrs() {
+        reconcile_attrs(txn, &node, &current_attrs, target.attrs());
     }
 
     match target {
@@ -719,9 +721,25 @@ fn apply_mark(txn: &mut TransactionMut, text: &TextRef, s: &str, m: &SpanMark) {
     text.format(txn, at, len, attrs);
 }
 
-/// Clear and reapply a `Text`'s formatting attributes to match `target` exactly.
+/// Bring a `Text`'s formatting attributes in step with `target` by **per-span
+/// difference**: clear only the spans no longer present (`current \ target`, via the
+/// Yjs convention that a `null` attribute value removes that format), apply only the
+/// spans that are new (`target \ current`). A span is a `(name, attrs, range)` run —
+/// the finest granularity the canonical span lists carry — so a mark the edit did not
+/// touch is not written at all.
+///
+/// It must not be: re-applying an unchanged mark gives it a fresh CRDT write that
+/// outlives a peer's *concurrent removal* of that very mark (issue #193). Both peers
+/// still converged — on a document that silently resurrected what the peer deleted.
+/// A mark the local edit really changed is still cleared/re-added, which is the honest
+/// same-mark conflict.
+///
 /// `current` is the text's present string and `current_marks` the spans read out of it
-/// (both **after** any splice), so the ranges being cleared are the live ones.
+/// (both **after** any splice), so the ranges being cleared are the live ones. Two
+/// spans of one name never overlap (both lists are canonical, coalesced runs), so a
+/// clear cannot blank a *kept* span of the same name — and all clears run before all
+/// applies, so a span that changed extent (cleared at the old range, re-applied at the
+/// new) nets out to exactly the new range.
 fn resync_marks(
     txn: &mut TransactionMut,
     text: &TextRef,
@@ -729,9 +747,10 @@ fn resync_marks(
     current_marks: &[SpanMark],
     target: &[SpanMark],
 ) {
-    // Clear every currently-active mark over its range. Per the Yjs convention a
-    // `null` attribute value removes that format.
     for m in current_marks {
+        if target.contains(m) {
+            continue;
+        }
         let (at, len) = u16_span(current, m.start, m.end);
         if len == 0 {
             continue;
@@ -744,7 +763,9 @@ fn resync_marks(
         );
     }
     for m in target {
-        apply_mark(txn, text, current, m);
+        if !current_marks.contains(m) {
+            apply_mark(txn, text, current, m);
+        }
     }
 }
 
@@ -1021,6 +1042,44 @@ fn write_attrs(txn: &mut TransactionMut, obj: &MapRef, attrs: &Attrs) {
         // absent" — storing it would be indistinguishable from a cleared key on
         // read-back.
         if let Some(any) = attr_to_any(v) {
+            obj.insert(txn, k.to_string(), any);
+        }
+    }
+}
+
+/// Bring a node's existing `attrs` map in step with `target` by **per-key**
+/// insert/remove on the same map object — never by replacing the object (see the
+/// caller, [`reconcile_node`], for why replacing loses concurrent peer edits).
+///
+/// `current` is the attr set already read back from the node (so the caller's
+/// changed-at-all check and this diff agree on what the CRDT holds). Keys the target
+/// no longer carries — or carries as [`AttrValue::Null`], which [`write_attrs`] never
+/// stores — are removed; keys whose value differs are written; equal keys are left
+/// untouched, keeping their CRDT history out of the transaction entirely.
+fn reconcile_attrs(txn: &mut TransactionMut, node: &MapRef, current: &Attrs, target: &Attrs) {
+    let obj = match node.get(txn, ATTRS) {
+        Some(Out::YMap(m)) => m,
+        // Every projected node is written with an attrs map (`write_node`), but a
+        // missing/foreign one is recoverable: install a fresh map, and the loop below
+        // fills it (nothing to remove — `current` is empty for a non-map entry).
+        _ => node.insert(txn, ATTRS, MapPrelim::default()),
+    };
+    // Remove stale keys. Collected first: the iteration holds a read borrow of the
+    // transaction. Iterating the live map (not `current`) also sweeps keys a foreign
+    // writer left in shapes `read_attrs` skips.
+    let stale: Vec<String> = obj
+        .iter(txn)
+        .map(|(k, _)| k.to_string())
+        .filter(|k| target.get(k).is_none_or(|v| attr_to_any(v).is_none()))
+        .collect();
+    for k in &stale {
+        obj.remove(txn, k);
+    }
+    // Write only the keys whose value actually changed.
+    for (k, v) in target.iter() {
+        if let Some(any) = attr_to_any(v)
+            && current.get(k) != Some(v)
+        {
             obj.insert(txn, k.to_string(), any);
         }
     }

--- a/crates/rinch-editor-collab/tests/collab.rs
+++ b/crates/rinch-editor-collab/tests/collab.rs
@@ -470,6 +470,137 @@ fn concurrent_heading_level_change_and_typing_converge() {
 }
 
 #[test]
+fn concurrent_bold_add_and_italic_removal_converge_without_resurrecting_the_italic() {
+    // Issue #193 repro (a). One paragraph, "one two three", italic over "three". One
+    // peer bolds "one"; the other concurrently REMOVES the italic. The two edits touch
+    // *different* marks, so both must survive: bold on "one", italic gone.
+    //
+    // Before the per-span diff, `resync_marks` cleared and re-applied EVERY mark on the
+    // block whenever ANY mark differed — so the bolding peer's resync re-wrote
+    // `italic: true` over "three", and that fresh write outlived the other peer's
+    // concurrent removal. Both peers converged (no divergence!) on a document that
+    // silently resurrected the italic. Deterministic in both role-orderings, hence the
+    // loop: the host owns the initial projection and yrs client ids break ties, so
+    // neither ordering may be assumed to cover the other.
+    for host_bolds in [true, false] {
+        let schema = Rc::new(Schema::starter_kit());
+        let italic = Mark::simple(schema.mark_type("italic").unwrap().clone());
+        let p = schema
+            .create_node(
+                "paragraph",
+                Default::default(),
+                Fragment::from_children(vec![
+                    schema.text("one two ").unwrap(),
+                    schema.text_with_marks("three", vec![italic]).unwrap(),
+                ]),
+            )
+            .unwrap();
+        let (schema, mut a, mut b) = {
+            let _ = &schema;
+            two_peers(vec![p])
+        };
+        // Model positions: "one" = 1..4, "three" = 9..14.
+        let unitalic = |peer: &mut Peer| {
+            // The mark handed to `remove_mark` must be the peer's OWN instance:
+            // `Mark`/`MarkType` equality is Rc-pointer identity, so one built from a
+            // different `Schema::starter_kit()` matches nothing and the removal is a
+            // silent no-op (the host's doc holds this test's outer-schema marks, a
+            // guest's holds its join-rebuild's). Pull it off the document itself.
+            let italic = {
+                let block = peer.state.doc.child(0);
+                (0..block.child_count())
+                    .flat_map(|i| block.child(i).marks().iter())
+                    .find(|m| m.type_name() == "italic")
+                    .expect("the italic mark is on the initial doc")
+                    .clone()
+            };
+            peer.local(|tr| {
+                tr.remove_mark(9, 14, italic).unwrap();
+            });
+        };
+        if host_bolds {
+            a.bold(1, 4);
+            unitalic(&mut b);
+        } else {
+            unitalic(&mut a);
+            b.bold(1, 4);
+        }
+        sync(&mut a, &mut b);
+        assert_converged(&a, &b, &schema);
+        let t = norm(&a.session.projected_doc(&schema).unwrap());
+        assert!(
+            t.contains("«one|bold[]»"),
+            "(host_bolds={host_bolds}) bold landed on exactly \"one\": {t}"
+        );
+        assert!(
+            !t.contains("italic"),
+            "(host_bolds={host_bolds}) the italic removal survived the concurrent \
+             unrelated-mark edit: {t}"
+        );
+    }
+}
+
+#[test]
+fn concurrent_edits_to_different_attrs_of_the_same_block_both_survive() {
+    // Issue #193 repro (b). A level-1 heading; one peer sets `level: 3`, the other
+    // concurrently sets `text_align: "center"`. Different keys of the same attrs map,
+    // so both edits must survive: level=3 AND text_align=center on both peers.
+    //
+    // Before the per-key diff, the attrs branch of `reconcile_node` replaced the WHOLE
+    // attrs map object whenever any attr differed. yrs merges map conflicts per key,
+    // but only within one map object — two peers each installing a fresh object is a
+    // conflict on the node's `attrs` key itself, one object wins wholesale, and the
+    // other peer's edit vanishes (converged, silently wrong: e.g. level=1 +
+    // text_align=center). Both role-orderings, as above.
+    for host_sets_level in [true, false] {
+        let schema = Rc::new(Schema::starter_kit());
+        let h = schema
+            .create_node(
+                "heading",
+                Attrs::new().with("level", 1i64),
+                Fragment::from_node(schema.text("Title").unwrap()),
+            )
+            .unwrap();
+        let (schema, mut a, mut b) = {
+            let _ = &schema;
+            two_peers(vec![h])
+        };
+        let set = |peer: &mut Peer, attr: &'static str, value: AttrValue| {
+            peer.local(|tr| {
+                tr.set_node_attr(0, attr, value).unwrap();
+            });
+        };
+        if host_sets_level {
+            set(&mut a, "level", AttrValue::Int(3));
+            set(&mut b, "text_align", AttrValue::from("center"));
+        } else {
+            set(&mut a, "text_align", AttrValue::from("center"));
+            set(&mut b, "level", AttrValue::Int(3));
+        }
+        sync(&mut a, &mut b);
+        assert_converged(&a, &b, &schema);
+        for (name, peer) in [("A", &a), ("B", &b)] {
+            let conv = peer.session.projected_doc(&schema).unwrap();
+            let attrs = conv.child(0).attrs().clone();
+            assert_eq!(
+                attrs.get_int("level"),
+                Some(3),
+                "(host_sets_level={host_sets_level}) peer {name}: the level change \
+                 survived the concurrent other-attr edit: {}",
+                norm(&conv)
+            );
+            assert_eq!(
+                attrs.get_str("text_align"),
+                Some("center"),
+                "(host_sets_level={host_sets_level}) peer {name}: the alignment change \
+                 survived the concurrent other-attr edit: {}",
+                norm(&conv)
+            );
+        }
+    }
+}
+
+#[test]
 fn multi_block_with_code_and_heading_round_trips() {
     let schema = Rc::new(Schema::starter_kit());
     let h = schema

--- a/crates/rinch-editor-collab/tests/collab.rs
+++ b/crates/rinch-editor-collab/tests/collab.rs
@@ -10,8 +10,8 @@ use std::rc::Rc;
 
 use rinch_editor_collab::{CollabPlugin, CollabSession, rebase_steps};
 use rinch_editor_core::{
-    AttrValue, Attrs, EditorState, Fragment, Mark, Node, Plugin, Pos, Schema, Selection, Slice,
-    Step, Transaction, default_plugins,
+    AttrValue, Attrs, EditorState, Fragment, Mark, Node, Plugin, Pos, Schema, Selection,
+    SetNodeAttrStep, Slice, Step, Transaction, default_plugins,
 };
 
 // --- harness -------------------------------------------------------------------
@@ -594,6 +594,76 @@ fn concurrent_edits_to_different_attrs_of_the_same_block_both_survive() {
                 Some("center"),
                 "(host_sets_level={host_sets_level}) peer {name}: the alignment change \
                  survived the concurrent other-attr edit: {}",
+                norm(&conv)
+            );
+        }
+    }
+}
+
+#[test]
+fn attr_set_vs_concurrent_attr_remove_of_different_key() {
+    // The stale-key sweep in `reconcile_attrs`, pinned directly — the sibling test
+    // above exercises only the insert half (mutation testing showed the sweep could
+    // be disabled with every directed test still green). Removing an attr projects
+    // as a per-key map REMOVE on the shared attrs object, which must coexist with a
+    // peer's concurrent write to a *different* key of the same object.
+    //
+    // A heading starts with both `level` and `text_align`; one peer sets `level: 3`,
+    // the other removes `text_align` outright (a `SetNodeAttrStep` with
+    // `value: None` — the model drops the key, so the projection's only way to
+    // mirror it is the sweep). Both edits must survive on both peers: level=3,
+    // text_align absent. Both role-orderings, as above.
+    for host_sets_level in [true, false] {
+        let schema = Rc::new(Schema::starter_kit());
+        let h = schema
+            .create_node(
+                "heading",
+                Attrs::new().with("level", 1i64).with("text_align", "left"),
+                Fragment::from_node(schema.text("Title").unwrap()),
+            )
+            .unwrap();
+        let (schema, mut a, mut b) = {
+            let _ = &schema;
+            two_peers(vec![h])
+        };
+        let set_level = |peer: &mut Peer| {
+            peer.local(|tr| {
+                tr.set_node_attr(0, "level", AttrValue::Int(3)).unwrap();
+            });
+        };
+        let remove_align = |peer: &mut Peer| {
+            peer.local(|tr| {
+                tr.step(Box::new(SetNodeAttrStep {
+                    pos: 0,
+                    attr: "text_align".into(),
+                    value: None,
+                }))
+                .unwrap();
+            });
+        };
+        if host_sets_level {
+            set_level(&mut a);
+            remove_align(&mut b);
+        } else {
+            remove_align(&mut a);
+            set_level(&mut b);
+        }
+        sync(&mut a, &mut b);
+        assert_converged(&a, &b, &schema);
+        for (name, peer) in [("A", &a), ("B", &b)] {
+            let conv = peer.session.projected_doc(&schema).unwrap();
+            let attrs = conv.child(0).attrs().clone();
+            assert_eq!(
+                attrs.get_int("level"),
+                Some(3),
+                "(host_sets_level={host_sets_level}) peer {name}: the level change \
+                 survived the concurrent removal of the other key: {}",
+                norm(&conv)
+            );
+            assert!(
+                attrs.get("text_align").is_none(),
+                "(host_sets_level={host_sets_level}) peer {name}: the text_align \
+                 removal survived the concurrent write to the other key: {}",
                 norm(&conv)
             );
         }

--- a/docs/design/yrs-migration.md
+++ b/docs/design/yrs-migration.md
@@ -208,6 +208,9 @@ deliberately not folded into PR1's scope:
 - **#193** — the mark/attr resync clears and re-applies *every* mark (or replaces
   the whole attrs map) on a changed block instead of diffing per mark/key, silently
   discarding a peer's concurrent unrelated mark or attr edit on the same block.
+  **Fixed** since (in its own change, not PR1): PR #216 diffs marks per span
+  (clear `current \ target`, apply `target \ current`) and attrs per key on the
+  existing map object, so an untouched mark or attr is never re-written.
 - **#194** — the A22 "all-or-nothing" guarantee only covers the validation pre-pass;
   an error partway through the write phase itself can commit a partial change and
   still broadcast it. PR1 narrowed an overclaiming comment describing this guarantee


### PR DESCRIPTION
## Mechanism

Both halves of #193 are the same shape: a reconcile path that rewrote **everything** when **anything** differed, handing yrs fresh writes for state the local edit never touched. Both peers converge — `model ≡ project(model)` holds on both sides — but on a document that silently drops a user's edit.

- **Marks** (`resync_marks`, `projection.rs`): when any mark on a block differed from the target, every current span was cleared (`null` format) and every target span re-applied. The re-apply of an *unchanged* mark is a fresh CRDT write that outlives a peer's concurrent removal of that very mark. Probe (a): italic on `"three"`, A bolds `"one"`, B concurrently removes the italic → converged with the italic resurrected, in both role-orderings.
- **Attrs** (`reconcile_node`'s attrs branch): when any attr differed, the whole `attrs` map object was replaced (`node.insert(ATTRS, MapPrelim::default())`). yrs merges map conflicts per key, but only within one map object — a freshly-installed object is a conflict on the node's `attrs` entry itself, one object wins wholesale, and the other peer's key edit vanishes. Probe (b): `heading{level:1}`, A sets `level:3`, B concurrently sets `text_align:center` → converged with one of the two edits gone (which one depends on the map-key tie-break).

## Fix

- `resync_marks` now writes only the per-span difference: clear `current \ target`, apply `target \ current`, where a span is a `(name, attrs, range)` run — the finest granularity the canonical span lists already carry. An untouched mark is not written at all; a mark the local edit really changed is still cleared/re-added (the honest same-mark conflict). Spans of one name never overlap (canonical coalesced runs), and all clears run before all applies, so an extent change nets out to exactly the new range.
- New `reconcile_attrs` inserts/removes **individual keys on the existing attrs map object**: stale keys (absent from the target, or target-`Null`, which `write_attrs` never stores) are removed via the map API; only keys whose value changed are written; equal keys stay out of the transaction entirely. Stale-key sweep iterates the live map, so shapes `read_attrs` skips are cleaned up too.

`reconcile_text` is untouched: pure text edits never enter `resync_marks` (the resync is skipped when the span lists agree), and yrs format-inheritance on insert-inside-a-run matches the model.

## Tests

Written first and confirmed **red** against `ad0c633`, green after the fix. Each asserts both role-orderings (host owns the initial projection and yrs client ids break ties, so neither ordering may be assumed to cover the other):

- `concurrent_bold_add_and_italic_removal_converge_without_resurrecting_the_italic` — probe (a): after convergence, bold sits exactly on `"one"` and the italic is gone, on both peers.
- `concurrent_edits_to_different_attrs_of_the_same_block_both_survive` — probe (b): converged attrs are `level=3` **and** `text_align=center`, on both peers.
- `concurrent_heading_level_change_and_typing_converge` (pre-existing, attr-vs-typing) still passes.

Test-harness note: the mark handed to `remove_mark` must be pulled off the peer's own document — `Mark`/`MarkType` equality is Rc-pointer identity, so a mark built from a different `Schema::starter_kit()` matches nothing and the removal silently no-ops.

## Gates (all green)

- `cargo test -p rinch-editor-collab` — 13 / 26 / 5 / 1 (baseline 13/24/5/1 + the 2 new tests)
- `cargo test -p rinch-editor-view --features collaboration` — 75 passed
- `cargo check -p rinch-editor-collab --target wasm32-unknown-unknown` — clean
- `cargo clippy -p rinch-editor-collab --all-targets -- -D warnings` — clean
- `cargo clippy -p rinch-editor-view --features collaboration --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

Fixes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)