### PR TITLE
fix(rinch-editor-collab): #196 — a poisoned session goes loud in both directions instead of one-way partitioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -767,8 +767,9 @@ post_remote_delta(container_id, delta_bytes);
 | `collab_state_vector() -> Option<Vec<u8>>` | This editor's state vector, to hand a peer for `collab_sync_diff` |
 | `collab_sync_diff(remote_state_vector) -> Option<Vec<u8>>` | The update a peer at `remote_state_vector` is missing; feed the result to that peer's `collab_receive` |
 | `is_collaborating()` / `stop_collaboration()` | Query / detach the session |
+| `is_collaboration_poisoned()` | Whether the session is **poisoned** (#196): an integrate left the shared CRDT unprojectable (yrs has no rollback), so every convergence call — inbound AND outbound — fails sticky with `CollabError::SessionPoisoned` instead of one-way partitioning. Recover via `stop_collaboration()` + rejoin from a healthy peer's snapshot |
 | `collab_snapshot() -> Option<Vec<u8>>` | Current shared-doc snapshot for a *late*-joining guest |
-| `collab_take_error() -> Option<CollabError>` | Take a fail-loud A22 projection error (the CRDT is left untouched — projection is all-or-nothing) |
+| `collab_take_error() -> Option<CollabError>` | Take a fail-loud collab error. A22 projection errors are transient (the CRDT is left untouched — projection is all-or-nothing); a `SessionPoisoned` is not a one-off — taking it does not un-poison, every affected call re-fails with it |
 
 Free functions `collab_receive_for(container_id, &delta)` (main thread) and `post_remote_delta(container_id, delta)` (any thread) route an inbound delta to a registered editor. Runnable two-pane in-process loopback: `examples/collab-editor-demo`.
 
@@ -787,8 +788,8 @@ Free functions `collab_receive_for(container_id, &delta)` (main thread) and `pos
 | `crates/rinch-editor-collab/src/sync.rs` | The yrs bytes transport on `CollabDoc` (`state_vector`, `diff_since`, `apply_update`, the outbox drain) |
 | `crates/rinch-editor-collab/src/plugin.rs` | `CollabPlugin` + `CollabState` |
 | `crates/rinch-editor-collab/src/rebase.rs` | `rebase_steps` — local steps rebased over a remote mapping |
-| `crates/rinch-editor-collab/src/error.rs` | `CollabError` — the crate's one error type (`Engine`/`Unsupported`/`Schema`) |
-| `crates/rinch-editor-view/src/handle.rs` | `EditorHandle`'s collab methods (`start_collaboration_host/guest`, `collab_receive`, `collab_state_vector`, `collab_sync_diff`, `collab_snapshot`, `collab_take_error`, `stop_collaboration`, `is_collaborating`) — **not** in `rinch-editor-collab` |
+| `crates/rinch-editor-collab/src/error.rs` | `CollabError` — the crate's one error type (`Engine`/`Unsupported`/`Schema`, plus the sticky `SessionPoisoned` a session fails with in both directions once an integrate has left the CRDT unprojectable — #196) |
+| `crates/rinch-editor-view/src/handle.rs` | `EditorHandle`'s collab methods (`start_collaboration_host/guest`, `collab_receive`, `collab_state_vector`, `collab_sync_diff`, `collab_snapshot`, `collab_take_error`, `stop_collaboration`, `is_collaborating`, `is_collaboration_poisoned`) — **not** in `rinch-editor-collab` |
 | `crates/rinch-editor-view/src/collab.rs` | `CollabBridge` — the seam driving `CollabSession` from an `EditorHandle` (outbound sink + last error) |
 | `crates/rinch-editor-view/src/registry.rs` | `collab_receive_for(container_id, &delta)` — routes an inbound delta to a registered editor |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -767,7 +767,7 @@ post_remote_delta(container_id, delta_bytes);
 | `collab_state_vector() -> Option<Vec<u8>>` | This editor's state vector, to hand a peer for `collab_sync_diff` |
 | `collab_sync_diff(remote_state_vector) -> Option<Vec<u8>>` | The update a peer at `remote_state_vector` is missing; feed the result to that peer's `collab_receive` |
 | `is_collaborating()` / `stop_collaboration()` | Query / detach the session |
-| `is_collaboration_poisoned()` | Whether the session is **poisoned** (#196): an integrate left the shared CRDT unprojectable (yrs has no rollback), so every convergence call — inbound AND outbound — fails sticky with `CollabError::SessionPoisoned` instead of one-way partitioning. Recover via `stop_collaboration()` + rejoin from a healthy peer's snapshot |
+| `is_collaboration_poisoned()` | Whether the session is **poisoned** (#196): an integrate left the shared CRDT unprojectable with nothing pending that could cure it (yrs has no rollback; a rebuild failure with updates parked on missing dependencies stays transient), so every convergence call — inbound AND outbound — fails sticky with `CollabError::SessionPoisoned` instead of one-way partitioning. Inbound is still attempted, and an update that makes the doc rebuildable again clears the poison; recovery in practice is `stop_collaboration()` + rejoin from a healthy peer's snapshot |
 | `collab_snapshot() -> Option<Vec<u8>>` | Current shared-doc snapshot for a *late*-joining guest |
 | `collab_take_error() -> Option<CollabError>` | Take a fail-loud collab error. A22 projection errors are transient (the CRDT is left untouched — projection is all-or-nothing); a `SessionPoisoned` is not a one-off — taking it does not un-poison, every affected call re-fails with it |
 
@@ -788,7 +788,7 @@ Free functions `collab_receive_for(container_id, &delta)` (main thread) and `pos
 | `crates/rinch-editor-collab/src/sync.rs` | The yrs bytes transport on `CollabDoc` (`state_vector`, `diff_since`, `apply_update`, the outbox drain) |
 | `crates/rinch-editor-collab/src/plugin.rs` | `CollabPlugin` + `CollabState` |
 | `crates/rinch-editor-collab/src/rebase.rs` | `rebase_steps` — local steps rebased over a remote mapping |
-| `crates/rinch-editor-collab/src/error.rs` | `CollabError` — the crate's one error type (`Engine`/`Unsupported`/`Schema`, plus the sticky `SessionPoisoned` a session fails with in both directions once an integrate has left the CRDT unprojectable — #196) |
+| `crates/rinch-editor-collab/src/error.rs` | `CollabError` — the crate's one error type (`Engine`/`Unsupported`/`Schema`, plus the sticky `SessionPoisoned` a session fails with in both directions once an integrate has left the CRDT unprojectable with nothing pending to cure it — #196; cleared by an inbound update that makes the doc rebuildable again) |
 | `crates/rinch-editor-view/src/handle.rs` | `EditorHandle`'s collab methods (`start_collaboration_host/guest`, `collab_receive`, `collab_state_vector`, `collab_sync_diff`, `collab_snapshot`, `collab_take_error`, `stop_collaboration`, `is_collaborating`, `is_collaboration_poisoned`) — **not** in `rinch-editor-collab` |
 | `crates/rinch-editor-view/src/collab.rs` | `CollabBridge` — the seam driving `CollabSession` from an `EditorHandle` (outbound sink + last error) |
 | `crates/rinch-editor-view/src/registry.rs` | `collab_receive_for(container_id, &delta)` — routes an inbound delta to a registered editor |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4930,6 +4930,7 @@ dependencies = [
  "rinch-core",
  "rinch-editor-collab",
  "rinch-editor-core",
+ "yrs",
 ]
 
 [[package]]

--- a/crates/rinch-editor-collab/src/error.rs
+++ b/crates/rinch-editor-collab/src/error.rs
@@ -27,6 +27,22 @@ pub enum CollabError {
     /// projection relied on was missing.
     #[error("schema/projection error: {0}")]
     Schema(String),
+
+    /// The session integrated peer bytes that left the shared CRDT document
+    /// **permanently unprojectable** (issue #196). yrs has no rollback, so once such
+    /// bytes are applied they cannot be un-applied, and every future rebuild fails the
+    /// same way. The error is **sticky**: once a [`CollabSession`](crate::CollabSession)
+    /// is poisoned, every convergence-relevant operation — `integrate_incremental`
+    /// *and* `record_local`/`save_incremental`/`sync_diff`/`projected_doc` — fails with
+    /// it, in **both** directions. A replica that can never receive again must not keep
+    /// broadcasting as though it were converging: one-way silence is the divergence
+    /// class this crate exists to kill. Recovery is a fresh session: detach
+    /// (`stop_collaboration` at the handle level) and rejoin from a healthy peer's
+    /// snapshot.
+    #[error(
+        "collab session poisoned — the shared CRDT is no longer projectable; stop and rejoin: {0}"
+    )]
+    SessionPoisoned(String),
 }
 
 impl CollabError {

--- a/crates/rinch-editor-collab/src/error.rs
+++ b/crates/rinch-editor-collab/src/error.rs
@@ -29,16 +29,21 @@ pub enum CollabError {
     Schema(String),
 
     /// The session integrated peer bytes that left the shared CRDT document
-    /// **permanently unprojectable** (issue #196). yrs has no rollback, so once such
-    /// bytes are applied they cannot be un-applied, and every future rebuild fails the
-    /// same way. The error is **sticky**: once a [`CollabSession`](crate::CollabSession)
-    /// is poisoned, every convergence-relevant operation — `integrate_incremental`
-    /// *and* `record_local`/`save_incremental`/`sync_diff`/`projected_doc` — fails with
-    /// it, in **both** directions. A replica that can never receive again must not keep
+    /// **unprojectable, with nothing pending that could cure it** (issue #196). yrs
+    /// has no rollback, so once such bytes are applied they cannot be un-applied, and
+    /// the rebuild keeps failing until some future inbound bytes change the content.
+    /// (A rebuild failure while updates are parked on *missing dependencies* is
+    /// deliberately **not** this — the missing delta cures it, so it stays a
+    /// transient `Engine`/`Schema`/`Unsupported` error.) The error is **sticky**:
+    /// once a [`CollabSession`](crate::CollabSession) is poisoned, every
+    /// convergence-relevant operation — `integrate_incremental` *and*
+    /// `record_local`/`save_incremental`/`sync_diff`/`projected_doc` — fails with it,
+    /// in **both** directions. A replica that cannot receive must not keep
     /// broadcasting as though it were converging: one-way silence is the divergence
-    /// class this crate exists to kill. Recovery is a fresh session: detach
-    /// (`stop_collaboration` at the handle level) and rejoin from a healthy peer's
-    /// snapshot.
+    /// class this crate exists to kill. Inbound integration is still *attempted*, and
+    /// an update that leaves the document rebuildable again clears the poison; the
+    /// recovery in practice is a fresh session — detach (`stop_collaboration` at the
+    /// handle level) and rejoin from a healthy peer's snapshot.
     #[error(
         "collab session poisoned — the shared CRDT is no longer projectable; stop and rejoin: {0}"
     )]

