### PR TITLE
fix(rinch-components): #229 — an external ColorPicker value applies atomically and silently

### DIFF
--- a/crates/rinch-components/Cargo.toml
+++ b/crates/rinch-components/Cargo.toml
@@ -10,3 +10,8 @@ rinch-core.workspace = true
 rinch-theme.workspace = true
 rinch-macros.workspace = true
 rinch-tabler-icons.workspace = true
+
+[dev-dependencies]
+# The MockDomDocument the ColorPicker tests render onto — a component's effect
+# topology is driveable headlessly, with no rinch-dom.
+rinch-core = { workspace = true, features = ["test-util"] }

--- a/crates/rinch-components/src/color_picker.rs
+++ b/crates/rinch-components/src/color_picker.rs
@@ -7,7 +7,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use rinch_core::dom::{NodeHandle, RenderScope};
-use rinch_core::{Component, Drag, InputCallback, Signal, get_click_context};
+use rinch_core::{Component, Drag, InputCallback, Signal, batch, get_click_context};
 
 use crate::color_swatch::ColorSwatch;
 use crate::color_utils::{
@@ -19,10 +19,11 @@ pub type ReactiveString = Rc<dyn Fn() -> String>;
 
 /// Raises the "an external value is being applied" flag for as long as it lives.
 ///
-/// RAII rather than a set/clear pair because the writes it spans flush effects
-/// synchronously: arbitrary code runs between them, and a panic anywhere in
-/// there would leave the flag up — muting the picker's `onchange` for the rest
-/// of the session, which is a worse failure than the one being prevented.
+/// RAII rather than a set/clear pair because the batched writes it spans flush
+/// effects before the batch returns: arbitrary subscriber code runs inside the
+/// guarded window, and a panic anywhere in there would leave the flag up —
+/// muting the picker's `onchange` for the rest of the session, which is a
+/// worse failure than the one being prevented.
 struct ApplyGuard<'a>(&'a Cell<bool>);
 
 impl<'a> ApplyGuard<'a> {
@@ -155,13 +156,20 @@ impl Component for ColorPicker {
                 let ctx = get_click_context();
                 let px = ctx.percent_x() as f64;
                 let py = ctx.percent_y() as f64;
-                sat.set(px);
-                val.set(1.0 - py);
+                // One gesture position = one transition: batched, so every
+                // observer (onchange included) sees saturation and value land
+                // together, never a mixture of new saturation with stale value.
+                batch(|| {
+                    sat.set(px);
+                    val.set(1.0 - py);
+                });
 
                 Drag::percent()
                     .on_move(move |px, py| {
-                        sat.set(px as f64);
-                        val.set(1.0 - py as f64);
+                        batch(|| {
+                            sat.set(px as f64);
+                            val.set(1.0 - py as f64);
+                        });
                     })
                     .start();
             });
@@ -310,10 +318,15 @@ impl Component for ColorPicker {
             {
                 let handler_id = __scope.register_input_handler(move |value: String| {
                     if let Some(parsed) = parse_color(&value) {
-                        hue.set(parsed.h);
-                        sat.set(parsed.s);
-                        val.set(parsed.v);
-                        alpha.set(parsed.a);
+                        // One typed colour = one transition: batched, so
+                        // onchange reports the committed colour once, not once
+                        // per component with mixtures in between.
+                        batch(|| {
+                            hue.set(parsed.h);
+                            sat.set(parsed.s);
+                            val.set(parsed.v);
+                            alpha.set(parsed.a);
+                        });
                     }
                 });
                 hex_input.set_attribute("data-oninput", &handler_id.to_string());
@@ -370,10 +383,14 @@ impl Component for ColorPicker {
                         let color = color.clone();
                         move || {
                             if let Some(parsed) = parse_color(&color) {
-                                hue.set(parsed.h);
-                                sat.set(parsed.s);
-                                val.set(parsed.v);
-                                alpha.set(parsed.a);
+                                // One swatch = one transition (see the hex
+                                // handler above).
+                                batch(|| {
+                                    hue.set(parsed.h);
+                                    sat.set(parsed.s);
+                                    val.set(parsed.v);
+                                    alpha.set(parsed.a);
+                                });
                             }
                         }
                     })),
