### PR TITLE
fix(rinch): #228 — a tabindex node takes real focus, so Tab moves on and Enter/Space activate it

### DIFF
--- a/crates/rinch-dom/src/dom_impl/mod.rs
+++ b/crates/rinch-dom/src/dom_impl/mod.rs
@@ -71,6 +71,16 @@ pub struct RinchDocument {
     pub(crate) theme_stylesheet: Option<style::stylesheets::DocumentStyleSheet>,
     /// App author stylesheets, in insertion (source) order.
     pub(crate) author_stylesheets: Vec<style::stylesheets::DocumentStyleSheet>,
+    /// Whether any loaded stylesheet has a rule whose rightmost compound is a
+    /// bare focus pseudo-class (`:focus` / `:focus-visible` / `:focus-within`
+    /// with no tag/class/id/attribute anchor) — e.g. the theme's
+    /// `:focus-visible { outline: ... }`. Stylo buckets such rules into a
+    /// state-gated `rare_pseudo_classes` map that is only consulted while the
+    /// element ALREADY has focus state, so `focus_sensitive` can never be set
+    /// on an unfocused node by them; focus changes must then invalidate
+    /// unconditionally (see `node_is_focus_sensitive`). Recomputed whenever a
+    /// stylesheet is loaded or the theme sheet is replaced.
+    pub(crate) has_bare_focus_rules: bool,
 }
 
 impl Default for RinchDocument {
@@ -132,6 +142,7 @@ impl RinchDocument {
             stylist,
             theme_stylesheet: None,
             author_stylesheets: Vec::new(),
+            has_bare_focus_rules: false,
         };
 
         // Set up default file-based image loader

--- a/crates/rinch-dom/src/node.rs
+++ b/crates/rinch-dom/src/node.rs
@@ -254,7 +254,9 @@ pub struct Node {
     pub computed_style_str: String,
     /// Whether this node is currently under the cursor (for CSS :hover).
     pub is_hovered: bool,
-    /// Whether this node or an ancestor has focus (for CSS :focus).
+    /// Whether this node is the focused node (for CSS :focus). Set on exactly
+    /// one node — `update_focus` never propagates it to ancestors (unlike
+    /// `update_active`).
     pub is_focused: bool,
     /// Whether focus arrived via the keyboard (for CSS :focus-visible).
     /// Only ever set on the focused node: Tab-driven focus sets it,

--- a/crates/rinch-dom/src/node.rs
+++ b/crates/rinch-dom/src/node.rs
@@ -256,6 +256,10 @@ pub struct Node {
     pub is_hovered: bool,
     /// Whether this node or an ancestor has focus (for CSS :focus).
     pub is_focused: bool,
+    /// Whether focus arrived via the keyboard (for CSS :focus-visible).
+    /// Only ever set on the focused node: Tab-driven focus sets it,
+    /// pointer-driven focus clears it, and losing focus clears it.
+    pub is_focus_visible: bool,
     /// Whether this node is currently being pressed (for CSS :active).
     pub is_active: bool,
     /// Whether this is an anonymous block box created by the layout engine.
@@ -348,6 +352,7 @@ impl Node {
             computed_style_str: String::new(),
             is_hovered: false,
             is_focused: false,
+            is_focus_visible: false,
             is_active: false,
             is_anonymous_block_box: false,
             is_pseudo_element: false,
@@ -392,6 +397,7 @@ impl Node {
             computed_style_str: String::new(),
             is_hovered: false,
             is_focused: false,
+            is_focus_visible: false,
             is_active: false,
             is_anonymous_block_box: false,
             is_pseudo_element: false,
@@ -435,6 +441,7 @@ impl Node {
             computed_style_str: String::new(),
             is_hovered: false,
             is_focused: false,
+            is_focus_visible: false,
             is_active: false,
             is_anonymous_block_box: false,
             is_pseudo_element: false,
@@ -476,6 +483,7 @@ impl Node {
             computed_style_str: String::new(),
             is_hovered: false,
             is_focused: false,
+            is_focus_visible: false,
             is_active: false,
             is_anonymous_block_box: false,
             is_pseudo_element: false,

--- a/crates/rinch-dom/src/style_resolution/mod.rs
+++ b/crates/rinch-dom/src/style_resolution/mod.rs
@@ -195,6 +195,109 @@ impl RinchDocument {
         // Mark stylesheets as changed so they'll be flushed on next style computation
         self.stylist
             .force_stylesheet_origins_dirty(Origin::Author.into());
+
+        self.recompute_bare_focus_rules();
+    }
+
+    /// Recompute [`Self::has_bare_focus_rules`] over the theme sheet and every
+    /// app author sheet. See the field's doc for why bare (unanchored) focus
+    /// selectors defeat the `focus_sensitive` invalidation scheme: stylo's
+    /// `SelectorMap` puts them in a bucket that is only consulted while the
+    /// element already has focus state, so matching never reaches them on an
+    /// unfocused node. (The UA sheet is not scanned — it carries no focus
+    /// rules.)
+    fn recompute_bare_focus_rules(&mut self) {
+        let sheets: Vec<style::stylesheets::DocumentStyleSheet> = self
+            .theme_stylesheet
+            .iter()
+            .chain(self.author_stylesheets.iter())
+            .cloned()
+            .collect();
+        let guard = self.tree.guard.read();
+        let found = sheets.iter().any(|sheet| {
+            let contents = sheet.0.contents.read_with(&guard);
+            Self::rules_have_bare_focus(contents.rules(&guard), &guard)
+        });
+        drop(guard);
+        self.has_bare_focus_rules = found;
+    }
+
+    /// Whether any style rule in `rules` (recursing into `@media` / `@supports`)
+    /// has a selector whose rightmost compound contains a focus pseudo-class and
+    /// no tag/class/id/attribute anchor — the shape stylo buckets into the
+    /// state-gated `rare_pseudo_classes` map.
+    fn rules_have_bare_focus(
+        rules: &[style::stylesheets::CssRule],
+        guard: &style::shared_lock::SharedRwLockReadGuard,
+    ) -> bool {
+        use style::stylesheets::CssRule;
+        rules.iter().any(|rule| match rule {
+            CssRule::Style(locked) => {
+                let style_rule = locked.read_with(guard);
+                style_rule
+                    .selectors
+                    .slice()
+                    .iter()
+                    .any(Self::selector_is_bare_focus)
+            }
+            CssRule::Media(media) => {
+                Self::rules_have_bare_focus(&media.rules.read_with(guard).0, guard)
+            }
+            CssRule::Supports(supports) => {
+                Self::rules_have_bare_focus(&supports.rules.read_with(guard).0, guard)
+            }
+            _ => false,
+        })
+    }
+
+    /// Whether a selector's rightmost compound contains a focus pseudo-class
+    /// (`:focus`, `:focus-visible`, `:focus-within` — directly or inside
+    /// `:not()`/`:is()`/`:where()`) without any tag/class/id/attribute/`:root`
+    /// anchor. Over-matching here is safe (it only costs an extra invalidation
+    /// on focus change); under-matching re-introduces the never-restyled ring.
+    fn selector_is_bare_focus(
+        selector: &selectors::parser::Selector<style::selector_parser::SelectorImpl>,
+    ) -> bool {
+        use selectors::parser::Component;
+        use style::selector_parser::NonTSPseudoClass;
+
+        fn component_has_focus(c: &Component<style::selector_parser::SelectorImpl>) -> bool {
+            match c {
+                Component::NonTSPseudoClass(pc) => matches!(
+                    pc,
+                    NonTSPseudoClass::Focus
+                        | NonTSPseudoClass::FocusVisible
+                        | NonTSPseudoClass::FocusWithin
+                ),
+                Component::Negation(list) | Component::Is(list) | Component::Where(list) => list
+                    .slice()
+                    .iter()
+                    .any(|s| s.iter().any(component_has_focus)),
+                _ => false,
+            }
+        }
+
+        let mut anchored = false;
+        let mut has_focus = false;
+        // `iter()` walks the rightmost compound only (stops at the first
+        // combinator), which is exactly the compound stylo buckets by.
+        for component in selector.iter() {
+            match component {
+                Component::LocalName(_)
+                | Component::ID(_)
+                | Component::Class(_)
+                | Component::AttributeInNoNamespaceExists { .. }
+                | Component::AttributeInNoNamespace { .. }
+                | Component::AttributeOther(_)
+                | Component::Root => anchored = true,
+                other => {
+                    if component_has_focus(other) {
+                        has_focus = true;
+                    }
+                }
+            }
+        }
+        has_focus && !anchored
     }
 
     /// Install (or replace) the theme stylesheet.
@@ -236,6 +339,8 @@ impl RinchDocument {
 
         self.stylist
             .force_stylesheet_origins_dirty(Origin::Author.into());
+
+        self.recompute_bare_focus_rules();
     }
 
     /// Get the default display type for a node based on its tag.

--- a/crates/rinch-dom/src/style_resolution/state_tracking.rs
+++ b/crates/rinch-dom/src/style_resolution/state_tracking.rs
@@ -130,11 +130,13 @@ impl RinchDocument {
             return false;
         }
 
-        // Clear old focus state
+        // Clear old focus state. A blurred node can't show the keyboard focus
+        // ring, so :focus-visible drops with :focus.
         if let Some(old_id) = old_focused
             && let Some(node) = self.tree.nodes.get_mut(old_id)
         {
             node.is_focused = false;
+            node.is_focus_visible = false;
         }
 
         // Set new focus state
@@ -166,6 +168,26 @@ impl RinchDocument {
         }
 
         needs_repaint
+    }
+
+    /// Set or clear the keyboard focus ring (CSS `:focus-visible`) on a node.
+    /// Tab-driven focus sets it; pointer-driven focus clears it (`update_focus`
+    /// is a no-op when the clicked node already holds focus, so the pointer
+    /// path clears the ring through here). Invalidates styles only when some
+    /// CSS rule depends on this node's focus state.
+    ///
+    /// Returns `true` if a repaint is needed.
+    pub fn set_focus_visible(&mut self, node_id: usize, visible: bool) -> bool {
+        match self.tree.nodes.get_mut(node_id) {
+            Some(node) if node.is_focus_visible != visible => node.is_focus_visible = visible,
+            _ => return false,
+        }
+        if self.node_is_focus_sensitive(node_id) {
+            self.invalidate_hover_node(node_id);
+            self.tree.styles_dirty = true;
+            return true;
+        }
+        false
     }
 
     /// Update active (mouse-pressed) state: set the active node and its

--- a/crates/rinch-dom/src/style_resolution/state_tracking.rs
+++ b/crates/rinch-dom/src/style_resolution/state_tracking.rs
@@ -102,10 +102,20 @@ impl RinchDocument {
     }
 
     fn node_is_focus_sensitive(&self, id: usize) -> bool {
-        self.tree
-            .nodes
-            .get(id)
-            .is_some_and(|n| n.focus_sensitive.get())
+        // The per-node flag is set by Stylo *matching* a focus pseudo-class
+        // against the node — but a rule whose rightmost compound is a bare
+        // focus pseudo (the theme's `:focus-visible { outline }`) lives in
+        // stylo's state-gated `rare_pseudo_classes` bucket, which is skipped
+        // entirely while the node is unfocused. The flag can then never be set
+        // before the first focus arrives, so with such rules loaded every node
+        // must be treated as focus-sensitive or the ring never paints
+        // (`has_bare_focus_rules`, recomputed on stylesheet load).
+        self.has_bare_focus_rules
+            || self
+                .tree
+                .nodes
+                .get(id)
+                .is_some_and(|n| n.focus_sensitive.get())
     }
 
     fn invalidate_hover_node(&mut self, id: usize) {

--- a/crates/rinch-dom/src/stylo_impl.rs
+++ b/crates/rinch-dom/src/stylo_impl.rs
@@ -373,6 +373,13 @@ impl<'a> Element for RinchNode<'a> {
                 self.node().focus_sensitive.set(true);
                 self.node().is_focused
             }
+            NonTSPseudoClass::FocusVisible => {
+                // Shares `focus_sensitive`: the flag only ever changes on the
+                // (gaining/losing) focused node, so focus-change invalidation
+                // covers :focus-visible rules too.
+                self.node().focus_sensitive.set(true);
+                self.node().is_focus_visible
+            }
             NonTSPseudoClass::Enabled => true,
             NonTSPseudoClass::Disabled => false,
             NonTSPseudoClass::Checked => {
@@ -556,6 +563,9 @@ impl<'a> TElement for RinchNode<'a> {
         }
         if self.node().is_focused {
             state |= ElementState::FOCUS;
+        }
+        if self.node().is_focus_visible {
+            state |= ElementState::FOCUSRING;
         }
         if self.node().is_active {
             state |= ElementState::ACTIVE;

--- a/crates/rinch-dom/tests/computed_style_tests.rs
+++ b/crates/rinch-dom/tests/computed_style_tests.rs
@@ -855,3 +855,53 @@ fn removing_attribute_restyles_the_node() {
         "removing [data-hl] must drop the highlight background"
     );
 }
+
+/// #228: a `:focus-visible` rule applies only while the keyboard focus ring
+/// flag is set — pointer-driven `:focus` alone must not match it, and clearing
+/// the flag must drop the rule again.
+#[test]
+fn focus_visible_rule_needs_the_keyboard_flag() {
+    let mut doc = RinchDocument::new();
+    doc.load_css("div:focus-visible { outline-width: 3px; outline-style: solid; }");
+    let body = doc.body();
+    let div = doc.create_element("div");
+    doc.set_attribute(div, "style", "width: 100px; height: 100px");
+    doc.set_attribute(div, "tabindex", "0");
+    doc.append_child(body, div);
+    doc.resolve_layout(800.0, 600.0);
+    let outline = |doc: &RinchDocument| doc.tree.get(div.0).unwrap().computed_style.outline_width;
+    assert_eq!(outline(&doc), 0.0, "unfocused: no ring");
+
+    // Pointer-driven focus: :focus only.
+    doc.update_focus(Some(div.0));
+    doc.resolve_layout(800.0, 600.0);
+    assert_eq!(
+        outline(&doc),
+        0.0,
+        ":focus alone must not match :focus-visible"
+    );
+
+    // Keyboard-driven focus sets the ring flag.
+    doc.set_focus_visible(div.0, true);
+    doc.resolve_layout(800.0, 600.0);
+    assert_eq!(
+        outline(&doc),
+        3.0,
+        "keyboard focus must match :focus-visible"
+    );
+
+    // Pointer interaction clears it again.
+    doc.set_focus_visible(div.0, false);
+    doc.resolve_layout(800.0, 600.0);
+    assert_eq!(outline(&doc), 0.0, "clearing the flag must drop the ring");
+
+    // And losing focus clears the flag itself.
+    doc.set_focus_visible(div.0, true);
+    doc.update_focus(None);
+    doc.resolve_layout(800.0, 600.0);
+    assert_eq!(outline(&doc), 0.0, "blur must drop the ring with the focus");
+    assert!(
+        !doc.tree.get(div.0).unwrap().is_focus_visible,
+        "update_focus(None) must clear is_focus_visible on the old node"
+    );
+}

--- a/crates/rinch-dom/tests/computed_style_tests.rs
+++ b/crates/rinch-dom/tests/computed_style_tests.rs
@@ -905,3 +905,38 @@ fn focus_visible_rule_needs_the_keyboard_flag() {
         "update_focus(None) must clear is_focus_visible on the old node"
     );
 }
+
+/// The theme's focus ring is a *bare* `:focus-visible { ... }` rule — stylo
+/// buckets it into a state-gated `rare_pseudo_classes` map that is never
+/// consulted for an unfocused node, so `focus_sensitive` cannot be set ahead
+/// of the first focus. The `has_bare_focus_rules` fallback must invalidate
+/// anyway or the default theme's ring never paints on the first Tab. (The
+/// test above sidesteps this with `div:focus-visible`, which buckets by tag.)
+#[test]
+fn bare_focus_visible_rule_paints_on_first_focus() {
+    let mut doc = RinchDocument::new();
+    doc.load_css(":focus-visible { outline-width: 2px; outline-style: solid; }");
+    let body = doc.body();
+    let div = doc.create_element("div");
+    doc.set_attribute(div, "style", "width: 100px; height: 100px");
+    doc.set_attribute(div, "tabindex", "0");
+    doc.append_child(body, div);
+    doc.resolve_layout(800.0, 600.0);
+    let outline = |doc: &RinchDocument| doc.tree.get(div.0).unwrap().computed_style.outline_width;
+    assert_eq!(outline(&doc), 0.0, "unfocused: no ring");
+
+    // First keyboard focus this node has ever seen: with the bare rule in a
+    // state-gated bucket, only the has_bare_focus_rules fallback invalidates.
+    doc.update_focus(Some(div.0));
+    doc.set_focus_visible(div.0, true);
+    doc.resolve_layout(800.0, 600.0);
+    assert_eq!(
+        outline(&doc),
+        2.0,
+        "a bare :focus-visible ring must paint on the FIRST focus"
+    );
+
+    doc.update_focus(None);
+    doc.resolve_layout(800.0, 600.0);
+    assert_eq!(outline(&doc), 0.0, "blur drops the bare ring");
+}

--- a/crates/rinch/src/app/click_handling.rs
+++ b/crates/rinch/src/app/click_handling.rs
@@ -257,6 +257,21 @@ impl RinchApp {
             None
         };
 
+        // A click on or inside a keyboard-focused generic node keeps its focus
+        // (the ring already dropped on mousedown); a click elsewhere blurs it.
+        let hit_inside_focused_node = if let FocusTarget::Node(fid) = self.focus_target {
+            let mut cur = Some(hit_id);
+            loop {
+                match cur {
+                    Some(nid) if nid == fid => break true,
+                    Some(nid) => cur = d.tree.get(nid).and_then(|n| n.parent),
+                    None => break false,
+                }
+            }
+        } else {
+            false
+        };
+
         // Drop the borrow before calling methods that re-borrow self.doc
         drop(d);
 
@@ -276,14 +291,16 @@ impl RinchApp {
             self.focused_input_state = Some(state);
             self.sync_input_cursor_to_dom();
             self.scene_dirty = true;
-        } else if matches!(
-            self.focus_target,
-            FocusTarget::Input(_) | FocusTarget::Surface(_)
-        ) {
-            // Clicked a non-input target: drop input/surface focus. Editor focus is
-            // preserved here so its toolbar buttons (data-rid, dispatched below) keep
-            // working; an empty/non-toolbar click already blurred the editor in
-            // Phase 2 (`ClickFocus::Blur`).
+        } else if !hit_inside_focused_node
+            && matches!(
+                self.focus_target,
+                FocusTarget::Input(_) | FocusTarget::Surface(_) | FocusTarget::Node(_)
+            )
+        {
+            // Clicked a non-input target: drop input/surface/generic-node focus.
+            // Editor focus is preserved here so its toolbar buttons (data-rid,
+            // dispatched below) keep working; an empty/non-toolbar click already
+            // blurred the editor in Phase 2 (`ClickFocus::Blur`).
             self.set_focus_target(FocusTarget::None);
         }
 

--- a/crates/rinch/src/app/event_dispatch.rs
+++ b/crates/rinch/src/app/event_dispatch.rs
@@ -454,10 +454,32 @@ impl RinchApp {
                 // Update :active and :focus pseudo-class state.
                 // Don't request redraw here — AboutToWait will pick up the
                 // dirty styles and batch them into a single repaint.
-                if let Some(doc) = &self.doc {
+                if let Some(doc) = self.doc.clone() {
                     let hit = {
                         let d = doc.borrow();
                         hit_test(&d.tree, x, y)
+                    };
+                    // An arbiter-held generic node (issue #228): a press inside
+                    // its subtree keeps both the claim and the node's own DOM
+                    // `:focus` (web-style — clicking a child of a focusable
+                    // focuses the focusable, not the child); a press anywhere
+                    // else releases the claim right here, so paths that return
+                    // before `handle_click` (pending drag, scrollbar, no hit)
+                    // can't strand an invisible, still-Enter-activatable claim.
+                    let node_claim = if let FocusTarget::Node(fid) = self.focus_target {
+                        let d = doc.borrow();
+                        let mut cur = hit;
+                        let mut inside = false;
+                        while let Some(nid) = cur {
+                            if nid == fid {
+                                inside = true;
+                                break;
+                            }
+                            cur = d.tree.get(nid).and_then(|n| n.parent);
+                        }
+                        Some((fid, inside))
+                    } else {
+                        None
                     };
                     // Any mousedown drops the keyboard focus ring wherever it
                     // is (it only ever lives on the focused node): pointer
@@ -471,8 +493,19 @@ impl RinchApp {
                         }
                         // :active applies while mouse is pressed
                         d.update_active(hit);
-                        // :focus applies to the clicked element (persists after release)
-                        d.update_focus(hit);
+                        // :focus applies to the clicked element (persists after
+                        // release); anchored on the focused node itself for a
+                        // press inside it.
+                        let focus_to = match node_claim {
+                            Some((fid, true)) => Some(fid),
+                            _ => hit,
+                        };
+                        d.update_focus(focus_to);
+                    }
+                    if let Some((_, false)) = node_claim {
+                        // No outstanding doc borrow here (set_focus_target's
+                        // teardown re-borrows).
+                        self.set_focus_target(FocusTarget::None);
                     }
                 }
 
@@ -938,6 +971,18 @@ impl RinchApp {
                     // inspect / Tab navigation / read-only text-selection caret
                     // motion.
                     FocusTarget::Input(_) | FocusTarget::None | FocusTarget::Node(_) => {
+                        // Self-heal a stale Node claim before routing, exactly
+                        // like the Editor arm's unmount handling above: node ids
+                        // are recycled slab indices (see
+                        // `live_focused_input_handler`), so a claim whose node
+                        // was unmounted must not swallow Enter/Space, anchor
+                        // Tab, or — worst — activate whatever unrelated node
+                        // reused the slot.
+                        if let FocusTarget::Node(id) = self.focus_target
+                            && !self.node_target_is_live(id)
+                        {
+                            self.set_focus_target(FocusTarget::None);
+                        }
                         #[cfg(feature = "desktop")]
                         if key == KeyCode::F12 {
                             actions.push(AppAction::ToggleDevTools);
@@ -962,24 +1007,26 @@ impl RinchApp {
                             KeyCode::KeyC if ctrl => self.handle_copy(),
                             KeyCode::KeyV if ctrl => self.handle_paste(),
                             KeyCode::KeyX if ctrl => self.handle_cut(),
-                            KeyCode::Enter if !ctrl => {
+                            KeyCode::Enter | KeyCode::Space
+                                if !ctrl && matches!(self.focus_target, FocusTarget::Node(_)) =>
+                            {
                                 if let FocusTarget::Node(id) = self.focus_target {
-                                    self.activate_focused_node(id, vp_w, vp_h);
-                                } else {
-                                    self.handle_enter();
+                                    // One activation per physical press: the OS
+                                    // auto-repeats KeyDown and `PlatformEvent`
+                                    // carries no repeat flag, so latch until the
+                                    // matching KeyUp (on the web a held Space
+                                    // activates exactly once, on keyup).
+                                    if self.node_activation_held != Some(key) {
+                                        self.node_activation_held = Some(key);
+                                        self.activate_focused_node(id, vp_w, vp_h);
+                                        actions.push(AppAction::RequestRedraw);
+                                    }
                                 }
                             }
-                            KeyCode::Space if !ctrl => {
-                                if let FocusTarget::Node(id) = self.focus_target {
-                                    self.activate_focused_node(id, vp_w, vp_h);
-                                } else if let Some(t) = &text
-                                    && !t.is_empty()
-                                {
-                                    // Preserve the pre-#228 path: Space is text
-                                    // input for a focused `<input>`.
-                                    self.handle_text_input(t);
-                                }
-                            }
+                            KeyCode::Enter if !ctrl => self.handle_enter(),
+                            // Space with no Node target falls through to the `_`
+                            // arm below — the one text-input path (pre-#228), so
+                            // a future change to that gate can't miss Space.
                             KeyCode::ArrowUp => self.handle_arrow_up(shift),
                             KeyCode::ArrowDown => self.handle_arrow_down(shift),
                             _ => {
@@ -995,6 +1042,11 @@ impl RinchApp {
                 }
             }
             PlatformEvent::KeyUp { key, modifiers } => {
+                // Release the Enter/Space activation latch (issue #228): the
+                // next KeyDown of this key is a fresh physical press.
+                if self.node_activation_held == Some(key) {
+                    self.node_activation_held = None;
+                }
                 // Forward key release to focused render surface.
                 if let Some(surface_id) = crate::render_surface::focused_surface_id() {
                     let key_str = format!("{:?}", key);

--- a/crates/rinch/src/app/event_dispatch.rs
+++ b/crates/rinch/src/app/event_dispatch.rs
@@ -459,10 +459,21 @@ impl RinchApp {
                         let d = doc.borrow();
                         hit_test(&d.tree, x, y)
                     };
-                    // :active applies while mouse is pressed
-                    doc.borrow_mut().update_active(hit);
-                    // :focus applies to the clicked element (persists after release)
-                    doc.borrow_mut().update_focus(hit);
+                    // Any mousedown drops the keyboard focus ring wherever it
+                    // is (it only ever lives on the focused node): pointer
+                    // interaction never shows :focus-visible, and `update_focus`
+                    // below is a no-op when the hit node already holds
+                    // (Tab-driven) focus.
+                    {
+                        let mut d = doc.borrow_mut();
+                        if let Some(prev) = d.tree.focused_node {
+                            d.set_focus_visible(prev, false);
+                        }
+                        // :active applies while mouse is pressed
+                        d.update_active(hit);
+                        // :focus applies to the clicked element (persists after release)
+                        d.update_focus(hit);
+                    }
                 }
 
                 // Check for draggable element — enter pending drag instead of
@@ -919,11 +930,14 @@ impl RinchApp {
                             return actions;
                         }
                     }
-                    // No widget owns the key, or a plain `<input>` does (its editing
+                    // No widget owns the key, a plain `<input>` does (its editing
                     // commands live in the global handlers, gated internally on
-                    // `focused_input_state`). Falls through to DevTools / inspect /
-                    // Tab navigation / read-only text-selection caret motion.
-                    FocusTarget::Input(_) | FocusTarget::None => {
+                    // `focused_input_state`), or a generic focusable node does
+                    // (Enter/Space activate it below; everything else falls
+                    // through so Tab keeps moving). Falls through to DevTools /
+                    // inspect / Tab navigation / read-only text-selection caret
+                    // motion.
+                    FocusTarget::Input(_) | FocusTarget::None | FocusTarget::Node(_) => {
                         #[cfg(feature = "desktop")]
                         if key == KeyCode::F12 {
                             actions.push(AppAction::ToggleDevTools);
@@ -948,7 +962,24 @@ impl RinchApp {
                             KeyCode::KeyC if ctrl => self.handle_copy(),
                             KeyCode::KeyV if ctrl => self.handle_paste(),
                             KeyCode::KeyX if ctrl => self.handle_cut(),
-                            KeyCode::Enter if !ctrl => self.handle_enter(),
+                            KeyCode::Enter if !ctrl => {
+                                if let FocusTarget::Node(id) = self.focus_target {
+                                    self.activate_focused_node(id, vp_w, vp_h);
+                                } else {
+                                    self.handle_enter();
+                                }
+                            }
+                            KeyCode::Space if !ctrl => {
+                                if let FocusTarget::Node(id) = self.focus_target {
+                                    self.activate_focused_node(id, vp_w, vp_h);
+                                } else if let Some(t) = &text
+                                    && !t.is_empty()
+                                {
+                                    // Preserve the pre-#228 path: Space is text
+                                    // input for a focused `<input>`.
+                                    self.handle_text_input(t);
+                                }
+                            }
                             KeyCode::ArrowUp => self.handle_arrow_up(shift),
                             KeyCode::ArrowDown => self.handle_arrow_down(shift),
                             _ => {

--- a/crates/rinch/src/app/focus.rs
+++ b/crates/rinch/src/app/focus.rs
@@ -58,6 +58,19 @@ impl RinchApp {
                 // app-created backdrop + panel nodes.
                 self.remove_select_popup_nodes();
             }
+            FocusTarget::Node(prev) => {
+                // Clear the node's DOM focus and keyboard focus ring. The
+                // `focused_node` guard keeps a successor that already moved DOM
+                // focus (the pointer path updates it on mousedown, before the
+                // arbiter runs) from being blurred by this teardown.
+                if let Some(doc) = &self.doc {
+                    let mut d = doc.borrow_mut();
+                    d.set_focus_visible(prev, false);
+                    if d.tree.focused_node == Some(prev) {
+                        d.update_focus(None);
+                    }
+                }
+            }
             #[cfg(feature = "desktop")]
             FocusTarget::Editor(prev) => {
                 // Hide the blurred editor's caret and selection highlight so an
@@ -97,6 +110,13 @@ impl RinchApp {
             FocusTarget::Input(node_id) => ImeState {
                 enabled: true,
                 cursor_area: self.input_caret_area(node_id),
+            },
+            // A generic focusable node is not a text target — explicit rather
+            // than folded into `_` so a future text-capable variant can't land
+            // here silently (issue #176 documents that trap for Surface).
+            FocusTarget::Node(_) => ImeState {
+                enabled: false,
+                cursor_area: None,
             },
             // Surfaces and no focus do not drive desktop IME.
             _ => ImeState {

--- a/crates/rinch/src/app/focus.rs
+++ b/crates/rinch/src/app/focus.rs
@@ -45,13 +45,27 @@ impl RinchApp {
                 // `set_focused_surface` dispatches `FocusLost` to the old surface.
                 crate::render_surface::set_focused_surface(None);
             }
-            FocusTarget::Input(_) => {
+            FocusTarget::Input(prev) => {
                 self.clear_input_focus_attrs();
                 self.focused_input_handler_id = None;
                 self.focused_input_value.clear();
                 self.focused_input_state = None;
                 self.focused_input_node_id = None;
                 self.focused_input_preedit = None;
+                // Clear the input's DOM focus and keyboard focus ring, exactly
+                // like the Node arm below — otherwise a blur that never goes
+                // through a left-mousedown (a click into the rich-text editor,
+                // a right/middle click, the stale-handler self-heal) leaves the
+                // input painting `:focus-visible` while something else owns the
+                // keyboard. The `focused_node` guard keeps a successor that
+                // already moved DOM focus from being blurred by this teardown.
+                if let Some(doc) = &self.doc {
+                    let mut d = doc.borrow_mut();
+                    d.set_focus_visible(prev, false);
+                    if d.tree.focused_node == Some(prev) {
+                        d.update_focus(None);
+                    }
+                }
             }
             FocusTarget::Select(_) => {
                 // Tearing down select focus dismisses its popup: remove the
@@ -129,6 +143,15 @@ impl RinchApp {
     /// Whether a text input element is currently focused.
     pub fn has_focused_input(&self) -> bool {
         matches!(self.focus_target, FocusTarget::Input(_))
+    }
+
+    /// Whether a generic focusable node (`tabindex`, `FocusTarget::Node`,
+    /// issue #228) holds focus. It consumes Enter/Space (and anchors Tab), so
+    /// embed hosts must route keyboard input to rinch while one is focused
+    /// (`RinchContext::wants_keyboard` includes it). Public beside
+    /// [`Self::has_focused_input`] / [`Self::has_focused_contenteditable`].
+    pub fn has_focused_node(&self) -> bool {
+        matches!(self.focus_target, FocusTarget::Node(_))
     }
 
     /// The container id of the focused new-editor, if one holds focus. Drives the

--- a/crates/rinch/src/app/mod.rs
+++ b/crates/rinch/src/app/mod.rs
@@ -146,6 +146,10 @@ pub(crate) enum FocusTarget {
     /// A rich-text editor (`rinch-editor-core`) instance, by container node id.
     #[cfg(feature = "desktop")]
     Editor(usize),
+    /// A generic focusable DOM node (`tabindex >= 0`, no text engine), by DOM
+    /// node id — a custom control reached via Tab or `request_focus`
+    /// (issue #228). Enter/Space dispatch its click handler; it drives no IME.
+    Node(usize),
 }
 
 // ── RinchApp ─────────────────────────────────────────────────────────────────
@@ -1550,10 +1554,30 @@ impl RinchApp {
             return;
         }
 
-        // Find current focused element
-        let current = self.focused_input_node_id;
+        // Find current focused element: a focused input, a generic focusable
+        // node held by the arbiter, or — falling back — the DOM's focused node
+        // resolved upward to its nearest focusable ancestor (a pointer click
+        // focuses the deepest hit element, so a click inside a focusable node
+        // must still anchor Tab there).
+        let current = self.focused_input_node_id.or(match self.focus_target {
+            FocusTarget::Node(id) => Some(id),
+            _ => None,
+        });
 
-        let current_idx = current.and_then(|id| focusable.iter().position(|&fid| fid == id));
+        let current_idx = current
+            .and_then(|id| focusable.iter().position(|&fid| fid == id))
+            .or_else(|| {
+                let doc = self.doc.as_ref()?;
+                let d = doc.borrow();
+                let mut cur = d.tree.focused_node;
+                while let Some(id) = cur {
+                    if let Some(idx) = focusable.iter().position(|&fid| fid == id) {
+                        return Some(idx);
+                    }
+                    cur = d.tree.get(id).and_then(|n| n.parent);
+                }
+                None
+            });
 
         let target_idx = match (current_idx, shift) {
             (Some(idx), false) => (idx + 1) % focusable.len(),
@@ -1580,24 +1604,18 @@ impl RinchApp {
                 continue;
             };
 
-            // Skip disabled nodes
-            if node
+            // A disabled or tabindex="-1" node is not itself focusable, but its
+            // children still are (web semantics remove only the node from the
+            // Tab order, not its subtree). Same for zero-size (invisible) nodes.
+            let skip_self = node
                 .attributes
                 .get("data-disabled")
                 .is_some_and(|v| v == "true")
-            {
-                continue;
-            }
+                || node.attributes.get("tabindex").is_some_and(|v| v == "-1")
+                || node.layout.width <= 0.0
+                || node.layout.height <= 0.0;
 
-            // Skip nodes with tabindex="-1"
-            if node.attributes.get("tabindex").is_some_and(|v| v == "-1") {
-                continue;
-            }
-
-            // Skip zero-size nodes (not visible)
-            if node.layout.width <= 0.0 || node.layout.height <= 0.0 {
-                // Still push children — a zero-size parent can have visible children
-            } else {
+            if !skip_self {
                 // Check if focusable
                 let has_oninput = node.attributes.contains_key("data-oninput");
                 let has_tabindex = node
@@ -1620,7 +1638,9 @@ impl RinchApp {
         result
     }
 
-    /// Focus a specific element by node ID (an `<input>`/`<textarea>`).
+    /// Focus a specific element by node ID via Tab: an `<input>`/`<textarea>`,
+    /// or a generic `tabindex >= 0` node (issue #228). Keyboard-driven, so the
+    /// focused node gets the `:focus-visible` ring either way.
     fn focus_element(&mut self, node_id: usize) {
         let has_oninput = {
             let Some(doc) = &self.doc else { return };
@@ -1635,14 +1655,88 @@ impl RinchApp {
             // `try_focus_input` takes focus through the arbiter (tears down any
             // prior surface / editor / input).
             self.try_focus_input(node_id);
-            // Update DOM focus state
-            if let Some(doc) = &self.doc {
-                let mut d = doc.borrow_mut();
-                d.update_focus(Some(node_id));
-            }
+        } else {
+            // A generic focusable node: take focus through the arbiter too, so
+            // the previous owner (an input's keys and IME included) is torn
+            // down instead of lingering alongside a focus that went nowhere.
+            self.set_focus_target(FocusTarget::Node(node_id));
+        }
+
+        // Update DOM focus state and mark the keyboard focus ring.
+        if let Some(doc) = &self.doc {
+            let mut d = doc.borrow_mut();
+            d.update_focus(Some(node_id));
+            d.set_focus_visible(node_id, true);
         }
 
         self.scene_dirty = true;
+    }
+
+    /// Enter/Space on a keyboard-focused generic node (issue #228): dispatch
+    /// the click handler of the nearest ancestor-or-self carrying a **live**
+    /// `data-rid` (the same liveness probe as the pointer path — a freed
+    /// handler must not swallow the key), with a `ClickContext` synthesized
+    /// from the handler node's absolute rect, cursor at its center. Returns
+    /// whether a handler was dispatched.
+    fn activate_focused_node(&mut self, node_id: usize, vp_w: f32, vp_h: f32) -> bool {
+        let Some(doc) = self.doc.clone() else {
+            return false;
+        };
+        let d = doc.borrow();
+        let mut current = Some(node_id);
+        while let Some(nid) = current {
+            let Some(node) = d.tree.get(nid) else { break };
+            if let Some(rid_str) = node.attributes.get("data-rid")
+                && let Ok(handler_id) = rid_str.parse::<usize>()
+                && events::has_click_handler(events::EventHandlerId(handler_id))
+            {
+                let (elem_x, elem_y, elem_w, elem_h) = {
+                    let mut ax = node.layout.x;
+                    let mut ay = node.layout.y;
+                    let mut pid = node.parent;
+                    while let Some(p) = pid {
+                        if let Some(pn) = d.tree.get(p) {
+                            ax += pn.layout.x;
+                            ay += pn.layout.y;
+                            ax -= pn.scroll_offset.0 as f32;
+                            ay -= pn.scroll_offset.1 as f32;
+                            pid = pn.parent;
+                        } else {
+                            break;
+                        }
+                    }
+                    (ax, ay, node.layout.width, node.layout.height)
+                };
+
+                events::set_click_context(events::ClickContext {
+                    mouse_x: elem_x + elem_w / 2.0,
+                    mouse_y: elem_y + elem_h / 2.0,
+                    element_x: elem_x,
+                    element_y: elem_y,
+                    element_width: elem_w,
+                    element_height: elem_h,
+                    text_hit: events::TextHitInfo::default(),
+                    viewport_width: vp_w,
+                    viewport_height: vp_h,
+                    button: events::MouseButton::Left,
+                    modifiers: self.modifier_state(),
+                });
+                events::set_click_ancestors(Self::collect_click_ancestors(&d.tree, nid));
+
+                drop(d);
+                events::dispatch_event(events::EventHandlerId(handler_id));
+                // The handler may have requested focus (e.g. opening a dialog
+                // that focuses an input) — honor it like the pointer path does.
+                if let Some(focus_node_id) = rinch_core::take_pending_focus_request(self.doc_key())
+                {
+                    self.try_focus_input(focus_node_id);
+                }
+                self.scene_dirty = true;
+                return true;
+            }
+            current = node.parent;
+        }
+        false
     }
 
     /// This app's document identity (see `DomDocument::doc_key`), or 0 before
@@ -1652,11 +1746,14 @@ impl RinchApp {
         self.doc.as_ref().map(|d| d.borrow().doc_key()).unwrap_or(0)
     }
 
-    /// Programmatically focus an input element by node ID.
+    /// Programmatically focus an element by node ID (`request_focus` /
+    /// `NodeHandle::focus()` land here).
     ///
-    /// Looks up the node in the DOM, checks for `data-oninput`, and sets up
-    /// the full input focus state (handler ID, editable state, cursor).
-    /// This is the programmatic equivalent of clicking on an input element.
+    /// For an input (`data-oninput`), sets up the full input focus state
+    /// (handler ID, editable state, cursor) — the programmatic equivalent of
+    /// clicking it. For a generic `tabindex >= 0` node, takes Node focus
+    /// through the arbiter (issue #228). Programmatic focus is not
+    /// keyboard-driven, so it does not set the `:focus-visible` ring.
     pub(crate) fn try_focus_input(&mut self, node_id: usize) {
         let Some(doc) = &self.doc else { return };
         let d = doc.borrow();
@@ -1665,6 +1762,19 @@ impl RinchApp {
         };
 
         let Some(oninput_str) = node.attributes.get("data-oninput") else {
+            let focusable = node
+                .attributes
+                .get("tabindex")
+                .and_then(|v| v.parse::<i32>().ok())
+                .is_some_and(|v| v >= 0);
+            drop(d);
+            if focusable {
+                self.set_focus_target(FocusTarget::Node(node_id));
+                if let Some(doc) = &self.doc {
+                    doc.borrow_mut().update_focus(Some(node_id));
+                }
+                self.scene_dirty = true;
+            }
             return;
         };
         let Ok(handler_id) = oninput_str.parse::<usize>() else {
@@ -2107,6 +2217,343 @@ mod layout_notification_tests {
             fired.borrow().len(),
             1,
             "clamp event must fire exactly once"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tab_focus_tests {
+    use super::*;
+    use rinch_core::events::{InputCallback, register_input_handler};
+    use std::cell::Cell;
+
+    /// Mount an `<input>` followed by a `tabindex="0"` div carrying a live
+    /// click handler. Returns the app, both node ids, and the click counter.
+    fn mount_input_and_div() -> (RinchApp, usize, usize, Rc<Cell<usize>>) {
+        let clicks: Rc<Cell<usize>> = Rc::new(Cell::new(0));
+        let clicks_in = clicks.clone();
+        let oninput_id = register_input_handler(InputCallback::new(|_| {}));
+        let ids: Rc<Cell<Option<(usize, usize)>>> = Rc::new(Cell::new(None));
+        let ids_in = ids.clone();
+        let mut app = RinchApp::new(move |scope: &mut RenderScope| {
+            let root = scope.create_element("div");
+            let input = scope.create_element("input");
+            input.set_attribute("style", "width: 200px; height: 30px");
+            input.set_attribute("data-oninput", &oninput_id.0.to_string());
+            let div = scope.create_element("div");
+            div.set_attribute("style", "width: 200px; height: 40px");
+            div.set_attribute("tabindex", "0");
+            let rid = scope.register_handler({
+                let clicks = clicks_in.clone();
+                move || clicks.set(clicks.get() + 1)
+            });
+            div.set_attribute("data-rid", &rid.0.to_string());
+            root.append_child(&input);
+            root.append_child(&div);
+            ids_in.set(Some((input.node_id().0, div.node_id().0)));
+            root
+        });
+        app.mount_component(800.0, 600.0);
+        app.resolve_and_repaint(800.0, 600.0);
+        let (input_id, div_id) = ids.get().expect("node ids captured at mount");
+        (app, input_id, div_id, clicks)
+    }
+
+    fn key(app: &mut RinchApp, key: KeyCode, text: Option<&str>, shift: bool) {
+        app.handle_event(
+            PlatformEvent::KeyDown {
+                key,
+                logical_key: None,
+                text: text.map(str::to_string),
+                modifiers: Modifiers {
+                    shift,
+                    ..Default::default()
+                },
+            },
+            (800, 600),
+            1.0,
+        );
+    }
+
+    fn click(app: &mut RinchApp, x: f32, y: f32) {
+        app.handle_event(
+            PlatformEvent::MouseDown {
+                x,
+                y,
+                button: MouseButton::Left,
+            },
+            (800, 600),
+            1.0,
+        );
+        app.handle_event(
+            PlatformEvent::MouseUp {
+                x,
+                y,
+                button: MouseButton::Left,
+            },
+            (800, 600),
+            1.0,
+        );
+    }
+
+    /// `(is_focused, is_focus_visible)` for a node.
+    fn focus_bits(app: &RinchApp, id: usize) -> (bool, bool) {
+        let d = app.doc.as_ref().unwrap().borrow();
+        let n = d.tree.get(id).unwrap();
+        (n.is_focused, n.is_focus_visible)
+    }
+
+    fn abs_center(app: &RinchApp, id: usize) -> (f32, f32) {
+        let d = app.doc.as_ref().unwrap().borrow();
+        let n = d.tree.get(id).unwrap();
+        let (mut ax, mut ay) = (n.layout.x, n.layout.y);
+        let mut pid = n.parent;
+        while let Some(p) = pid {
+            let pn = d.tree.get(p).unwrap();
+            ax += pn.layout.x;
+            ay += pn.layout.y;
+            pid = pn.parent;
+        }
+        (ax + n.layout.width / 2.0, ay + n.layout.height / 2.0)
+    }
+
+    /// #228, the trap itself: Tab must advance past a `tabindex="0"` node in
+    /// both directions, tearing each owner down as it goes. Before the fix the
+    /// second Tab recomputed the same target forever while the input kept
+    /// focus, keys, and IME.
+    #[test]
+    fn tab_advances_past_a_tabindex_node() {
+        let (mut app, input_id, div_id, _clicks) = mount_input_and_div();
+
+        key(&mut app, KeyCode::Tab, None, false);
+        assert_eq!(
+            app.focused_input_node_id,
+            Some(input_id),
+            "first Tab focuses the input"
+        );
+
+        key(&mut app, KeyCode::Tab, None, false);
+        assert_eq!(
+            app.focus_target,
+            FocusTarget::Node(div_id),
+            "second Tab must move to the tabindex div (pre-#228 it stuck on the input)"
+        );
+        assert_eq!(
+            app.focused_input_node_id, None,
+            "the input's focus state is torn down"
+        );
+        assert_eq!(focus_bits(&app, input_id), (false, false));
+        assert_eq!(
+            focus_bits(&app, div_id),
+            (true, true),
+            "the div holds :focus and :focus-visible"
+        );
+
+        key(&mut app, KeyCode::Tab, None, false);
+        assert_eq!(
+            app.focused_input_node_id,
+            Some(input_id),
+            "third Tab wraps back to the input — the Node teardown ran"
+        );
+        assert_eq!(focus_bits(&app, div_id), (false, false));
+        assert_eq!(focus_bits(&app, input_id), (true, true));
+
+        key(&mut app, KeyCode::Tab, None, true);
+        assert_eq!(
+            app.focus_target,
+            FocusTarget::Node(div_id),
+            "Shift+Tab moves backwards onto the div"
+        );
+    }
+
+    /// Enter and Space on a keyboard-focused generic node each dispatch its
+    /// click handler exactly once.
+    #[test]
+    fn enter_and_space_activate_the_focused_node() {
+        let (mut app, _input_id, div_id, clicks) = mount_input_and_div();
+        key(&mut app, KeyCode::Tab, None, false);
+        key(&mut app, KeyCode::Tab, None, false);
+        assert_eq!(app.focus_target, FocusTarget::Node(div_id));
+
+        key(&mut app, KeyCode::Enter, None, false);
+        assert_eq!(clicks.get(), 1, "Enter dispatches the click handler once");
+
+        key(&mut app, KeyCode::Space, Some(" "), false);
+        assert_eq!(clicks.get(), 2, "Space dispatches the click handler once");
+    }
+
+    /// A focused node with no live `data-rid` in its ancestor chain: Enter is
+    /// a quiet no-op (no panic) and Tab keeps moving.
+    #[test]
+    fn node_without_handler_neither_panics_nor_swallows_tab() {
+        let ids: Rc<Cell<Option<(usize, usize)>>> = Rc::new(Cell::new(None));
+        let ids_in = ids.clone();
+        let mut app = RinchApp::new(move |scope: &mut RenderScope| {
+            let root = scope.create_element("div");
+            let a = scope.create_element("div");
+            a.set_attribute("style", "width: 100px; height: 40px");
+            a.set_attribute("tabindex", "0");
+            let b = scope.create_element("div");
+            b.set_attribute("style", "width: 100px; height: 40px");
+            b.set_attribute("tabindex", "0");
+            root.append_child(&a);
+            root.append_child(&b);
+            ids_in.set(Some((a.node_id().0, b.node_id().0)));
+            root
+        });
+        app.mount_component(800.0, 600.0);
+        app.resolve_and_repaint(800.0, 600.0);
+        let (a_id, b_id) = ids.get().unwrap();
+
+        key(&mut app, KeyCode::Tab, None, false);
+        assert_eq!(app.focus_target, FocusTarget::Node(a_id));
+        key(&mut app, KeyCode::Enter, None, false);
+        assert_eq!(
+            app.focus_target,
+            FocusTarget::Node(a_id),
+            "Enter is a no-op"
+        );
+        key(&mut app, KeyCode::Tab, None, false);
+        assert_eq!(
+            app.focus_target,
+            FocusTarget::Node(b_id),
+            "Tab still advances"
+        );
+    }
+
+    /// Pointer interaction drops the keyboard focus ring; a click inside the
+    /// focused node keeps its focus (and still dispatches the click handler).
+    #[test]
+    fn pointer_click_clears_the_ring_but_keeps_focus() {
+        let (mut app, _input_id, div_id, clicks) = mount_input_and_div();
+        key(&mut app, KeyCode::Tab, None, false);
+        key(&mut app, KeyCode::Tab, None, false);
+        assert_eq!(focus_bits(&app, div_id), (true, true));
+
+        let (cx, cy) = abs_center(&app, div_id);
+        click(&mut app, cx, cy);
+        assert_eq!(
+            app.focus_target,
+            FocusTarget::Node(div_id),
+            "a click inside the focused node keeps its focus"
+        );
+        assert_eq!(
+            focus_bits(&app, div_id),
+            (true, false),
+            "pointer interaction clears :focus-visible but not :focus"
+        );
+        assert_eq!(clicks.get(), 1, "the click itself still dispatches");
+    }
+
+    /// `request_focus` / `NodeHandle::focus()` on a tabindex node takes Node
+    /// focus (it was a silent no-op before #228). Programmatic focus is not
+    /// keyboard-driven, so no focus ring.
+    #[test]
+    fn request_focus_takes_node_focus_programmatically() {
+        let (mut app, _input_id, div_id, _clicks) = mount_input_and_div();
+        app.try_focus_input(div_id);
+        assert_eq!(app.focus_target, FocusTarget::Node(div_id));
+        assert_eq!(focus_bits(&app, div_id), (true, false));
+    }
+
+    /// Tab after a pointer click anchors at the clicked position: the click
+    /// focuses the deepest hit element, and Tab resolves upward to its nearest
+    /// focusable ancestor rather than restarting from the top.
+    #[test]
+    fn tab_after_click_anchors_at_the_clicked_position() {
+        let oninput_id = register_input_handler(InputCallback::new(|_| {}));
+        let ids: Rc<Cell<Option<(usize, usize)>>> = Rc::new(Cell::new(None));
+        let ids_in = ids.clone();
+        let mut app = RinchApp::new(move |scope: &mut RenderScope| {
+            let root = scope.create_element("div");
+            let input = scope.create_element("input");
+            input.set_attribute("style", "width: 200px; height: 30px");
+            input.set_attribute("data-oninput", &oninput_id.0.to_string());
+            let mid = scope.create_element("div");
+            mid.set_attribute("style", "width: 200px; height: 40px");
+            mid.set_attribute("tabindex", "0");
+            let last = scope.create_element("div");
+            last.set_attribute("style", "width: 200px; height: 40px");
+            last.set_attribute("tabindex", "0");
+            root.append_child(&input);
+            root.append_child(&mid);
+            root.append_child(&last);
+            ids_in.set(Some((mid.node_id().0, last.node_id().0)));
+            root
+        });
+        app.mount_component(800.0, 600.0);
+        app.resolve_and_repaint(800.0, 600.0);
+        let (mid_id, last_id) = ids.get().unwrap();
+
+        let (cx, cy) = abs_center(&app, mid_id);
+        click(&mut app, cx, cy);
+        assert_eq!(
+            app.focus_target,
+            FocusTarget::None,
+            "a pointer click does not claim arbiter Node focus"
+        );
+
+        key(&mut app, KeyCode::Tab, None, false);
+        assert_eq!(
+            app.focus_target,
+            FocusTarget::Node(last_id),
+            "Tab continues from the clicked node, not from the top"
+        );
+    }
+
+    /// `data-disabled="true"` / `tabindex="-1"` remove only the node from the
+    /// Tab order, not its subtree (web semantics).
+    #[test]
+    fn disabled_and_negative_tabindex_skip_only_the_node() {
+        let ids: Rc<Cell<Option<[usize; 4]>>> = Rc::new(Cell::new(None));
+        let ids_in = ids.clone();
+        let mut app = RinchApp::new(move |scope: &mut RenderScope| {
+            let root = scope.create_element("div");
+            let disabled_wrap = scope.create_element("div");
+            disabled_wrap.set_attribute("style", "width: 200px; height: 60px");
+            disabled_wrap.set_attribute("tabindex", "0");
+            disabled_wrap.set_attribute("data-disabled", "true");
+            let child_a = scope.create_element("div");
+            child_a.set_attribute("style", "width: 100px; height: 40px");
+            child_a.set_attribute("tabindex", "0");
+            disabled_wrap.append_child(&child_a);
+            let neg_wrap = scope.create_element("div");
+            neg_wrap.set_attribute("style", "width: 200px; height: 60px");
+            neg_wrap.set_attribute("tabindex", "-1");
+            let child_b = scope.create_element("div");
+            child_b.set_attribute("style", "width: 100px; height: 40px");
+            child_b.set_attribute("tabindex", "0");
+            neg_wrap.append_child(&child_b);
+            root.append_child(&disabled_wrap);
+            root.append_child(&neg_wrap);
+            ids_in.set(Some([
+                disabled_wrap.node_id().0,
+                child_a.node_id().0,
+                neg_wrap.node_id().0,
+                child_b.node_id().0,
+            ]));
+            root
+        });
+        app.mount_component(800.0, 600.0);
+        app.resolve_and_repaint(800.0, 600.0);
+        let [disabled_wrap, child_a, neg_wrap, child_b] = ids.get().unwrap();
+
+        let focusable = app.collect_focusable_nodes();
+        assert!(
+            !focusable.contains(&disabled_wrap),
+            "a disabled node is not tabbable"
+        );
+        assert!(
+            !focusable.contains(&neg_wrap),
+            "a tabindex=\"-1\" node is not tabbable"
+        );
+        assert!(
+            focusable.contains(&child_a),
+            "children of a disabled node stay tabbable"
+        );
+        assert!(
+            focusable.contains(&child_b),
+            "children of a tabindex=\"-1\" node stay tabbable"
         );
     }
 }

--- a/crates/rinch/src/app/mod.rs
+++ b/crates/rinch/src/app/mod.rs
@@ -236,6 +236,12 @@ pub struct RinchApp {
     /// (`focused_input_*`, the surface/editor registries) via
     /// [`Self::set_focus_target`].
     pub(crate) focus_target: FocusTarget,
+    /// The Enter/Space key currently latched by a `FocusTarget::Node`
+    /// activation (issue #228). OS auto-repeat delivers indistinguishable
+    /// KeyDowns (`PlatformEvent::KeyDown` carries no repeat flag), so a held
+    /// key must activate once per physical press; cleared on the matching
+    /// KeyUp.
+    pub(crate) node_activation_held: Option<KeyCode>,
     /// The open native-`<select>` popup, if any. Present exactly when
     /// `focus_target == FocusTarget::Select(_)`. Holds the app-created popup DOM
     /// node ids and the keyboard highlight state (issue #121).
@@ -310,6 +316,7 @@ impl RinchApp {
             focused_input_node_id: None,
             focused_input_preedit: None,
             focus_target: FocusTarget::None,
+            node_activation_held: None,
             open_select: None,
             select_css_injected: false,
             #[cfg(feature = "desktop")]
@@ -1559,10 +1566,14 @@ impl RinchApp {
         // resolved upward to its nearest focusable ancestor (a pointer click
         // focuses the deepest hit element, so a click inside a focusable node
         // must still anchor Tab there).
-        let current = self.focused_input_node_id.or(match self.focus_target {
-            FocusTarget::Node(id) => Some(id),
-            _ => None,
-        });
+        let current = match self.focus_target {
+            // The arbiter is the source of truth; `focused_input_node_id` only
+            // ever accompanies `Input` (kept as a fallback so a broken
+            // invariant degrades to the same answer rather than anchoring Tab
+            // on a stale input).
+            FocusTarget::Input(id) | FocusTarget::Node(id) => Some(id),
+            _ => self.focused_input_node_id,
+        };
 
         let current_idx = current
             .and_then(|id| focusable.iter().position(|&fid| fid == id))
@@ -1604,16 +1615,28 @@ impl RinchApp {
                 continue;
             };
 
-            // A disabled or tabindex="-1" node is not itself focusable, but its
-            // children still are (web semantics remove only the node from the
-            // Tab order, not its subtree). Same for zero-size (invisible) nodes.
+            // A disabled or negative-tabindex node is not itself focusable, but
+            // its children still are (web semantics remove only the node from
+            // the Tab order, not its subtree). Same for zero-size or
+            // `visibility: hidden` (invisible, unclickable) nodes. The tabindex
+            // test parses like the focusable test below so `-2`, `-01`, … are
+            // negative too, not just the literal string "-1".
             let skip_self = node
                 .attributes
                 .get("data-disabled")
                 .is_some_and(|v| v == "true")
-                || node.attributes.get("tabindex").is_some_and(|v| v == "-1")
+                || node
+                    .attributes
+                    .get("tabindex")
+                    .and_then(|v| v.parse::<i32>().ok())
+                    .is_some_and(|v| v < 0)
                 || node.layout.width <= 0.0
-                || node.layout.height <= 0.0;
+                || node.layout.height <= 0.0
+                || matches!(
+                    node.computed_style.visibility,
+                    rinch_dom::computed_style::VisibilityValue::Hidden
+                        | rinch_dom::computed_style::VisibilityValue::Collapse
+                );
 
             if !skip_self {
                 // Check if focusable
@@ -1662,11 +1685,24 @@ impl RinchApp {
             self.set_focus_target(FocusTarget::Node(node_id));
         }
 
-        // Update DOM focus state and mark the keyboard focus ring.
-        if let Some(doc) = &self.doc {
+        // Update DOM focus state and mark the keyboard focus ring — but only
+        // when the arbiter actually claimed this node. `try_focus_input` bails
+        // on a malformed `data-oninput` (or a vanished node); painting `:focus`
+        // + the ring on a node that owns no keys would split the visual focus
+        // from the keyboard focus.
+        let claimed = matches!(
+            self.focus_target,
+            FocusTarget::Input(id) | FocusTarget::Node(id) if id == node_id
+        );
+        if claimed && let Some(doc) = &self.doc {
             let mut d = doc.borrow_mut();
             d.update_focus(Some(node_id));
             d.set_focus_visible(node_id, true);
+            // Sequential focus navigation scrolls the new focus into view
+            // (applied by `apply_scroll_into_view` after the next layout pass),
+            // like browsers — Tab must never land on a control the user can't
+            // see because it sits below the fold of a scroll container.
+            d.request_scroll_into_view(rinch_core::dom::NodeId(node_id));
         }
 
         self.scene_dirty = true;
@@ -1676,11 +1712,11 @@ impl RinchApp {
     /// the click handler of the nearest ancestor-or-self carrying a **live**
     /// `data-rid` (the same liveness probe as the pointer path — a freed
     /// handler must not swallow the key), with a `ClickContext` synthesized
-    /// from the handler node's absolute rect, cursor at its center. Returns
-    /// whether a handler was dispatched.
-    fn activate_focused_node(&mut self, node_id: usize, vp_w: f32, vp_h: f32) -> bool {
+    /// from the handler node's absolute rect, cursor at its center. A node with
+    /// no live handler anywhere in its chain is a quiet no-op.
+    fn activate_focused_node(&mut self, node_id: usize, vp_w: f32, vp_h: f32) {
         let Some(doc) = self.doc.clone() else {
-            return false;
+            return;
         };
         let d = doc.borrow();
         let mut current = Some(node_id);
@@ -1690,23 +1726,12 @@ impl RinchApp {
                 && let Ok(handler_id) = rid_str.parse::<usize>()
                 && events::has_click_handler(events::EventHandlerId(handler_id))
             {
-                let (elem_x, elem_y, elem_w, elem_h) = {
-                    let mut ax = node.layout.x;
-                    let mut ay = node.layout.y;
-                    let mut pid = node.parent;
-                    while let Some(p) = pid {
-                        if let Some(pn) = d.tree.get(p) {
-                            ax += pn.layout.x;
-                            ay += pn.layout.y;
-                            ax -= pn.scroll_offset.0 as f32;
-                            ay -= pn.scroll_offset.1 as f32;
-                            pid = pn.parent;
-                        } else {
-                            break;
-                        }
-                    }
-                    (ax, ay, node.layout.width, node.layout.height)
-                };
+                // The same absolute-rect walk as the pointer path, via the
+                // shared helper (it stops at `position: fixed`, which is
+                // viewport-relative — the hand-rolled copy this replaces did
+                // not).
+                let (elem_x, elem_y) = Self::compute_absolute_position(&d.tree, nid);
+                let (elem_w, elem_h) = (node.layout.width, node.layout.height);
 
                 events::set_click_context(events::ClickContext {
                     mouse_x: elem_x + elem_w / 2.0,
@@ -1732,9 +1757,40 @@ impl RinchApp {
                     self.try_focus_input(focus_node_id);
                 }
                 self.scene_dirty = true;
-                return true;
+                return;
             }
             current = node.parent;
+        }
+    }
+
+    /// Whether a `FocusTarget::Node` claim still names a live, attached,
+    /// focusable node. Node ids are recycled slab indices (the same hazard
+    /// [`Self::live_focused_input_handler`] documents for inputs), so a claim
+    /// that outlived its node must be dropped before it swallows Enter/Space,
+    /// anchors Tab, or activates whatever unrelated node reused the slot. A
+    /// recycled slot that happens to hold another focusable node is still
+    /// accepted — full protection needs an unmount notification (like the
+    /// editor registry gives the Editor target).
+    fn node_target_is_live(&self, node_id: usize) -> bool {
+        let Some(doc) = &self.doc else { return false };
+        let d = doc.borrow();
+        let focusable = d.tree.get(node_id).is_some_and(|n| {
+            n.attributes
+                .get("tabindex")
+                .and_then(|v| v.parse::<i32>().ok())
+                .is_some()
+        });
+        if !focusable {
+            return false;
+        }
+        // Attached to the root? A detached node keeps its slab slot (and its
+        // attributes) but must not stay focus-owner.
+        let mut cur = Some(node_id);
+        while let Some(nid) = cur {
+            if nid == 0 {
+                return true;
+            }
+            cur = d.tree.get(nid).and_then(|n| n.parent);
         }
         false
     }
@@ -1762,11 +1818,15 @@ impl RinchApp {
         };
 
         let Some(oninput_str) = node.attributes.get("data-oninput") else {
+            // Any parseable tabindex makes a node programmatically focusable —
+            // including negative ones: `tabindex="-1"` is the standard
+            // focusable-but-not-tabbable idiom (`element.focus()` into a
+            // just-opened dialog), and only the Tab collector excludes it.
             let focusable = node
                 .attributes
                 .get("tabindex")
                 .and_then(|v| v.parse::<i32>().ok())
-                .is_some_and(|v| v >= 0);
+                .is_some();
             drop(d);
             if focusable {
                 self.set_focus_target(FocusTarget::Node(node_id));
@@ -1786,6 +1846,14 @@ impl RinchApp {
         // Take input focus through the arbiter (tears down a prior surface / CE /
         // editor / different input; re-focusing the same input is a no-op).
         self.set_focus_target(FocusTarget::Input(node_id));
+
+        // Move DOM `:focus` too, like the generic-node branch above — the
+        // programmatic path has no mousedown to do it, and the Node teardown
+        // may just have blurred the previous holder, so skipping this would
+        // leave the newly focused input matching no `:focus` CSS at all.
+        if let Some(doc) = &self.doc {
+            doc.borrow_mut().update_focus(Some(node_id));
+        }
 
         self.focused_input_handler_id = Some(handler_id);
         self.focused_input_value = value.clone();
@@ -2306,14 +2374,9 @@ mod tab_focus_tests {
     fn abs_center(app: &RinchApp, id: usize) -> (f32, f32) {
         let d = app.doc.as_ref().unwrap().borrow();
         let n = d.tree.get(id).unwrap();
-        let (mut ax, mut ay) = (n.layout.x, n.layout.y);
-        let mut pid = n.parent;
-        while let Some(p) = pid {
-            let pn = d.tree.get(p).unwrap();
-            ax += pn.layout.x;
-            ay += pn.layout.y;
-            pid = pn.parent;
-        }
+        // The same walk the click/hit paths use (scroll offsets included), so
+        // these clicks stay on target if a fixture ever gains a scroller.
+        let (ax, ay) = RinchApp::compute_absolute_position(&d.tree, id);
         (ax + n.layout.width / 2.0, ay + n.layout.height / 2.0)
     }
 
@@ -2380,6 +2443,56 @@ mod tab_focus_tests {
 
         key(&mut app, KeyCode::Space, Some(" "), false);
         assert_eq!(clicks.get(), 2, "Space dispatches the click handler once");
+    }
+
+    /// A held key auto-repeats KeyDown with no repeat flag: activation must
+    /// latch until the matching KeyUp — one physical press, one activation
+    /// (a held Space on the web activates exactly once).
+    #[test]
+    fn held_key_activates_once_per_physical_press() {
+        let (mut app, _input_id, div_id, clicks) = mount_input_and_div();
+        key(&mut app, KeyCode::Tab, None, false);
+        key(&mut app, KeyCode::Tab, None, false);
+        assert_eq!(app.focus_target, FocusTarget::Node(div_id));
+
+        key(&mut app, KeyCode::Enter, None, false);
+        key(&mut app, KeyCode::Enter, None, false); // OS auto-repeat
+        key(&mut app, KeyCode::Enter, None, false); // OS auto-repeat
+        assert_eq!(clicks.get(), 1, "auto-repeat must not re-activate");
+
+        app.handle_event(
+            PlatformEvent::KeyUp {
+                key: KeyCode::Enter,
+                modifiers: Modifiers::default(),
+            },
+            (800, 600),
+            1.0,
+        );
+        key(&mut app, KeyCode::Enter, None, false);
+        assert_eq!(clicks.get(), 2, "a fresh press after KeyUp activates again");
+    }
+
+    /// A mousedown outside the focused node releases the arbiter claim right
+    /// away — even for presses that never reach `handle_click` (empty space,
+    /// draggables, scrollbars) — so an invisible claim can't keep swallowing
+    /// Enter.
+    #[test]
+    fn mousedown_outside_releases_the_node_claim() {
+        let (mut app, _input_id, div_id, clicks) = mount_input_and_div();
+        key(&mut app, KeyCode::Tab, None, false);
+        key(&mut app, KeyCode::Tab, None, false);
+        assert_eq!(app.focus_target, FocusTarget::Node(div_id));
+
+        // Far below the content: hits empty space (or at most the root), not
+        // the div's subtree.
+        click(&mut app, 700.0, 500.0);
+        assert_eq!(
+            app.focus_target,
+            FocusTarget::None,
+            "an outside press must release the Node claim"
+        );
+        key(&mut app, KeyCode::Enter, None, false);
+        assert_eq!(clicks.get(), 0, "the blurred node must not activate");
     }
 
     /// A focused node with no live `data-rid` in its ancestor chain: Enter is

--- a/crates/rinch/src/embed.rs
+++ b/crates/rinch/src/embed.rs
@@ -329,12 +329,17 @@ impl RinchContext {
         true
     }
 
-    /// Returns `true` if a text input or contenteditable is focused.
+    /// Returns `true` if a text input, contenteditable, or generic focusable
+    /// node (`tabindex`, issue #228) is focused.
     ///
     /// When this returns `true`, the game should route keyboard events to
-    /// rinch instead of handling them as game input.
+    /// rinch instead of handling them as game input. A Tab-focused generic
+    /// node counts: rinch consumes Enter/Space to activate it, so a host that
+    /// kept the keyboard would double-handle those keys.
     pub fn wants_keyboard(&self) -> bool {
-        self.app.has_focused_input() || self.app.has_focused_contenteditable()
+        self.app.has_focused_input()
+            || self.app.has_focused_contenteditable()
+            || self.app.has_focused_node()
     }
 
     /// Register font data for text rendering **after** the initial mount.


### PR DESCRIPTION
Fixes #228.

## The trap, mechanically

`collect_focusable_nodes` collects `tabindex >= 0` nodes into the Tab order, but `focus_element` did real work only for `data-oninput` nodes — for a tabindex-only node the body was just `scene_dirty = true`. No arbiter claim, no DOM focus, no teardown of the previous owner. And `handle_tab` derived its position solely from `focused_input_node_id`, so every Tab recomputed the same target: with nothing focused it targeted index 0 forever; with an input focused it targeted the same next index forever **while the input kept focus, keys, and IME**. Giving a custom control a tabindex created a keyboard trap (the shipped `Tree` component is an in-tree victim: `tabindex="0"` + `data-rid` + a `:focus-visible` outline rule).

Separately, `:focus-visible` could never match anything: rinch-dom's `match_non_ts_pseudo_class` had no `FocusVisible` arm (it fell to `_ => false`) and nothing ever set a keyboard-focus flag. **The default theme (`FocusRing::Auto`) emits `:focus:not(:focus-visible) { outline: none }` + `:focus-visible { outline: ... }` — so desktop rendered no focus ring for anything, ordinary inputs included.** This PR un-breaks that for the whole default theme, not just custom controls.

## The fix — the generic-focusable-node slice (desktop)

- **`FocusTarget::Node(id)`** — Tab onto a `tabindex >= 0` node claims focus through the `set_focus_target` choke-point, tearing down the prior input/editor/surface/select (including the lingering-IME half of the trap). Its teardown arm clears the node's DOM focus + focus ring; `ime_state` gets an **explicit** non-IME `Node` arm rather than the `_` fallback (#176 documented that trap).
- **`handle_tab`** resolves the current position from `focused_input_node_id` OR the arbiter's `Node` target, falling back to the nearest focusable *ancestor* of the DOM's focused node — a pointer click focuses the deepest hit element, so Tab now continues from where you clicked instead of restarting at the top.
- **Enter/Space activation**: with `FocusTarget::Node(id)` focused, Enter/Space walk up from the node for the nearest **live** `data-rid` (same liveness probe as the pointer path, so a freed handler can't swallow the key) and dispatch it with a `ClickContext` synthesized from the handler node's absolute rect (cursor at its center). Everything else falls through, so Tab keeps moving; a node with no handler is a quiet no-op.
- **`:focus-visible`** — `is_focus_visible` on `Node` beside `is_focused`; a `NonTSPseudoClass::FocusVisible` matching arm (shares `focus_sensitive`, since the flag only ever changes on the gaining/losing focused node); `FOCUSRING` OR'd into `state()`. Tab-driven focus sets the flag (inputs and Node targets both); any mousedown clears it wherever it is; losing focus clears it with `:focus`.
- **`request_focus` / `NodeHandle::focus()`** on a tabindex node now takes Node focus through the same arbiter path instead of silently no-opping (`try_focus_input` bailed on the missing `data-oninput`). Programmatic focus is not keyboard-driven, so it does not set the ring.
- **Subtree-skip fix** in `collect_focusable_nodes`: `data-disabled="true"` / `tabindex="-1"` previously `continue`d before pushing children, removing the whole subtree from the Tab order; web semantics remove only the node. Fixed.
- A click **inside** the focused Node target keeps its focus (ring already dropped on mousedown); a click elsewhere blurs it through the existing non-input-click blur branch.

## Tests

`rinch::app::tab_focus_tests` (7) + one rinch-dom style test. Verified failing-first by temporarily restoring the parent's `focus_element`/`handle_tab` bodies: 5 of 7 fail against that simulation (`tab_advances_past_a_tabindex_node` — the trap itself, `enter_and_space_activate_the_focused_node`, `node_without_handler_neither_panics_nor_swallows_tab`, `pointer_click_clears_the_ring_but_keeps_focus`, `tab_after_click_anchors_at_the_clicked_position`); the other two (`request_focus_takes_node_focus_programmatically`, `disabled_and_negative_tabindex_skip_only_the_node`) exercise `try_focus_input`/`collect_focusable_nodes` paths that fail on the true parent (silent bail / subtree `continue`).

- The trap: input + tabindex div; second Tab **moves** (arbiter holds `Node(div)`, input torn down, div has `:focus` + `:focus-visible`); third Tab wraps back (Node teardown ran); Shift+Tab goes backwards.
- Enter and Space each dispatch the div's click handler exactly once, through real `PlatformEvent::KeyDown` routing.
- A focused node with no live handler: Enter no-ops without panicking, Tab still advances.
- Pointer click on the Tab-focused node clears `:focus-visible`, keeps `:focus` and the arbiter claim, and still dispatches the click.
- Tab after a click on a middle control continues from there, not from the top.
- `data-disabled`/`tabindex="-1"` wrappers: children stay tabbable, wrappers don't.
- rinch-dom (`focus_visible_rule_needs_the_keyboard_flag`): a `div:focus-visible` rule applies only with the flag; pointer `:focus` alone doesn't match; blur clears the flag.

`cargo +1.98.0 clippy --workspace --all-targets -- -D warnings` clean; full workspace pre-commit gate green.

## Deliberately deferred

- **#147**: the focus callback registry (`on_focus_gained/lost`, `on_key`), window-blur forwarding, and pointer-driven *arbiter* claiming for custom controls.
- **#176**: IME for custom targets (the new `ime_state` arm is explicitly non-IME).
- **Web keyboard-activation parity**: rinch-web registers no click listener (pointerdown only), so Enter/Space activation is dead on web even for native buttons — separate small follow-up.
- **Positive-tabindex ordering** (`tabindex="1"` jumping ahead of document order): still document-order; noted, out of scope.
- No focus/keyboard guide page exists under `docs/src/guide/` to extend; if one gets written, this PR's behavior (Tab order, `:focus-visible` semantics, Enter/Space activation) is the content for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