--- a/crates/rinch-editor-collab/src/session.rs
+++ b/crates/rinch-editor-collab/src/session.rs
@@ -24,17 +24,27 @@
 //! yrs has no rollback: once inbound bytes are applied, they cannot be un-applied. If
 //! an integrate leaves the shared document **unprojectable** — foreign bytes whose
 //! `content` root was built as the wrong yrs type, or a peer delta that parked
-//! out-of-scope content (an embed) inside a block — every future rebuild fails the same
-//! way, so the session can never receive again. Detecting that costs nothing extra:
-//! the converged rebuild ([`CollabDoc::to_doc`]) already runs on every integrate, and
-//! its failure *after* bytes touched the CRDT **is** the diagnosis. The session then
-//! turns **sticky-loud in both directions**
+//! out-of-scope content (an embed) inside a block — the rebuild keeps failing until
+//! some future inbound bytes change the content, so the session cannot receive.
+//! Detecting that costs nothing extra: the converged rebuild ([`CollabDoc::to_doc`])
+//! already runs on every integrate, and its failure *after* bytes touched the CRDT
+//! **is** the diagnosis — with one carve-out. A rebuild failure while yrs holds
+//! updates parked on **missing dependencies** ([`CollabDoc::has_pending_updates`]) is
+//! *transient*, not poison: a misrouted reconciliation diff can delete a map item
+//! whose replacement waits on an insertion this replica has not seen, and the missing
+//! delta alone cures the read-back — poisoning there would kill a self-healing state
+//! and refuse the very bytes that heal it.
+//!
+//! A poisoned session turns **sticky-loud in both directions**
 //! ([`CollabError::SessionPoisoned`](crate::CollabError::SessionPoisoned)): inbound
 //! kept failing anyway, and outbound (`record_local`/`save_incremental`/`sync_diff`)
-//! now refuses too — a replica that can never converge must not keep broadcasting,
-//! and a poisoned document's diff must not be handed to healthy peers. A *decode*
-//! failure, by contrast, leaves the CRDT untouched and stays transient. Recovery is a
-//! fresh session from a healthy peer's snapshot.
+//! now refuses too — a replica that cannot converge must not keep broadcasting, and a
+//! poisoned document's diff must not be handed to healthy peers. Inbound integration
+//! is still *attempted*, though: an update that leaves the document rebuildable again
+//! (say, the damaged lineage deleting its own offending content) **clears** the
+//! poison; until then every attempt reports the sticky error. A *decode* failure
+//! leaves the CRDT untouched and stays transient. Recovery in practice is a fresh
+//! session from a healthy peer's snapshot.
 
 use yrs::updates::decoder::Decode;
 use yrs::updates::encoder::Encode;
@@ -81,9 +91,11 @@ impl CollabSession {
     }
 
     /// Whether this session is **poisoned** — an integrate left the shared CRDT
-    /// permanently unprojectable, so every convergence-relevant operation now fails
-    /// with the sticky [`CollabError::SessionPoisoned`] (see the module docs). The
-    /// only recovery is a fresh session from a healthy peer's snapshot.
+    /// unprojectable with nothing pending that could cure it, so every
+    /// convergence-relevant operation now fails with the sticky
+    /// [`CollabError::SessionPoisoned`] (see the module docs). Cleared by an inbound
+    /// integration that leaves the document rebuildable again; recovery in practice
+    /// is a fresh session from a healthy peer's snapshot.
     pub fn is_poisoned(&self) -> bool {
         self.poisoned.is_some()
     }
@@ -96,15 +108,43 @@ impl CollabSession {
         }
     }
 