@@ -393,13 +410,12 @@ impl Component for ColorPicker {
         // when the parent is mid-re-render. See GH #23.
         //
         // An external apply is the same principle carried to its conclusion: the
-        // caller knows every value it hands us, not just the first. And it is not
-        // one write but four — hue, then saturation, then value, then alpha —
-        // each flushing this effect synchronously. Reporting them would report
-        // three colours that nobody chose (the new hue against the old
-        // saturation, and so on) and, for a consumer that stores what it hears,
-        // re-enter the still-running apply with its own echo. So an external
-        // apply is atomic and silent, and only an author's act is reported. See
+        // caller knows every value it hands us, not just the first. The apply's
+        // four writes are batched into one transition, so this effect sees only
+        // the completed colour — but even that one coherent report would echo
+        // state the caller handed us, and a consumer that stores what it hears
+        // would re-enter the still-running apply with it. So an external apply
+        // is atomic and silent, and only an author's act is reported. See
         // GH #229.
         if let Some(ref onchange) = self.onchange {
             let onchange = onchange.clone();
@@ -443,15 +459,19 @@ impl Component for ColorPicker {
                         || (parsed.v - current.v).abs() > 0.005
                         || (parsed.a - current.a).abs() > 0.005
                     {
-                        // These four writes are one apply: nothing is reported
-                        // until all of them have landed, and then nothing is —
-                        // the caller handed us this value. The guard drops on
-                        // the way out of the block, including on unwind.
+                        // These four writes are one apply: batched, so every
+                        // observer runs once against the completed colour, and
+                        // silent — the caller handed us this value. The batch
+                        // flushes before it returns, still inside the guard's
+                        // window; the guard drops on the way out of the block,
+                        // including on unwind.
                         let _applying = ApplyGuard::raise(&applying_external);
-                        hue.set(parsed.h);
-                        sat.set(parsed.s);
-                        val.set(parsed.v);
-                        alpha.set(parsed.a);
+                        batch(|| {
+                            hue.set(parsed.h);
+                            sat.set(parsed.s);
+                            val.set(parsed.v);
+                            alpha.set(parsed.a);
+                        });
                     }
                 }
             });
