### PR TITLE
fix(rinch-editor-collab): #194 — validate CRDT-side read-back in the pre-pass so project_change is all-or-nothing

### DIFF
--- a/crates/rinch-editor-collab/src/project.rs
+++ b/crates/rinch-editor-collab/src/project.rs
@@ -131,7 +131,9 @@ impl CollabDoc {
 
         // Pre-pass gate 3, CRDT side (issue #194): read back every CRDT node the write
         // phase will read — the blocks being reconciled in place, recursively (a
-        // container's whole subtree, exactly what `reconcile_node` walks). This
+        // container's whole subtree, at least what `reconcile_node` walks: on the
+        // kind-mismatch wholesale-replace path this reads a superset, which is
+        // over-strict in the safe direction, never a hole). This
         // surfaces every CRDT-side failure the model-side gates cannot see — an embed
         // parked in a block's text, a corrupt mark value, a node that is neither
         // text-block nor container — before the first write. Blocks being *deleted*

--- a/crates/rinch-editor-collab/src/project.rs
+++ b/crates/rinch-editor-collab/src/project.rs
@@ -20,16 +20,23 @@
 //! `before` or `after` fails loud ([`CollabError::Unsupported`], design A22).
 //!
 //! The diff trusts `before` to describe what the CRDT holds — which is the invariant —
-//! with **one** exception it must handle itself: a CRDT holding zero blocks (issue #192)
-//! has no model that mirrors it, so `before` carries a starter paragraph the CRDT does
-//! not. That case skips the diff entirely and inserts the whole of `after`.
+//! but it **verifies** that trust before writing (issue #194): the pre-pass checks the
+//! model/CRDT block counts match and reads back every CRDT node the write phase will
+//! read, so a mismatch in either direction — a stray CRDT block the model lacks, or a
+//! model block the CRDT lacks — fails loud with the CRDT untouched, never a partial
+//! commit and never a silent divergence. The **one** exception the diff handles itself:
+//! a CRDT holding zero blocks (issue #192) has no model that mirrors it, so `before`
+//! carries a starter paragraph the CRDT does not. That case skips the diff entirely and
+//! inserts the whole of `after`.
 
 use yrs::{Array, Transact};
 
 use rinch_editor_core::{Node, Transaction};
 
-use crate::error::Result;
-use crate::projection::{CollabDoc, check_index, insert_node, read_node, reconcile_node};
+use crate::error::{CollabError, Result};
+use crate::projection::{
+    CollabDoc, check_index, insert_node, read_node, read_node_data, reconcile_node,
+};
 
 impl CollabDoc {
     /// Project a freshly-applied local transaction onto the CRDT. A no-op for a
@@ -65,6 +72,22 @@ impl CollabDoc {
         let bn = before.child_count();
         let an = after.child_count();
 
+        // Pre-pass gate 1 (issue #194): `before` must describe what the CRDT holds —
+        // starting with how many blocks there are. Without this check a mismatch either
+        // partially commits (model ahead: the delete/reconcile loop runs off the end of
+        // the CRDT *after* earlier blocks were already reconciled, and yrs has no
+        // rollback) or silently diverges (CRDT ahead: the diff reconciles the blocks the
+        // model knows about and leaves the stray one, returning `Ok` — issue #192 review
+        // finding 5). Both directions are the same broken invariant, so both fail loud
+        // here, before any write. The zero-block CRDT is the one legitimate mismatch and
+        // returned above.
+        if crdt_blocks as usize != bn {
+            return Err(CollabError::schema(format!(
+                "model/CRDT out of step: the model document holds {bn} block(s) but the \
+                 CRDT holds {crdt_blocks}"
+            )));
+        }
+
         // Unchanged leading blocks (Rc identity — O(1) per block).
         let mut prefix = 0;
         while prefix < bn && prefix < an && before.child(prefix).same_ref(after.child(prefix)) {
@@ -85,11 +108,11 @@ impl CollabDoc {
         let post_mid = an - prefix - suffix; // changed post blocks
         let common = pre_mid.min(post_mid);
 
-        // Validation pre-pass (design A22 fail-loud must be all-or-nothing): read and
-        // validate EVERY block this change will touch — the `after` blocks to
-        // reconcile/insert, and the `before` blocks to delete — BEFORE issuing any
-        // CRDT write, and before the write transaction is even opened. A mixed
-        // in-scope/out-of-scope change (e.g. pasting or loading a table while
+        // Pre-pass gate 2, model side (design A22 fail-loud must be all-or-nothing):
+        // read and validate EVERY model block this change will touch — the `after`
+        // blocks to reconcile/insert, and the `before` blocks to delete — BEFORE
+        // issuing any CRDT write, and before the write transaction is even opened. A
+        // mixed in-scope/out-of-scope change (e.g. pasting or loading a table while
         // collaborating) then leaves the CRDT *exactly* at the prior converged state
         // and returns `Unsupported`, instead of partially mutating it and wedging the
         // session in a half-projected state.
@@ -106,13 +129,31 @@ impl CollabDoc {
             read_node(before.child(idx))?;
         }
 
-        // Writes — one transaction for the whole change.
-        //
-        // The all-or-nothing guarantee the pre-pass buys covers the **content-scope**
-        // class only: no out-of-scope node can reach a write. An error raised from here on
-        // — a corrupt-CRDT read-back, a bounds check — still commits whatever this
-        // transaction wrote before it, because yrs has no rollback. Extending the pre-pass
-        // to cover that class too is tracked separately.
+        // Pre-pass gate 3, CRDT side (issue #194): read back every CRDT node the write
+        // phase will read — the blocks being reconciled in place, recursively (a
+        // container's whole subtree, exactly what `reconcile_node` walks). This
+        // surfaces every CRDT-side failure the model-side gates cannot see — an embed
+        // parked in a block's text, a corrupt mark value, a node that is neither
+        // text-block nor container — before the first write. Blocks being *deleted*
+        // are not read back: removal never reads their content. The read transaction
+        // is scoped so it drops before `transact_mut` opens (yrs cannot nest
+        // transaction acquisitions).
+        {
+            let txn = self.doc.transact();
+            for k in 0..common {
+                read_node_data(&txn, &self.content, (prefix + k) as u32)?;
+            }
+        }
+
+        // Writes — one transaction for the whole change, which yrs commits on drop:
+        // there is no rollback primitive, so the pre-pass above is the *only*
+        // all-or-nothing lever. It is sufficient: gate 1 pinned the block count (so
+        // every index below is in range for both the insert and delete loops), gates
+        // 2–3 read back everything this phase reads (model and CRDT side), and a
+        // splice/format write cannot invent content a read-back would reject. The
+        // error returns below are therefore unreachable for a change the pre-pass
+        // admitted; they stay as defense in depth against a projection bug, not as a
+        // supported failure path.
         let content = self.content.clone();
         let mut txn = self.doc.transact_mut();
         // Reconcile the overlapping changed blocks in place (keeps identity). A changed
@@ -155,5 +196,143 @@ impl CollabDoc {
             insert_node(&mut txn, &content, i as u32, nd)?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! The all-or-nothing pre-pass, CRDT side (issue #194). yrs transactions commit on
+    //! drop with no rollback, so a write-phase failure would leave the CRDT — and the
+    //! next broadcast delta — holding a partial edit. Each test therefore asserts three
+    //! things: the error is loud, the CRDT bytes are untouched, and the outbox holds no
+    //! delta for a peer to receive. The model-side twin of these pins lives in
+    //! `tests/collab.rs` (`unsupported_change_does_not_partially_mutate`).
+
+    use std::rc::Rc;
+
+    use yrs::{Any, Array, Map, Out, Text, Transact};
+
+    use rinch_editor_core::{Fragment, Node, Schema};
+
+    use crate::error::CollabError;
+    use crate::projection::CollabDoc;
+
+    fn schema() -> Rc<Schema> {
+        Rc::new(Schema::starter_kit())
+    }
+
+    fn para(s: &Schema, text: &str) -> Node {
+        let content = if text.is_empty() {
+            Fragment::empty()
+        } else {
+            Fragment::from_node(s.text(text).unwrap())
+        };
+        s.branch("paragraph", content).unwrap()
+    }
+
+    fn doc_of(s: &Schema, blocks: Vec<Node>) -> Node {
+        s.branch("doc", Fragment::from_children(blocks)).unwrap()
+    }
+
+    /// Drain the outbox, then capture the full CRDT state — the "nothing may change
+    /// past this point" baseline the assertions below compare against.
+    fn baseline(cdoc: &mut CollabDoc) -> Vec<u8> {
+        let _ = cdoc.take_outbox().unwrap();
+        cdoc.save()
+    }
+
+    /// The three-part all-or-nothing assertion: the CRDT state is byte-for-byte what it
+    /// was before the failed projection, and no broadcast delta escaped.
+    fn assert_untouched(cdoc: &mut CollabDoc, baseline: &[u8], what: &str) {
+        assert_eq!(
+            cdoc.save(),
+            baseline,
+            "{what}: the CRDT must be byte-for-byte untouched"
+        );
+        assert!(
+            cdoc.take_outbox().unwrap().is_empty(),
+            "{what}: no broadcast delta may carry a partial edit"
+        );
+    }
+
+    #[test]
+    fn an_embed_found_in_the_crdt_mid_change_does_not_partially_mutate() {
+        // Repro (a) of issue #194: the model-side pre-pass cannot see an embed parked
+        // in the *CRDT's* copy of a block's text — only `reconcile_text`'s read-back
+        // hits it. Before the CRDT-side pre-pass, that read-back happened during the
+        // write phase, after block 0's new text "ALPHA" had already been written; the
+        // transaction committed on drop and the partial edit shipped in the next delta.
+        let s = schema();
+        let before = doc_of(&s, vec![para(&s, "alpha"), para(&s, "beta")]);
+        let mut cdoc = CollabDoc::from_doc(&before).unwrap();
+
+        // Park an embed inside block 1's text, the way a foreign/corrupt writer could.
+        {
+            let mut txn = cdoc.doc.transact_mut();
+            let Some(Out::YMap(node)) = cdoc.content.get(&txn, 1) else {
+                panic!("block 1 must be a node map");
+            };
+            let Some(Out::YText(text)) = node.get(&txn, "text") else {
+                panic!("block 1 must carry a text");
+            };
+            text.insert_embed(&mut txn, 2, Any::Bool(true));
+        }
+        let base = baseline(&mut cdoc);
+
+        // Both blocks change, so the write phase would reconcile block 0 ("ALPHA")
+        // before discovering the embed in block 1.
+        let after = doc_of(&s, vec![para(&s, "ALPHA"), para(&s, "BETA")]);
+        let err = cdoc.project_change(&before, &after).unwrap_err();
+        assert!(
+            matches!(err, CollabError::Unsupported(_)),
+            "the embed must fail loud as Unsupported, got {err:?}"
+        );
+        assert_untouched(&mut cdoc, &base, "embed in CRDT text");
+    }
+
+    #[test]
+    fn a_model_block_the_crdt_lacks_fails_before_any_write() {
+        // Repro (b) of issue #194: the model believes in a block the CRDT does not
+        // hold. Before the count gate this surfaced as `Schema("content index 2 out of
+        // range")` from the write phase's own bounds check — with block 0 already
+        // reconciled and committed.
+        let s = schema();
+        let crdt_doc = doc_of(&s, vec![para(&s, "alpha"), para(&s, "beta")]);
+        let mut cdoc = CollabDoc::from_doc(&crdt_doc).unwrap();
+        let base = baseline(&mut cdoc);
+
+        let before = doc_of(
+            &s,
+            vec![para(&s, "alpha"), para(&s, "beta"), para(&s, "gamma")],
+        );
+        let after = doc_of(&s, vec![para(&s, "ALPHA"), para(&s, "beta")]);
+        let err = cdoc.project_change(&before, &after).unwrap_err();
+        assert!(
+            matches!(err, CollabError::Schema(_)),
+            "a model/CRDT count mismatch must fail loud as Schema, got {err:?}"
+        );
+        assert_untouched(&mut cdoc, &base, "model ahead of CRDT");
+    }
+
+    #[test]
+    fn a_stray_crdt_block_the_model_lacks_fails_loud_not_silently() {
+        // Issue #192 review finding 5, the mirror image of the case above: the CRDT
+        // holds a block the model does not know about. This used to return `Ok`,
+        // reconcile the blocks the model *did* know, and leave the stray block behind —
+        // silent divergence (`model ≠ project(model)`) with no error at all, the exact
+        // class the fail-loud design exists to kill.
+        let s = schema();
+        let crdt_doc = doc_of(&s, vec![para(&s, "solo"), para(&s, "stray")]);
+        let mut cdoc = CollabDoc::from_doc(&crdt_doc).unwrap();
+        let base = baseline(&mut cdoc);
+
+        let before = doc_of(&s, vec![para(&s, "solo")]);
+        let after = doc_of(&s, vec![para(&s, "SOLO")]);
+        let err = cdoc.project_change(&before, &after).unwrap_err();
+        assert!(
+            matches!(err, CollabError::Schema(_)),
+            "a stray CRDT block must fail loud as Schema, got {err:?}"
+        );
+        assert_untouched(&mut cdoc, &base, "CRDT ahead of model");
     }
 }

--- a/crates/rinch-editor-collab/src/projection.rs
+++ b/crates/rinch-editor-collab/src/projection.rs
@@ -810,7 +810,7 @@ fn read_text_data<T: ReadTxn>(txn: &T, text: &TextRef) -> Result<(String, Vec<Sp
 /// carrying a `text` object is a text-block; a node carrying a `content` array is a
 /// container, read recursively. Fails loud on a node that is neither (a corrupt
 /// projection), rather than materializing a broken shape.
-fn read_node_data<T: ReadTxn>(txn: &T, list: &ArrayRef, index: u32) -> Result<NodeData> {
+pub(crate) fn read_node_data<T: ReadTxn>(txn: &T, list: &ArrayRef, index: u32) -> Result<NodeData> {
     let node = child_map(txn, list, index)
         .ok_or_else(|| CollabError::schema("read_node_data: missing node"))?;
     let type_name = node_type(txn, &node).ok_or_else(|| CollabError::schema("node has no type"))?;


### PR DESCRIPTION
## Mechanism

`CollabDoc::project_change` is contractually all-or-nothing (design A22, fail-loud): either the whole local change lands in the CRDT or nothing does. But yrs transactions **commit on drop — there is no rollback primitive** — so any error raised inside the write loop committed whatever the transaction had already written. The existing pre-pass validated only the **model** side (`read_node` on the `after`/deleted blocks); every CRDT-side read or index check in the write loop could still fail mid-transaction:

- **Repro (a):** an embed inside block 1's CRDT text → `reconcile_text`'s read-back returns `Unsupported` *after* block 0's new text "ALPHA" was written. The partial edit committed and shipped in the next broadcast delta.
- **Repro (b):** model holds more blocks than the CRDT → `Schema("content index 2 out of range")` from the write loop's bounds check, with block 0 already reconciled and committed.
- **#192 review finding 5 (same class, worse):** CRDT holds more blocks than the model → `project_change` returned **Ok**, reconciled the blocks the model knew about, and left the stray CRDT block behind — silent divergence (`model ≠ project(model)`), no error at all.

## Fix

Since there is no commit-then-undo option, the pre-pass is the only all-or-nothing lever. It now has three gates, all before `transact_mut` opens:

1. **Block count (both directions):** `before` must hold exactly as many blocks as the CRDT. Model-ahead (repro b) and CRDT-ahead (finding 5) both fail loud as `Schema` with the CRDT untouched. The **#192/#215 zero-block heal is preserved**: a zero-block CRDT still short-circuits into `project_whole_doc` before this gate — it remains the one legitimate mismatch.
2. **Model side (unchanged):** `read_node` on every `after` block to reconcile/insert and every `before` block to delete.
3. **CRDT side (new):** `read_node_data` on every CRDT block the write phase will reconcile — recursively, exactly the subtree `reconcile_node` walks — under a read transaction that drops before the write transaction opens (yrs cannot nest transaction acquisitions). Embeds in text, corrupt mark values, and nodes that are neither text-block nor container now surface before the first write.

Gate 1 also pins every write-loop index in range (yrs `remove_range`/array ops **panic** on OOB, so this is panic safety, not just atomicity). With gates 2–3 reading back everything the write phase reads, the write-phase error returns are now unreachable for admitted inputs; they stay as defense in depth, and the comment above the write phase states the restored all-or-nothing guarantee (it had been honestly narrowed in #197).

Only change outside `project.rs`: `read_node_data` in `projection.rs` becomes `pub(crate)`.

## Tests

Three new unit tests in `project.rs` (hand-crafting the corrupt/mismatched CRDT needs crate internals — same pattern as the existing `projection.rs` corruption tests). Each asserts a loud error **and** byte-for-byte untouched CRDT (`save()` before vs after) **and** an empty outbox (no broadcast delta carries a partial edit):

| Test | Red evidence against pre-fix behavior |
|---|---|
| `an_embed_found_in_the_crdt_mid_change_does_not_partially_mutate` | `Unsupported` returned but post-attempt bytes contained "ALPHA" (partial commit) |
| `a_model_block_the_crdt_lacks_fails_before_any_write` | `Schema` returned but block 0's "ALPHA" committed |
| `a_stray_crdt_block_the_model_lacks_fails_loud_not_silently` | panicked `unwrap_err() on an Ok value` — the silent Ok + stray block observed |

Red was demonstrated by temporarily neutralizing gates 1 and 3 (restoring main's behavior); all three fail exactly as the issue describes, then pass with the gates in place. Regression pins kept green unchanged: the #215 zero-heal tests (`concurrent_deletion_of_different_blocks_empties_the_crdt_and_self_heals`, `a_late_joiner_can_join_a_session_with_no_blocks_left`, `load_accepts_a_projection_that_has_no_blocks_left`) and the model-side pin `unsupported_change_does_not_partially_mutate`.

## Gates (all green, run serially)

1. `cargo test -p rinch-editor-collab` — lib **16** (13 baseline + 3 new), tests/collab.rs **27**, tests/fuzz.rs **5**, doc-tests **1**, 0 failed
2. `cargo test -p rinch-editor-view --features collaboration` — **75** passed, 0 failed
3. `cargo check -p rinch-editor-collab --target wasm32-unknown-unknown` — clean
4. `cargo clippy -p rinch-editor-collab --all-targets -- -D warnings` — clean
5. `cargo clippy -p rinch-editor-view --features collaboration --all-targets -- -D warnings` — clean
6. `cargo fmt --all -- --check` — clean

The fuzz suite passing is the strongest signal the count gate never fires on legitimate edit streams.

Fixes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)