-    /// Mark this session poisoned by `cause` and return the sticky error every
-    /// subsequent operation will keep failing with.
-    fn poison(&mut self, cause: &CollabError) -> CollabError {
+    /// The sticky poison error if this session is poisoned, otherwise `err`
+    /// unchanged — inbound failures on a poisoned session keep reporting the poison
+    /// rather than a shifting mix of underlying errors.
+    fn sticky_or(&self, err: CollabError) -> CollabError {
+        self.poisoned.clone().unwrap_or(err)
+    }
+
+    /// Classify an inbound failure that left the shared document failing its
+    /// converged rebuild, and return the error to surface.
+    ///
+    /// * Already poisoned → the sticky error, unchanged.
+    /// * Updates parked on missing dependencies → **transient** (`cause` as-is): the
+    ///   missing delta alone can cure the read-back, so this must neither poison nor
+    ///   be reported as poison (#196 review, F1 — a misrouted reconciliation diff is
+    ///   the reachable shape).
+    /// * Otherwise → poison: mark the session and return the sticky error every
+    ///   affected operation will keep failing with until an inbound integration
+    ///   heals it.
+    fn classify_unprojectable(&mut self, cause: CollabError) -> CollabError {
+        if let Some(sticky) = &self.poisoned {
+            return sticky.clone();
+        }
+        if self.cdoc.has_pending_updates() {
+            return cause;
+        }
         let err = CollabError::SessionPoisoned(cause.to_string());
         self.poisoned = Some(err.clone());
         err
     }
 
     /// Save the whole CRDT (hand to a peer so they can `from_bytes` and join).
+    ///
+    /// Not poison-guarded (the signature is infallible), so a poisoned session still
+    /// yields its bytes. Don't hand them to a joiner: [`CollabDoc::load`]'s content
+    /// gate validates *shape*, not schema, so some poisoned states (e.g. a block
+    /// `type` rewritten to a name the schema lacks) load fine and only fail loud one
+    /// step later, at the joiner's first [`Self::projected_doc`].
     pub fn snapshot(&self) -> Vec<u8> {
         self.cdoc.save()
     }
@@ -116,7 +156,7 @@ impl CollabSession {
     /// projection is all-or-nothing, issue #194) and the offending *local* content can
     /// be edited away (undo the table paste), after which projection resumes. On a
     /// [poisoned](Self::is_poisoned) session, though, this refuses with the sticky
-    /// error before reading anything: a replica that can never receive must not keep
+    /// error before reading anything: a replica that cannot receive must not keep
     /// projecting-and-broadcasting as though it were converging (issue #196).
     pub fn record_local(&mut self, before: &Node, after: &Node) -> Result<()> {
         self.guard()?;
@@ -146,8 +186,8 @@ impl CollabSession {
     /// Fails only if a parked update cannot be re-decoded to be merged with its
     /// neighbours, which would mean this replica produced a malformed update; the parked
     /// updates are left in place, so the error is not a silent loss — or, sticky, on a
-    /// [poisoned](Self::is_poisoned) session, so no delta leaves a replica that can
-    /// never converge (issue #196).
+    /// [poisoned](Self::is_poisoned) session, so no delta leaves a replica that
+    /// cannot converge (issue #196).
     pub fn save_incremental(&mut self) -> Result<Vec<u8>> {
         self.guard()?;
         self.cdoc.take_outbox()
@@ -203,44 +243,58 @@ impl CollabSession {
     /// * Bytes that don't **decode** never touch the CRDT — a transient
     ///   [`Engine`](CollabError::Engine) error; the next valid delta integrates fine.
     /// * Bytes that were **applied** but leave the document failing its converged
-    ///   rebuild ([`CollabDoc::to_doc`]) can never be un-applied (yrs has no rollback),
-    ///   so the session **poisons itself**: this call — and every subsequent
-    ///   convergence-relevant call, outbound included — fails with the sticky
-    ///   [`SessionPoisoned`](CollabError::SessionPoisoned). The read that decides this
-    ///   is the rebuild every integrate already performs, so a healthy delta pays
-    ///   nothing extra.
+    ///   rebuild ([`CollabDoc::to_doc`]) cannot be un-applied (yrs has no rollback).
+    ///   If yrs holds updates parked on **missing dependencies**, the failure is
+    ///   transient — the missing delta cures it. Otherwise the session **poisons
+    ///   itself**: this call — and every subsequent convergence-relevant call,
+    ///   outbound included — fails with the sticky
+    ///   [`SessionPoisoned`](CollabError::SessionPoisoned). The read that decides
+    ///   this is the rebuild every integrate already performs, so a healthy delta
+    ///   pays nothing extra.
+    /// * On a poisoned session, integration is still **attempted**: an update that
+    ///   leaves the document rebuildable again clears the poison and applies
+    ///   normally; any other inbound failure re-reports the sticky error.
     pub fn integrate_incremental(
         &mut self,
         state: &EditorState,
         changes: &[u8],
     ) -> Result<Option<EditorState>> {
-        self.guard()?;
         if changes.is_empty() || changes == EMPTY_UPDATE {
+            // Nothing to apply — and therefore nothing that could heal a poisoned
+            // session, so the sticky error still reports.
+            self.guard()?;
             return Ok(None);
         }
-        // Decode failure: the CRDT is untouched, so the error is transient by
-        // construction — never poison here.
-        let update = Update::decode_v1(changes)?;
+        // Decode failure: the CRDT is untouched, so this can neither poison nor heal.
+        let update = match Update::decode_v1(changes) {
+            Ok(update) => update,
+            Err(e) => return Err(self.sticky_or(e.into())),
+        };
         if let Err(apply_err) = self.cdoc.apply_decoded(update) {
             // yrs commits on drop with no rollback, so a failed apply may have
-            // partially integrated. Projectability decides transient vs permanent:
-            // if the document still rebuilds, the session is still convergent.
+            // partially integrated. Projectability decides how loud to be: if the
+            // document still rebuilds, the session is still convergent (transient);
+            // if not, classify (pending-aware) like any unprojectable state. The
+            // model was not advanced, so a still-projectable outcome does not clear
+            // an existing poison — only a full, successful integration does.
             return match self.cdoc.to_doc(state.schema()) {
-                Ok(_) => Err(apply_err),
-                Err(_) => Err(self.poison(&apply_err)),
+                Ok(_) => Err(self.sticky_or(apply_err)),
+                Err(_) => Err(self.classify_unprojectable(apply_err)),
             };
         }
-        // The converged rebuild. Its failure after a successful apply is the
-        // permanently-unprojectable state: these bytes are in the CRDT for good, and
-        // every future rebuild hits the same content.
+        // The converged rebuild — the projectability verdict for these bytes.
         let target = match self.cdoc.to_doc(state.schema()) {
             Ok(target) => target,
-            Err(cause) => return Err(self.poison(&cause)),
+            Err(cause) => return Err(self.classify_unprojectable(cause)),
         };
-        // Past this point the document is projectable, so a failure is not the
-        // permanent class: building/applying the model transaction reads only the
-        // validated rebuild (and is unreachable in practice for a doc `to_doc`
-        // admitted). Defense in depth, not a supported failure path.
+        // The document is projectable: a previously-poisoned session is healed by
+        // exactly this — a full inbound integration whose rebuild succeeds (the
+        // returned state below is what brings the model back in step).
+        self.poisoned = None;
+        // Past this point a failure is not the unprojectable class: building/applying
+        // the model transaction reads only the validated rebuild (and is unreachable
+        // in practice for a doc `to_doc` admitted). Defense in depth, not a supported
+        // failure path.
         match build_remote_transaction(state, &target)? {
             Some(tr) => Ok(Some(state.apply(tr))),
             None => Ok(None),

--- a/crates/rinch-editor-collab/src/session.rs
+++ b/crates/rinch-editor-collab/src/session.rs
@@ -35,6 +35,11 @@
 //! delta alone cures the read-back — poisoning there would kill a self-healing state
 //! and refuse the very bytes that heal it.
 //!
+//! The carve-out has a window: while dependencies are pending, even an
+//! interior-damage shape classifies transient and outbound stays open — exactly the
+//! pre-#196 baseline, no worse — and the latch fires on the first integrate after the
+//! pending set drains without curing the read-back.
+//!
 //! A poisoned session turns **sticky-loud in both directions**
 //! ([`CollabError::SessionPoisoned`](crate::CollabError::SessionPoisoned)): inbound
 //! kept failing anyway, and outbound (`record_local`/`save_incremental`/`sync_diff`)
@@ -42,9 +47,12 @@
 //! poisoned document's diff must not be handed to healthy peers. Inbound integration
 //! is still *attempted*, though: an update that leaves the document rebuildable again
 //! (say, the damaged lineage deleting its own offending content) **clears** the
-//! poison; until then every attempt reports the sticky error. A *decode* failure
-//! leaves the CRDT untouched and stays transient. Recovery in practice is a fresh
-//! session from a healthy peer's snapshot.
+//! poison; until then every attempt reports the sticky error. A heal re-syncs the
+//! model to the converged shared document, discarding any local edits made during the
+//! poison window — each was already refused loudly at commit time — the same
+//! semantics as stopping and rejoining. A *decode* failure leaves the CRDT untouched
+//! and stays transient. Recovery in practice is a fresh session from a healthy peer's
+//! snapshot.
 
 use yrs::updates::decoder::Decode;
 use yrs::updates::encoder::Encode;
@@ -110,9 +118,18 @@ impl CollabSession {
 
     /// The sticky poison error if this session is poisoned, otherwise `err`
     /// unchanged — inbound failures on a poisoned session keep reporting the poison
-    /// rather than a shifting mix of underlying errors.
+    /// rather than a shifting mix of underlying errors. The masked failure's own
+    /// message is appended for diagnostics (an app logging the error still sees why
+    /// *this* delta failed); the stored poison keeps the original cause, so repeated
+    /// failures do not accrete.
     fn sticky_or(&self, err: CollabError) -> CollabError {
-        self.poisoned.clone().unwrap_or(err)
+        match &self.poisoned {
+            Some(CollabError::SessionPoisoned(cause)) => {
+                CollabError::SessionPoisoned(format!("{cause}; latest inbound failure: {err}"))
+            }
+            Some(sticky) => sticky.clone(),
+            None => err,
+        }
     }
 
     /// Classify an inbound failure that left the shared document failing its

--- a/crates/rinch-editor-collab/src/session.rs
+++ b/crates/rinch-editor-collab/src/session.rs
@@ -18,14 +18,31 @@
 //!
 //! Because both peers rebuild from the same converged CRDT, their models converge. The
 //! session never consults the host DOM — it is pure model ↔ CRDT.
+//!
+//! ## Poisoning (issue #196)
+//!
+//! yrs has no rollback: once inbound bytes are applied, they cannot be un-applied. If
+//! an integrate leaves the shared document **unprojectable** — foreign bytes whose
+//! `content` root was built as the wrong yrs type, or a peer delta that parked
+//! out-of-scope content (an embed) inside a block — every future rebuild fails the same
+//! way, so the session can never receive again. Detecting that costs nothing extra:
+//! the converged rebuild ([`CollabDoc::to_doc`]) already runs on every integrate, and
+//! its failure *after* bytes touched the CRDT **is** the diagnosis. The session then
+//! turns **sticky-loud in both directions**
+//! ([`CollabError::SessionPoisoned`](crate::CollabError::SessionPoisoned)): inbound
+//! kept failing anyway, and outbound (`record_local`/`save_incremental`/`sync_diff`)
+//! now refuses too — a replica that can never converge must not keep broadcasting,
+//! and a poisoned document's diff must not be handed to healthy peers. A *decode*
+//! failure, by contrast, leaves the CRDT untouched and stays transient. Recovery is a
+//! fresh session from a healthy peer's snapshot.
 
-use yrs::StateVector;
 use yrs::updates::decoder::Decode;
 use yrs::updates::encoder::Encode;
+use yrs::{StateVector, Update};
 
 use rinch_editor_core::{EditorState, Node, Schema};
 
-use crate::error::Result;
+use crate::error::{CollabError, Result};
 use crate::projection::CollabDoc;
 use crate::remote::build_remote_transaction;
 
@@ -40,6 +57,9 @@ const EMPTY_UPDATE: &[u8] = &[0, 0];
 #[derive(Debug)]
 pub struct CollabSession {
     cdoc: CollabDoc,
+    /// The sticky poison error, set the moment an integrate leaves the CRDT
+    /// unprojectable (see the module docs). `None` for a healthy session.
+    poisoned: Option<CollabError>,
 }
 
 impl CollabSession {
@@ -48,6 +68,7 @@ impl CollabSession {
     pub fn new(state: &EditorState) -> Result<CollabSession> {
         Ok(CollabSession {
             cdoc: CollabDoc::from_doc(&state.doc)?,
+            poisoned: None,
         })
     }
 
@@ -55,7 +76,32 @@ impl CollabSession {
     pub fn from_bytes(bytes: &[u8]) -> Result<CollabSession> {
         Ok(CollabSession {
             cdoc: CollabDoc::load(bytes)?,
+            poisoned: None,
         })
+    }
+
+    /// Whether this session is **poisoned** — an integrate left the shared CRDT
+    /// permanently unprojectable, so every convergence-relevant operation now fails
+    /// with the sticky [`CollabError::SessionPoisoned`] (see the module docs). The
+    /// only recovery is a fresh session from a healthy peer's snapshot.
+    pub fn is_poisoned(&self) -> bool {
+        self.poisoned.is_some()
+    }
+
+    /// Fail with the sticky poison error if this session is poisoned.
+    fn guard(&self) -> Result<()> {
+        match &self.poisoned {
+            Some(e) => Err(e.clone()),
+            None => Ok(()),
+        }
+    }
+
+    /// Mark this session poisoned by `cause` and return the sticky error every
+    /// subsequent operation will keep failing with.
+    fn poison(&mut self, cause: &CollabError) -> CollabError {
+        let err = CollabError::SessionPoisoned(cause.to_string());
+        self.poisoned = Some(err.clone());
+        err
     }
 
     /// Save the whole CRDT (hand to a peer so they can `from_bytes` and join).
@@ -65,7 +111,15 @@ impl CollabSession {
 
     /// Project a just-applied local change (`before` = old `state.doc`, `after` = new
     /// `state.doc`) onto the CRDT. Fails loud on out-of-scope content.
+    ///
+    /// An ordinary failure here is **not** sticky: the CRDT is untouched (the
+    /// projection is all-or-nothing, issue #194) and the offending *local* content can
+    /// be edited away (undo the table paste), after which projection resumes. On a
+    /// [poisoned](Self::is_poisoned) session, though, this refuses with the sticky
+    /// error before reading anything: a replica that can never receive must not keep
+    /// projecting-and-broadcasting as though it were converging (issue #196).
     pub fn record_local(&mut self, before: &Node, after: &Node) -> Result<()> {
+        self.guard()?;
         self.cdoc.project_change(before, after)
     }
 
@@ -91,8 +145,11 @@ impl CollabSession {
     ///
     /// Fails only if a parked update cannot be re-decoded to be merged with its
     /// neighbours, which would mean this replica produced a malformed update; the parked
-    /// updates are left in place, so the error is not a silent loss.
+    /// updates are left in place, so the error is not a silent loss — or, sticky, on a
+    /// [poisoned](Self::is_poisoned) session, so no delta leaves a replica that can
+    /// never converge (issue #196).
     pub fn save_incremental(&mut self) -> Result<Vec<u8>> {
+        self.guard()?;
         self.cdoc.take_outbox()
     }
 
@@ -112,7 +169,12 @@ impl CollabSession {
     /// The update a peer whose state vector is `remote_state_vector` is missing. Feed
     /// the result to that peer's [`Self::integrate_incremental`]; one exchange in each
     /// direction reconciles two replicas that have drifted apart.
+    ///
+    /// Sticky-refused on a [poisoned](Self::is_poisoned) session: this diff carries
+    /// document content, and a poisoned document's content must not be handed to a
+    /// healthy peer (issue #196).
     pub fn sync_diff(&self, remote_state_vector: &[u8]) -> Result<Vec<u8>> {
+        self.guard()?;
         let sv = StateVector::decode_v1(remote_state_vector)?;
         Ok(self.cdoc.diff_since(&sv))
     }
@@ -135,36 +197,71 @@ impl CollabSession {
     /// what [`Self::save_incremental`] returns when it has nothing to send. Neither is
     /// decodable as an update, so recognising them here is what keeps a caller that
     /// forwards its own empty delta from parking a spurious decode error.
+    ///
+    /// # Failure semantics (issue #196)
+    ///
+    /// * Bytes that don't **decode** never touch the CRDT — a transient
+    ///   [`Engine`](CollabError::Engine) error; the next valid delta integrates fine.
+    /// * Bytes that were **applied** but leave the document failing its converged
+    ///   rebuild ([`CollabDoc::to_doc`]) can never be un-applied (yrs has no rollback),
+    ///   so the session **poisons itself**: this call — and every subsequent
+    ///   convergence-relevant call, outbound included — fails with the sticky
+    ///   [`SessionPoisoned`](CollabError::SessionPoisoned). The read that decides this
+    ///   is the rebuild every integrate already performs, so a healthy delta pays
+    ///   nothing extra.
     pub fn integrate_incremental(
         &mut self,
         state: &EditorState,
         changes: &[u8],
     ) -> Result<Option<EditorState>> {
+        self.guard()?;
         if changes.is_empty() || changes == EMPTY_UPDATE {
             return Ok(None);
         }
-        self.cdoc.apply_update(changes)?;
-        self.apply_converged(state)
+        // Decode failure: the CRDT is untouched, so the error is transient by
+        // construction — never poison here.
+        let update = Update::decode_v1(changes)?;
+        if let Err(apply_err) = self.cdoc.apply_decoded(update) {
+            // yrs commits on drop with no rollback, so a failed apply may have
+            // partially integrated. Projectability decides transient vs permanent:
+            // if the document still rebuilds, the session is still convergent.
+            return match self.cdoc.to_doc(state.schema()) {
+                Ok(_) => Err(apply_err),
+                Err(_) => Err(self.poison(&apply_err)),
+            };
+        }
+        // The converged rebuild. Its failure after a successful apply is the
+        // permanently-unprojectable state: these bytes are in the CRDT for good, and
+        // every future rebuild hits the same content.
+        let target = match self.cdoc.to_doc(state.schema()) {
+            Ok(target) => target,
+            Err(cause) => return Err(self.poison(&cause)),
+        };
+        // Past this point the document is projectable, so a failure is not the
+        // permanent class: building/applying the model transaction reads only the
+        // validated rebuild (and is unreachable in practice for a doc `to_doc`
+        // admitted). Defense in depth, not a supported failure path.
+        match build_remote_transaction(state, &target)? {
+            Some(tr) => Ok(Some(state.apply(tr))),
+            None => Ok(None),
+        }
     }
 
     /// Merge another peer's CRDT wholesale into this one (test/utility convenience).
+    /// Refused — sticky — when either side is [poisoned](Self::is_poisoned), for the
+    /// same reason as [`Self::sync_diff`]: poison must not spread.
     pub fn merge(&mut self, other: &CollabSession) -> Result<()> {
+        self.guard()?;
+        other.guard()?;
         self.cdoc.merge_from(&other.cdoc)
     }
 
     /// The model document the CRDT currently projects to — the canonical converged
     /// read-back (both peers reconstruct identically). The rock-solid convergence
-    /// assertion in tests.
+    /// assertion in tests. On a [poisoned](Self::is_poisoned) session this returns the
+    /// sticky error rather than re-deriving the underlying read failure.
     pub fn projected_doc(&self, schema: &Schema) -> Result<Node> {
+        self.guard()?;
         self.cdoc.to_doc(schema)
-    }
-
-    /// Rebuild the model from the converged CRDT and apply it as a remote transaction.
-    fn apply_converged(&mut self, state: &EditorState) -> Result<Option<EditorState>> {
-        let target = self.cdoc.to_doc(state.schema())?;
-        match build_remote_transaction(state, &target)? {
-            Some(tr) => Ok(Some(state.apply(tr))),
-            None => Ok(None),
-        }
     }
 }

--- a/crates/rinch-editor-collab/src/sync.rs
+++ b/crates/rinch-editor-collab/src/sync.rs
@@ -57,6 +57,15 @@ impl CollabDoc {
     /// would echo. Forwarding them to *other* peers is the transport's job.
     pub fn apply_update(&mut self, bytes: &[u8]) -> Result<()> {
         let update = Update::decode_v1(bytes)?;
+        self.apply_decoded(update)
+    }
+
+    /// Apply an already-decoded update. Split from [`Self::apply_update`] for the
+    /// session's integrate path, which must tell a *decode* failure (the CRDT is
+    /// untouched — transient) from an *apply* failure (the update may be partially
+    /// integrated — yrs commits on drop and has no rollback), because only the latter
+    /// can leave the document unprojectable (issue #196).
+    pub(crate) fn apply_decoded(&mut self, update: Update) -> Result<()> {
         let mut txn = self
             .doc
             .transact_mut_with(Origin::from(ENGINE_APPLY_ORIGIN));

--- a/crates/rinch-editor-collab/src/sync.rs
+++ b/crates/rinch-editor-collab/src/sync.rs
@@ -73,6 +73,16 @@ impl CollabDoc {
         Ok(())
     }
 
+    /// Whether the store holds updates parked on **missing dependencies** — applied
+    /// bytes whose causal predecessors this replica has not seen yet (an out-of-order
+    /// delivery, or a misrouted reconciliation diff computed for a peer that had seen
+    /// more). While this is true, a failing content read-back may be cured by the
+    /// missing update alone, so the session must classify it *transient* — poisoning
+    /// would turn a self-healing state into a dead one (#196 review, F1).
+    pub(crate) fn has_pending_updates(&self) -> bool {
+        self.doc.transact().has_missing_updates()
+    }
+
     /// Take everything the outbox has collected since the last drain, as one update.
     ///
     /// Empty when no locally-projected transaction has run since — unlike a

--- a/crates/rinch-editor-collab/tests/poison.rs
+++ b/crates/rinch-editor-collab/tests/poison.rs
@@ -1,0 +1,390 @@
+//! The poisoned-session contract (issue #196): a live session that integrates bytes
+//! leaving the shared CRDT **unprojectable** must go loud in **both** directions —
+//! sticky [`CollabError::SessionPoisoned`] on inbound *and* outbound — instead of
+//! one-way partitioning (inbound dead forever while `record_local` keeps `Ok`-ing and
+//! `save_incremental` keeps broadcasting).
+//!
+//! The probe matrix these tests pin (mid-session integrate of foreign whole-doc
+//! bytes, by the foreign `content` root's type):
+//!
+//! * **Map root** — entries land in the array branch's invisible map component;
+//!   harmless, must stay accepted-and-ignored.
+//! * **Text root** — the characters read back as non-map array entries; the rebuild
+//!   fails forever → poison.
+//! * **Array of scalars** — same unprojectable read-back → poison (the same sticky
+//!   kind, converged deliberately).
+//! * **Array holding a valid projected block** — a legitimate merge; the transport
+//!   chose the peers, not a defect. Must stay adopted.
+//!
+//! Plus the two boundary cases: undecodable bytes never touch the CRDT (transient,
+//! no poison), and **interior damage** — a shared-lineage delta parking an embed
+//! inside one block's text, which changes no block count and so slipped every #218
+//! gate: on unfixed code that was the last remaining one-way partition (integrate
+//! `Err` forever, `record_local` of *another* block `Ok`, a delta broadcast).
+
+use std::rc::Rc;
+
+use rinch_editor_collab::{CollabError, CollabSession};
+use rinch_editor_core::{EditorState, Fragment, Node, Pos, Schema, Selection, default_plugins};
+use yrs::updates::decoder::Decode;
+use yrs::{
+    Any, Array, Doc, Map, MapPrelim, ReadTxn, StateVector, Text, TextPrelim, Transact, Update,
+};
+
+// --- harness -------------------------------------------------------------------
+
+fn para(schema: &Schema, text: &str) -> Node {
+    let content = if text.is_empty() {
+        Fragment::empty()
+    } else {
+        Fragment::from_node(schema.text(text).unwrap())
+    };
+    schema.branch("paragraph", content).unwrap()
+}
+
+fn doc_of(schema: &Schema, blocks: Vec<Node>) -> Node {
+    schema
+        .branch("doc", Fragment::from_children(blocks))
+        .unwrap()
+}
+
+/// One live editor+session, its initial projection already drained (mid-session).
+struct Live {
+    schema: Rc<Schema>,
+    state: EditorState,
+    session: CollabSession,
+}
+
+fn live(texts: &[&str]) -> Live {
+    let schema = Rc::new(Schema::starter_kit());
+    let blocks = texts.iter().map(|t| para(&schema, t)).collect();
+    let state = EditorState::create(schema.clone(), doc_of(&schema, blocks), default_plugins());
+    let mut session = CollabSession::new(&state).unwrap();
+    let _ = session.save_incremental().unwrap(); // drain the initial projection
+    Live {
+        schema,
+        state,
+        session,
+    }
+}
+
+impl Live {
+    /// Insert `text` at `pos` in the model and record it onto the CRDT, returning
+    /// the projection result (the state advances regardless, as a real editor's
+    /// would — the edit is already applied when projection is attempted).
+    fn type_at(&mut self, pos: usize, text: &str) -> Result<(), CollabError> {
+        let mut tr = self.state.tr();
+        tr.set_selection(Selection::cursor(Pos(pos)));
+        tr.insert_text(text).unwrap();
+        let before = self.state.doc.clone();
+        let next = self.state.apply(tr);
+        let r = self.session.record_local(&before, &next.doc);
+        self.state = next;
+        r
+    }
+
+    /// A valid delta from a legitimate peer that joined this session's snapshot and
+    /// typed one character.
+    fn valid_peer_delta(&self) -> Vec<u8> {
+        let mut peer = CollabSession::from_bytes(&self.session.snapshot()).unwrap();
+        let doc = peer.projected_doc(&self.schema).unwrap();
+        let mut state = EditorState::create(self.schema.clone(), doc, default_plugins());
+        let mut tr = state.tr();
+        tr.set_selection(Selection::cursor(Pos(1)));
+        tr.insert_text("P").unwrap();
+        let before = state.doc.clone();
+        state = state.apply(tr);
+        peer.record_local(&before, &state.doc).unwrap();
+        let delta = peer.save_incremental().unwrap();
+        assert!(!delta.is_empty(), "the peer edit must produce a delta");
+        delta
+    }
+}
+
+/// Whole-document bytes of a foreign yrs doc built by `build` — bytes that decode
+/// and apply fine but were never one of our projections.
+fn foreign_update(build: impl FnOnce(&Doc)) -> Vec<u8> {
+    let doc = Doc::new();
+    build(&doc);
+    doc.transact()
+        .encode_state_as_update_v1(&StateVector::default())
+}
+
+/// Assert the full sticky contract after a poisoning integrate: every direction of
+/// the session fails with `SessionPoisoned`, and no broadcast delta escapes.
+/// `valid_delta` is a legitimate peer delta captured **before** the poisoning, so the
+/// inbound refusal is shown on bytes that would otherwise integrate fine.
+fn assert_poisoned_both_directions(l: &mut Live, valid_delta: &[u8], what: &str) {
+    assert!(l.session.is_poisoned(), "{what}: is_poisoned");
+    assert!(
+        matches!(
+            l.session.projected_doc(&l.schema),
+            Err(CollabError::SessionPoisoned(_))
+        ),
+        "{what}: projected_doc is sticky-refused"
+    );
+    // Outbound: a local edit must NOT be projected-and-broadcast.
+    let r = l.type_at(1, "L");
+    assert!(
+        matches!(r, Err(CollabError::SessionPoisoned(_))),
+        "{what}: record_local must fail sticky, got {r:?}"
+    );
+    assert!(
+        matches!(
+            l.session.save_incremental(),
+            Err(CollabError::SessionPoisoned(_))
+        ),
+        "{what}: save_incremental must fail sticky (no delta may leave)"
+    );
+    // Reconciliation: a poisoned document's content must not reach healthy peers.
+    let sv = l.session.state_vector();
+    assert!(
+        matches!(
+            l.session.sync_diff(&sv),
+            Err(CollabError::SessionPoisoned(_))
+        ),
+        "{what}: sync_diff must fail sticky"
+    );
+    // Inbound: even a perfectly valid peer delta — and the empty update — is refused
+    // with the sticky kind, so an app polling errors sees "dead", not a mix.
+    let state = l.state.clone();
+    assert!(
+        matches!(
+            l.session.integrate_incremental(&state, valid_delta),
+            Err(CollabError::SessionPoisoned(_))
+        ),
+        "{what}: a valid peer delta is sticky-refused once poisoned"
+    );
+    assert!(
+        matches!(
+            l.session.integrate_incremental(&state, &[0, 0]),
+            Err(CollabError::SessionPoisoned(_))
+        ),
+        "{what}: even the empty update is sticky-refused once poisoned"
+    );
+}
+
+// --- the matrix ----------------------------------------------------------------
+
+#[test]
+fn foreign_text_root_bytes_poison_the_session_in_both_directions() {
+    // The issue's headline shape: `content` was created as a Text type in some
+    // unrelated yrs document. On unfixed code this one-way partitioned — integrate
+    // failed forever with Schema("read_node_data: missing node") while the local
+    // user kept typing and broadcasting.
+    let mut l = live(&["hello"]);
+    let valid_delta = l.valid_peer_delta();
+    let bytes = foreign_update(|d| {
+        let t = d.get_or_insert_text("content");
+        t.insert(&mut d.transact_mut(), 0, "foreign");
+    });
+    let state = l.state.clone();
+    let err = l.session.integrate_incremental(&state, &bytes).unwrap_err();
+    assert!(
+        matches!(err, CollabError::SessionPoisoned(_)),
+        "the poisoning integrate itself returns the sticky kind, got {err:?}"
+    );
+    assert_poisoned_both_directions(&mut l, &valid_delta, "text root");
+}
+
+#[test]
+fn foreign_scalar_array_bytes_poison_the_same_way() {
+    // An array root holding scalars instead of node maps: unprojectable for the same
+    // reason, and deliberately converged on the same sticky kind.
+    let mut l = live(&["hello"]);
+    let valid_delta = l.valid_peer_delta();
+    let bytes = foreign_update(|d| {
+        let a = d.get_or_insert_array("content");
+        a.insert(&mut d.transact_mut(), 0, Any::String("junk".into()));
+    });
+    let state = l.state.clone();
+    let err = l.session.integrate_incremental(&state, &bytes).unwrap_err();
+    assert!(
+        matches!(err, CollabError::SessionPoisoned(_)),
+        "got {err:?}"
+    );
+    assert_poisoned_both_directions(&mut l, &valid_delta, "scalar array");
+}
+
+#[test]
+fn foreign_map_root_bytes_stay_harmless() {
+    // A foreign Map root named `content`: its entries land in the array branch's map
+    // component, invisible to list reads. Harmless before the fix, and must stay so —
+    // the rebuild succeeds, so nothing may poison.
+    let mut l = live(&["hello"]);
+    let bytes = foreign_update(|d| {
+        let m = d.get_or_insert_map("content");
+        m.insert(&mut d.transact_mut(), "k", Any::Bool(true));
+    });
+    let state = l.state.clone();
+    assert!(
+        l.session
+            .integrate_incremental(&state, &bytes)
+            .unwrap()
+            .is_none(),
+        "map-root entries are invisible to the projection"
+    );
+    assert!(!l.session.is_poisoned());
+    assert!(l.type_at(1, "X").is_ok(), "local edits still project");
+    assert!(
+        !l.session.save_incremental().unwrap().is_empty(),
+        "and still broadcast"
+    );
+    let delta = l.valid_peer_delta();
+    let state = l.state.clone();
+    assert!(
+        l.session
+            .integrate_incremental(&state, &delta)
+            .unwrap()
+            .is_some(),
+        "a valid peer delta still integrates"
+    );
+}
+
+#[test]
+fn a_valid_foreign_block_is_still_adopted() {
+    // An array root holding a well-formed projected node: a legitimate block merge —
+    // the transport chose the peers, not a defect. Must NOT regress into poison.
+    let mut l = live(&["hello"]);
+    let bytes = foreign_update(|d| {
+        let a = d.get_or_insert_array("content");
+        let mut txn = d.transact_mut();
+        let node = a.insert(&mut txn, 0, MapPrelim::default());
+        node.insert(&mut txn, "type", Any::String("paragraph".into()));
+        node.insert(&mut txn, "attrs", MapPrelim::default());
+        node.insert(&mut txn, "text", TextPrelim::new("peer"));
+    });
+    let state = l.state.clone();
+    let next = l
+        .session
+        .integrate_incremental(&state, &bytes)
+        .unwrap()
+        .expect("the foreign block is a real document change");
+    l.state = next;
+    assert!(!l.session.is_poisoned());
+    let all: String = (0..l.state.doc.child_count())
+        .map(|i| {
+            let b = l.state.doc.child(i);
+            (0..b.child_count())
+                .filter_map(|j| b.child(j).text().map(str::to_string))
+                .collect::<String>()
+        })
+        .collect();
+    assert!(
+        all.contains("peer") && all.contains("hello"),
+        "both blocks live in the adopted document: {all}"
+    );
+    assert!(l.type_at(1, "X").is_ok(), "collaboration continues");
+    assert!(!l.session.save_incremental().unwrap().is_empty());
+}
+
+#[test]
+fn undecodable_bytes_do_not_poison() {
+    // A garbage blob fails to decode, so the CRDT is untouched — a transient Engine
+    // error. The next valid delta must integrate normally.
+    let mut l = live(&["hello"]);
+    let state = l.state.clone();
+    let err = l
+        .session
+        .integrate_incremental(&state, &[0xff, 0xff, 0xff, 0xff])
+        .unwrap_err();
+    assert!(
+        matches!(err, CollabError::Engine(_)),
+        "a decode failure is transient, got {err:?}"
+    );
+    assert!(!l.session.is_poisoned());
+    let delta = l.valid_peer_delta();
+    assert!(
+        l.session
+            .integrate_incremental(&state, &delta)
+            .unwrap()
+            .is_some(),
+        "the next valid delta integrates — no sticky state"
+    );
+    assert!(l.type_at(1, "X").is_ok());
+}
+
+#[test]
+fn interior_damage_with_shared_lineage_poisons_and_silences_the_broadcast() {
+    // The last one-way partition on unfixed code (probe-verified): a delta with
+    // SHARED lineage (forked from our snapshot) parks an embed inside block 0's
+    // text. The top-level block count is unchanged, so #218's gate 1 cannot see it,
+    // and a local edit to block 1 skips damaged block 0 by Rc identity, so gates 2–3
+    // cannot either. Unfixed: integrate `Err(Unsupported)` forever, record_local of
+    // block 1 `Ok`, save_incremental a 24-byte broadcast — inbound-dead,
+    // outbound-alive. Fixed: sticky poison, silent in no direction.
+    let mut l = live(&["alpha", "beta"]);
+
+    let peer_doc = Doc::new();
+    {
+        let update = Update::decode_v1(&l.session.snapshot()).unwrap();
+        peer_doc.transact_mut().apply_update(update).unwrap();
+    }
+    {
+        let content = peer_doc.get_or_insert_array("content");
+        let mut txn = peer_doc.transact_mut();
+        let Some(yrs::Out::YMap(node)) = content.get(&txn, 0) else {
+            panic!("block 0 must be a node map");
+        };
+        let Some(yrs::Out::YText(text)) = node.get(&txn, "text") else {
+            panic!("block 0 must carry a text");
+        };
+        text.insert_embed(&mut txn, 2, Any::Bool(true));
+    }
+    let delta = {
+        let sv = StateVector::decode_v1(&l.session.state_vector()).unwrap();
+        peer_doc.transact().encode_diff_v1(&sv)
+    };
+
+    let state = l.state.clone();
+    let err = l.session.integrate_incremental(&state, &delta).unwrap_err();
+    assert!(
+        matches!(err, CollabError::SessionPoisoned(_)),
+        "interior damage poisons on the integrate that applied it, got {err:?}"
+    );
+    // The headline: an edit to the UNDAMAGED block must now refuse loudly instead of
+    // projecting and broadcasting from an inbound-dead replica.
+    let r = l.type_at(8, "L"); // inside "beta"
+    assert!(
+        matches!(r, Err(CollabError::SessionPoisoned(_))),
+        "record_local of the other block must fail sticky, got {r:?}"
+    );
+    assert!(
+        matches!(
+            l.session.save_incremental(),
+            Err(CollabError::SessionPoisoned(_))
+        ),
+        "no delta may leave the poisoned replica"
+    );
+    assert!(l.session.is_poisoned());
+}
+
+#[test]
+fn recovery_is_a_fresh_session_from_a_healthy_snapshot() {
+    // The documented recovery path: drop the poisoned session, rejoin from a healthy
+    // peer's snapshot, collaborate on.
+    let mut l = live(&["hello"]);
+    let healthy_snapshot = l.session.snapshot();
+    let bytes = foreign_update(|d| {
+        let t = d.get_or_insert_text("content");
+        t.insert(&mut d.transact_mut(), 0, "foreign");
+    });
+    let state = l.state.clone();
+    let _ = l.session.integrate_incremental(&state, &bytes).unwrap_err();
+    assert!(l.session.is_poisoned());
+
+    let mut fresh = CollabSession::from_bytes(&healthy_snapshot).unwrap();
+    assert!(!fresh.is_poisoned());
+    let doc = fresh.projected_doc(&l.schema).unwrap();
+    let mut state = EditorState::create(l.schema.clone(), doc, default_plugins());
+    let mut tr = state.tr();
+    tr.set_selection(Selection::cursor(Pos(1)));
+    tr.insert_text("R").unwrap();
+    let before = state.doc.clone();
+    state = state.apply(tr);
+    fresh.record_local(&before, &state.doc).unwrap();
+    assert!(
+        !fresh.save_incremental().unwrap().is_empty(),
+        "the fresh session collaborates normally"
+    );
+}

--- a/crates/rinch-editor-collab/tests/poison.rs
+++ b/crates/rinch-editor-collab/tests/poison.rs
@@ -16,16 +16,22 @@
 //! * **Array holding a valid projected block** — a legitimate merge; the transport
 //!   chose the peers, not a defect. Must stay adopted.
 //!
-//! Plus the two boundary cases: undecodable bytes never touch the CRDT (transient,
-//! no poison), and **interior damage** — a shared-lineage delta parking an embed
-//! inside one block's text, which changes no block count and so slipped every #218
-//! gate: on unfixed code that was the last remaining one-way partition (integrate
-//! `Err` forever, `record_local` of *another* block `Ok`, a delta broadcast).
+//! Plus the boundary cases: undecodable bytes never touch the CRDT (transient, no
+//! poison); **interior damage** — a shared-lineage delta parking an embed inside one
+//! block's text, which changes no block count and so slipped every #218 gate: on
+//! unfixed code that was the last remaining one-way partition (integrate `Err`
+//! forever, `record_local` of *another* block `Ok`, a delta broadcast); a rebuild
+//! failure with updates parked on **missing dependencies**, which must stay
+//! transient because the missing delta cures it (review finding F1); and the
+//! **heal**: poison clears when an inbound update makes the document rebuildable
+//! again, while outbound stays refused for the whole poisoned window.
 
 use std::rc::Rc;
 
 use rinch_editor_collab::{CollabError, CollabSession};
-use rinch_editor_core::{EditorState, Fragment, Node, Pos, Schema, Selection, default_plugins};
+use rinch_editor_core::{
+    Attrs, EditorState, Fragment, Node, Pos, Schema, Selection, default_plugins,
+};
 use yrs::updates::decoder::Decode;
 use yrs::{
     Any, Array, Doc, Map, MapPrelim, ReadTxn, StateVector, Text, TextPrelim, Transact, Update,
@@ -45,6 +51,25 @@ fn para(schema: &Schema, text: &str) -> Node {
 fn doc_of(schema: &Schema, blocks: Vec<Node>) -> Node {
     schema
         .branch("doc", Fragment::from_children(blocks))
+        .unwrap()
+}
+
+fn heading(schema: &Schema, level: i64, text: &str) -> Node {
+    schema
+        .create_node(
+            "heading",
+            Attrs::new().with("level", level),
+            Fragment::from_node(schema.text(text).unwrap()),
+        )
+        .unwrap()
+}
+
+fn code_block(schema: &Schema, text: &str) -> Node {
+    schema
+        .branch(
+            "code_block",
+            Fragment::from_node(schema.text(text).unwrap()),
+        )
         .unwrap()
 }
 
@@ -145,8 +170,9 @@ fn assert_poisoned_both_directions(l: &mut Live, valid_delta: &[u8], what: &str)
         ),
         "{what}: sync_diff must fail sticky"
     );
-    // Inbound: even a perfectly valid peer delta — and the empty update — is refused
-    // with the sticky kind, so an app polling errors sees "dead", not a mix.
+    // Inbound: integration is still *attempted*, but neither a perfectly valid peer
+    // delta nor the empty update removes the junk, so the rebuild keeps failing and
+    // both report the sticky kind — an app polling errors sees "dead", not a mix.
     let state = l.state.clone();
     assert!(
         matches!(
@@ -357,6 +383,201 @@ fn interior_damage_with_shared_lineage_poisons_and_silences_the_broadcast() {
         "no delta may leave the poisoned replica"
     );
     assert!(l.session.is_poisoned());
+}
+
+#[test]
+fn a_misrouted_reconciliation_diff_with_missing_dependencies_is_transient_and_heals() {
+    // PR #219 review finding F1. A rebuild failure while yrs holds updates parked on
+    // **missing dependencies** is NOT the permanent class: the missing bytes cure it.
+    //
+    // The reachable shape: C rewrites block 0's `type` (delete old item + insert
+    // C-item); B — who has seen C — rewrites it again (delete C-item + insert
+    // B-item). B answers *C's* state vector with a reconciliation diff, which a hub
+    // fans to A as opaque bytes (diffs and broadcasts are indistinguishable on the
+    // wire). That diff carries B's insertion and the COMPLETE delete set
+    // (`encode_diff_v1` always writes it) but not C's insertion — so at A the
+    // original `type` item is deleted while B's successor parks on the missing
+    // C-dependency, and the node reads back with no type. Poisoning here would turn
+    // a self-healing state into a dead one AND refuse the very bytes that heal it.
+    let schema = Rc::new(Schema::starter_kit());
+    let doc0 = doc_of(&schema, vec![para(&schema, "hello")]);
+    let a_state = EditorState::create(schema.clone(), doc0.clone(), default_plugins());
+    let mut a = CollabSession::new(&a_state).unwrap();
+    let _ = a.save_incremental().unwrap();
+
+    let mut b = CollabSession::from_bytes(&a.snapshot()).unwrap();
+    let mut c = CollabSession::from_bytes(&a.snapshot()).unwrap();
+
+    // C rewrites the block's type: paragraph -> heading.
+    let heading_doc = doc_of(&schema, vec![heading(&schema, 1, "hello")]);
+    c.record_local(&doc0, &heading_doc).unwrap();
+    let delta_c = c.save_incremental().unwrap();
+    assert!(!delta_c.is_empty());
+
+    // B integrates C, then rewrites the type again: heading -> code_block.
+    let b_state = EditorState::create(schema.clone(), doc0.clone(), default_plugins());
+    let b_state = b
+        .integrate_incremental(&b_state, &delta_c)
+        .unwrap()
+        .expect("B adopts C's rewrite");
+    let code_doc = doc_of(&schema, vec![code_block(&schema, "hello")]);
+    b.record_local(&b_state.doc, &code_doc).unwrap();
+    let _ = b.save_incremental().unwrap();
+
+    // The misroute: B's reconciliation answer FOR C, delivered to A.
+    let misrouted = b.sync_diff(&c.state_vector()).unwrap();
+    let err = a.integrate_incremental(&a_state, &misrouted).unwrap_err();
+    assert!(
+        !matches!(err, CollabError::SessionPoisoned(_)),
+        "a dependency-pending rebuild failure must stay transient, got {err:?}"
+    );
+    assert!(
+        !a.is_poisoned(),
+        "the session must not poison while updates are parked on missing dependencies"
+    );
+
+    // The missing dependency arrives (C's ordinary broadcast); the session heals.
+    let healed = a
+        .integrate_incremental(&a_state, &delta_c)
+        .unwrap()
+        .expect("the healing delta is a real document change");
+    assert!(!a.is_poisoned());
+    assert_eq!(
+        healed.doc.child(0).type_name(),
+        "code_block",
+        "A converged on B's rewrite once the dependency arrived"
+    );
+    let pa = a.projected_doc(&schema).unwrap();
+    let pb = b.projected_doc(&schema).unwrap();
+    assert_eq!(pa, pb, "A and B project the same converged document");
+
+    // And A keeps collaborating: a local edit projects and broadcasts.
+    let edited = doc_of(&schema, vec![code_block(&schema, "hello!")]);
+    a.record_local(&healed.doc, &edited).unwrap();
+    assert!(
+        !a.save_incremental().unwrap().is_empty(),
+        "the healed session broadcasts again"
+    );
+}
+
+#[test]
+fn poison_clears_when_inbound_bytes_make_the_document_projectable_again() {
+    // Poison is sticky, not fatal: inbound integration keeps being *attempted*, and
+    // an update that leaves the document rebuildable again — here the damaged-lineage
+    // peer deleting its own embedded range — clears the poison. Outbound stays
+    // refused for the whole poisoned window.
+    let mut l = live(&["alpha", "beta"]);
+
+    let peer_doc = Doc::new();
+    {
+        let update = Update::decode_v1(&l.session.snapshot()).unwrap();
+        peer_doc.transact_mut().apply_update(update).unwrap();
+    }
+    // The peer parks an embed inside block 0's text (interior damage)...
+    {
+        let content = peer_doc.get_or_insert_array("content");
+        let mut txn = peer_doc.transact_mut();
+        let Some(yrs::Out::YMap(node)) = content.get(&txn, 0) else {
+            panic!("block 0 must be a node map");
+        };
+        let Some(yrs::Out::YText(text)) = node.get(&txn, "text") else {
+            panic!("block 0 must carry a text");
+        };
+        text.insert_embed(&mut txn, 2, Any::Bool(true));
+    }
+    let damage = {
+        let sv = StateVector::decode_v1(&l.session.state_vector()).unwrap();
+        peer_doc.transact().encode_diff_v1(&sv)
+    };
+    let state = l.state.clone();
+    let err = l
+        .session
+        .integrate_incremental(&state, &damage)
+        .unwrap_err();
+    assert!(
+        matches!(err, CollabError::SessionPoisoned(_)),
+        "got {err:?}"
+    );
+    assert!(l.session.is_poisoned());
+    assert!(
+        matches!(l.type_at(8, "L"), Err(CollabError::SessionPoisoned(_))),
+        "outbound is refused while poisoned"
+    );
+
+    // ...then deletes the embedded range and sends that delta.
+    {
+        let content = peer_doc.get_or_insert_array("content");
+        let mut txn = peer_doc.transact_mut();
+        let Some(yrs::Out::YMap(node)) = content.get(&txn, 0) else {
+            panic!("block 0 must be a node map");
+        };
+        let Some(yrs::Out::YText(text)) = node.get(&txn, "text") else {
+            panic!("block 0 must carry a text");
+        };
+        text.remove_range(&mut txn, 2, 1); // the embed occupies one unit
+    }
+    let heal = {
+        let sv = StateVector::decode_v1(&l.session.state_vector()).unwrap();
+        peer_doc.transact().encode_diff_v1(&sv)
+    };
+    let state = l.state.clone();
+    let healed = l.session.integrate_incremental(&state, &heal).unwrap();
+    assert!(
+        !l.session.is_poisoned(),
+        "a successful converged rebuild clears the poison"
+    );
+    // The healed CRDT matches the model A already held, so integrating may report
+    // "no document change" — what matters is that the session works again.
+    let _ = healed;
+    assert!(l.type_at(8, "L").is_ok(), "outbound projects again");
+    assert!(
+        !l.session.save_incremental().unwrap().is_empty(),
+        "and broadcasts again"
+    );
+    let pd = l.session.projected_doc(&l.schema).unwrap();
+    assert_eq!(pd, l.state.doc, "model ≡ project(model) is restored");
+}
+
+#[test]
+fn merge_refuses_to_touch_or_spread_poison() {
+    // PR #219 review finding F2: pin `merge`'s refusal surface in BOTH directions —
+    // a poisoned session must not merge, and a healthy session must not pull a
+    // poisoned peer's document in.
+    let mut poisoned = live(&["hello"]);
+    let bytes = foreign_update(|d| {
+        let t = d.get_or_insert_text("content");
+        t.insert(&mut d.transact_mut(), 0, "foreign");
+    });
+    let state = poisoned.state.clone();
+    let _ = poisoned
+        .session
+        .integrate_incremental(&state, &bytes)
+        .unwrap_err();
+    assert!(poisoned.session.is_poisoned());
+
+    let mut healthy = live(&["clean"]);
+    assert!(
+        matches!(
+            poisoned.session.merge(&healthy.session),
+            Err(CollabError::SessionPoisoned(_))
+        ),
+        "a poisoned session refuses to merge (its own guard)"
+    );
+    assert!(
+        matches!(
+            healthy.session.merge(&poisoned.session),
+            Err(CollabError::SessionPoisoned(_))
+        ),
+        "a healthy session refuses to merge FROM a poisoned peer (the other-side guard)"
+    );
+    assert!(
+        !healthy.session.is_poisoned(),
+        "the refusal protected the healthy session"
+    );
+    assert!(
+        healthy.type_at(1, "X").is_ok() && !healthy.session.save_incremental().unwrap().is_empty(),
+        "the healthy session keeps collaborating"
+    );
 }
 
 #[test]

--- a/crates/rinch-editor-collab/tests/poison.rs
+++ b/crates/rinch-editor-collab/tests/poison.rs
@@ -188,6 +188,21 @@ fn assert_poisoned_both_directions(l: &mut Live, valid_delta: &[u8], what: &str)
         ),
         "{what}: even the empty update is sticky-refused once poisoned"
     );
+    // An inbound failure that never touches the CRDT (an undecodable blob) also
+    // reports the sticky kind while poisoned, not its own transient kind — the
+    // shape `sticky_or` exists for (#219 review, R2-2).
+    assert!(
+        matches!(
+            l.session
+                .integrate_incremental(&state, &[0xff, 0xff, 0xff, 0xff]),
+            Err(CollabError::SessionPoisoned(_))
+        ),
+        "{what}: an undecodable blob while poisoned reports the sticky kind"
+    );
+    assert!(
+        l.session.is_poisoned(),
+        "{what}: still poisoned after the blob"
+    );
 }
 
 // --- the matrix ----------------------------------------------------------------

--- a/crates/rinch-editor-view/Cargo.toml
+++ b/crates/rinch-editor-view/Cargo.toml
@@ -21,3 +21,8 @@ collaboration = ["dep:rinch-editor-collab"]
 # The MockDomDocument the view/handle tests project onto (proof the seam is
 # renderer-agnostic — no rinch-dom/Parley needed).
 rinch-core = { workspace = true, features = ["test-util"] }
+# Raw yrs, to forge the foreign CRDT bytes the poisoned-session tests feed
+# `collab_receive` (#196). Bytes-only coupling: the tests hand `Vec<u8>` across, so
+# this only needs to speak the same lib0 v1 wire encoding as rinch-editor-collab's
+# pin — no types are shared.
+yrs = "0.27"

--- a/crates/rinch-editor-view/src/handle.rs
+++ b/crates/rinch-editor-view/src/handle.rs
@@ -993,20 +993,28 @@ impl EditorHandle {
     }
 
     /// Whether the attached collaboration session is **poisoned** (issue #196): an
-    /// inbound delta left the shared CRDT permanently unprojectable, so the session
-    /// can never receive again — and, to avoid the silent one-way partition of a
-    /// replica that keeps broadcasting while receiving nothing, it refuses to send
-    /// as well. Every affected call keeps failing with the sticky
-    /// [`CollabError::SessionPoisoned`] (also visible via
+    /// inbound delta left the shared CRDT unprojectable with nothing pending that
+    /// could cure it, so the session cannot receive — and, to avoid the silent
+    /// one-way partition of a replica that keeps broadcasting while receiving
+    /// nothing, it refuses to send as well. Every affected call keeps failing with
+    /// the sticky [`CollabError::SessionPoisoned`] (also visible via
     /// [`Self::collab_take_error`], which distinguishes it from a transient error
-    /// such as an undecodable blob). `false` when not collaborating.
+    /// such as an undecodable blob or a rebuild still waiting on a missing
+    /// dependency). Inbound deltas are still *attempted*: one that makes the shared
+    /// document rebuildable again clears the poison. `false` when not collaborating.
     ///
-    /// Recovery: [`Self::stop_collaboration`], then rejoin from a healthy peer's
-    /// snapshot ([`Self::start_collaboration_guest`]).
+    /// Recovery in practice: [`Self::stop_collaboration`], then rejoin from a
+    /// healthy peer's snapshot ([`Self::start_collaboration_guest`]).
+    ///
+    /// Uses `try_borrow` — soft, like [`Self::collab_receive`] — so an `outbound`
+    /// sink may call it without panicking. While the handle is borrowed a local edit
+    /// is being committed, which a poisoned session refuses, so `false` is the
+    /// consistent answer for that window.
     pub fn is_collaboration_poisoned(&self) -> bool {
-        self.inner
-            .borrow()
-            .collab
+        let Ok(core) = self.inner.try_borrow() else {
+            return false;
+        };
+        core.collab
             .as_ref()
             .is_some_and(|b| b.session.is_poisoned())
     }
@@ -2244,11 +2252,13 @@ mod tests {
         // ── The poisoned session (issue #196) ────────────────────────────────
         //
         // Foreign bytes whose `content` root was created as the wrong yrs type leave
-        // the shared CRDT permanently unprojectable once integrated (yrs has no
-        // rollback). The session must then go loud in BOTH directions — sticky
-        // `SessionPoisoned` on inbound and outbound — instead of one-way
-        // partitioning: keeping `record_local` Ok and broadcasting while every
-        // receive fails forever was the dangerous silent half.
+        // the shared CRDT unprojectable once integrated, with nothing pending that
+        // could cure it (yrs has no rollback). The session must then go loud in BOTH
+        // directions — sticky `SessionPoisoned` on inbound and outbound — instead of
+        // one-way partitioning: keeping `record_local` Ok and broadcasting while
+        // every receive fails was the dangerous silent half. (Inbound stays
+        // *attempted*: an update that makes the document rebuildable again clears
+        // the poison — pinned at the session level in tests/poison.rs.)
 
         /// Whole-document bytes of a foreign yrs doc whose `content` root is a
         /// **Text** type — the issue's headline poison shape. Decodes and applies

--- a/crates/rinch-editor-view/src/handle.rs
+++ b/crates/rinch-editor-view/src/handle.rs
@@ -992,6 +992,25 @@ impl EditorHandle {
         self.inner.borrow().collab.is_some()
     }
 
+    /// Whether the attached collaboration session is **poisoned** (issue #196): an
+    /// inbound delta left the shared CRDT permanently unprojectable, so the session
+    /// can never receive again — and, to avoid the silent one-way partition of a
+    /// replica that keeps broadcasting while receiving nothing, it refuses to send
+    /// as well. Every affected call keeps failing with the sticky
+    /// [`CollabError::SessionPoisoned`] (also visible via
+    /// [`Self::collab_take_error`], which distinguishes it from a transient error
+    /// such as an undecodable blob). `false` when not collaborating.
+    ///
+    /// Recovery: [`Self::stop_collaboration`], then rejoin from a healthy peer's
+    /// snapshot ([`Self::start_collaboration_guest`]).
+    pub fn is_collaboration_poisoned(&self) -> bool {
+        self.inner
+            .borrow()
+            .collab
+            .as_ref()
+            .is_some_and(|b| b.session.is_poisoned())
+    }
+
     /// A snapshot of the shared document **as it stands now**, for a *late-joining*
     /// peer: hand it to a new guest's [`Self::start_collaboration_guest`] so they
     /// adopt the current content (not just the host's original document). `None`
@@ -1061,6 +1080,12 @@ impl EditorHandle {
     /// Take (and clear) the most recent collaboration error — e.g. an edit outside
     /// the staged flat-text scope that could not be projected (design A22). `None`
     /// when not collaborating or no error is pending.
+    ///
+    /// A [`CollabError::SessionPoisoned`] here is **not** a one-off: the session is
+    /// dead in both directions and every affected call re-fails with it (taking it
+    /// does not un-poison — see [`Self::is_collaboration_poisoned`]). Anything else
+    /// (an undecodable blob, an out-of-scope local edit) is transient: the session
+    /// keeps collaborating.
     pub fn collab_take_error(&self) -> Option<CollabError> {
         self.inner
             .borrow_mut()
@@ -2214,6 +2239,130 @@ mod tests {
                 "hello world",
                 "a late joiner adopts the current shared document"
             );
+        }
+
+        // ── The poisoned session (issue #196) ────────────────────────────────
+        //
+        // Foreign bytes whose `content` root was created as the wrong yrs type leave
+        // the shared CRDT permanently unprojectable once integrated (yrs has no
+        // rollback). The session must then go loud in BOTH directions — sticky
+        // `SessionPoisoned` on inbound and outbound — instead of one-way
+        // partitioning: keeping `record_local` Ok and broadcasting while every
+        // receive fails forever was the dangerous silent half.
+
+        /// Whole-document bytes of a foreign yrs doc whose `content` root is a
+        /// **Text** type — the issue's headline poison shape. Decodes and applies
+        /// fine; the read-back is what can never succeed.
+        fn foreign_text_root_bytes() -> Vec<u8> {
+            use yrs::{ReadTxn, Text, Transact};
+            let doc = yrs::Doc::new();
+            let t = doc.get_or_insert_text("content");
+            t.insert(&mut doc.transact_mut(), 0, "foreign");
+            doc.transact()
+                .encode_state_as_update_v1(&yrs::StateVector::default())
+        }
+
+        #[test]
+        fn a_poisoning_delta_turns_the_session_loud_in_both_directions() {
+            let s = schema();
+            let host = mount(doc_node(&s, vec![para(&s, "hello")])).handle;
+            let guest = mount(doc_node(&s, vec![para(&s, "")])).handle;
+            loopback(&host, &guest);
+
+            // Foreign bytes reach the HOST mid-session.
+            assert!(!host.collab_receive(&foreign_text_root_bytes()));
+            assert!(
+                host.is_collaboration_poisoned(),
+                "the host session is poisoned"
+            );
+            assert!(
+                !guest.is_collaboration_poisoned(),
+                "the guest never saw the bytes and stays healthy"
+            );
+            assert!(
+                matches!(
+                    host.collab_take_error(),
+                    Some(CollabError::SessionPoisoned(_))
+                ),
+                "the parked error is the sticky kind, distinguishable from a transient one"
+            );
+
+            // The host keeps editing locally, but nothing may leave the poisoned
+            // replica — on unfixed code this edit was projected AND broadcast.
+            host.set_selection(Selection::cursor(Pos(6)));
+            assert!(host.insert_text("X"));
+            assert_eq!(doc_text(&host), "helloX", "the local model still edits");
+            assert_eq!(
+                doc_text(&guest),
+                "hello",
+                "no delta left the poisoned replica"
+            );
+            assert!(
+                matches!(
+                    host.collab_take_error(),
+                    Some(CollabError::SessionPoisoned(_))
+                ),
+                "each refused edit re-reports the sticky error"
+            );
+
+            // Inbound stays refused for perfectly valid peer deltas too.
+            guest.set_selection(Selection::cursor(Pos(1)));
+            assert!(guest.insert_text("G"));
+            assert_eq!(doc_text(&guest), "Ghello");
+            assert_eq!(
+                doc_text(&host),
+                "helloX",
+                "the poisoned host can no longer receive"
+            );
+
+            // Recovery: stop, rejoin from the healthy peer's snapshot.
+            host.stop_collaboration();
+            assert!(
+                !host.is_collaboration_poisoned(),
+                "no session, no poison to report"
+            );
+            let snapshot = guest.collab_snapshot().expect("guest is collaborating");
+            let g_in = guest.clone();
+            host.start_collaboration_guest(&snapshot, move |d| {
+                g_in.collab_receive(&d);
+            })
+            .expect("rejoining from a healthy snapshot works");
+            assert_eq!(
+                doc_text(&host),
+                "Ghello",
+                "the rejoined host adopts the healthy shared document"
+            );
+            host.set_selection(Selection::cursor(Pos(1)));
+            assert!(host.insert_text("R"));
+            assert_eq!(
+                doc_text(&guest),
+                "RGhello",
+                "collaboration flows again after the rejoin"
+            );
+        }
+
+        #[test]
+        fn an_undecodable_blob_is_transient_not_poison() {
+            // A garbage blob never touches the CRDT, so it must NOT trip the sticky
+            // state — the session keeps collaborating in both directions.
+            let s = schema();
+            let host = mount(doc_node(&s, vec![para(&s, "hello")])).handle;
+            let guest = mount(doc_node(&s, vec![para(&s, "")])).handle;
+            loopback(&host, &guest);
+
+            assert!(!host.collab_receive(&[0xff, 0xff, 0xff, 0xff]));
+            assert!(
+                matches!(host.collab_take_error(), Some(CollabError::Engine(_))),
+                "a decode failure surfaces as a transient engine error"
+            );
+            assert!(!host.is_collaboration_poisoned());
+
+            guest.set_selection(Selection::cursor(Pos(1)));
+            assert!(guest.insert_text("G"));
+            assert_eq!(doc_text(&host), "Ghello", "inbound still works");
+            host.set_selection(Selection::cursor(Pos(7)));
+            assert!(host.insert_text("X"));
+            assert_eq!(doc_text(&guest), "GhelloX", "outbound still works");
         }
 
         // ── The zero-block state (issue #192) ────────────────────────────────

--- a/docs/src/guide/contenteditable.md
+++ b/docs/src/guide/contenteditable.md
@@ -374,6 +374,21 @@ outside that scope fails loud rather than silently diverging —
 not projected). A runnable two-pane loopback (both editors in one window, no network)
 lives at `examples/collab-editor-demo/src/main.rs`.
 
+**Errors: transient vs poisoned.** Most collaboration errors are *transient*: an
+undecodable blob from the transport, or a local edit outside the staged scope —
+the session keeps collaborating, and `collab_take_error()` tells you what was
+refused. One class is not: inbound bytes that, once integrated, leave the shared
+CRDT document **unprojectable** (e.g. bytes from a foreign, non-rinch yrs document,
+or a peer delta carrying content this build can never read back). yrs has no
+rollback, so such a session could never receive again — and, before issue #196, it
+would keep *broadcasting* while receiving nothing, silently partitioning the
+peers. The session now **poisons** itself instead: sticky
+`CollabError::SessionPoisoned` on every affected call, in **both** directions
+(receives are refused *and* local edits stop being projected/broadcast).
+`is_collaboration_poisoned()` queries the state; the recovery is
+`stop_collaboration()` followed by rejoining from a healthy peer's snapshot
+(`collab_snapshot()` → `start_collaboration_guest`).
+
 ### On the web
 
 The **same** adapter runs in the browser — yrs compiled to wasm. Enable the

--- a/docs/src/guide/contenteditable.md
+++ b/docs/src/guide/contenteditable.md
@@ -375,17 +375,20 @@ not projected). A runnable two-pane loopback (both editors in one window, no net
 lives at `examples/collab-editor-demo/src/main.rs`.
 
 **Errors: transient vs poisoned.** Most collaboration errors are *transient*: an
-undecodable blob from the transport, or a local edit outside the staged scope —
-the session keeps collaborating, and `collab_take_error()` tells you what was
-refused. One class is not: inbound bytes that, once integrated, leave the shared
-CRDT document **unprojectable** (e.g. bytes from a foreign, non-rinch yrs document,
-or a peer delta carrying content this build can never read back). yrs has no
-rollback, so such a session could never receive again — and, before issue #196, it
-would keep *broadcasting* while receiving nothing, silently partitioning the
-peers. The session now **poisons** itself instead: sticky
+undecodable blob from the transport, a local edit outside the staged scope, or a
+rebuild still waiting on an out-of-order delta's missing dependency — the session
+keeps collaborating, and `collab_take_error()` tells you what was refused. One
+class is not: inbound bytes that, once integrated, leave the shared CRDT document
+**unprojectable with nothing pending that could cure it** (e.g. bytes from a
+foreign, non-rinch yrs document, or a peer delta carrying content this build
+cannot read back). yrs has no rollback, so such a session cannot receive — and,
+before issue #196, it would keep *broadcasting* while receiving nothing, silently
+partitioning the peers. The session now **poisons** itself instead: sticky
 `CollabError::SessionPoisoned` on every affected call, in **both** directions
-(receives are refused *and* local edits stop being projected/broadcast).
-`is_collaboration_poisoned()` queries the state; the recovery is
+(local edits stop being projected/broadcast, and receives keep failing — though
+they are still *attempted*, so an inbound update that makes the document
+rebuildable again clears the poison on its own).
+`is_collaboration_poisoned()` queries the state; the recovery in practice is
 `stop_collaboration()` followed by rejoining from a healthy peer's snapshot
 (`collab_snapshot()` → `start_collaboration_guest`).
 

--- a/docs/src/guide/contenteditable.md
+++ b/docs/src/guide/contenteditable.md
@@ -387,7 +387,10 @@ partitioning the peers. The session now **poisons** itself instead: sticky
 `CollabError::SessionPoisoned` on every affected call, in **both** directions
 (local edits stop being projected/broadcast, and receives keep failing — though
 they are still *attempted*, so an inbound update that makes the document
-rebuildable again clears the poison on its own).
+rebuildable again clears the poison on its own). A heal re-syncs the editor to
+the converged shared document, discarding any local edits made during the
+poison window — each was already refused loudly when it happened — the same
+semantics as stopping and rejoining.
 `is_collaboration_poisoned()` queries the state; the recovery in practice is
 `stop_collaboration()` followed by rejoining from a healthy peer's snapshot
 (`collab_snapshot()` → `start_collaboration_guest`).


### PR DESCRIPTION
## Mechanism

A live `CollabSession` that integrates inbound bytes leaving the shared CRDT **unprojectable** could not receive — yrs has no rollback, so the bytes cannot be un-applied — yet kept projecting local edits and broadcasting deltas as though it were converging. Inbound-dead, outbound-alive: a silent one-way partition.

**Probe matrix, re-verified on `062a96e`** (the issue's probes predate #216/#218):

| Foreign `content` root shape | Behavior on 062a96e |
|---|---|
| Map | `Ok(None)`, harmless (entries land in the array branch's invisible map component) |
| Text | integrate `Err(Schema)` forever; `record_local` now **also** fails (#218 gate 1 count mismatch), 0-byte save — loud both ways but indistinguishable from a transient error |
| Array of scalars | same as Text — loud both ways, same indistinguishability |
| Array w/ valid projected block | adopted (legitimate merge) |
| **Interior damage** (shared-lineage delta parking an embed inside block 0's text) | **the surviving one-way partition**: integrate `Err(Unsupported)` forever, `record_local` of *another* block `Ok` (block count unchanged → gate 1 blind; undamaged-block edit → gates 2–3 blind), `save_incremental` a 24-byte broadcast |

So two defects remained: the interior-damage silent partition, and no way for an app to tell "one bad delta was dropped" from "this session is dead" via `collab_take_error()`.

## Fix

**Detect-after-apply + sticky-but-clearable poison** (not prevent-before-apply): prevention would need a per-delta full-doc clone-and-try (deltas arrive per keystroke), while detection is **free on the hot path** — the converged rebuild (`to_doc`) already runs on every integrate, and its failure *after* bytes touched the CRDT is the diagnosis. Boundaries (post-review semantics):

- **Decode failure** → CRDT untouched → transient `Engine` error, never poisons.
- **Rebuild failure with updates parked on missing dependencies** (`has_missing_updates()`) → **transient** (review F1): a misrouted reconciliation diff can delete a map item whose successor waits on an unseen insertion — the missing delta alone cures the read-back, so poisoning there would kill a self-healing state and refuse the very bytes that heal it. Both latch sites are gated.
- **Rebuild failure with nothing pending** → **poison**: sticky `CollabError::SessionPoisoned` on every convergence-relevant call, in **both** directions — `integrate_incremental` AND `record_local` / `save_incremental` (no delta leaves a replica that cannot converge) / `sync_diff` + `merge` (poisoned content must not reach healthy peers) / `projected_doc`.
- **Poison is clearable** (review F1, adopted): inbound integration is always *attempted*; a full integration whose rebuild succeeds clears the poison (e.g. the damaged lineage deleting its own embedded range). Outbound stays refused for the whole poisoned window; inbound failures while poisoned keep reporting the sticky kind. Any residual misclassification is therefore self-healing rather than fatal.
- **Apply failure** → the update may be partially integrated; classified by the same projectability + pending check. A still-projectable outcome does not clear an existing poison (the model was not advanced) — only a full successful integration does.
- `build_remote_transaction` failure after a successful rebuild leaves the doc projectable → transient (defense-in-depth; practically unreachable for a doc `to_doc` admitted).

**Ordinary local A22 refusals stay transient** — deliberately asymmetric: a failed `record_local` leaves the CRDT untouched (#218 all-or-nothing) and the offending *local* content can be edited away; foreign bytes in the CRDT cannot.

API surface (minimal): `CollabSession::is_poisoned()`, `EditorHandle::is_collaboration_poisoned()` (try_borrow-soft like `collab_receive`, so an `outbound` sink may call it; a borrowed handle answers `false`, consistent because a borrowed handle is committing a local edit, which a poisoned session refuses). Recovery in practice: `stop_collaboration()` + rejoin from a healthy peer's snapshot. Note the joiner protection is *shape-level* only: `load`'s content gate validates `read_node_data` shape, not schema, so some poisoned snapshots (e.g. a block `type` rewritten to an unknown name) load and fail loud one step later at the joiner's first `projected_doc` — documented on `snapshot()`.

## Tests

`crates/rinch-editor-collab/tests/poison.rs` (10, new file):
- `foreign_text_root_bytes_poison_the_session_in_both_directions`, `foreign_scalar_array_bytes_poison_the_same_way` — sticky on integrate/record_local/save_incremental/sync_diff/projected_doc; a valid peer delta and the empty update both still report the sticky kind
- `foreign_map_root_bytes_stay_harmless`, `a_valid_foreign_block_is_still_adopted` — the accept side must not regress
- `undecodable_bytes_do_not_poison` — transient-vs-permanent distinction
- `interior_damage_with_shared_lineage_poisons_and_silences_the_broadcast` — the headline red case (on 062a96e: `record_local` Ok + 24-byte broadcast while inbound-dead, probe-verified)
- `a_misrouted_reconciliation_diff_with_missing_dependencies_is_transient_and_heals` — **review F1 regression** (red on the pre-review branch: `SessionPoisoned("node has no type")` latched on the pending mid-state and refused the healing delta; green now: transient mid-state, heal, convergence with the B peer, collaboration continues)
- `poison_clears_when_inbound_bytes_make_the_document_projectable_again` — the clearable heal (red pre-review: the guard refused the healing bytes)
- `merge_refuses_to_touch_or_spread_poison` — **review F2** mutation pin on both `merge` guards
- `recovery_is_a_fresh_session_from_a_healthy_snapshot`

`crates/rinch-editor-view` (handle surface, mounted loopback pair; +`yrs` dev-dep to forge foreign bytes — bytes-only coupling):
- `a_poisoning_delta_turns_the_session_loud_in_both_directions` — observable via `is_collaboration_poisoned()`/`collab_take_error()`, no delta escapes, stop + rejoin recovers
- `an_undecodable_blob_is_transient_not_poison`

All existing tests pass, including the #215 zero-heal set and the #218 gate pins.

## Gates (fix-round re-run)

- `cargo test -p rinch-editor-collab` — 16 + 27 + 5 + **10 (new)** + 1 doc-test, all green
- `cargo test -p rinch-editor-view --features collaboration` — **77** (75 baseline + 2 new), green
- `cargo check -p rinch-editor-collab --target wasm32-unknown-unknown` — green
- `cargo clippy -p rinch-editor-collab --all-targets -- -D warnings` — green
- `cargo clippy -p rinch-editor-view --features collaboration --all-targets -- -D warnings` — green
- `cargo fmt --all -- --check` — clean
- (extra) `cargo check -p rinch --features collaboration` — green

Docs updated: CLAUDE.md (`CollabError` file-table row, `EditorHandle` collab-method table incl. the new query, `collab_take_error` row — all pending-aware/clearable wording), `docs/src/guide/contenteditable.md` ("Errors: transient vs poisoned" paragraph with the recovery flow).

Fixes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)