@@ -467,10 +487,10 @@ mod apply_guard_tests {
 
     /// The flag falls even when the apply unwinds.
     ///
-    /// The writes an `ApplyGuard` spans flush effects synchronously, so a panic
-    /// in any subscriber lands inside the guarded window. A flag left up there
-    /// would mute `onchange` permanently. The panic this test provokes is
-    /// deliberate — its message on stderr is expected output.
+    /// The batched writes an `ApplyGuard` spans flush effects before the batch
+    /// returns, so a panic in any subscriber lands inside the guarded window.
+    /// A flag left up there would mute `onchange` permanently. The panic this
+    /// test provokes is deliberate — its message on stderr is expected output.
     #[test]
     fn the_flag_falls_when_an_apply_panics() {
         let flag = Rc::new(Cell::new(false));

--- a/crates/rinch-components/src/color_picker.rs
+++ b/crates/rinch-components/src/color_picker.rs
@@ -3,6 +3,7 @@
 //! An interactive color picker with a saturation panel, hue slider,
 //! optional alpha slider, hex input, and preset swatches.
 
+use std::cell::Cell;
 use std::rc::Rc;
 
 use rinch_core::dom::{NodeHandle, RenderScope};
@@ -15,6 +16,27 @@ use crate::color_utils::{
 
 /// Reactive callback type for string state.
 pub type ReactiveString = Rc<dyn Fn() -> String>;
+
+/// Raises the "an external value is being applied" flag for as long as it lives.
+///
+/// RAII rather than a set/clear pair because the writes it spans flush effects
+/// synchronously: arbitrary code runs between them, and a panic anywhere in
+/// there would leave the flag up — muting the picker's `onchange` for the rest
+/// of the session, which is a worse failure than the one being prevented.
+struct ApplyGuard<'a>(&'a Cell<bool>);
+
+impl<'a> ApplyGuard<'a> {
+    fn raise(flag: &'a Cell<bool>) -> Self {
+        flag.set(true);
+        ApplyGuard(flag)
+    }
+}
+
+impl Drop for ApplyGuard<'_> {
+    fn drop(&mut self) {
+        self.0.set(false);
+    }
+}
 
 /// An interactive color picker with saturation panel, hue/alpha sliders, hex input, and swatches.
 #[derive(Default)]
@@ -79,6 +101,11 @@ impl Component for ColorPicker {
         let sat = Signal::new(initial.s);
         let val = Signal::new(initial.v);
         let alpha = Signal::new(initial.a);
+
+        // Raised while the `value_fn` binding at the bottom of this function is
+        // writing those four signals, so the coordinating effect can tell the
+        // picker restoring itself from an author editing it.
+        let applying_external = Rc::new(Cell::new(false));
 
         // Root container
         let size_class = match self.size.as_str() {
@@ -364,10 +391,23 @@ impl Component for ColorPicker {
         // (the caller already knows — they seeded `value:`). Firing on mount can
         // re-enter `flush_effects` from inside `run_effect`'s borrow_mut and panic
         // when the parent is mid-re-render. See GH #23.
+        //
+        // An external apply is the same principle carried to its conclusion: the
+        // caller knows every value it hands us, not just the first. And it is not
+        // one write but four — hue, then saturation, then value, then alpha —
+        // each flushing this effect synchronously. Reporting them would report
+        // three colours that nobody chose (the new hue against the old
+        // saturation, and so on) and, for a consumer that stores what it hears,
+        // re-enter the still-running apply with its own echo. So an external
+        // apply is atomic and silent, and only an author's act is reported. See
+        // GH #229.
         if let Some(ref onchange) = self.onchange {
             let onchange = onchange.clone();
+            let applying_external = applying_external.clone();
             let mut first_run = true;
             __scope.create_effect(move || {
+                // Read all four before any early return, so this effect stays
+                // subscribed to each of them whatever it decides to do.
                 let hsv = Hsva {
                     h: hue.get(),
                     s: sat.get(),
@@ -376,6 +416,9 @@ impl Component for ColorPicker {
                 };
                 if first_run {
                     first_run = false;
+                    return;
+                }
+                if applying_external.get() {
                     return;
                 }
                 onchange.invoke(format_color(hsv, color_format));
@@ -400,6 +443,11 @@ impl Component for ColorPicker {
                         || (parsed.v - current.v).abs() > 0.005
                         || (parsed.a - current.a).abs() > 0.005
                     {
+                        // These four writes are one apply: nothing is reported
+                        // until all of them have landed, and then nothing is —
+                        // the caller handed us this value. The guard drops on
+                        // the way out of the block, including on unwind.
+                        let _applying = ApplyGuard::raise(&applying_external);
                         hue.set(parsed.h);
                         sat.set(parsed.s);
                         val.set(parsed.v);
@@ -410,5 +458,31 @@ impl Component for ColorPicker {
         }
 
         root
+    }
+}
+
+#[cfg(test)]
+mod apply_guard_tests {
+    use super::*;
+
+    /// The flag falls even when the apply unwinds.
+    ///
+    /// The writes an `ApplyGuard` spans flush effects synchronously, so a panic
+    /// in any subscriber lands inside the guarded window. A flag left up there
+    /// would mute `onchange` permanently. The panic this test provokes is
+    /// deliberate — its message on stderr is expected output.
+    #[test]
+    fn the_flag_falls_when_an_apply_panics() {
+        let flag = Rc::new(Cell::new(false));
+
+        let raised = flag.clone();
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _applying = ApplyGuard::raise(&raised);
+            assert!(raised.get(), "raised for the duration of the apply");
+            panic!("a subscriber blew up mid-apply");
+        }));
+
+        assert!(outcome.is_err(), "the panic was not swallowed");
+        assert!(!flag.get(), "and the picker is not left muted");
     }
 }

--- a/crates/rinch-components/tests/color_picker_external_apply.rs
+++ b/crates/rinch-components/tests/color_picker_external_apply.rs
@@ -1,0 +1,339 @@
+//! ColorPicker: an external value arrives whole, and silently (#229).
+//!
+//! `value_fn` applies an incoming value by setting four independent signals in
+//! sequence, and the coordinating effect that fires `onchange` observes all
+//! four. Without a guard, every external apply emits `onchange` once per set —
+//! each carrying a mixture of new and old components — and a consumer that
+//! writes that emission back to the store `value_fn` reads re-enters the
+//! still-running apply.
+//!
+//! These tests drive the real component headlessly: `MockDomDocument` +
+//! `RenderScope` build the DOM, and the handler registry dispatches the same
+//! click/input events the shell dispatches.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use rinch_components::color_picker::ColorPicker;
+use rinch_components::color_utils::parse_color;
+use rinch_core::dom::traits::DomDocument;
+use rinch_core::dom::{NodeHandle, RenderScope, mock::MockDomDocument};
+use rinch_core::events::{
+    ClickContext, EventHandlerId, dispatch_event, dispatch_input_event, set_click_context,
+    update_drag,
+};
+use rinch_core::reactive::Effect;
+use rinch_core::{Component, InputCallback, Signal};
+
+/// Red at full saturation and value — the picker's own fallback, and a colour
+/// no component of the target shares.
+const START: &str = "#ff0000";
+/// The colour this defect was measured with: H 266.7° / S 0.69 / V 0.87.
+/// Arriving from [`START`], its mid-sequence mixtures are `#7100ff` (the new
+/// hue against the old saturation and value) then `#9d4eff`.
+const REMOTE: &str = "#8844dd";
+
+/// Whether the consumer writes each emission back to the bound store.
+///
+/// `Echo::Back` is the production shape this defect was measured in: a
+/// collaborative store that `value_fn` reads and `onchange` writes.
+#[derive(Clone, Copy, PartialEq)]
+enum Echo {
+    Back,
+    Never,
+}
+
+struct Picker {
+    // These three are kept alive for the test's duration: the document owns the
+    // nodes the effects patch, the scope owns the picker's effects and
+    // handlers, and the recorder observes the store.
+    _doc: Rc<RefCell<MockDomDocument>>,
+    _scope: RenderScope,
+    _recorder: Effect,
+    root: NodeHandle,
+    store: Signal<String>,
+    emissions: Rc<RefCell<Vec<String>>>,
+    published: Rc<RefCell<Vec<String>>>,
+}
+
+impl Picker {
+    /// A picker seeded with `initial` and bound to a store holding it too — the
+    /// well-formed call site.
+    fn mount(initial: &str, echo: Echo) -> Self {
+        Self::mount_with(initial, initial, echo)
+    }
+
+    /// A picker bound to a store but given no `value:` — the #229 call site.
+    /// It mounts on its internal fallback (pure red) and must adopt the bound
+    /// colour without reporting the fallback to anyone.
+    fn mount_bound_only(stored: &str, echo: Echo) -> Self {
+        Self::mount_with("", stored, echo)
+    }
+
+    fn mount_with(seed: &str, stored: &str, echo: Echo) -> Self {
+        let doc = Rc::new(RefCell::new(MockDomDocument::new()));
+        let body = doc.borrow().body();
+        let mut scope = RenderScope::new(doc.clone(), body);
+
+        let store = Signal::new(stored.to_string());
+        let emissions: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
+
+        // Every value the store ever holds — what a peer on the other end of a
+        // collaborative document would receive. Registered before the picker so
+        // it sees each write in order.
+        let published: Rc<RefCell<Vec<String>>> = Rc::new(RefCell::new(Vec::new()));
+        let recorded = published.clone();
+        let recorder = Effect::new(move || {
+            let value = store.get();
+            recorded.borrow_mut().push(value);
+        });
+
+        let seen = emissions.clone();
+        let picker = ColorPicker {
+            value: seed.to_string(),
+            value_fn: Some(Rc::new(move || store.get())),
+            onchange: Some(InputCallback::new(move |value: String| {
+                seen.borrow_mut().push(value.clone());
+                if echo == Echo::Back {
+                    store.set(value);
+                }
+            })),
+            alpha: true,
+            with_input: true,
+            swatches: vec!["#22aa55".into()],
+            ..Default::default()
+        };
+        let root = picker.render(&mut scope, &[]);
+
+        Self {
+            _doc: doc,
+            _scope: scope,
+            _recorder: recorder,
+            root,
+            store,
+            emissions,
+            published,
+        }
+    }
+
+    fn emissions(&self) -> Vec<String> {
+        self.emissions.borrow().clone()
+    }
+
+    fn published(&self) -> Vec<String> {
+        self.published.borrow().clone()
+    }
+
+    /// What the hex field shows — the picker's internal state, as an author reads it.
+    fn displayed(&self) -> String {
+        find_by_class(&self.root, "rinch-color-picker__hex-input")
+            .expect("hex input")
+            .get_attribute("value")
+            .expect("hex input has a value")
+    }
+
+    fn handler(&self, class: &str, attr: &str) -> EventHandlerId {
+        let node = find_by_class(&self.root, class).expect("element exists");
+        EventHandlerId(
+            node.get_attribute(attr)
+                .expect("element carries a handler id")
+                .parse()
+                .expect("handler id is numeric"),
+        )
+    }
+}
+
+fn find_by_class(node: &NodeHandle, class: &str) -> Option<NodeHandle> {
+    if node.get_attribute("class").as_deref() == Some(class) {
+        return Some(node.clone());
+    }
+    node.children().iter().find_map(|c| find_by_class(c, class))
+}
+
+/// A click at (`px`, `py`) of a 200×200 element at the origin.
+fn click_at(px: f32, py: f32) {
+    set_click_context(ClickContext {
+        mouse_x: px * 200.0,
+        mouse_y: py * 200.0,
+        element_x: 0.0,
+        element_y: 0.0,
+        element_width: 200.0,
+        element_height: 200.0,
+        ..Default::default()
+    });
+}
+
+fn hue_of(color: &str) -> f64 {
+    parse_color(color).expect("a formatted colour parses").h
+}
+
+/// An external value change is not a user act, so it emits nothing.
+///
+/// Pre-fix this emitted once per signal the apply wrote — `#7100ff`, `#9d4eff`,
+/// `#8844dd`, `#8844dd` — so two of the four colours it reported were mixtures
+/// nobody chose.
+#[test]
+fn an_external_value_change_emits_no_onchange() {
+    let picker = Picker::mount(START, Echo::Never);
+    assert!(picker.emissions().is_empty(), "mount is not a change");
+
+    picker.store.set(REMOTE.to_string());
+
+    assert_eq!(
+        picker.emissions(),
+        Vec::<String>::new(),
+        "an external apply must be silent: the caller already has this value"
+    );
+    assert_eq!(
+        picker.displayed(),
+        REMOTE,
+        "and it must land whole — every component applied"
+    );
+}
+
+/// The measured case: a peer's colour, with the consumer writing emissions back.
+///
+/// Pre-fix each mid-sequence emission was written to the store — so a peer's
+/// document momentarily carried `#7100ff` and `#9d4eff`, mixtures of the
+/// arriving hue with the local saturation and value, and each of those writes
+/// re-entered the still-running `value_fn` effect. Convergence is not the test:
+/// what the store *published* is, because every write is an edit peers see.
+#[test]
+fn a_peers_colour_arrives_without_publishing_mixtures() {
+    let picker = Picker::mount(START, Echo::Back);
+
+    picker.store.set(REMOTE.to_string());
+
+    assert_eq!(
+        picker.published(),
+        vec![START.to_string(), REMOTE.to_string()],
+        "the store must hold only what was authored: the seed, then the peer's colour"
+    );
+    assert_eq!(picker.displayed(), REMOTE);
+    assert!(
+        picker.emissions().is_empty(),
+        "nothing was authored here, so nothing is reported: {:?}",
+        picker.emissions()
+    );
+}
+
+/// A picker given only `value_fn` adopts the bound colour at mount, and reports
+/// nothing — least of all its own fallback.
+///
+/// This is #229's headline: pre-fix, mounting without `value:` reported the red
+/// fallback blended with the arriving colour, so a consumer that stores what it
+/// hears had its data rewritten by opening the picker.
+#[test]
+fn mounting_with_only_a_binding_adopts_it_silently() {
+    let picker = Picker::mount_bound_only(REMOTE, Echo::Back);
+
+    assert_eq!(
+        picker.displayed(),
+        REMOTE,
+        "the bound colour is what the picker shows"
+    );
+    assert!(
+        picker.emissions().is_empty(),
+        "mounting is not an edit: {:?}",
+        picker.emissions()
+    );
+    assert_eq!(
+        picker.published(),
+        vec![REMOTE.to_string()],
+        "and the bound data is untouched"
+    );
+}
+
+/// The guard is a window, not a state: an author's next act reports normally.
+#[test]
+fn a_user_act_after_an_external_apply_still_reports() {
+    let picker = Picker::mount(START, Echo::Back);
+    picker.store.set(REMOTE.to_string());
+
+    let hex = picker.handler("rinch-color-picker__hex-input", "data-oninput");
+    dispatch_input_event(hex, "#22aa55".to_string());
+
+    assert_eq!(
+        picker.emissions().last().map(String::as_str),
+        Some("#22aa55"),
+        "the picker is not muted by the apply that preceded this edit"
+    );
+    assert_eq!(picker.store.get(), "#22aa55");
+}
+
+/// A typed hex is a user act: it reports, and it commits to the store.
+#[test]
+fn a_hex_commit_reaches_the_consumer() {
+    let picker = Picker::mount(START, Echo::Back);
+    let hex = picker.handler("rinch-color-picker__hex-input", "data-oninput");
+
+    dispatch_input_event(hex, REMOTE.to_string());
+
+    assert_eq!(
+        picker.emissions().last().map(String::as_str),
+        Some(REMOTE),
+        "the committed colour is what the consumer last heard"
+    );
+    assert_eq!(picker.store.get(), REMOTE);
+    assert_eq!(picker.displayed(), REMOTE);
+}
+
+/// A swatch click is a user act: same contract as the hex field.
+#[test]
+fn a_swatch_click_reaches_the_consumer() {
+    let picker = Picker::mount(START, Echo::Back);
+    let swatch = find_by_class(&picker.root, "rinch-color-picker__swatches")
+        .expect("swatches grid")
+        .children()
+        .first()
+        .expect("one swatch")
+        .clone();
+    let id = EventHandlerId(
+        swatch
+            .get_attribute("data-rid")
+            .expect("swatch is clickable")
+            .parse()
+            .expect("handler id is numeric"),
+    );
+
+    click_at(0.5, 0.5);
+    dispatch_event(id);
+
+    assert_eq!(
+        picker.emissions().last().map(String::as_str),
+        Some("#22aa55")
+    );
+    assert_eq!(picker.store.get(), "#22aa55");
+}
+
+/// A saturation drag reports every frame, and does not lose the hue it started
+/// from. (Hue *is* re-derived from the round trip below s·v ≈ 0.235 — issue
+/// #227, untouched here; this drag stays well above that.)
+#[test]
+fn a_saturation_drag_reports_each_frame_and_keeps_its_hue() {
+    let picker = Picker::mount(REMOTE, Echo::Back);
+    let overlay = picker.handler("rinch-color-picker__saturation-overlay", "data-rid");
+
+    click_at(0.8, 0.1); // s = 0.8, v = 0.9
+    dispatch_event(overlay);
+    let after_press = picker.emissions().len();
+    assert!(after_press > 0, "the press itself is a change");
+
+    update_drag(120.0, 40.0); // s = 0.6, v = 0.8
+    assert!(
+        picker.emissions().len() > after_press,
+        "each drag frame reports"
+    );
+
+    let last = picker.emissions().last().cloned().expect("an emission");
+    assert_eq!(
+        picker.store.get(),
+        last,
+        "the store holds what was reported"
+    );
+    assert_eq!(picker.displayed(), last, "and the field agrees");
+    assert!(
+        (hue_of(&last) - hue_of(REMOTE)).abs() < 1.0,
+        "dragging saturation must not move the hue: {last}"
+    );
+}

--- a/crates/rinch-components/tests/color_picker_external_apply.rs
+++ b/crates/rinch-components/tests/color_picker_external_apply.rs
@@ -144,7 +144,10 @@ impl Picker {
 }
 
 fn find_by_class(node: &NodeHandle, class: &str) -> Option<NodeHandle> {
-    if node.get_attribute("class").as_deref() == Some(class) {
+    let matches = node
+        .get_attribute("class")
+        .is_some_and(|attr| attr.split_whitespace().any(|c| c == class));
+    if matches {
         return Some(node.clone());
     }
     node.children().iter().find_map(|c| find_by_class(c, class))
@@ -254,14 +257,19 @@ fn a_user_act_after_an_external_apply_still_reports() {
     dispatch_input_event(hex, "#22aa55".to_string());
 
     assert_eq!(
-        picker.emissions().last().map(String::as_str),
-        Some("#22aa55"),
-        "the picker is not muted by the apply that preceded this edit"
+        picker.emissions(),
+        vec!["#22aa55".to_string()],
+        "the picker is not muted by the apply that preceded this edit — and \
+         the silent apply emitted nothing"
     );
     assert_eq!(picker.store.get(), "#22aa55");
 }
 
-/// A typed hex is a user act: it reports, and it commits to the store.
+/// A typed hex is a user act: it reports once, whole, and commits to the store.
+///
+/// One commit is one transition (the four component writes are batched), so
+/// exactly one colour is reported — never the per-component mixtures
+/// (`#7100ff`, `#9d4eff`) an unbatched sequence would leak to the consumer.
 #[test]
 fn a_hex_commit_reaches_the_consumer() {
     let picker = Picker::mount(START, Echo::Back);
@@ -270,9 +278,14 @@ fn a_hex_commit_reaches_the_consumer() {
     dispatch_input_event(hex, REMOTE.to_string());
 
     assert_eq!(
-        picker.emissions().last().map(String::as_str),
-        Some(REMOTE),
-        "the committed colour is what the consumer last heard"
+        picker.emissions(),
+        vec![REMOTE.to_string()],
+        "one commit reports once, with the completed colour"
+    );
+    assert_eq!(
+        picker.published(),
+        vec![START.to_string(), REMOTE.to_string()],
+        "and the store never held a colour nobody typed"
     );
     assert_eq!(picker.store.get(), REMOTE);
     assert_eq!(picker.displayed(), REMOTE);
@@ -300,8 +313,9 @@ fn a_swatch_click_reaches_the_consumer() {
     dispatch_event(id);
 
     assert_eq!(
-        picker.emissions().last().map(String::as_str),
-        Some("#22aa55")
+        picker.emissions(),
+        vec!["#22aa55".to_string()],
+        "one click reports once, with the swatch's colour"
     );
     assert_eq!(picker.store.get(), "#22aa55");
 }
@@ -316,13 +330,17 @@ fn a_saturation_drag_reports_each_frame_and_keeps_its_hue() {
 
     click_at(0.8, 0.1); // s = 0.8, v = 0.9
     dispatch_event(overlay);
-    let after_press = picker.emissions().len();
-    assert!(after_press > 0, "the press itself is a change");
+    assert_eq!(
+        picker.emissions().len(),
+        1,
+        "the press is one change: saturation and value land together"
+    );
 
     update_drag(120.0, 40.0); // s = 0.6, v = 0.8
-    assert!(
-        picker.emissions().len() > after_press,
-        "each drag frame reports"
+    assert_eq!(
+        picker.emissions().len(),
+        2,
+        "each drag frame reports exactly once"
     );
 
     let last = picker.emissions().last().cloned().expect("an emission");

--- a/crates/rinch-dom/src/paint/skia_painter.rs
+++ b/crates/rinch-dom/src/paint/skia_painter.rs
@@ -330,7 +330,7 @@ impl TinySkiaPainter {
             let row_start = (row * pw + x0) as usize * 4;
             let row_end = (row * pw + x1) as usize * 4;
             let row_data = &mut data[row_start..row_end];
-            for pixel in row_data.chunks_exact_mut(4) {
+            for pixel in row_data.as_chunks_mut::<4>().0 {
                 pixel[0] = r;
                 pixel[1] = g;
                 pixel[2] = b;
@@ -389,7 +389,7 @@ impl TinySkiaPainter {
         // Create a pixmap from the source RGBA data.
         // tiny-skia expects premultiplied alpha, so premultiply in-place.
         let mut premul = pixels[..expected].to_vec();
-        for chunk in premul.chunks_exact_mut(4) {
+        for chunk in premul.as_chunks_mut::<4>().0 {
             let a = chunk[3] as u16;
             if a == 0 {
                 chunk[0] = 0;

--- a/crates/rinch-video/src/native/mpv_player.rs
+++ b/crates/rinch-video/src/native/mpv_player.rs
@@ -331,7 +331,7 @@ impl MpvPlayer {
         self.do_sw_render(buf.as_mut_ptr(), w, h, stride);
 
         // Fix alpha channel: rgb0 format gives A=0, we need A=255 for opaque video
-        for pixel in buf.chunks_exact_mut(4) {
+        for pixel in buf.as_chunks_mut::<4>().0 {
             pixel[3] = 255;
         }
 

--- a/crates/rinch-webrtc/src/native/audio_codec.rs
+++ b/crates/rinch-webrtc/src/native/audio_codec.rs
@@ -132,7 +132,7 @@ fn run_encoder(
                     && config.channels == 1
                 {
                     // Stereo to mono downmix.
-                    for pair in chunk.samples.chunks_exact(2) {
+                    for pair in chunk.samples.as_chunks::<2>().0 {
                         pending.push((pair[0] + pair[1]) * 0.5);
                     }
                 } else if chunk.channels != config.channels

--- a/crates/rinch/src/shell/screenshot.rs
+++ b/crates/rinch/src/shell/screenshot.rs
@@ -83,7 +83,7 @@ pub fn capture_texture_rgba(
         match format {
             TextureFormat::Bgra8Unorm | TextureFormat::Bgra8UnormSrgb => {
                 // BGRA -> RGBA
-                for pixel in row_data.chunks_exact(4) {
+                for pixel in row_data.as_chunks::<4>().0 {
                     rgba.push(pixel[2]); // R
                     rgba.push(pixel[1]); // G
                     rgba.push(pixel[0]); // B

--- a/crates/rinch/src/tray.rs
+++ b/crates/rinch/src/tray.rs
@@ -201,7 +201,7 @@ impl TrayIconBuilder {
         // Convert RGBA → ARGB32 (network byte order) for ksni.
         let icon_pixmap = if let Some((rgba, width, height)) = icon_data {
             let mut argb = Vec::with_capacity(rgba.len());
-            for pixel in rgba.chunks_exact(4) {
+            for pixel in rgba.as_chunks::<4>().0 {
                 argb.push(pixel[3]); // A
                 argb.push(pixel[0]); // R
                 argb.push(pixel[1]); // G

--- a/docs/src/guide/component-props.md
+++ b/docs/src/guide/component-props.md
@@ -352,10 +352,12 @@ Interactive color picker with saturation panel, hue/alpha sliders, hex input, an
 
 **`onchange` reports author edits only.** A value arriving through `value_fn` — a
 peer's edit, a programmatic set — is adopted silently: the picker applies all
-four of its internal components (hue, saturation, value, alpha) and fires
-nothing, because the caller already has that value. Only a drag, a typed hex or
-a swatch click reports. This is what lets a consumer bind `value_fn` to the same
-store `onchange` writes without the two chasing each other.
+four of its internal components (hue, saturation, value, alpha) as one batched
+transition and fires nothing, because the caller already has that value. Only a
+drag, a typed hex or a swatch click reports — once per act, with the completed
+colour, never a partially-applied mixture. This is what lets a consumer bind
+`value_fn` to the same store `onchange` writes without the two chasing each
+other.
 
 ### ColorInput
 

--- a/docs/src/guide/component-props.md
+++ b/docs/src/guide/component-props.md
@@ -350,6 +350,13 @@ Interactive color picker with saturation panel, hue/alpha sliders, hex input, an
 | `size` | `String` | `"md"` | Size: sm, md, lg, xl |
 | `with_input` | `bool` | `false` | Show hex text input |
 
+**`onchange` reports author edits only.** A value arriving through `value_fn` — a
+peer's edit, a programmatic set — is adopted silently: the picker applies all
+four of its internal components (hue, saturation, value, alpha) and fires
+nothing, because the caller already has that value. Only a drag, a typed hex or
+a swatch click reports. This is what lets a consumer bind `value_fn` to the same
+store `onchange` writes without the two chasing each other.
+
 ### ColorInput
 
 Text input with inline color preview and dropdown ColorPicker.

--- a/examples/game-embed/src/main.rs
+++ b/examples/game-embed/src/main.rs
@@ -919,7 +919,7 @@ impl App {
         // ── Rinch UI update + render to texture ─────────────────────────────
 
         let ctx = self.rinch_ctx.as_mut().unwrap();
-        let events: Vec<_> = self.pending_events.drain(..).collect();
+        let events = std::mem::take(&mut self.pending_events);
         let _actions = ctx.update(&events);
         let scene = ctx.scene();
 

--- a/examples/paint/src/lib.rs
+++ b/examples/paint/src/lib.rs
@@ -63,7 +63,7 @@ impl PaintState {
     fn new() -> Self {
         let size = (CANVAS_W * CANVAS_H * 4) as usize;
         let mut canvas = vec![255u8; size];
-        for chunk in canvas.chunks_exact_mut(4) {
+        for chunk in canvas.as_chunks_mut::<4>().0 {
             chunk[3] = 255;
         }
         Self {
@@ -116,7 +116,7 @@ impl PaintState {
 
     fn clear(&mut self) {
         self.push_undo();
-        for chunk in self.canvas.chunks_exact_mut(4) {
+        for chunk in self.canvas.as_chunks_mut::<4>().0 {
             chunk[0] = 255;
             chunk[1] = 255;
             chunk[2] = 255;

--- a/examples/video-call/src/main.rs
+++ b/examples/video-call/src/main.rs
@@ -159,7 +159,7 @@ fn RemoteVideo() -> NodeHandle {
     surface.set_render_callback(|writer, w, h| {
         // Dark background when no remote video
         let mut pixels = vec![0u8; (w * h * 4) as usize];
-        for chunk in pixels.chunks_exact_mut(4) {
+        for chunk in pixels.as_chunks_mut::<4>().0 {
             chunk[0] = 30;
             chunk[1] = 30;
             chunk[2] = 30;


### PR DESCRIPTION
## The mechanism

`ColorPicker` keeps its colour in four independent signals — `hue`, `sat`, `val`, `alpha` — and two effects meet on them:

- the **coordinating effect** observes all four and fires `onchange` whenever any one of them changes;
- the **`value_fn` effect** applies an incoming external value by writing all four, in sequence.

Outside a `batch`, a signal write flushes effects synchronously. So an external apply is not one transition, it is four, and the coordinating effect reports each one — three of them mid-sequence, each a colour nobody chose: the arriving hue against the local saturation and value, then that plus the new saturation, and so on.

Driven headless from red to `#8844dd` (H 266.7 / S 0.69 / V 0.87), the picker emits:

```
#7100ff   <- new hue, old saturation and value
#9d4eff   <- new hue and saturation, old value
#8844dd
#8844dd
```

A consumer that writes what it hears into a store then *publishes* those two mixtures as real edits, which on a collaborative document every peer receives. That is the same store `value_fn` reads, so each of those writes also re-enters the `value_fn` effect that is still running:

- **at `1d2b70e`** (the rev this was measured against in a browser) `run_effect` held a hard `borrow_mut`, so the re-entry was `panicked at rinch-core/src/reactive/effect.rs:180: RefCell already borrowed`. A local drag panicked on its first move, the hue slider snapped back, a typed hex never committed, and a peer's `#8844dd` came back as `#7129cc` — hue applied, saturation and value stale.
- **on `main`** the re-entrant run is skipped instead of fatal (#141 PR4, `25bd954`), so the crash is gone — but the apply it interrupted is simply abandoned, and the mixtures are still emitted and still published. The data defect outlived the crash.

## The fix

A flag shared between the two effects, raised for the duration of the four writes. The coordinating effect still observes all four signals and still runs; it just does not report while the flag is up.

The component already stated the principle for its first run — `onchange` reports *changes*, not state the caller handed us (the existing "the caller already knows — they seeded `value:`" comment, GH #23). An external apply is that principle carried to its conclusion: the caller knows every value it gives us, not just the first. So an external apply is one atomic, silent transition, and only an author's act — a drag, a typed hex, a swatch click — reports, exactly as before.

The flag is an RAII guard rather than a set/clear pair: the writes it spans run arbitrary subscriber code, and a panic in there must not leave the picker muted for the rest of the session.

**The four signals stay four.** Collapsing them into one `Signal<Hsva>` would also end the mixtures, but it would erase the hue and saturation the picker holds independently of what 8-bit RGB can represent — the degrees of freedom #227 is about.

## What is tested

`crates/rinch-components/tests/color_picker_external_apply.rs` drives the real component headless: `MockDomDocument` + `RenderScope` build the DOM, and the handler registry dispatches the same click/input events the shell does. **Three of its seven cases fail on the parent commit** (`0d5fb37`); the other four are controls that must not change.

| Case | Pins |
|---|---|
| `an_external_value_change_emits_no_onchange` | an external apply reports nothing, and lands whole |
| `a_peers_colour_arrives_without_publishing_mixtures` | with a store-writing consumer, the store publishes only `#ff0000` then `#8844dd` — no mixtures reach a peer |
| `mounting_with_only_a_binding_adopts_it_silently` | a picker given `value_fn` but no `value:` adopts the bound colour instead of reporting its red fallback (#229's call site) |
| `a_hex_commit_reaches_the_consumer` | control: a typed hex still reports and still commits |
| `a_swatch_click_reaches_the_consumer` | control: a swatch click still reports |
| `a_saturation_drag_reports_each_frame_and_keeps_its_hue` | control: a drag still reports per frame, and its hue survives |
| `a_user_act_after_an_external_apply_still_reports` | the guard is a window, not a state — the picker is not muted afterwards |

Plus a unit test in `color_picker.rs` for the guard's unwind contract (the flag falls even if an apply panics).

**What only a browser proves:** the panic itself. On `main`, that re-entry is already a skip rather than a `borrow_mut`, so no in-tree test can reach `effect.rs:180` — the crash is reproducible only at `1d2b70e`, along with its visible consequences (the popover rendering empty, the hue thumb snapping back mid-drag). What the tests do pin is the mechanism that *caused* the re-entry, which is also the data defect that survived PR4.

Gates: `cargo test --workspace --release` and `cargo clippy --workspace --all-targets --release` clean.

## Scope

Refs #229. This discharges its second ask — the `value_fn`-without-`value` combination is now well-defined: the picker adopts the bound colour and never writes its fallback back. Its first ask (the reactive runtime should not be panickable by a component's own effects) was answered independently by #141 PR4, which turned that re-entry into a skip. I have not marked the issue `Fixes`, since this PR does not touch the runtime — close it if you agree both halves are now covered.

**Does not address #227** (hue re-derived from a lossy round trip below s·v ≈ 0.235). The `value_fn` effect's compare-against-round-trip logic is untouched, and `a_saturation_drag_reports_each_frame_and_keeps_its_hue` drags well above that threshold specifically so this PR cannot mask or worsen it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
